### PR TITLE
Rename wpa-eap-suite-b192 to wpa-eap-suite-b-192

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -152,7 +152,7 @@
                       "wpa-psk",
                       "sae",
                       "wpa-eap",
-                      "wpa-eap-suite-b192"
+                      "wpa-eap-suite-b-192"
                     ]
                   },
                   "ssid": {

--- a/rust/agama-lib/src/network/proxies.rs
+++ b/rust/agama-lib/src/network/proxies.rs
@@ -108,7 +108,7 @@ trait Wireless {
     /// Wireless Security property
     ///
     /// Possible values are 'none', 'owe', 'ieee8021x', 'wpa-psk', 'sae',
-    ///     'wpa-eap', 'wpa-eap-suite-b192'
+    ///     'wpa-eap', 'wpa-eap-suite-b-192'
     #[dbus_proxy(property)]
     fn security(&self) -> zbus::Result<String>;
     #[dbus_proxy(property)]

--- a/rust/agama-server/src/network/model.rs
+++ b/rust/agama-server/src/network/model.rs
@@ -1169,7 +1169,7 @@ pub enum SecurityProtocol {
     WPA2,           // WPA2 + WPA3 personal ("wpa-psk")
     WPA3Personal,   // WPA3 personal only ("sae")
     WPA2Enterprise, // WPA2 + WPA3 Enterprise ("wpa-eap")
-    WPA3Only,       // WPA3 only ("wpa-eap-suite-b192")
+    WPA3Only,       // WPA3 only ("wpa-eap-suite-b-192")
 }
 
 impl fmt::Display for SecurityProtocol {
@@ -1181,7 +1181,7 @@ impl fmt::Display for SecurityProtocol {
             SecurityProtocol::WPA2 => "wpa-psk",
             SecurityProtocol::WPA3Personal => "sae",
             SecurityProtocol::WPA2Enterprise => "wpa-eap",
-            SecurityProtocol::WPA3Only => "wpa-eap-suite-b192",
+            SecurityProtocol::WPA3Only => "wpa-eap-suite-b-192",
         };
         write!(f, "{}", value)
     }
@@ -1198,7 +1198,7 @@ impl TryFrom<&str> for SecurityProtocol {
             "wpa-psk" => Ok(SecurityProtocol::WPA2),
             "sae" => Ok(SecurityProtocol::WPA3Personal),
             "wpa-eap" => Ok(SecurityProtocol::WPA2Enterprise),
-            "wpa-eap-suite-b192" => Ok(SecurityProtocol::WPA3Only),
+            "wpa-eap-suite-b-192" => Ok(SecurityProtocol::WPA3Only),
             _ => Err(NetworkStateError::InvalidSecurityProtocol(
                 value.to_string(),
             )),

--- a/rust/agama-server/src/network/nm/model.rs
+++ b/rust/agama-server/src/network/nm/model.rs
@@ -140,7 +140,7 @@ impl TryFrom<NmKeyManagement> for SecurityProtocol {
             "wpa-psk" => Ok(SecurityProtocol::WPA2),
             "wpa-eap" => Ok(SecurityProtocol::WPA3Personal),
             "sae" => Ok(SecurityProtocol::WPA2Enterprise),
-            "wpa-eap-suite-b192" => Ok(SecurityProtocol::WPA2Enterprise),
+            "wpa-eap-suite-b-192" => Ok(SecurityProtocol::WPA2Enterprise),
             "none" => Ok(SecurityProtocol::WEP),
             _ => Err(NmError::UnsupportedSecurityProtocol(value.to_string())),
         }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 25 14:33:50 UTC 2024 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
+
+- Rename wireless key-mgmt value wpa-eap-suite-b192 to
+  wpa-eap-suite-b-192 (gh#agama-project/agama#1640)
+
+-------------------------------------------------------------------
 Fri Sep 20 11:42:06 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 10


### PR DESCRIPTION
## Problem

* `NetworkManger` complain if we use `wpa-eap-suite-b192` as `802-11-wireless-security.key-mgmt` [¹](https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html) with:
```
Could not update the network configuration: D-Bus service error: org.freedesktop.NetworkManager.Settings.Connection.InvalidProperty: 802-11-wireless-security.key-mgmt: 'wpa-eap-suite-b192' is not a valid value for the property
```

I hope it's not to late to change it everywhere. If it is to late, we could only handle `WPA3Only` in `rust/agama-server/src/network/nm/model.rs` properly.
