### PR TITLE
Better fork detection in GitHub Actions

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     # do not run scheduled jobs in forks, in forks only allow manual run ("workflow_dispatch")
-    if: github.repository_owner == 'openSUSE' || github.event_name == 'workflow_dispatch'
+    if: (!github.event.repository.fork) || github.event_name == 'workflow_dispatch'
 
     steps:
 
@@ -101,7 +101,7 @@ jobs:
       # see https://github.com/marketplace/actions/irc-message-action
       uses: Gottox/irc-message-action@v2
       # never run in forks or when triggered manually
-      if: failure() && github.repository_owner == 'openSUSE' && github.event_name != 'workflow_dispatch'
+      if: failure() && !github.event.repository.fork && github.event_name != 'workflow_dispatch'
       with:
         channel: "#yast"
         nickname: github-action

--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     # do not run in forks
-    if: github.repository == 'openSUSE/agama'
+    if: !github.event.repository.fork
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     # do not run in forks
-    if: github.repository == 'openSUSE/agama'
+    if: !github.event.repository.fork
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     # do not run in forks
-    if: github.repository_owner == 'openSUSE'
+    if: !github.event.repository.fork
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   update-pot:
     # do not run in forks
-    if: github.repository == 'openSUSE/agama'
+    if: !github.event.repository.fork
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Problem

- The weblate GitHub Actions do not run because the Git repository was moved to a different organization.

## Solution

- Use generic `github.event.repository.fork` which does not use any hardcoded name.