### PR TITLE
RFC: Move Manager to Rust

### DIFF
--- a/rust/agama-dbus-server/src/dbus.rs
+++ b/rust/agama-dbus-server/src/dbus.rs
@@ -1,0 +1,1 @@
+pub mod interfaces;

--- a/rust/agama-dbus-server/src/dbus/interfaces.rs
+++ b/rust/agama-dbus-server/src/dbus/interfaces.rs
@@ -1,0 +1,1 @@
+pub mod progress;

--- a/rust/agama-dbus-server/src/dbus/interfaces/progress.rs
+++ b/rust/agama-dbus-server/src/dbus/interfaces/progress.rs
@@ -1,0 +1,108 @@
+use zbus::{dbus_interface, Connection, InterfaceRef, SignalContext};
+use crate::error::Error;
+
+pub struct Progress {
+    iface_ref: Option<InterfaceRef<Progress>>,
+    total_steps: u8,
+    current_step: Option<Step>,
+}
+
+#[derive(Clone)]
+struct Step(u8, String);
+
+impl Default for Step {
+    fn default() -> Self {
+        Step(0, String::new())
+    }
+}
+
+type ProgressResult = Result<(), Error>;
+
+impl Progress {
+    pub fn new() -> Self {
+        Self {
+            iface_ref: None,
+            total_steps: 0,
+            current_step: None
+        }
+    }
+
+    pub fn set_iface_ref(&mut self, iface_ref: InterfaceRef<Self>) {
+        self.iface_ref = Some(iface_ref);
+    }
+
+    pub async fn start(&mut self, total_steps: u8) -> ProgressResult {
+        self.set_total_steps(total_steps).await?;
+        self.set_current_step(None).await?;
+        Ok(())
+    }
+
+    pub async fn step(&mut self, description: String) -> ProgressResult {
+        let Step(index, _) = self.current_step.clone().unwrap_or_default();
+        self.set_current_step(Some(Step(index + 1, description))).await
+    }
+
+    pub async fn finish(&mut self) -> ProgressResult {
+        self.set_total_steps(0).await?;
+        self.set_current_step(None).await?;
+        Ok(())
+    }
+
+    async fn set_total_steps(&mut self, value: u8) -> ProgressResult {
+        self.total_steps = value;
+        self.total_steps_signal().await
+    }
+
+    async fn set_current_step(&mut self, step: Option<Step>) -> ProgressResult {
+        self.current_step = step;
+        self.current_step_signal().await
+    }
+
+    async fn total_steps_signal(&self) -> ProgressResult {
+        if let Some(signal_context) = self.signal_context() {
+            self.total_steps_changed(signal_context).await?;
+        }
+        Ok(())
+    }
+
+    async fn current_step_signal(&self) -> ProgressResult {
+        if let Some(signal_context) = self.signal_context() {
+            self.current_step_changed(signal_context).await?;
+        }
+        Ok(())
+    }
+
+    fn signal_context(&self) -> Option<&SignalContext> {
+        self.iface_ref
+            .as_ref()
+            .and_then(|iref| Some(iref.signal_context()))
+    }
+}
+
+#[dbus_interface(name = "org.opensuse.Agama1.Progress")]
+impl Progress {
+    #[dbus_interface(property)]
+    fn total_steps(&self) -> u8 {
+        self.total_steps
+    }
+
+    #[dbus_interface(property)]
+    fn current_step(&self) -> (u8, String) {
+        let Step(index, description) = self.current_step.clone().unwrap_or_default();
+        (index, description)
+    }
+}
+
+pub async fn export_interface(
+    connection: &Connection,
+    path: &str,
+) -> Result<InterfaceRef<Progress>, Box<dyn std::error::Error>> {
+    let progress = Progress::new();
+    connection.object_server().at(path, progress).await?;
+
+    let iface_ref = connection.object_server().interface::<_, Progress>(path).await?;
+    let mut iface = iface_ref.get_mut().await;
+    iface.set_iface_ref(iface_ref.clone());
+
+    Ok(iface_ref.clone())
+}

--- a/rust/agama-dbus-server/src/lib.rs
+++ b/rust/agama-dbus-server/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod dbus;
 pub mod error;
 pub mod locale;
 pub mod network;
+pub mod manager;
 pub mod questions;

--- a/rust/agama-dbus-server/src/main.rs
+++ b/rust/agama-dbus-server/src/main.rs
@@ -1,4 +1,4 @@
-use agama_dbus_server::{locale, network, questions};
+use agama_dbus_server::{manager, locale, network, questions};
 
 use agama_lib::connection_to;
 use anyhow::Context;
@@ -38,6 +38,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Started locale interface");
     network::export_dbus_objects(&connection).await?;
     log::info!("Started network interface");
+    manager::export_dbus_objects(&connection).await?;
+    log::info!("Started manager interface");
 
     connection
         .request_name(SERVICE_NAME)

