### PR TITLE
Fix optional network settings

### DIFF
--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -81,13 +81,13 @@ pub struct WirelessSettings {
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub hidden: bool,
     /// A list of group/broadcast encryption algorithms
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub group_algorithms: Vec<String>,
     /// A list of pairwise encryption algorithms
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub pairwise_algorithms: Vec<String>,
     /// A list of allowed WPA protocol versions
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub wpa_protocol_versions: Vec<String>,
     /// Indicates whether Protected Management Frames must be enabled for the connection
     #[serde(skip_serializing_if = "is_zero", default)]
@@ -118,7 +118,7 @@ impl Default for BondSettings {
 #[serde(rename_all = "camelCase")]
 pub struct IEEE8021XSettings {
     /// List of EAP methods used
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub eap: Vec<String>,
     /// Phase 2 inner auth method
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -154,7 +154,7 @@ pub struct IEEE8021XSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peap_version: Option<String>,
     /// Force the use of the new PEAP label during key derivation
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub peap_label: bool,
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Sep 27 13:09:10 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
 
-- Fix optional network settings (gh#openSUSE/agama#1641).
+- Fix optional network settings (gh#agama-project/agama#1641).
 
 -------------------------------------------------------------------
 Fri Sep 27 10:44:22 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Sep 26 9:09:10 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Fix optional network settings (gh#openSUSE/agama#1641).
+
+-------------------------------------------------------------------
 Wed Sep 25 14:33:50 UTC 2024 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
 
 - Rename wireless key-mgmt value wpa-eap-suite-b192 to


### PR DESCRIPTION
## Problem

Some settings in the network configuration are wrongly not optional or optional

## Solution

Make the right settings optional

## Testing

- *Tested manually*
```
sudo agama auth login && AGAMA_TOKEN=`sudo agama auth show`
curl http://localhost/api/network/connections \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN" \
    -d '{ "id": "wifi", "method4": "auto", "method6": "auto", "ignoreAutoDns": false, "wireless": { "security": "wpa-psk", "ssid": "test-ssid", "mode": "infrastructure"}, "status": "down" }'
```