### PR TITLE
Add Ipv6Method

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama1.Network.Connection.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama1.Network.Connection.bus.xml
@@ -71,15 +71,15 @@
 
      Possible values: "disabled", "auto", "manual" or "link-local".
 
-     See [crate::network::model::IpMethod].
+     See [crate::network::model::Ipv4Method].
      -->
     <property name="Method4" type="s" access="readwrite"/>
     <!--
      IPv6 configuration method.
 
-     Possible values: "disabled", "auto", "manual" or "link-local".
+     Possible values: "disabled", "auto", "manual", "link-local", "ignore" or "dhcp".
 
-     See [crate::network::model::IpMethod].
+     See [crate::network::model::Ipv6Method].
      -->
     <property name="Method6" type="s" access="readwrite"/>
     <!--

--- a/doc/dbus/org.opensuse.Agama1.Network.Connection.IP.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.Network.Connection.IP.doc.xml
@@ -24,15 +24,15 @@
 
      Possible values: "disabled", "auto", "manual" or "link-local".
 
-     See [crate::network::model::IpMethod].
+     See [crate::network::model::Ipv4Method].
      -->
     <property name="Method4" type="s" access="readwrite"/>
     <!--
      IPv6 configuration method.
 
-     Possible values: "disabled", "auto", "manual" or "link-local".
+     Possible values: "disabled", "auto", "manual", "link-local", "ignore" or "dhcp".
 
-     See [crate::network::model::IpMethod].
+     See [crate::network::model::Ipv6Method].
      -->
     <property name="Method6" type="s" access="readwrite"/>
     <!--

--- a/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
+++ b/rust/agama-dbus-server/src/network/dbus/interfaces/ip_config.rs
@@ -6,7 +6,7 @@
 //! to the `Ip<T>` struct.
 use crate::network::{
     action::Action,
-    model::{Connection as NetworkConnection, IpConfig, IpMethod},
+    model::{Connection as NetworkConnection, IpConfig, Ipv4Method, Ipv6Method},
 };
 use async_std::{channel::Sender, sync::Arc};
 use cidr::IpInet;
@@ -95,7 +95,7 @@ impl Ip {
     ///
     /// Possible values: "disabled", "auto", "manual" or "link-local".
     ///
-    /// See [crate::network::model::IpMethod].
+    /// See [crate::network::model::Ipv4Method].
     #[dbus_interface(property)]
     pub async fn method4(&self) -> String {
         let ip_config = self.get_ip_config().await;
@@ -104,15 +104,15 @@ impl Ip {
 
     #[dbus_interface(property)]
     pub async fn set_method4(&mut self, method: &str) -> zbus::fdo::Result<()> {
-        let method: IpMethod = method.parse()?;
+        let method: Ipv4Method = method.parse()?;
         self.update_config(|ip| ip.method4 = method).await
     }
 
     /// IPv6 configuration method.
     ///
-    /// Possible values: "disabled", "auto", "manual" or "link-local".
+    /// Possible values: "disabled", "auto", "manual", "link-local", "ignore" or "dhcp".
     ///
-    /// See [crate::network::model::IpMethod].
+    /// See [crate::network::model::Ipv6Method].
     #[dbus_interface(property)]
     pub async fn method6(&self) -> String {
         let ip_config = self.get_ip_config().await;
@@ -121,7 +121,7 @@ impl Ip {
 
     #[dbus_interface(property)]
     pub async fn set_method6(&mut self, method: &str) -> zbus::fdo::Result<()> {
-        let method: IpMethod = method.parse()?;
+        let method: Ipv6Method = method.parse()?;
         self.update_config(|ip| ip.method6 = method).await
     }
 

--- a/rust/agama-dbus-server/src/network/model.rs
+++ b/rust/agama-dbus-server/src/network/model.rs
@@ -331,8 +331,8 @@ pub enum Status {
 
 #[derive(Default, Debug, PartialEq, Clone)]
 pub struct IpConfig {
-    pub method4: IpMethod,
-    pub method6: IpMethod,
+    pub method4: Ipv4Method,
+    pub method6: Ipv6Method,
     pub addresses: Vec<IpInet>,
     pub nameservers: Vec<IpAddr>,
     pub gateway4: Option<IpAddr>,
@@ -352,34 +352,76 @@ pub struct MatchConfig {
 pub struct UnknownIpMethod(String);
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub enum IpMethod {
+pub enum Ipv4Method {
     #[default]
     Disabled = 0,
     Auto = 1,
     Manual = 2,
     LinkLocal = 3,
 }
-impl fmt::Display for IpMethod {
+
+impl fmt::Display for Ipv4Method {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match &self {
-            IpMethod::Disabled => "disabled",
-            IpMethod::Auto => "auto",
-            IpMethod::Manual => "manual",
-            IpMethod::LinkLocal => "link-local",
+            Ipv4Method::Disabled => "disabled",
+            Ipv4Method::Auto => "auto",
+            Ipv4Method::Manual => "manual",
+            Ipv4Method::LinkLocal => "link-local",
         };
         write!(f, "{}", name)
     }
 }
 
-impl FromStr for IpMethod {
+impl FromStr for Ipv4Method {
     type Err = UnknownIpMethod;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "disabled" => Ok(IpMethod::Disabled),
-            "auto" => Ok(IpMethod::Auto),
-            "manual" => Ok(IpMethod::Manual),
-            "link-local" => Ok(IpMethod::LinkLocal),
+            "disabled" => Ok(Ipv4Method::Disabled),
+            "auto" => Ok(Ipv4Method::Auto),
+            "manual" => Ok(Ipv4Method::Manual),
+            "link-local" => Ok(Ipv4Method::LinkLocal),
+            _ => Err(UnknownIpMethod(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub enum Ipv6Method {
+    #[default]
+    Disabled = 0,
+    Auto = 1,
+    Manual = 2,
+    LinkLocal = 3,
+    Ignore = 4,
+    Dhcp = 5,
+}
+
+impl fmt::Display for Ipv6Method {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match &self {
+            Ipv6Method::Disabled => "disabled",
+            Ipv6Method::Auto => "auto",
+            Ipv6Method::Manual => "manual",
+            Ipv6Method::LinkLocal => "link-local",
+            Ipv6Method::Ignore => "ignore",
+            Ipv6Method::Dhcp => "dhcp",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+impl FromStr for Ipv6Method {
+    type Err = UnknownIpMethod;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(Ipv6Method::Disabled),
+            "auto" => Ok(Ipv6Method::Auto),
+            "manual" => Ok(Ipv6Method::Manual),
+            "link-local" => Ok(Ipv6Method::LinkLocal),
+            "ignore" => Ok(Ipv6Method::Ignore),
+            "dhcp" => Ok(Ipv6Method::Dhcp),
             _ => Err(UnknownIpMethod(s.to_string())),
         }
     }

--- a/rust/agama-dbus-server/src/network/nm/dbus.rs
+++ b/rust/agama-dbus-server/src/network/nm/dbus.rs
@@ -518,8 +518,8 @@ mod test {
                 "::ffff:c0a8:102".parse::<IpAddr>().unwrap()
             ]
         );
-        assert_eq!(ip_config.method4, IpMethod::Auto);
-        assert_eq!(ip_config.method6, IpMethod::Auto);
+        assert_eq!(ip_config.method4, Ipv4Method::Auto);
+        assert_eq!(ip_config.method6, Ipv6Method::Auto);
     }
 
     #[test]

--- a/rust/agama-dbus-server/src/network/nm/model.rs
+++ b/rust/agama-dbus-server/src/network/nm/model.rs
@@ -7,11 +7,12 @@
 /// Using the newtype pattern around an String is enough. For proper support, we might replace this
 /// struct with an enum.
 use crate::network::{
-    model::{IpMethod, SecurityProtocol, WirelessMode},
+    model::{Ipv4Method, Ipv6Method, SecurityProtocol, WirelessMode},
     nm::error::NmError,
 };
 use agama_lib::network::types::DeviceType;
 use std::fmt;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
 pub struct NmWirelessMode(pub String);
@@ -150,15 +151,23 @@ impl NmMethod {
     }
 }
 
-impl TryFrom<NmMethod> for IpMethod {
+impl TryFrom<NmMethod> for Ipv4Method {
     type Error = NmError;
 
     fn try_from(value: NmMethod) -> Result<Self, Self::Error> {
-        match value.as_str() {
-            "auto" => Ok(IpMethod::Auto),
-            "manual" => Ok(IpMethod::Manual),
-            "disabled" => Ok(IpMethod::Disabled),
-            "link-local" => Ok(IpMethod::LinkLocal),
+        match Ipv4Method::from_str(value.as_str()) {
+            Ok(method) => Ok(method),
+            _ => Err(NmError::UnsupportedIpMethod(value.to_string())),
+        }
+    }
+}
+
+impl TryFrom<NmMethod> for Ipv6Method {
+    type Error = NmError;
+
+    fn try_from(value: NmMethod) -> Result<Self, Self::Error> {
+        match Ipv6Method::from_str(value.as_str()) {
+            Ok(method) => Ok(method),
             _ => Err(NmError::UnsupportedIpMethod(value.to_string())),
         }
     }

--- a/rust/agama-dbus-server/tests/network.rs
+++ b/rust/agama-dbus-server/tests/network.rs
@@ -3,7 +3,7 @@ mod common;
 use self::common::DBusServer;
 use agama_dbus_server::network::{
     self,
-    model::{self, IpMethod},
+    model::{self, Ipv4Method, Ipv6Method},
     Adapter, NetworkService, NetworkState,
 };
 use agama_lib::network::{settings, types::DeviceType, NetworkClient};
@@ -91,9 +91,9 @@ async fn test_add_connection() {
     assert_eq!(conn.device_type(), DeviceType::Wireless);
     assert_eq!(&conn.addresses, &addresses);
     let method4 = conn.method4.as_ref().unwrap();
-    assert_eq!(method4, &IpMethod::Auto.to_string());
+    assert_eq!(method4, &Ipv4Method::Auto.to_string());
     let method6 = conn.method6.as_ref().unwrap();
-    assert_eq!(method6, &IpMethod::Disabled.to_string());
+    assert_eq!(method6, &Ipv6Method::Disabled.to_string());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

NetworkManager can have different method values for ipv4 and ipv6. Currently some values for ipv6 are missing.


## Solution

Add different `IpMethod` types for v4 and v6.


## Testing

- *Tested manually*