--- a/rust/agama-dbus-server/src/manager.rs
+++ b/rust/agama-dbus-server/src/manager.rs
@@ -1,0 +1,42 @@
+use crate::dbus::interfaces::progress::{export_interface, Progress};
+use zbus::{dbus_interface, Connection, InterfaceRef};
+use crate::error::Error;
+
+pub struct Manager {
+    progress_ref: InterfaceRef<Progress>,
+}
+
+impl Manager {
+    pub fn new(progress_ref: InterfaceRef<Progress>) -> Self {
+        Self {
+            progress_ref,
+        }
+    }
+}
+
+#[dbus_interface(name = "org.opensuse.Agama1.Manager")]
+impl Manager {
+    pub async fn probe(&mut self) -> Result<(), Error> {
+        let mut progress = self.progress_ref.get_mut().await;
+
+        // TODO
+        progress.start(2).await?;
+        progress.step("step 1".to_string()).await?;
+        progress.step("step 2".to_string()).await?;
+        progress.finish().await?;
+
+        Ok(())
+    }
+}
+
+pub async fn export_dbus_objects(
+    connection: &Connection,
+) -> Result<(), Box<dyn std::error::Error>> {
+    const PATH: &str = "/org/opensuse/Agama1";
+
+    let progress_ref = export_interface(connection, PATH).await?;
+    let manager = Manager::new(progress_ref);
+    connection.object_server().at(PATH, manager).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Introduction

This branch starts the migration of the *Manager* service from Ruby to Rust code. For more details,  see the associated HackWeek project https://hackweek.opensuse.org/23/projects/port-agamas-manager-to-rust.   

## Manager and progress reporting

*Manager* and other services implement the *org.opensuse.Agama1.Progress* D-Bus interface. That interface is used to report the progress of the current action being performed by the service. 

That progress interface only has read-only properties:

~~~
org.opensuse.Agama1.Progress

NAME                         TYPE      SIGNATURE RESULT/VALUE FLAGS
.CurrentStep                 property  (ys)      0 ""         emits-change
.TotalSteps                  property  y         0            emits-change
~~~

And the code reporting progress should be able to `start`, `step` and `finish` a progress. For example:

~~~
progress.start(total_steps: 3)
progress.step("Reading data")
...
progress.step("Configuring")
...
progress.step("Writing data")
...
progress.finish
~~~ 

The calls to `#start`, `#step` or `#finish` changes the data of the progess (e.g., total steps and current step), so a `PropertiesChanged` signal should be properly emited in D-Bus in order to notify about changes in `CurrentStep` and `TotalSteps` properties.

Typically, D-Bus libraries like *ruby-dbus* or *zbus* automatically emit a signal when a property is set by means of a D-Bus property setter. But, the progress interface lacks of such setters (it only has read-only properties). Therefore, the progress should implement any kind of strategy for emiting D-Bus signasl as part of the `#start`, `#step` and `#finish` methods.

In short, the problem to solve consists on emiting a D-Bus signal from outside of the D-Bus interface.

## Ruby solution in Agama 

In the ruby code this problem was already solved by using callbacks:

~~~ruby
class Progress
  def start(total_steps)
    @total_steps = total_steps
    @on_change_callbacks.each(&:run)
  end

  def on_change(&block)
    @on_change_callbacks ||= []
    @on_change_callbacks << block
  end
end

module DBus
  class Manager < DBus::Object
    def initialize(progress)
       progress.on_change do
          dbus_properties_changed(PROGRESS_INTERFACE, progress_properties, [])
       end
    end
  end
end
~~~

Basically, the D-Bus object adds a callback to `Progress` in order to emit a signal when progress changes.

## RFC: Rust solution

This PR proposes a possible solution in Rust. In Agama we are using *zbus* crate for working with D-Bus. Again, emiting a property changed signal is trivial when you do it from the D-Bus interface implementation:

~~~rust
#[dbus_interface(name = "org.opensuse.Agama1.Progress")]
impl Progress {
    #[dbus_interface(property)]
    fn total_steps(&self) -> u8 {
        self.total_steps
    }
    async fn start(
        &mut self,
        total_steps: u8,
        #[zbus(signal_context)]
        ctxt: SignalContext<'_>,
    ) -> fdo::Result<()> {
        self.total_steps = total_steps;
        self.total_steps_changed(&ctxt).await?;
       
        Ok(())
    }
}
~~~

Note that for emiting a signal (e.g., `#total_steps_changed`) we need the signal context reference, which is automatically provided by *zbus* as parameter of the methods defining the D-Bus interface. But we don't want `#start` to be part of the D-Bus interface, so how could we get the signal context reference from outside the D-Bus interface?

The solution proposed by this PR consists on recovering and storing a reference to the D-Bus interface. Having the interface reference we can get the signal context and emit signals:

~~~rust
pub async fn export_interface(
    connection: &Connection,
    path: &str,
) -> Result<InterfaceRef<Progress>, Box<dyn std::error::Error>> {
    let progress = Progress::new();
    connection.object_server().at(path, progress).await?;

    let iface_ref = connection.object_server().interface::<_, Progress>(path).await?;
    let mut iface = iface_ref.get_mut().await;
    iface.set_iface_ref(iface_ref.clone());

    Ok(iface_ref.clone())
}

impl Progress {
    pub async fn start(&mut self, total_steps: u8) -> Resutl<(), Error> {
        self.total_steps = total_steps;
        self.total_steps_changed(self.iface_ref.signal_context()).await?;

        Ok(())
    }
}

#[dbus_interface(name = "org.opensuse.Agama1.Progress")]
impl Progress {
    #[dbus_interface(property)]
    fn total_steps(&self) -> u8 {
        self.total_steps
    }
}
~~~

Now `#start` does not belong to the D-Bus interface implementation. Services can call to `Progress#start`, which automatically emits the proper D-Bus signals.
