### PR TITLE
Update links to the agama-weblate repository

### DIFF
--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: agama-weblate
-          repository: openSUSE/agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
 
       - name: Update PO files
         working-directory: ./agama

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: agama-weblate
-          repository: openSUSE/agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
   
       - name: Validate the product PO files
         working-directory: ./agama-weblate

--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: agama-weblate
-          repository: openSUSE/agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
   
       - name: Validate the service PO files
         working-directory: ./agama-weblate

--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: agama-weblate
-          repository: openSUSE/agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
           token:  ${{ secrets.GH_TOKEN }}
 
       - name: Configure Git

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -84,13 +84,13 @@ The basic translation workflow looks like this:
 1. The translatable texts are marked for translation in the source code, usually
    with the `_()` function or something similar
 2. The translatable string are collected into a POT file which is uploaded to
-   the staging [agama-weblate](https://github.com/openSUSE/agama-weblate) GitHub
+   the staging [agama-weblate](https://github.com/project-agama/agama-weblate) GitHub
    repository
 3. The POT file is loaded by the Weblate into the
    [agama](https://l10n.opensuse.org/projects/agama/) project
 4. Translators then can translate the English texts into other languages
 5. Weblate pushes back the translations in the PO files back to the
-   [agama-weblate](https://github.com/openSUSE/agama-weblate) repository
+   [agama-weblate](https://github.com/project-agama/agama-weblate) repository
 6. The translations in the PO files are regularly copied to the main repository
    using pull requests
 7. The PO files are processed during build so the translations can be used
@@ -98,7 +98,7 @@ The basic translation workflow looks like this:
 
 ## Staging Translation Repository
 
-The special [agama-weblate](https://github.com/openSUSE/agama-weblate)
+The special [agama-weblate](https://github.com/project-agama/agama-weblate)
 repository works like a buffer between the Agama sources and the Weblate tool.
 
 We do not want to spam the Weblate tool with every trivial change in the texts
@@ -114,7 +114,7 @@ of seconds.
 ## Synchronization
 
 The content between the main [agama](https://github.com/openSUSE/agama) and
-the translation [agama-weblate](https://github.com/openSUSE/agama-weblate)
+the translation [agama-weblate](https://github.com/project-agama/agama-weblate)
 GitHub repositories is synchronized automatically using the GitHub Actions.
 
 ### Uploading Translatable Texts
@@ -160,7 +160,7 @@ separate translation component for each Agama part (the web frontend, the D-Bus
 backend and the command line interface).
 
 For reading the translations it uses the [agama-weblate](
-https://github.com/openSUSE/agama-weblate) GitHub repository, but for the source
+https://github.com/project-agama/agama-weblate) GitHub repository, but for the source
 code locations it uses the original [agama](https://github.com/openSUSE/agama)
 repository. That means after clicking the source location link in the Weblate
 you will see the correct source location in the other repository.
@@ -526,14 +526,14 @@ UI.
    [language package](#backend-translations) is installed.
 3. The text should be [extracted into the POT file](#building-pot-file)
 4. The [agama.pot](
-   https://github.com/openSUSE/agama-weblate/blob/master/web/agama.pot) in the
+   https://github.com/project-agama/agama-weblate/blob/master/web/agama.pot) in the
    `agama-weblate` repository is up to date, if not then run the [Weblate Update
    POT](https://github.com/openSUSE/agama/actions/workflows/weblate-update-pot.yml)
    Github Action manually.
 5. The text is translated in the [Weblate repository](
    https://l10n.opensuse.org/projects/agama/).
 6. The translation is included in the respective PO file in the [agama-weblate](
-   https://github.com/openSUSE/agama-weblate) repository.
+   https://github.com/project-agama/agama-weblate) repository.
 7. The PO file in the [agama](
    https://github.com/openSUSE/agama/tree/master/web/po) repository is up to
    date, if not the check whether there is an [open pull request](

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -84,13 +84,13 @@ The basic translation workflow looks like this:
 1. The translatable texts are marked for translation in the source code, usually
    with the `_()` function or something similar
 2. The translatable string are collected into a POT file which is uploaded to
-   the staging [agama-weblate](https://github.com/project-agama/agama-weblate) GitHub
+   the staging [agama-weblate](https://github.com/agama-project/agama-weblate) GitHub
    repository
 3. The POT file is loaded by the Weblate into the
    [agama](https://l10n.opensuse.org/projects/agama/) project
 4. Translators then can translate the English texts into other languages
 5. Weblate pushes back the translations in the PO files back to the
-   [agama-weblate](https://github.com/project-agama/agama-weblate) repository
+   [agama-weblate](https://github.com/agama-project/agama-weblate) repository
 6. The translations in the PO files are regularly copied to the main repository
    using pull requests
 7. The PO files are processed during build so the translations can be used
@@ -98,7 +98,7 @@ The basic translation workflow looks like this:
 
 ## Staging Translation Repository
 
-The special [agama-weblate](https://github.com/project-agama/agama-weblate)
+The special [agama-weblate](https://github.com/agama-project/agama-weblate)
 repository works like a buffer between the Agama sources and the Weblate tool.
 
 We do not want to spam the Weblate tool with every trivial change in the texts
@@ -114,7 +114,7 @@ of seconds.
 ## Synchronization
 
 The content between the main [agama](https://github.com/openSUSE/agama) and
-the translation [agama-weblate](https://github.com/project-agama/agama-weblate)
+the translation [agama-weblate](https://github.com/agama-project/agama-weblate)
 GitHub repositories is synchronized automatically using the GitHub Actions.
 
 ### Uploading Translatable Texts
@@ -160,7 +160,7 @@ separate translation component for each Agama part (the web frontend, the D-Bus
 backend and the command line interface).
 
 For reading the translations it uses the [agama-weblate](
-https://github.com/project-agama/agama-weblate) GitHub repository, but for the source
+https://github.com/agama-project/agama-weblate) GitHub repository, but for the source
 code locations it uses the original [agama](https://github.com/openSUSE/agama)
 repository. That means after clicking the source location link in the Weblate
 you will see the correct source location in the other repository.
@@ -526,14 +526,14 @@ UI.
    [language package](#backend-translations) is installed.
 3. The text should be [extracted into the POT file](#building-pot-file)
 4. The [agama.pot](
-   https://github.com/project-agama/agama-weblate/blob/master/web/agama.pot) in the
+   https://github.com/agama-project/agama-weblate/blob/master/web/agama.pot) in the
    `agama-weblate` repository is up to date, if not then run the [Weblate Update
    POT](https://github.com/openSUSE/agama/actions/workflows/weblate-update-pot.yml)
    Github Action manually.
 5. The text is translated in the [Weblate repository](
    https://l10n.opensuse.org/projects/agama/).
 6. The translation is included in the respective PO file in the [agama-weblate](
-   https://github.com/project-agama/agama-weblate) repository.
+   https://github.com/agama-project/agama-weblate) repository.
 7. The PO file in the [agama](
    https://github.com/openSUSE/agama/tree/master/web/po) repository is up to
    date, if not the check whether there is an [open pull request](

--- a/products.d/README.md
+++ b/products.d/README.md
@@ -7,11 +7,11 @@ This directory contains product definitions for the Agama installer.
 For updating the translations use the [Agama Weblate
 project](https://l10n.opensuse.org/projects/agama/agama-products/). The changes
 in the Weblate are automatically saved to the
-[agama-weblate](https://github.com/project-agama/agama-weblate/products) repository
+[agama-weblate](https://github.com/agama-project/agama-weblate/products) repository
 and later a pull request with the changes is automatically created for merging
 the changes here.
 
 Alternatively you can open a pull request against the
-[agama-weblate](https://github.com/project-agama/agama-weblate/products) GitHub
+[agama-weblate](https://github.com/agama-project/agama-weblate/products) GitHub
 repository. But that requires manual approving and merging, prefer using the
 Weblate tool, it merges automatically.

--- a/products.d/README.md
+++ b/products.d/README.md
@@ -7,11 +7,11 @@ This directory contains product definitions for the Agama installer.
 For updating the translations use the [Agama Weblate
 project](https://l10n.opensuse.org/projects/agama/agama-products/). The changes
 in the Weblate are automatically saved to the
-[agama-weblate](https://github.com/openSUSE/agama-weblate/products) repository
+[agama-weblate](https://github.com/project-agama/agama-weblate/products) repository
 and later a pull request with the changes is automatically created for merging
 the changes here.
 
 Alternatively you can open a pull request against the
-[agama-weblate](https://github.com/openSUSE/agama-weblate/products) GitHub
+[agama-weblate](https://github.com/project-agama/agama-weblate/products) GitHub
 repository. But that requires manual approving and merging, prefer using the
 Weblate tool, it merges automatically.

--- a/web/po/README.md
+++ b/web/po/README.md
@@ -7,7 +7,7 @@ installer. See more details in the main [i18n](../../doc/i18n.md) documentation.
 
 :warning: *WARNING: Do not manually change any files here! The files are
 automatically overwritten by the files from the
-[agama-weblate](https://github.com/project-agama/agama-weblate/tree/master/web) Git
+[agama-weblate](https://github.com/agama-project/agama-weblate/tree/master/web) Git
 repository! Your changes would be lost on the next synchronization!* :warning:
 
 For updating the translations use the [Agama Weblate
@@ -17,6 +17,6 @@ and later a pull request with the changes is automatically created for merging
 the changes here.
 
 Alternatively you can open a pull request against the
-[agama-weblate](https://github.com/project-agama/agama-weblate/web) GitHub
+[agama-weblate](https://github.com/agama-project/agama-weblate/web) GitHub
 repository. But that requires manual approving and merging, prefer using the
 Weblate tool, it merges automatically.

--- a/web/po/README.md
+++ b/web/po/README.md
@@ -7,7 +7,7 @@ installer. See more details in the main [i18n](../../doc/i18n.md) documentation.
 
 :warning: *WARNING: Do not manually change any files here! The files are
 automatically overwritten by the files from the
-[agama-weblate](https://github.com/openSUSE/agama-weblate/tree/master/web) Git
+[agama-weblate](https://github.com/project-agama/agama-weblate/tree/master/web) Git
 repository! Your changes would be lost on the next synchronization!* :warning:
 
 For updating the translations use the [Agama Weblate
@@ -17,6 +17,6 @@ and later a pull request with the changes is automatically created for merging
 the changes here.
 
 Alternatively you can open a pull request against the
-[agama-weblate](https://github.com/openSUSE/agama-weblate/web) GitHub
+[agama-weblate](https://github.com/project-agama/agama-weblate/web) GitHub
 repository. But that requires manual approving and merging, prefer using the
 Weblate tool, it merges automatically.


### PR DESCRIPTION
## Problem

- The `agama-weblate` repository has been also moved

## Solution

- Update the references in the GitHub Actions to use generic `github.repository_owner` (the actions use `!github.event.repository.fork` condition so they should never run outside of the `project-agama` , but this is more flexible)
- Update the links in the documentation

## Notes

- I was thinking about using relative URLs in the documentation, but then it would not work in forks (unless you fork the `agama-weblate` repository as well). Absolute URLs are probably better here, I do not expect we move the location anytime soon. :smiley:
