### PR TITLE
doc: adapt the shell instructions in backend-for-testing

### DIFF
--- a/rust/agama-cli/doc/backend-for-testing.md
+++ b/rust/agama-cli/doc/backend-for-testing.md
@@ -25,7 +25,7 @@ bit old and the D-Bus API was mismatched between frontend and backend.
 ## Details
 
 The container used is built in
-[OBS YaST:Head:Containers/agama-testing](agama-testing) and
+[OBS YaST:Head:Containers/agama-testing][agama-testing] and
 downloaded from registry.o.o specified below.
 
 [agama-testing]: https://build.opensuse.org/package/show/YaST:Head:Containers/agama-testing


### PR DESCRIPTION
the docs still referenced `dinstaller` and `d-installer`, and I needed them to work

TODO
- [x] adapt the intro too, 
- [ ] and probably move it to `/doc`?

### Testing

tested it by pasting the lines to my terminal, having first removed the old `dinstaller` container