### PR TITLE
Fix list search

### DIFF
--- a/web/src/components/core/ListSearch.jsx
+++ b/web/src/components/core/ListSearch.jsx
@@ -25,11 +25,13 @@ import { _ } from "~/i18n";
 import { noop, useDebounce } from "~/utils";
 
 const search = (elements, term) => {
+  const lowerCaseTerm = term.toLowerCase();
+
   const match = (element) => {
     return Object.values(element)
       .join('')
       .toLowerCase()
-      .includes(term);
+      .includes(lowerCaseTerm);
   };
 
   return elements.filter(match);

--- a/web/src/components/core/ListSearch.test.jsx
+++ b/web/src/components/core/ListSearch.test.jsx
@@ -25,10 +25,10 @@ import { plainRender } from "~/test-utils";
 import { ListSearch } from "~/components/core";
 
 const fruits = [
-  { name: "apple", color: "red", size: "medium" },
-  { name: "banana", color: "yellow", size: "medium" },
-  { name: "grape", color: "green", size: "small" },
-  { name: "pear", color: "green", size: "medium" }
+  { name: "Apple", color: "Red", size: "medium" },
+  { name: "Banana", color: "Yellow", size: "medium" },
+  { name: "Grape", color: "Green", size: "small" },
+  { name: "Pear", color: "Green", size: "medium" }
 ];
 
 const FruitList = ({ fruits }) => {
@@ -50,51 +50,51 @@ it("searches for elements matching the given text", async () => {
   const searchInput = screen.getByRole("search");
 
   // Search for "medium" size fruit
-  await user.type(searchInput, "medium");
+  await user.type(searchInput, "mEdium");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /grape/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Grape/ })).not.toBeInTheDocument())
   );
-  screen.getByRole("option", { name: /apple/ });
-  screen.getByRole("option", { name: /banana/ });
-  screen.getByRole("option", { name: /pear/ });
+  screen.getByRole("option", { name: /Apple/i });
+  screen.getByRole("option", { name: /Banana/ });
+  screen.getByRole("option", { name: /Pear/ });
 
   // Search for "green" fruit
   await user.clear(searchInput);
   await user.type(searchInput, "green");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /apple/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Apple/ })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /banana/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Banana/ })).not.toBeInTheDocument())
   );
-  screen.getByRole("option", { name: /grape/ });
-  screen.getByRole("option", { name: /pear/ });
+  screen.getByRole("option", { name: /Grape/ });
+  screen.getByRole("option", { name: /Pear/ });
 
   // Search for known fruit
   await user.clear(searchInput);
-  await user.type(searchInput, "ap");
+  await user.type(searchInput, "AP");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /banana/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Banana/ })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /pear/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Pear/ })).not.toBeInTheDocument())
   );
-  screen.getByRole("option", { name: /apple/ });
-  screen.getByRole("option", { name: /grape/ });
+  screen.getByRole("option", { name: /Apple/ });
+  screen.getByRole("option", { name: /Grape/ });
 
   // Search for unknown fruit
   await user.clear(searchInput);
   await user.type(searchInput, "tomato");
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /apple/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Apple/ })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /banana/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Banana/ })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /grape/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Grape/ })).not.toBeInTheDocument())
   );
   await waitFor(() => (
-    expect(screen.queryByRole("option", { name: /pear/ })).not.toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: /Pear/ })).not.toBeInTheDocument())
   );
 });


### PR DESCRIPTION
## Problem

New component `ListSearch` was not filtering correctly when the search term contains capital letters.

## Solution

Fix the matcher in `ListSearch` component.

## Testing

* Adapted unti tests.
* Tested manually


## Screenshots

![localhost_8080_(iPad Mini) (19)](https://github.com/openSUSE/agama/assets/1112304/a9bfe8b4-8138-40fd-a372-fc0ff902bb08)
