### PR TITLE
Fixed failing setup for docs CI

### DIFF
--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install Ruby development files and XML tooling
       run: zypper --non-interactive install --no-recommends
            gcc gcc-c++ make libopenssl-devel ruby-devel augeas-devel diff
-           libxslt-devel libxml2-devel xmlstarlet
+           libxslt-devel libxml2-devel xmlstarlet 'rubygem(ruby-augeas)'
 
     - name: Cache RubyGems
       uses: actions/cache@v3
@@ -64,7 +64,7 @@ jobs:
       env:
         NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
       run: |
-        bundle config set --local path 'vendor/bundle'
+        bundle config set --local disable_shared_gems 0
         bundle install
       working-directory: ./service
 

--- a/service/lib/agama/storage/config_size_solver.rb
+++ b/service/lib/agama/storage/config_size_solver.rb
@@ -103,7 +103,7 @@ module Agama
         config_builder.default_size(path, having_paths: paths, with_snapshots: snapshots)
       end
 
-      # @param config [Configs::Partition, Configs::LogicalVolume]
+      # @param device [Y2Storage::Device]
       # @return [Configs::Size]
       def size_from_device(device)
         Configs::Size.new.tap do |config|


### PR DESCRIPTION
The augeas Ruby gem 0.5.0 from rubygems.org is not compatible with Ruby 3.3 but the preinstalled RPM package is patched in OBS. Confugure the bundler to use the system gems.

Copied from fac8bb6e7afc16feb63a2feb4b27f5dc1a9edfd0 by lslezak
