### PR TITLE
require cockpit.socket

### DIFF
--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=D-Installer Service
-Requires=dbus.socket
+Requires=dbus.socket cockpit.socket
 
 [Service]
 Type=dbus


### PR DESCRIPTION
## Problem

cockpit is not automatically started for d-installer systemd service.

## Solution

Require cockpit.socket.