### PR TITLE
fix(rust): localize the keymaps descriptions

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 27 10:44:22 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Expose keymaps localized descriptions (gh#agama-project/agama#1643).
+
+-------------------------------------------------------------------
 Wed Sep 25 14:33:50 UTC 2024 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
 
 - Rename wireless key-mgmt value wpa-eap-suite-b192 to


### PR DESCRIPTION
## Problem

Agama's UI always displays the keymaps descriptions in English.

## Solution

Translate keymaps descriptions at API level.

## Testing

- Tested manually