### PR TITLE
Install btrfsprogs

### DIFF
--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -92,7 +92,9 @@ module DInstaller
       # as we use liveDVD with normal like ENV, lets temporary switch to normal to use its repos
       Yast::Stage.Set("normal")
       # FIXME: workaround to have at least reasonable proposal
-      Yast::PackagesProposal.AddResolvables("the-installer", :pattern, ["base", "enhanced_base"])
+      Yast::PackagesProposal.AddResolvables("d-installer", :pattern, ["base", "enhanced_base"])
+      # FIXME: temporary workaround to get btrfsprogs into the installed system
+      Yast::PackagesProposal.AddResolvables("d-installer", :package, ["btrfsprogs"])
       proposal = Yast::Packages.Proposal(force_reset = false, reinit = false, _simple = true)
       logger.info "proposal #{proposal["raw_proposal"]}"
       res = Yast::Pkg.PkgSolve(unused = true)


### PR DESCRIPTION
At this point, the btrfsprogs package is not installed. We should do something like [this](https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/clients/inst_disk_proposal.rb#L164), but for this first release this fix is good enough.