### PR TITLE
[WIP] Simplify DBusError tests

### DIFF
--- a/web/src/DBusError.test.jsx
+++ b/web/src/DBusError.test.jsx
@@ -22,25 +22,27 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { installerRender } from "./test-utils";
+import { installerRender, plainRender } from "./test-utils";
 
 import DBusError from "./DBusError";
 
 describe("DBusError", () => {
-  it("includes a generic D-Bus connection problem message", async () => {
-    installerRender(<DBusError />);
+  it("includes a generic D-Bus connection problem message", () => {
+    plainRender(<DBusError />);
 
-    await screen.findByText(/Could not connect to the D-Bus service/i);
+    expect(screen.getByText(/Could not connect to the D-Bus service/i))
+      .toBeInTheDocument()
   });
 
-  it("includes a button for reloading", async () => {
-    installerRender(<DBusError />);
+  it("includes a button for reloading", () => {
+    plainRender(<DBusError />);
 
-    await screen.findByRole("button", { name: /Reload/i });
+    expect(screen.getByText(/Could not connect to the D-Bus service/i))
+      .toBeInTheDocument()
   });
 
   it("calls location.reload when user clicks on 'Reload'", async () => {
-    const { user } = installerRender(<DBusError />);
+    const { user } = plainRender(<DBusError />);
 
     const reloadButton = await screen.findByRole("button", { name: /Reload/i });
 

--- a/web/src/test-utils.js
+++ b/web/src/test-utils.js
@@ -36,4 +36,9 @@ const installerRender = (ui, options = {}) => ({
   ...render(ui, { wrapper: InstallerProvider, ...options })
 });
 
-export { installerRender };
+const plainRender = (ui, options = {}) => ({
+  user: userEvent.setup(),
+  ...render(ui, options)
+});
+
+export { installerRender, plainRender };


### PR DESCRIPTION
## Problem

`DBusError` tests:

* rely on installer context
* run on async

Running on installer context is not needed (not even desired) and async is only needed for the last test.


## Solution

* Allow rendering a component without the installer context.
* Use async only where it is needed.

