### PR TITLE
feature(storage): config support for generating physical volumes

### DIFF
--- a/doc/auto_storage.md
+++ b/doc/auto_storage.md
@@ -944,6 +944,81 @@ The *mandatory* keyword can be used for only generating the mandatory partitions
 }
 ```
 
+### Generating Physical Volumes
+
+Volume groups can be configured to explicitly use a set of devices as physical volumes. The aliases
+of the devices to use are added to the list of physical volumes:
+
+```json
+"storage": {
+  "drives": [
+    {
+      "search": "/dev/vda",
+      "partitions": [
+        { "alias": "pv2" },
+        { "alias": "pv1" }
+      ]
+    }
+  ],
+  "volumeGroups": [
+    {
+      "physicalVolumes": ["pv1", "pv2"]
+    }
+  ]
+}
+```
+
+The physical volumes can be automatically generated too, by simply indicating the target devices in
+which to create the partitions. For that, a *generate* section is added to the list of physical
+volumes:
+
+```json
+"storage": {
+  "drives": [
+    {
+      "search": "/dev/vda",
+      "alias": "pvs-disk"
+    }
+  ],
+  "volumeGroups": [
+    {
+      "physicalVolumes": [
+        { "generate": ["pvs-disk"] }
+      ]
+    }
+  ]
+}
+```
+
+If the auto-generated physical volumes have to be encrypted, then the encryption config is added to
+the *generate* section:
+
+
+```json
+"storage": {
+  "drives": [
+    {
+      "search": "/dev/vda",
+      "alias": "pvs-disk"
+    }
+  ],
+  "volumeGroups": [
+    {
+      "physicalVolumes": [
+        {
+          "generate": {
+            "targetDevices": ["pvs-disk"],
+            "encryption": {
+              "luks2": { "password": "12345" }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ### Using the Automatic Proposal
 
 On the first implementations, Agama can rely on the process known as Guided Proposal to calculate

--- a/rust/agama-lib/share/examples/storage/generate_pvs.json
+++ b/rust/agama-lib/share/examples/storage/generate_pvs.json
@@ -1,0 +1,48 @@
+{
+  "storage": {
+    "drives": [
+      {
+        "alias": "first-disk"
+      },
+      {
+        "partitions": [
+          {
+            "alias": "pv1",
+            "id": "lvm",
+            "size": { "min": "10 GiB" }
+          }
+        ]
+      }
+    ],
+    "volumeGroups": [
+      {
+        "name": "system",
+        "physicalVolumes": ["pv1"],
+        "logicalVolumes": [
+          {
+            "filesystem": { "path": "/" }
+          }
+        ]
+      },
+      {
+        "name": "logs",
+        "physicalVolumes": [
+          { "generate": ["first-disk"] }
+        ]
+      },
+      {
+        "name": "data",
+        "physicalVolumes": [
+          {
+            "generate": {
+              "targetDevices": ["first-disk"],
+              "encryption": {
+                "luks2": { "password": "12345" }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -529,11 +529,56 @@
               "physicalVolumes": {
                 "title": "Physical volumes",
                 "description": "Devices to use as physical volumes.",
-                "type": "array",
-                "items": {
-                  "title": "Device alias",
-                  "type": "string"
-                }
+                "$comment": "In the future it would be possible to indicate both aliases and 'generate' items together.",
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "title": "Device alias",
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "title": "Generate physical volumes",
+                      "description": "Automatically creates the needed physical volumes in the indicated devices.",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["generate"],
+                      "properties": {
+                        "generate": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "title": "Device alias",
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": ["targetDevices"],
+                              "properties": {
+                                "targetDevices": {
+                                  "type": "array",
+                                  "items": {
+                                    "title": "Device alias",
+                                    "type": "string"
+                                  }
+                                },
+                                "encryption": {
+                                  "$ref": "#/$defs/encryption"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
               },
               "logicalVolumes": {
                 "title": "Logical volumes",

--- a/service/lib/agama/config.rb
+++ b/service/lib/agama/config.rb
@@ -186,7 +186,30 @@ module Agama
       end.compact
     end
 
+    # Default paths to be created for the product.
+    #
+    # @return [Array<String>]
+    def default_paths
+      data.dig("storage", "volumes") || []
+    end
+
+    # Mandatory paths to be created for the product.
+    #
+    # @return [Array<String>]
+    def mandatory_paths
+      default_paths.select { |p| mandatory_path?(p) }
+    end
+
   private
+
+    def mandatory_path?(path)
+      templates = data.dig("storage", "volume_templates") || []
+      template = templates.find { |t| t["mount_path"] == path }
+
+      return false unless template
+
+      template.dig("outline", "required") || false
+    end
 
     # Simple deep merge
     #

--- a/service/lib/agama/storage/config.rb
+++ b/service/lib/agama/storage/config.rb
@@ -55,16 +55,6 @@ module Agama
         @nfs_mounts = []
       end
 
-      # Creates a config from JSON hash according to schema.
-      #
-      # @param config_json [Hash]
-      # @param product_config [Agama::Config]
-      #
-      # @return [Storage::Config]
-      def self.new_from_json(config_json, product_config:)
-        ConfigConversions::FromJSON.new(config_json, product_config: product_config).convert
-      end
-
       # Name of the device that will presumably be used to boot the target system
       #
       # @return [String, nil] nil if there is no enough information to infer a possible boot disk

--- a/service/lib/agama/storage/config_checker.rb
+++ b/service/lib/agama/storage/config_checker.rb
@@ -39,14 +39,20 @@ module Agama
       #
       # @return [Array<Issue>]
       def issues
-        config.drives.flat_map { |d| drive_issues(d) } +
-          config.volume_groups.flat_map { |v| volume_group_issues(v) }
+        drives_issues + volume_groups_issues
       end
 
     private
 
       # @return [Storage::Config]
       attr_reader :config
+
+      # Issues from drives.
+      #
+      # @return [Array<Issue>]
+      def drives_issues
+        config.drives.flat_map { |d| drive_issues(d) }
+      end
 
       # Issues from a drive config.
       #
@@ -58,49 +64,6 @@ module Agama
           encryption_issues(config),
           partitions_issues(config)
         ].flatten.compact
-      end
-
-      # Issues from partitions.
-      #
-      # @param config [Configs::Drive]
-      # @return [Array<Issue>]
-      def partitions_issues(config)
-        config.partitions.flat_map { |p| partition_issues(p) }
-      end
-
-      # Issues from a partition config.
-      #
-      # @param config [Configs::Partition]
-      # @return [Array<Issue>]
-      def partition_issues(config)
-        [
-          search_issue(config),
-          encryption_issues(config)
-        ].flatten.compact
-      end
-
-      # Issues from a volume group config.
-      #
-      # @param config [Configs::VolumeGroup]
-      # @return [Array<Issue>]
-      def volume_group_issues(config)
-        lvs_issues = config.logical_volumes.flat_map { |v| logical_volume_issues(v, config) }
-        pvs_issues = config.physical_volumes.map { |v| missing_physical_volume_issue(v) }.compact
-
-        lvs_issues + pvs_issues
-      end
-
-      # Issues from a logical volume config.
-      #
-      # @param lv_config [Configs::LogicalVolume]
-      # @param vg_config [Configs::VolumeGroup]
-      #
-      # @return [Array<Issue>]
-      def logical_volume_issues(lv_config, vg_config)
-        [
-          encryption_issues(lv_config),
-          missing_thin_pool_issue(lv_config, vg_config)
-        ].compact.flatten
       end
 
       # Issue for not found device.
@@ -123,47 +86,6 @@ module Agama
         end
       end
 
-      # @see #logical_volume_issues
-      #
-      # @param lv_config [Configs::LogicalVolume]
-      # @param vg_config [Configs::VolumeGroup]
-      #
-      # @return [Issue, nil]
-      def missing_thin_pool_issue(lv_config, vg_config)
-        return unless lv_config.thin_volume?
-
-        pool = vg_config.logical_volumes
-          .select(&:pool?)
-          .find { |p| p.alias == lv_config.used_pool }
-
-        return if pool
-
-        error(
-          format(
-            # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
-            _("There is no LVM thin pool volume with alias %s"),
-            lv_config.used_pool
-          )
-        )
-      end
-
-      # @see #logical_volume_issues
-      #
-      # @param pv_alias [String]
-      # @return [Issue, nil]
-      def missing_physical_volume_issue(pv_alias)
-        configs = config.drives + config.drives.flat_map(&:partitions)
-        return if configs.any? { |c| c.alias == pv_alias }
-
-        error(
-          format(
-            # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
-            _("There is no LVM physical volume with alias %s"),
-            pv_alias
-          )
-        )
-      end
-
       # Issues related to encryption.
       #
       # @param config [Configs::Drive, Configs::Partition, Configs::LogicalVolume]
@@ -172,35 +94,35 @@ module Agama
         return [] unless config.encryption
 
         [
-          missing_encryption_password_issue(config),
-          available_encryption_method_issue(config),
+          missing_encryption_password_issue(config.encryption),
+          unavailable_encryption_method_issue(config.encryption),
           wrong_encryption_method_issue(config)
         ].compact
       end
 
       # @see #encryption_issues
       #
-      # @param config [Configs::Drive, Configs::Partition, Configs::LogicalVolume]
+      # @param config [Configs::Encryption]
       # @return [Issue, nil]
       def missing_encryption_password_issue(config)
-        return unless config.encryption&.missing_password?
+        return unless config.missing_password?
 
         error(
           format(
             # TRANSLATORS: 'crypt_method' is the identifier of the method to encrypt the device
             #   (e.g., 'luks1', 'random_swap').
             _("No passphrase provided (required for using the method '%{crypt_method}')."),
-            crypt_method: config.encryption.method.id.to_s
+            crypt_method: config.method.to_human_string
           )
         )
       end
 
       # @see #encryption_issues
       #
-      # @param config [Configs::Drive, Configs::Partition, Configs::LogicalVolume]
+      # @param config [Configs::Encryption]
       # @return [Issue, nil]
-      def available_encryption_method_issue(config)
-        method = config.encryption&.method
+      def unavailable_encryption_method_issue(config)
+        method = config.method
         return if !method || method.available?
 
         error(
@@ -208,7 +130,7 @@ module Agama
             # TRANSLATORS: 'crypt_method' is the identifier of the method to encrypt the device
             #   (e.g., 'luks1', 'random_swap').
             _("Encryption method '%{crypt_method}' is not available in this system."),
-            crypt_method: method.id.to_s
+            crypt_method: method.to_human_string
           )
         )
       end
@@ -227,9 +149,230 @@ module Agama
             # TRANSLATORS: 'crypt_method' is the identifier of the method to encrypt the device
             #   (e.g., 'luks1', 'random_swap').
             _("'%{crypt_method}' is not a suitable method to encrypt the device."),
-            crypt_method: method.id.to_s
+            crypt_method: method.to_human_string
           )
         )
+      end
+
+      # Issues from partitions.
+      #
+      # @param config [Configs::Drive]
+      # @return [Array<Issue>]
+      def partitions_issues(config)
+        config.partitions.flat_map { |p| partition_issues(p) }
+      end
+
+      # Issues from a partition config.
+      #
+      # @param config [Configs::Partition]
+      # @return [Array<Issue>]
+      def partition_issues(config)
+        [
+          search_issue(config),
+          encryption_issues(config)
+        ].flatten.compact
+      end
+
+      # Issues from volume groups.
+      #
+      # @return [Array<Issue>]
+      def volume_groups_issues
+        [
+          overused_physical_volumes_devices_issues,
+          config.volume_groups.flat_map { |v| volume_group_issues(v) }
+        ].flatten
+      end
+
+      # Issues for overused target devices for physical volumes.
+      #
+      # @note The Agama proposal is not able to calculate if the same target device is used by more
+      #   than one volume group having several target devices.
+      #
+      # @return [Array<Issue>]
+      def overused_physical_volumes_devices_issues
+        overused = overused_physical_volumes_devices
+        return [] if overused.none?
+
+        overused.map do |device|
+          error(
+            format(
+              # TRANSLATORS: %s is the replaced by a device alias (e.g., "disk1").
+              _("The device '%s' is used several times as target device for physical volumes"),
+              device
+            )
+          )
+        end
+      end
+
+      # Aliases of overused target devices for physical volumes.
+      #
+      # @return [Array<String>]
+      def overused_physical_volumes_devices
+        config.volume_groups
+          .map(&:physical_volumes_devices)
+          .map(&:uniq)
+          .select { |d| d.size > 1 }
+          .flatten
+          .tally
+          .select { |_, v| v > 1 }
+          .keys
+      end
+
+      # Issues from a volume group config.
+      #
+      # @param config [Configs::VolumeGroup]
+      # @return [Array<Issue>]
+      def volume_group_issues(config)
+        [
+          logical_volumes_issues(config),
+          physical_volumes_issues(config),
+          physical_volumes_devices_issues(config),
+          physical_volumes_encryption_issues(config)
+        ].flatten
+      end
+
+      # Issues from a logical volumes.
+      #
+      # @param config [Configs::VolumeGroup]
+      # @return [Array<Issue>]
+      def logical_volumes_issues(config)
+        config.logical_volumes.flat_map { |v| logical_volume_issues(v, config) }
+      end
+
+      # Issues from a logical volume config.
+      #
+      # @param lv_config [Configs::LogicalVolume]
+      # @param vg_config [Configs::VolumeGroup]
+      #
+      # @return [Array<Issue>]
+      def logical_volume_issues(lv_config, vg_config)
+        [
+          encryption_issues(lv_config),
+          missing_thin_pool_issue(lv_config, vg_config)
+        ].compact.flatten
+      end
+
+      # @see #logical_volume_issues
+      #
+      # @param lv_config [Configs::LogicalVolume]
+      # @param vg_config [Configs::VolumeGroup]
+      #
+      # @return [Issue, nil]
+      def missing_thin_pool_issue(lv_config, vg_config)
+        return unless lv_config.thin_volume?
+
+        pool = vg_config.logical_volumes
+          .select(&:pool?)
+          .find { |p| p.alias == lv_config.used_pool }
+
+        return if pool
+
+        error(
+          format(
+            # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
+            _("There is no LVM thin pool volume with alias '%s'"),
+            lv_config.used_pool
+          )
+        )
+      end
+
+      # Issues from physical volumes.
+      #
+      # @param config [Configs::VolumeGroup]
+      # @return [Array<Issue>]
+      def physical_volumes_issues(config)
+        config.physical_volumes.map { |v| missing_physical_volume_issue(v) }.compact
+      end
+
+      # @see #physical_volumes_issues
+      #
+      # @param pv_alias [String]
+      # @return [Issue, nil]
+      def missing_physical_volume_issue(pv_alias)
+        configs = config.drives + config.drives.flat_map(&:partitions)
+        return if configs.any? { |c| c.alias == pv_alias }
+
+        error(
+          format(
+            # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
+            _("There is no LVM physical volume with alias '%s'"),
+            pv_alias
+          )
+        )
+      end
+
+      # Issues from physical volumes devices (target devices).
+      #
+      # @param config [Configs::VolumeGroup]
+      # @return [Array<Issue>]
+      def physical_volumes_devices_issues(config)
+        config.physical_volumes_devices
+          .map { |d| missing_physical_volumes_device_issue(d) }
+          .compact
+      end
+
+      # @see #physical_volumes_devices_issue
+      #
+      # @param device_alias [String]
+      # @return [Issue, nil]
+      def missing_physical_volumes_device_issue(device_alias)
+        return if config.drives.any? { |d| d.alias == device_alias }
+
+        error(
+          format(
+            # TRANSLATORS: %s is the replaced by a device alias (e.g., "disk1").
+            _("There is no target device for LVM physical volumes with alias '%s'"),
+            device_alias
+          )
+        )
+      end
+
+      # Issues from physical volumes encryption.
+      #
+      # @param config [Configs::VolumeGroup]
+      # @return [Array<Issue>]
+      def physical_volumes_encryption_issues(config)
+        encryption = config.physical_volumes_encryption
+        return [] unless encryption
+
+        [
+          missing_encryption_password_issue(encryption),
+          unavailable_encryption_method_issue(encryption),
+          wrong_physical_volumes_encryption_method_issue(encryption)
+        ].compact
+      end
+
+      # @see #physical_volumes_encryption_issues
+      #
+      # @param config [Configs::Encryption]
+      # @return [Issue, nil]
+      def wrong_physical_volumes_encryption_method_issue(config)
+        method = config.method
+        return if method.nil? || valid_physical_volumes_encryption_method?(method)
+
+        error(
+          format(
+            # TRANSLATORS: 'crypt_method' is the identifier of the method to encrypt the device
+            #   (e.g., 'luks1').
+            _("'%{crypt_method}' is not a suitable method to encrypt the physical volumes."),
+            crypt_method: method.to_human_string
+          )
+        )
+      end
+
+      # Whether an encryption method can be used for encrypting physical volumes.
+      #
+      # @param method [Y2Storage::EncryptionMethod]
+      # @return [Boolean]
+      def valid_physical_volumes_encryption_method?(method)
+        valid_methods = [
+          Y2Storage::EncryptionMethod::LUKS1,
+          Y2Storage::EncryptionMethod::LUKS2,
+          Y2Storage::EncryptionMethod::PERVASIVE_LUKS2,
+          Y2Storage::EncryptionMethod::TPM_FDE
+        ]
+
+        valid_methods.include?(method)
       end
 
       # Creates a warning issue.

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/base.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/base.rb
@@ -25,35 +25,32 @@ module Agama
       module FromJSONConversions
         # Base class for conversions from JSON hash according to schema.
         class Base
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(config_builder = nil)
-            @config_builder = config_builder
+          def initialize(config_json)
+            @config_json = config_json
           end
 
           # Performs the conversion from Hash according to the JSON schema.
           #
-          # @param default [Object] A {Config} or any its configs from {Storage::Configs}.
+          # @param config [Object] A {Config} or any of its configs from {Storage::Configs}.
           # @return [Object] A {Config} or any its configs from {Storage::Configs}.
-          def convert(default)
-            default.dup.tap do |config|
-              conversions(config).each do |property, value|
-                next if value.nil?
+          def convert(config)
+            conversions.each do |property, value|
+              next if value.nil?
 
-                config.public_send("#{property}=", value)
-              end
+              config.public_send("#{property}=", value)
             end
+
+            config
           end
 
         private
 
-          # @return [ConfigBuilder, nil]
-          attr_reader :config_builder
+          attr_reader :config_json
 
           # Values to apply to the config.
           #
-          # @param _default [Object] A {Config} or any its configs from {Storage::Configs}.
           # @return [Hash] e.g., { name: "/dev/vda" }.
-          def conversions(_default)
+          def conversions
             {}
           end
         end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/boot.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/boot.rb
@@ -28,30 +28,19 @@ module Agama
       module FromJSONConversions
         # Boot conversion from JSON hash according to schema.
         class Boot < Base
-          # @param boot_json [Hash]
-          def initialize(boot_json)
-            super()
-            @boot_json = boot_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Boot, nil]
           # @return [Configs::Boot]
-          def convert(default = nil)
-            super(default || Configs::Boot.new)
+          def convert
+            super(Configs::Boot.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :boot_json
+          alias_method :boot_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param _default [Configs::Boot]
           # @return [Hash]
-          def conversions(_default)
+          def conversions
             {
               configure: boot_json[:configure],
               device:    boot_json[:device]

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/btrfs.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/btrfs.rb
@@ -28,30 +28,19 @@ module Agama
       module FromJSONConversions
         # Btrfs conversion from JSON hash according to schema.
         class Btrfs < Base
-          # @param btrfs_json [Hash]
-          def initialize(btrfs_json)
-            super()
-            @btrfs_json = btrfs_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Btrfs, nil]
           # @return [Configs::Btrfs]
-          def convert(default = nil)
-            super(default || Configs::Btrfs.new)
+          def convert
+            super(Configs::Btrfs.new)
           end
 
         private
 
-          # @return [String]
-          attr_reader :btrfs_json
+          alias_method :btrfs_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param _default [Configs::Btrfs]
           # @return [Hash]
-          def conversions(_default)
+          def conversions
             {
               snapshots: btrfs_json[:snapshots]
             }

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/config.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/config.rb
@@ -31,45 +31,30 @@ module Agama
       module FromJSONConversions
         # Config conversion from JSON hash according to schema.
         class Config < Base
-          # @param config_json [Hash]
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(config_json, config_builder: nil)
-            super(config_builder)
-            @config_json = config_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Config, nil]
           # @return [Config]
-          def convert(default = nil)
-            super(default || Storage::Config.new)
+          def convert
+            super(Storage::Config.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :config_json
-
           # @see Base#conversions
-          #
-          # @param default [Config]
           # @return [Hash]
-          def conversions(default)
+          def conversions
             {
-              boot:          convert_boot(default.boot),
+              boot:          convert_boot,
               drives:        convert_drives,
               volume_groups: convert_volume_groups
             }
           end
 
-          # @param default [Configs::Boot, nil]
           # @return [Configs::Boot, nil]
-          def convert_boot(default = nil)
+          def convert_boot
             boot_json = config_json[:boot]
             return unless boot_json
 
-            FromJSONConversions::Boot.new(boot_json).convert(default)
+            FromJSONConversions::Boot.new(boot_json).convert
           end
 
           # @return [Array<Configs::Drive>, nil]
@@ -83,7 +68,7 @@ module Agama
           # @param drive_json [Hash]
           # @return [Configs::Drive]
           def convert_drive(drive_json)
-            FromJSONConversions::Drive.new(drive_json, config_builder: config_builder).convert
+            FromJSONConversions::Drive.new(drive_json).convert
           end
 
           # @return [Array<Configs::VolumeGroup>, nil]
@@ -97,9 +82,7 @@ module Agama
           # @param volume_group_json [Hash]
           # @return [Configs::VolumeGroup]
           def convert_volume_group(volume_group_json)
-            FromJSONConversions::VolumeGroup
-              .new(volume_group_json, config_builder: config_builder)
-              .convert
+            FromJSONConversions::VolumeGroup.new(volume_group_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/drive.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/drive.rb
@@ -39,38 +39,26 @@ module Agama
           include WithPtableType
           include WithPartitions
 
-          # @param drive_json [Hash]
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(drive_json, config_builder: nil)
-            super(config_builder)
-            @drive_json = drive_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Drive, nil]
           # @return [Configs::Drive]
-          def convert(default = nil)
-            super(default || Configs::Drive.new)
+          def convert
+            super(Configs::Drive.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :drive_json
+          alias_method :drive_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param default [Configs::Drive]
           # @return [Hash]
-          def conversions(default)
+          def conversions
             {
-              search:      convert_search(drive_json, default: default.search),
+              search:      convert_search,
               alias:       drive_json[:alias],
-              encryption:  convert_encryption(drive_json, default: default.encryption),
-              filesystem:  convert_filesystem(drive_json, default: default.filesystem),
-              ptable_type: convert_ptable_type(drive_json),
-              partitions:  convert_partitions(drive_json)
+              encryption:  convert_encryption,
+              filesystem:  convert_filesystem,
+              ptable_type: convert_ptable_type,
+              partitions:  convert_partitions
             }
           end
         end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/encryption.rb
@@ -30,34 +30,19 @@ module Agama
       module FromJSONConversions
         # Encryption conversion from JSON hash according to schema.
         class Encryption < Base
-          # @param encryption_json [Hash, String]
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(encryption_json, config_builder: nil)
-            super(config_builder)
-            @encryption_json = encryption_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Encryption, nil]
           # @return [Configs::Encryption]
-          def convert(default = nil)
-            super(default || self.default)
+          def convert
+            super(Configs::Encryption.new)
           end
 
         private
 
-          # @return [Hash, String]
-          attr_reader :encryption_json
-
-          # @return [Configs::Encryption]
-          attr_reader :default_config
+          alias_method :encryption_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param _default [Configs::Encryption]
           # @return [Hash]
-          def conversions(_default)
+          def conversions
             return luks1_conversions if luks1?
             return luks2_conversions if luks2?
             return pervasive_luks2_conversions if pervasive_luks2?
@@ -158,15 +143,6 @@ module Agama
           # @return [Y2Storage::PbkdFunction, nil]
           def convert_pbkd_function
             Y2Storage::PbkdFunction.find(encryption_json.dig(:luks2, :pbkdFunction))
-          end
-
-          # Default encryption config.
-          #
-          # @return [Configs::Encryption]
-          def default
-            return Configs::Encryption.new unless config_builder
-
-            config_builder.default_encryption
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/encryption.rb
@@ -65,7 +65,7 @@ module Agama
           def pervasive_luks2?
             return false unless encryption_json.is_a?(Hash)
 
-            !encryption_json[:pervasive_luks2].nil?
+            !encryption_json[:pervasiveLuks2].nil?
           end
 
           # @return [Hash]
@@ -96,7 +96,7 @@ module Agama
 
           # @return [Hash]
           def pervasive_luks2_conversions
-            pervasive_json = encryption_json[:pervasive_luks2]
+            pervasive_json = encryption_json[:pervasiveLuks2]
 
             {
               method:   Y2Storage::EncryptionMethod::PERVASIVE_LUKS2,

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/filesystem.rb
@@ -30,31 +30,19 @@ module Agama
       module FromJSONConversions
         # Filesystem conversion from JSON hash according to schema.
         class Filesystem < Base
-          # @param filesystem_json [Hash]
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(filesystem_json, config_builder: nil)
-            super(config_builder)
-            @filesystem_json = filesystem_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Filesystem, nil]
           # @return [Configs::Filesystem]
-          def convert(default = nil)
-            super(default || self.default)
+          def convert
+            super(Configs::Filesystem.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :filesystem_json
+          alias_method :filesystem_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param default [Configs::Filesystem]
           # @return [Hash]
-          def conversions(default)
+          def conversions
             {
               reuse:         filesystem_json[:reuseIfPossible],
               label:         filesystem_json[:label],
@@ -62,7 +50,7 @@ module Agama
               mount_options: filesystem_json[:mountOptions],
               mkfs_options:  filesystem_json[:mkfsOptions],
               mount_by:      convert_mount_by,
-              type:          convert_type(default.type)
+              type:          convert_type
             }
           end
 
@@ -74,22 +62,12 @@ module Agama
             Y2Storage::Filesystems::MountByType.find(value.to_sym)
           end
 
-          # @param default [Configs::FilesystemType, nil]
           # @return [Configs::FilesystemType, nil]
-          def convert_type(default = nil)
+          def convert_type
             filesystem_type_json = filesystem_json[:type]
             return unless filesystem_type_json
 
-            FromJSONConversions::FilesystemType.new(filesystem_type_json).convert(default)
-          end
-
-          # Default filesystem config.
-          #
-          # @return [Configs::Filesystem]
-          def default
-            return Configs::Filesystem.new unless config_builder
-
-            config_builder.default_filesystem(filesystem_json[:path])
+            FromJSONConversions::FilesystemType.new(filesystem_type_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/filesystem_type.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/filesystem_type.rb
@@ -31,33 +31,22 @@ module Agama
       module FromJSONConversions
         # Filesystem type conversion from JSON hash according to schema.
         class FilesystemType < Base
-          # @param filesystem_type_json [Hash, String]
-          def initialize(filesystem_type_json)
-            super()
-            @filesystem_type_json = filesystem_type_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::FilesystemType, nil]
           # @return [Configs::FilesystemType]
-          def convert(default = nil)
-            super(default || Configs::FilesystemType.new)
+          def convert
+            super(Configs::FilesystemType.new)
           end
 
         private
 
-          # @return [Hash, String]
-          attr_reader :filesystem_type_json
+          alias_method :filesystem_type_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param default [Configs::FilesystemType]
           # @return [Hash]
-          def conversions(default)
+          def conversions
             {
               fs_type: convert_type,
-              btrfs:   convert_btrfs(default.btrfs)
+              btrfs:   convert_btrfs
             }
           end
 
@@ -67,15 +56,14 @@ module Agama
             Y2Storage::Filesystems::Type.find(value.to_sym)
           end
 
-          # @param default [Configs::Btrfs, nil]
           # @return [Configs::Btrfs, nil]
-          def convert_btrfs(default = nil)
+          def convert_btrfs
             return if filesystem_type_json.is_a?(String)
 
             btrfs_json = filesystem_type_json[:btrfs]
             return unless btrfs_json
 
-            FromJSONConversions::Btrfs.new(btrfs_json).convert(default)
+            FromJSONConversions::Btrfs.new(btrfs_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/logical_volume.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/logical_volume.rb
@@ -36,36 +36,24 @@ module Agama
           include WithFilesystem
           include WithSize
 
-          # @param logical_volume_json [Hash]
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(logical_volume_json, config_builder: nil)
-            super(config_builder)
-            @logical_volume_json = logical_volume_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::LogicalVolume, nil]
           # @return [Configs::LogicalVolume]
-          def convert(default = nil)
-            super(default || Configs::LogicalVolume.new)
+          def convert
+            super(Configs::LogicalVolume.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :logical_volume_json
+          alias_method :logical_volume_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param default [Configs::LogicalVolume]
           # @return [Hash]
-          def conversions(default)
+          def conversions
             {
               alias:       logical_volume_json[:alias],
-              encryption:  convert_encryption(logical_volume_json, default: default.encryption),
-              filesystem:  convert_filesystem(logical_volume_json, default: default.filesystem),
-              size:        convert_size(logical_volume_json, default: default.size),
+              encryption:  convert_encryption,
+              filesystem:  convert_filesystem,
+              size:        convert_size,
               name:        logical_volume_json[:name],
               stripes:     logical_volume_json[:stripes],
               stripe_size: convert_stripe_size,

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/partition.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/partition.rb
@@ -38,36 +38,25 @@ module Agama
           include WithFilesystem
           include WithSize
 
-          # @param partition_json [Hash]
-          def initialize(partition_json, config_builder: nil)
-            super(config_builder)
-            @partition_json = partition_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Partition, nil]
           # @return [Configs::Partition]
-          def convert(default = nil)
-            super(default || Configs::Partition.new)
+          def convert
+            super(Configs::Partition.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :partition_json
+          alias_method :partition_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param default [Configs::Partition]
           # @return [Hash]
-          def conversions(default)
+          def conversions
             {
-              search:           convert_search(partition_json, default: default.search),
+              search:           convert_search,
               alias:            partition_json[:alias],
-              encryption:       convert_encryption(partition_json, default: default.encryption),
-              filesystem:       convert_filesystem(partition_json, default: default.filesystem),
-              size:             convert_size(partition_json, default: default.size),
+              encryption:       convert_encryption,
+              filesystem:       convert_filesystem,
+              size:             convert_size,
               id:               convert_id,
               delete:           partition_json[:delete],
               delete_if_needed: partition_json[:deleteIfNeeded]

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
@@ -28,30 +28,19 @@ module Agama
       module FromJSONConversions
         # Search conversion from JSON hash according to schema.
         class Search < Base
-          # @param search_json [Hash, String]
-          def initialize(search_json)
-            super()
-            @search_json = search_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Search, nil]
           # @return [Configs::Search]
-          def convert(default = nil)
-            super(default || Configs::Search.new)
+          def convert
+            super(Configs::Search.new)
           end
 
         private
 
-          # @return [Hash, String]
-          attr_reader :search_json
+          alias_method :search_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param _default [Configs::Partition]
           # @return [Hash]
-          def conversions(_default)
+          def conversions
             {
               name:         convert_name,
               if_not_found: convert_not_found

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/size.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/size.rb
@@ -29,30 +29,19 @@ module Agama
       module FromJSONConversions
         # Size conversion from JSON hash according to schema.
         class Size < Base
-          # @param size_json [Hash]
-          def initialize(size_json)
-            super()
-            @size_json = size_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::Size, nil]
           # @return [Configs::Size]
-          def convert(default = nil)
-            super(default || Configs::Size.new)
+          def convert
+            super(Configs::Size.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :size_json
+          alias_method :size_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param _default [Configs::Size]
           # @return [Hash]
-          def conversions(_default)
+          def conversions
             {
               default: false,
               min:     convert_min_size,

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/volume_group.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/volume_group.rb
@@ -21,7 +21,7 @@
 
 require "agama/storage/config_conversions/from_json_conversions/base"
 require "agama/storage/config_conversions/from_json_conversions/logical_volume"
-require "agama/storage/configs/drive"
+require "agama/storage/configs/volume_group"
 
 module Agama
   module Storage
@@ -29,31 +29,19 @@ module Agama
       module FromJSONConversions
         # Volume group conversion from JSON hash according to schema.
         class VolumeGroup < Base
-          # @param volume_group_json [Hash]
-          # @param config_builder [ConfigBuilder, nil]
-          def initialize(volume_group_json, config_builder: nil)
-            super(config_builder)
-            @volume_group_json = volume_group_json
-          end
-
           # @see Base#convert
-          #
-          # @param default [Configs::VolumeGroup, nil]
           # @return [Configs::VolumeGroup]
-          def convert(default = nil)
-            super(default || Configs::VolumeGroup.new)
+          def convert
+            super(Configs::VolumeGroup.new)
           end
 
         private
 
-          # @return [Hash]
-          attr_reader :volume_group_json
+          alias_method :volume_group_json, :config_json
 
           # @see Base#conversions
-          #
-          # @param _default [Configs::VolumeGroup]
           # @return [Hash]
-          def conversions(_default)
+          def conversions
             {
               name:             volume_group_json[:name],
               extent_size:      convert_extent_size,
@@ -81,9 +69,7 @@ module Agama
           # @param logical_volume_json [Hash]
           # @return [Configs::LogicalVolume]
           def convert_logical_volume(logical_volume_json)
-            FromJSONConversions::LogicalVolume
-              .new(logical_volume_json, config_builder: config_builder)
-              .convert
+            FromJSONConversions::LogicalVolume.new(logical_volume_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/with_encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/with_encryption.rb
@@ -27,17 +27,12 @@ module Agama
       module FromJSONConversions
         # Mixin for encryption conversion.
         module WithEncryption
-          # @param json [Hash]
-          # @param default [Configs::Encryption, nil]
-          #
           # @return [Configs::Encryption, nil]
-          def convert_encryption(json, default: nil)
-            encryption_json = json[:encryption]
+          def convert_encryption
+            encryption_json = config_json[:encryption]
             return unless encryption_json
 
-            FromJSONConversions::Encryption
-              .new(encryption_json, config_builder: config_builder)
-              .convert(default)
+            FromJSONConversions::Encryption.new(encryption_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/with_filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/with_filesystem.rb
@@ -27,20 +27,12 @@ module Agama
       module FromJSONConversions
         # Mixin for filesystem conversion.
         module WithFilesystem
-          # @param json [Hash]
-          # @param default [Configs::Filesystem, nil]
-          #
           # @return [Configs::Filesystem, nil]
-          def convert_filesystem(json, default: nil)
-            filesystem_json = json[:filesystem]
+          def convert_filesystem
+            filesystem_json = config_json[:filesystem]
             return unless filesystem_json
 
-            # @todo Check whether the given filesystem can be used for the mount point.
-            # @todo Check whether snapshots can be configured and restore to default if needed.
-
-            FromJSONConversions::Filesystem
-              .new(filesystem_json, config_builder: config_builder)
-              .convert(default)
+            FromJSONConversions::Filesystem.new(filesystem_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/with_partitions.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/with_partitions.rb
@@ -27,10 +27,9 @@ module Agama
       module FromJSONConversions
         # Mixin for partitions conversion.
         module WithPartitions
-          # @param json [Hash]
           # @return [Array<Configs::Partition>, nil]
-          def convert_partitions(json)
-            partitions_json = json[:partitions]
+          def convert_partitions
+            partitions_json = config_json[:partitions]
             return unless partitions_json
 
             partitions_json.map { |p| convert_partition(p) }
@@ -39,9 +38,7 @@ module Agama
           # @param partition_json [Hash]
           # @return [Configs::Partition]
           def convert_partition(partition_json)
-            FromJSONConversions::Partition
-              .new(partition_json, config_builder: config_builder)
-              .convert
+            FromJSONConversions::Partition.new(partition_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/with_ptable_type.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/with_ptable_type.rb
@@ -27,11 +27,9 @@ module Agama
       module FromJSONConversions
         # Mixin for partition table type conversion.
         module WithPtableType
-          # @param json [Hash]
-          #
           # @return [Y2Storage::PartitionTables::Type, nil]
-          def convert_ptable_type(json)
-            value = json[:ptableType]
+          def convert_ptable_type
+            value = config_json[:ptableType]
             return unless value
 
             Y2Storage::PartitionTables::Type.find(value)

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/with_search.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/with_search.rb
@@ -27,16 +27,12 @@ module Agama
       module FromJSONConversions
         # Mixin for search conversion.
         module WithSearch
-          # @param json [Hash]
-          # @param default [Configs::Search, nil]
-          #
           # @return [Configs::Search, nil]
-          def convert_search(json, default: nil)
-            search_json = json[:search]
+          def convert_search
+            search_json = config_json[:search]
             return unless search_json
 
-            converter = FromJSONConversions::Search.new(search_json)
-            converter.convert(default)
+            FromJSONConversions::Search.new(search_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/with_size.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/with_size.rb
@@ -27,15 +27,12 @@ module Agama
       module FromJSONConversions
         # Mixin for size conversion.
         module WithSize
-          # @param json [Hash]
-          # @param default [Configs::Size, nil]
-          #
           # @return [Configs::Size, nil]
-          def convert_size(json, default: nil)
-            size_json = json[:size]
+          def convert_size
+            size_json = config_json[:size]
             return unless size_json
 
-            FromJSONConversions::Size.new(size_json).convert(default)
+            FromJSONConversions::Size.new(size_json).convert
           end
         end
       end

--- a/service/lib/agama/storage/config_encryption_solver.rb
+++ b/service/lib/agama/storage/config_encryption_solver.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/config_builder"
+
+module Agama
+  module Storage
+    # Solver for the encryption configs.
+    #
+    # The encryption configs are solved by assigning the default encryption values defined by the
+    # productd, if needed.
+    class ConfigEncryptionSolver
+      # @param product_config [Agama::Config]
+      def initialize(product_config)
+        @product_config = product_config
+      end
+
+      # Solves all the encryption configs within a given config.
+      #
+      # @note The config object is modified.
+      #
+      # @param config [Config]
+      def solve(config)
+        @config = config
+
+        configs_with_encryption.each { |c| solve_encryption(c) }
+      end
+
+    private
+
+      # @return [Agama::Config]
+      attr_reader :product_config
+
+      # @return [Config]
+      attr_reader :config
+
+      # @param config [#encryption]
+      def solve_encryption(config)
+        return unless config.encryption
+
+        encryption = config.encryption
+        encryption.method ||= default_encryption.method
+
+        # Recovering values from the default encryption only makes sense if the encryption method is
+        # the same.
+        solve_encryption_values(encryption) if encryption.method == default_encryption.method
+      end
+
+      # @param config [Configs::Encryption]
+      def solve_encryption_values(config)
+        config.password ||= default_encryption.password
+        config.pbkd_function ||= default_encryption.pbkd_function
+        config.label ||= default_encryption.label
+        config.cipher ||= default_encryption.cipher
+        config.key_size ||= default_encryption.key_size
+      end
+
+      # @return [Array<#encryption>]
+      def configs_with_encryption
+        config.drives + config.partitions + config.logical_volumes
+      end
+
+      # Default encryption defined by the product.
+      #
+      # @return [Configs::Encryption]
+      def default_encryption
+        @default_encryption ||= config_builder.default_encryption
+      end
+
+      # @return [ConfigBuilder]
+      def config_builder
+        @config_builder ||= ConfigBuilder.new(product_config)
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/config_filesystem_solver.rb
+++ b/service/lib/agama/storage/config_filesystem_solver.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/config_builder"
+
+module Agama
+  module Storage
+    # Solver for the filesystem configs.
+    #
+    # The filesystem configs are solved by assigning the default filesystem values defined by the
+    # productd, if needed.
+    class ConfigFilesystemSolver
+      # @param product_config [Agama::Config]
+      def initialize(product_config)
+        @product_config = product_config
+      end
+
+      # Solves all the filesystem configs within a given config.
+      #
+      # @note The config object is modified.
+      #
+      # @param config [Config]
+      def solve(config)
+        @config = config
+
+        configs_with_filesystem.each { |c| solve_filesystem(c) }
+      end
+
+    private
+
+      # @return [Agama::Config]
+      attr_reader :product_config
+
+      # @return [Config]
+      attr_reader :config
+
+      # @param config [#filesystem]
+      def solve_filesystem(config)
+        return unless config.filesystem
+
+        default_filesystem = default_filesystem(config.filesystem.path)
+
+        config.filesystem.type ||= default_filesystem.type
+        config.filesystem.type.btrfs ||= default_filesystem.type.btrfs
+        solve_btrfs_values(config)
+      end
+
+      # @param config [#filesystem]
+      def solve_btrfs_values(config)
+        btrfs = config.filesystem.type.btrfs
+        return unless btrfs
+
+        default_btrfs = default_btrfs(config.filesystem.path)
+
+        btrfs.snapshots = default_btrfs.snapshots? if btrfs.snapshots.nil?
+        btrfs.read_only = default_btrfs.read_only? if btrfs.read_only.nil?
+        btrfs.subvolumes ||= default_btrfs.subvolumes
+        btrfs.default_subvolume ||= (default_btrfs.default_subvolume || "")
+      end
+
+      # @return [Array<#filesystem>]
+      def configs_with_filesystem
+        config.drives + config.partitions + config.logical_volumes
+      end
+
+      # Default filesystem defined by the product.
+      #
+      # @param path [String, nil]
+      # @return [Configs::Filesystem]
+      def default_filesystem(path = nil)
+        config_builder.default_filesystem(path)
+      end
+
+      # Default btrfs config defined by the product.
+      #
+      # @param path [String, nil]
+      # @return [Configs::Btrfs]
+      def default_btrfs(path = nil)
+        default_filesystem(path).type.btrfs
+      end
+
+      # @return [ConfigBuilder]
+      def config_builder
+        @config_builder ||= ConfigBuilder.new(product_config)
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/config_size_solver.rb
+++ b/service/lib/agama/storage/config_size_solver.rb
@@ -175,6 +175,10 @@ module Agama
         !config.size.default? && (config.size.min.nil? || config.size.max.nil?)
       end
 
+      # Whether the config has to be considered.
+      #
+      # Note that a config could be ignored if a device is not found for its search.
+      #
       # @param config [Object] Any config from {Configs}.
       # @return [Boolean]
       def valid?(config)

--- a/service/lib/agama/storage/configs/btrfs.rb
+++ b/service/lib/agama/storage/configs/btrfs.rb
@@ -26,26 +26,33 @@ module Agama
       class Btrfs
         # Whether there are snapshots.
         #
-        # @return [Boolean]
+        # @return [Boolean, nil]
         attr_accessor :snapshots
-        alias_method :snapshots?, :snapshots
 
-        # @return [Boolean]
+        # @return [Boolean, nil]
         attr_accessor :read_only
-        alias_method :read_only?, :read_only
 
         # @return [Array<Y2Storage::SubvolSpecification>, nil] if nil, a historical fallback list
         #   may be applied depending on the mount path of the volume
         attr_accessor :subvolumes
 
-        # @return [String]
+        # @return [String, nil]
         attr_accessor :default_subvolume
 
         # Constructor
         def initialize
           @snapshots = false
           @read_only = false
-          @default_subvolume = ""
+        end
+
+        # @return [Boolean]
+        def snapshots?
+          !!snapshots
+        end
+
+        # @return [Boolean]
+        def read_only?
+          !!read_only
         end
       end
     end

--- a/service/lib/agama/storage/configs/volume_group.rb
+++ b/service/lib/agama/storage/configs/volume_group.rb
@@ -30,6 +30,18 @@ module Agama
         # @return [Y2Storage::DiskSize, nil]
         attr_accessor :extent_size
 
+        # Aliases of the devices used for automatically creating new physical volumes.
+        #
+        # @return [Array<String>]
+        attr_accessor :physical_volumes_devices
+
+        # Encryption for the new physical volumes created at the {physical_volumes_devices}.
+        #
+        # @return [Encryption, nil]
+        attr_accessor :physical_volumes_encryption
+
+        # Aliases of the devices used as physical volumes.
+        #
         # @return [Array<String>]
         attr_accessor :physical_volumes
 
@@ -37,6 +49,7 @@ module Agama
         attr_accessor :logical_volumes
 
         def initialize
+          @physical_volumes_devices = []
           @physical_volumes = []
           @logical_volumes = []
         end

--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -234,9 +234,12 @@ module Agama
       # @param storage_json [Hash] e.g., { "drives": [] }.
       # @return [Boolean] Whether the proposal successes.
       def calculate_agama_from_json(storage_json)
-        storage_config = ConfigConversions::FromJSON
-          .new(storage_json, product_config: config)
-          .convert
+        storage_config = ConfigConversions::FromJSON.new(
+          storage_json,
+          default_paths:   config.default_paths,
+          mandatory_paths: config.mandatory_paths
+        ).convert
+
         calculate_agama(storage_config)
       end
 

--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -96,7 +96,10 @@ module Y2Storage
         .new(initial_devicegraph, product_config)
         .solve(config)
 
-      issues = Agama::Storage::ConfigChecker.new(config).issues
+      issues = Agama::Storage::ConfigChecker
+        .new(config, product_config)
+        .issues
+
       issues_list.concat(issues)
 
       if fatal_error?

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct  7 06:58:48 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Storage: add support to the storage config for automatically
+  creating physical volumes (gh#agama-project/agama#1652).
+
+-------------------------------------------------------------------
 Fri Sep 27 14:15:16 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: add support for automatically generating 'default' and

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -592,10 +592,10 @@ describe Agama::DBus::Storage::Manager do
 
     context "if an agama proposal has been calculated" do
       before do
-        proposal.calculate_agama(config)
+        proposal.calculate_agama(storage_config)
       end
 
-      let(:config) do
+      let(:storage_config) do
         fs_type = Agama::Storage::Configs::FilesystemType.new.tap do |t|
           t.fs_type = Y2Storage::Filesystems::Type::BTRFS
         end

--- a/service/test/agama/storage/config_checker_test.rb
+++ b/service/test/agama/storage/config_checker_test.rb
@@ -1,0 +1,574 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "./storage_helpers"
+require "agama/config"
+require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_checker"
+require "agama/storage/config_solver"
+require "y2storage"
+require "y2storage/refinements"
+
+using Y2Storage::Refinements::SizeCasts
+
+shared_examples "encryption issues" do
+  let(:filesystem) { nil }
+
+  context "without password" do
+    let(:encryption) do
+      { luks1: {} }
+    end
+
+    it "includes the expected issue" do
+      issues = subject.issues
+      expect(issues.size).to eq(1)
+
+      issue = issues.first
+      expect(issue.error?).to eq(true)
+      expect(issue.description).to match("No passphrase")
+    end
+  end
+
+  context "with unavailable method" do
+    let(:encryption) do
+      {
+        pervasiveLuks2: {
+          password: "12345"
+        }
+      }
+    end
+
+    before do
+      allow_any_instance_of(Y2Storage::EncryptionMethod::PervasiveLuks2)
+        .to(receive(:available?))
+        .and_return(false)
+    end
+
+    it "includes the expected issue" do
+      issues = subject.issues
+      expect(issues.size).to eq(1)
+
+      issue = issues.first
+      expect(issue.error?).to eq(true)
+      expect(issue.description).to match("'Pervasive Volume Encryption' is not available")
+    end
+  end
+
+  context "with invalid method" do
+    let(:encryption) { "protected_swap" }
+    let(:filesystem) { { path: "/" } }
+
+    before do
+      allow_any_instance_of(Y2Storage::EncryptionMethod::ProtectedSwap)
+        .to(receive(:available?))
+        .and_return(true)
+    end
+
+    it "includes the expected issue" do
+      issues = subject.issues
+      expect(issues.size).to eq(1)
+
+      issue = issues.first
+      expect(issue.error?).to eq(true)
+      expect(issue.description)
+        .to(match("'Encryption with Volatile Protected Key' is not a suitable"))
+    end
+  end
+
+  context "with a valid encryption" do
+    let(:encryption) do
+      {
+        luks1: {
+          password: "12345"
+        }
+      }
+    end
+
+    let(:filesystem) { { path: "/" } }
+
+    it "does not include an issue" do
+      expect(subject.issues.size).to eq(0)
+    end
+  end
+end
+
+describe Agama::Storage::ConfigChecker do
+  include Agama::RSpec::StorageHelpers
+
+  subject { described_class.new(config) }
+
+  let(:config) do
+    Agama::Storage::ConfigConversions::FromJSON
+      .new(config_json)
+      .convert
+  end
+
+  let(:config_json) { nil }
+
+  before do
+    mock_storage(devicegraph: scenario)
+    # To speed-up the tests
+    allow(Y2Storage::EncryptionMethod::TPM_FDE)
+      .to(receive(:possible?))
+      .and_return(true)
+  end
+
+  describe "#issues" do
+    before do
+      # Solves the config before checking.
+      devicegraph = Y2Storage::StorageManager.instance.probed
+      product_config = Agama::Config.new
+
+      Agama::Storage::ConfigSolver
+        .new(devicegraph, product_config)
+        .solve(config)
+    end
+
+    let(:scenario) { "disks.yaml" }
+
+    context "if a drive has not found device" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              search: {
+                condition:  { name: "/dev/vdd" },
+                ifNotFound: if_not_found
+              }
+            }
+          ]
+        }
+      end
+
+      context "and the drive should be skipped" do
+        let(:if_not_found) { "skip" }
+
+        it "includes the expected issue" do
+          issues = subject.issues
+          expect(issues.size).to eq(1)
+
+          issue = issues.first
+          expect(issue.error?).to eq(false)
+          expect(issue.description).to eq("No device found for an optional drive")
+        end
+      end
+
+      context "and the drive should not be skipped" do
+        let(:if_not_found) { "error" }
+
+        it "includes the expected issue" do
+          issues = subject.issues
+          expect(issues.size).to eq(1)
+
+          issue = issues.first
+          expect(issue.error?).to eq(true)
+          expect(issue.description).to eq("No device found for a mandatory drive")
+        end
+      end
+    end
+
+    context "if a drive has a found device" do
+      let(:config_json) do
+        {
+          drives: [
+            { search: "/dev/vda" }
+          ]
+        }
+      end
+
+      it "does not include an issue" do
+        expect(subject.issues.size).to eq(0)
+      end
+    end
+
+    context "if a drive has encryption" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              encryption: encryption,
+              filesystem: filesystem
+            }
+          ]
+        }
+      end
+
+      include_examples "encryption issues"
+    end
+
+    context "if a drive has partitions" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: [partition]
+            }
+          ]
+        }
+      end
+
+      context "and a partition has not found device" do
+        let(:partition) do
+          {
+            search: {
+              condition:  { name: "/dev/vdb1" },
+              ifNotFound: if_not_found
+            }
+          }
+        end
+
+        context "and the partition should be skipped" do
+          let(:if_not_found) { "skip" }
+
+          it "includes the expected issue" do
+            issues = subject.issues
+            expect(issues.size).to eq(1)
+
+            issue = issues.first
+            expect(issue.error?).to eq(false)
+            expect(issue.description).to eq("No device found for an optional partition")
+          end
+        end
+
+        context "and the partition should not be skipped" do
+          let(:if_not_found) { "error" }
+
+          it "includes the expected issue" do
+            issues = subject.issues
+            expect(issues.size).to eq(1)
+
+            issue = issues.first
+            expect(issue.error?).to eq(true)
+            expect(issue.description).to eq("No device found for a mandatory partition")
+          end
+        end
+      end
+
+      context "and the partition has a found device" do
+        let(:partition) do
+          { search: "/dev/vda1" }
+        end
+
+        it "does not include an issue" do
+          expect(subject.issues.size).to eq(0)
+        end
+      end
+
+      context "and a partition has encryption" do
+        let(:partition) do
+          {
+            encryption: encryption,
+            filesystem: filesystem
+          }
+        end
+
+        include_examples "encryption issues"
+      end
+    end
+
+    context "if a volume group has logical volumes" do
+      let(:config_json) do
+        {
+          volumeGroups: [
+            {
+              logicalVolumes: [
+                logical_volume,
+                {
+                  alias: "pool",
+                  pool:  true
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      context "and a logical volume has encryption" do
+        let(:logical_volume) do
+          {
+            encryption: encryption,
+            filesystem: filesystem
+          }
+        end
+
+        include_examples "encryption issues"
+      end
+
+      context "and a logical volume has an unknown pool" do
+        let(:logical_volume) do
+          { usedPool: "unknown" }
+        end
+
+        it "includes the expected issue" do
+          issues = subject.issues
+          expect(issues.size).to eq(1)
+
+          issue = issues.first
+          expect(issue.error?).to eq(true)
+          expect(issue.description).to match("no LVM thin pool")
+        end
+      end
+
+      context "and a logical volume has a known pool" do
+        let(:logical_volume) do
+          { usedPool: "pool" }
+        end
+
+        it "does not include an issue" do
+          expect(subject.issues.size).to eq(0)
+        end
+      end
+    end
+
+    context "if a volume group has an unknown physical volume" do
+      let(:config_json) do
+        {
+          drives:       [
+            {
+              alias: "first-disk"
+            }
+          ],
+          volumeGroups: [
+            {
+              physicalVolumes: ["first-disk", "pv1"]
+            }
+          ]
+        }
+      end
+
+      it "includes the expected issue" do
+        issues = subject.issues
+        expect(issues.size).to eq(1)
+
+        issue = issues.first
+        expect(issue.error?).to eq(true)
+        expect(issue.description).to match("no LVM physical volume with alias 'pv1'")
+      end
+    end
+
+    context "if a volume group has an unknown target device for physical volumes" do
+      let(:config_json) do
+        {
+          drives:       [
+            {
+              alias: "first-disk"
+            }
+          ],
+          volumeGroups: [
+            {
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["first-disk", "second-disk"]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "includes the expected issue" do
+        issues = subject.issues
+        expect(issues.size).to eq(1)
+
+        issue = issues.first
+        expect(issue.error?).to eq(true)
+        expect(issue.description)
+          .to(match("no target device for LVM physical volumes with alias 'second-disk'"))
+      end
+    end
+
+    context "if a volume group has encryption for physical volumes" do
+      let(:config_json) do
+        {
+          drives:       [
+            {
+              alias: "first-disk"
+            }
+          ],
+          volumeGroups: [
+            {
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["first-disk"],
+                    encryption:    encryption
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      context "without password" do
+        let(:encryption) do
+          { luks1: {} }
+        end
+
+        it "includes the expected issue" do
+          issues = subject.issues
+          expect(issues.size).to eq(1)
+
+          issue = issues.first
+          expect(issue.error?).to eq(true)
+          expect(issue.description).to match("No passphrase")
+        end
+      end
+
+      context "with unavailable method" do
+        let(:encryption) do
+          {
+            luks2: {
+              password: "12345"
+            }
+          }
+        end
+
+        before do
+          allow_any_instance_of(Y2Storage::EncryptionMethod::Luks2)
+            .to(receive(:available?))
+            .and_return(false)
+        end
+
+        it "includes the expected issue" do
+          issues = subject.issues
+          expect(issues.size).to eq(1)
+
+          issue = issues.first
+          expect(issue.error?).to eq(true)
+          expect(issue.description).to match("'Regular LUKS2' is not available")
+        end
+      end
+
+      context "with invalid method" do
+        let(:encryption) { "random_swap" }
+
+        it "includes the expected issue" do
+          issues = subject.issues
+          expect(issues.size).to eq(1)
+
+          issue = issues.first
+          expect(issue.error?).to eq(true)
+          expect(issue.description)
+            .to(match("'Encryption with Volatile Random Key' is not a suitable method"))
+        end
+      end
+
+      context "with a valid encryption" do
+        let(:encryption) do
+          {
+            luks1: {
+              password: "12345"
+            }
+          }
+        end
+
+        it "does not include an issue" do
+          expect(subject.issues.size).to eq(0)
+        end
+      end
+    end
+
+    context "if there are overused physical volumes devices" do
+      let(:config_json) do
+        {
+          drives:       [
+            { alias: "disk1" },
+            { alias: "disk2" },
+            { alias: "disk3" }
+          ],
+          volumeGroups: [
+            {
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["disk1", "disk2"]
+                  }
+                }
+              ]
+            },
+            {
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["disk2"]
+                  }
+                }
+              ]
+            },
+            {
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["disk1", "disk3", "disk3"]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "includes the expected issues" do
+        issues = subject.issues
+        expect(issues.size).to eq(1)
+
+        issue = issues.first
+        expect(issue.error?).to eq(true)
+        expect(issue.description).to(match("The device 'disk1' is used several times"))
+      end
+    end
+
+    context "if the config has several issues" do
+      let(:config_json) do
+        {
+          drives:       [
+            {
+              search:     "/dev/vdd",
+              encryption: { luks2: {} }
+            }
+          ],
+          volumeGroups: [
+            {
+              physicalVolumes: ["pv1"]
+            }
+          ]
+        }
+      end
+
+      it "includes the expected issues" do
+        expect(subject.issues).to contain_exactly(
+          an_object_having_attributes(
+            description: match(/No device found for a mandatory drive/)
+          ),
+          an_object_having_attributes(
+            description: match(/No passphrase provided/)
+          ),
+          an_object_having_attributes(
+            description: match(/There is no LVM physical volume with alias 'pv1'/)
+          )
+        )
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/config_conversions/from_json_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_test.rb
@@ -179,6 +179,28 @@ shared_examples "with encryption" do |config_proc|
       expect(encryption.label).to be_nil
     end
   end
+
+  context "if 'encryption' is 'pervasiveLuks2'" do
+    let(:encryption) do
+      {
+        pervasiveLuks2: {
+          password: "12345"
+        }
+      }
+    end
+
+    it "sets #encryption to the expected value" do
+      config = config_proc.call(subject.convert)
+      encryption = config.encryption
+      expect(encryption).to be_a(Agama::Storage::Configs::Encryption)
+      expect(encryption.method).to eq(Y2Storage::EncryptionMethod::PERVASIVE_LUKS2)
+      expect(encryption.password).to eq("12345")
+      expect(encryption.key_size).to be_nil
+      expect(encryption.pbkd_function).to be_nil
+      expect(encryption.cipher).to be_nil
+      expect(encryption.label).to be_nil
+    end
+  end
 end
 
 shared_examples "with filesystem" do |config_proc|

--- a/service/test/agama/storage/config_solver_test.rb
+++ b/service/test/agama/storage/config_solver_test.rb
@@ -1,0 +1,728 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "./storage_helpers"
+require "agama/config"
+require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_solver"
+require "y2storage"
+require "y2storage/refinements"
+
+using Y2Storage::Refinements::SizeCasts
+
+describe Agama::Storage::ConfigSolver do
+  include Agama::RSpec::StorageHelpers
+
+  let(:product_data) do
+    {
+      "storage" => {
+        "lvm"              => false,
+        "space_policy"     => "delete",
+        "encryption"       => {
+          "method"        => "luks2",
+          "pbkd_function" => "argon2i"
+        },
+        "volumes"          => ["/", "swap"],
+        "volume_templates" => [
+          {
+            "mount_path" => "/", "filesystem" => "btrfs",
+            "size" => { "auto" => true, "min" => "5 GiB", "max" => "10 GiB" },
+            "btrfs" => {
+              "snapshots" => true, "default_subvolume" => "@",
+              "subvolumes" => ["home", "opt", "root", "srv"]
+            },
+            "outline" => {
+              "required" => true, "snapshots_configurable" => true,
+              "auto_size" => {
+                "base_min" => "5 GiB", "base_max" => "10 GiB",
+                "min_fallback_for" => min_fallbacks, "max_fallback_for" => max_fallbacks,
+                "snapshots_increment" => snapshots_increment
+              }
+            }
+          },
+          {
+            "mount_path" => "/home", "size" => { "auto" => false, "min" => "5 GiB" },
+            "filesystem" => "xfs", "outline" => { "required" => false }
+          },
+          {
+            "mount_path" => "swap", "filesystem" => "swap", "size" => { "auto" => true },
+            "outline"    => {
+              "auto_size" => {
+                "adjust_by_ram" => true,
+                "base_min"      => "2 GiB",
+                "base_max"      => "4 GiB"
+              }
+            }
+          },
+          { "mount_path" => "", "filesystem" => "ext4",
+            "size" => { "min" => "100 MiB" } }
+        ]
+      }
+    }
+  end
+
+  let(:min_fallbacks) { [] }
+
+  let(:max_fallbacks) { [] }
+
+  let(:snapshots_increment) { nil }
+
+  let(:product_config) { Agama::Config.new(product_data) }
+
+  let(:default_paths) { product_config.default_paths }
+
+  let(:mandatory_paths) { product_config.mandatory_paths }
+
+  let(:config_json) { nil }
+
+  let(:config) do
+    Agama::Storage::ConfigConversions::FromJSON
+      .new(config_json)
+      .convert
+  end
+
+  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
+
+  before do
+    mock_storage(devicegraph: scenario)
+    # To speed-up the tests
+    allow(Y2Storage::EncryptionMethod::TPM_FDE)
+      .to(receive(:possible?))
+      .and_return(true)
+  end
+
+  subject { described_class.new(devicegraph, product_config) }
+
+  describe "#solve" do
+    let(:scenario) { "empty-hd-50GiB.yaml" }
+
+    context "if a config does not specify all the encryption properties" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              encryption: {
+                luks2: { password: "12345" }
+              }
+            }
+          ]
+        }
+      end
+
+      it "completes the encryption config according to the product info" do
+        subject.solve(config)
+
+        drive = config.drives.first
+        encryption = drive.encryption
+        expect(encryption.method).to eq(Y2Storage::EncryptionMethod::LUKS2)
+        expect(encryption.password).to eq("12345")
+        expect(encryption.pbkd_function).to eq(Y2Storage::PbkdFunction::ARGON2I)
+      end
+    end
+
+    context "if a config does not specify all the filesystem properties" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              filesystem: { path: "/" }
+            }
+          ]
+        }
+      end
+
+      it "completes the filesystem config according to the product info" do
+        subject.solve(config)
+
+        drive = config.drives.first
+        filesystem = drive.filesystem
+        expect(filesystem.type).to be_a(Agama::Storage::Configs::FilesystemType)
+        expect(filesystem.type.fs_type).to eq(Y2Storage::Filesystems::Type::BTRFS)
+        expect(filesystem.type.btrfs).to be_a(Agama::Storage::Configs::Btrfs)
+        expect(filesystem.type.btrfs.snapshots?).to eq(true)
+        expect(filesystem.type.btrfs.read_only?).to eq(false)
+        expect(filesystem.type.btrfs.default_subvolume).to eq("@")
+        expect(filesystem.type.btrfs.subvolumes).to all(be_a(Y2Storage::SubvolSpecification))
+      end
+    end
+
+    partition_proc = proc { |c| c.drives.first.partitions.first }
+
+    context "if a config does not specify size" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: partitions
+            }
+          ]
+        }
+      end
+
+      let(:partitions) do
+        [
+          {
+            filesystem: { path: "/" }
+          },
+          {
+            filesystem: { path: "/home" }
+          },
+          {}
+        ]
+      end
+
+      let(:scenario) { "disks.yaml" }
+
+      it "sets a size according to the product info" do
+        subject.solve(config)
+
+        drive = config.drives.first
+        p1, p2, p3 = drive.partitions
+
+        expect(p1.size.default?).to eq(true)
+        expect(p1.size.min).to eq(5.GiB)
+        expect(p1.size.max).to eq(10.GiB)
+
+        expect(p2.size.default?).to eq(true)
+        expect(p2.size.min).to eq(5.GiB)
+        expect(p2.size.max).to eq(Y2Storage::DiskSize.unlimited)
+
+        expect(p3.size.default?).to eq(true)
+        expect(p3.size.min).to eq(100.MiB)
+        expect(p3.size.max).to eq(Y2Storage::DiskSize.unlimited)
+      end
+
+      context "and there is a device assigned" do
+        let(:partitions) do
+          [
+            {
+              search:     "/dev/vda2",
+              filesystem: { path: "/" }
+            }
+          ]
+        end
+
+        # Enable fallbacks and snapshots to check they don't affect in this case.
+        let(:min_fallbacks) { ["/home"] }
+        let(:max_fallbacks) { ["/home"] }
+        let(:snapshots_increment) { "300%" }
+
+        it "sets the device size" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(false)
+          expect(partition.size.min).to eq(20.GiB)
+          expect(partition.size.max).to eq(20.GiB)
+        end
+      end
+
+      context "and the product defines size fallbacks" do
+        let(:min_fallbacks) { ["/home"] }
+        let(:max_fallbacks) { ["/home"] }
+        let(:snapshots_increment) { "300%" }
+
+        context "and the config does not specify some of the paths" do
+          let(:partitions) do
+            [
+              {
+                filesystem: {
+                  type: "xfs",
+                  path: "/"
+                }
+              }
+            ]
+          end
+
+          it "sets a size adding the fallback sizes" do
+            subject.solve(config)
+            partition = partition_proc.call(config)
+            expect(partition.size.default?).to eq(true)
+            expect(partition.size.min).to eq(10.GiB)
+            expect(partition.size.max).to eq(Y2Storage::DiskSize.unlimited)
+          end
+
+          context "and snapshots are enabled" do
+            let(:partitions) do
+              [
+                {
+                  filesystem: {
+                    type: "btrfs",
+                    path: "/"
+                  }
+                }
+              ]
+            end
+
+            it "sets a size adding the fallback and snapshots sizes" do
+              subject.solve(config)
+              partition = partition_proc.call(config)
+              expect(partition.size.default?).to eq(true)
+              expect(partition.size.min).to eq(40.GiB)
+              expect(partition.size.max).to eq(Y2Storage::DiskSize.unlimited)
+            end
+          end
+        end
+
+        context "and the config specifies the fallback paths" do
+          let(:partitions) do
+            [
+              {
+                filesystem: {
+                  type: filesystem,
+                  path: "/"
+                }
+              },
+              {
+                filesystem: { path: "/home" }
+              }
+            ]
+          end
+
+          let(:filesystem) { "xfs" }
+
+          it "sets a size ignoring the fallback sizes" do
+            subject.solve(config)
+            partition = partition_proc.call(config)
+            expect(partition.size.default?).to eq(true)
+            expect(partition.size.min).to eq(5.GiB)
+            expect(partition.size.max).to eq(10.GiB)
+          end
+
+          context "and snapshots are enabled" do
+            let(:filesystem) { "btrfs" }
+
+            it "sets a size adding the snapshots size" do
+              subject.solve(config)
+              partition = partition_proc.call(config)
+              expect(partition.size.default?).to eq(true)
+              expect(partition.size.min).to eq(20.GiB)
+              expect(partition.size.max).to eq(40.GiB)
+            end
+          end
+        end
+      end
+
+      context "and the volume has to be enlarged according to RAM size" do
+        before do
+          allow_any_instance_of(Y2Storage::Arch).to receive(:ram_size).and_return(8.GiB)
+        end
+
+        let(:partitions) do
+          [
+            {
+              filesystem: { path: "swap" }
+            }
+          ]
+        end
+
+        it "sets the RAM size" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(true)
+          expect(partition.size.min).to eq(8.GiB)
+          expect(partition.size.max).to eq(8.GiB)
+        end
+      end
+    end
+
+    context "if a config specifies a size" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: [
+                {
+                  search:     search,
+                  filesystem: { path: "/" },
+                  size:       {
+                    min: "10 GiB",
+                    max: "15 GiB"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:scenario) { "disks.yaml" }
+
+      # Enable fallbacks and snapshots to check they don't affect in this case.
+      let(:min_fallbacks) { ["/home"] }
+      let(:max_fallbacks) { ["/home"] }
+      let(:snapshots_increment) { "300%" }
+
+      context "and there is no device assigned" do
+        let(:search) { nil }
+
+        it "sets the given size" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(false)
+          expect(partition.size.min).to eq(10.GiB)
+          expect(partition.size.max).to eq(15.GiB)
+        end
+      end
+
+      context "and there is a device assigned" do
+        let(:search) { "/dev/vda2" }
+
+        it "sets the given size" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(false)
+          expect(partition.size.min).to eq(10.GiB)
+          expect(partition.size.max).to eq(15.GiB)
+        end
+      end
+    end
+
+    context "if a config specifies 'current' for min size" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: [
+                {
+                  search:     search,
+                  filesystem: { path: "/" },
+                  size:       {
+                    min: "current",
+                    max: "40 GiB"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      context "and there is no device assigned" do
+        let(:search) { nil }
+
+        it "sets a size according to the product info" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(true)
+          expect(partition.size.min).to eq(5.GiB)
+          expect(partition.size.max).to eq(10.GiB)
+        end
+      end
+
+      context "and there is a device assigned" do
+        let(:scenario) { "disks.yaml" }
+
+        let(:search) { "/dev/vda2" }
+
+        it "sets the device size as min size" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(false)
+          expect(partition.size.min).to eq(20.GiB)
+          expect(partition.size.max).to eq(40.GiB)
+        end
+      end
+    end
+
+    context "if a config specifies 'current' for max size" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: [
+                {
+                  search:     search,
+                  filesystem: { path: "/" },
+                  size:       {
+                    min: "10 GiB",
+                    max: "current"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      context "and there is no device assigned" do
+        let(:search) { nil }
+
+        it "sets a size according to the product info" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(true)
+          expect(partition.size.min).to eq(5.GiB)
+          expect(partition.size.max).to eq(10.GiB)
+        end
+      end
+
+      context "and there is a device assigned" do
+        let(:scenario) { "disks.yaml" }
+
+        let(:search) { "/dev/vda2" }
+
+        it "sets the device size as max size" do
+          subject.solve(config)
+          partition = partition_proc.call(config)
+          expect(partition.size.default?).to eq(false)
+          expect(partition.size.min).to eq(10.GiB)
+          expect(partition.size.max).to eq(20.GiB)
+        end
+      end
+    end
+  end
+
+  context "if a drive has a search without a device name" do
+    let(:config_json) { { drives: drives } }
+
+    let(:drives) do
+      [
+        {},
+        {},
+        {}
+      ]
+    end
+
+    let(:scenario) { "disks.yaml" }
+
+    it "sets the first unassigned device to the drive" do
+      subject.solve(config)
+      search1, search2, search3 = config.drives.map(&:search)
+      expect(search1.solved?).to eq(true)
+      expect(search1.device.name).to eq("/dev/vda")
+      expect(search2.solved?).to eq(true)
+      expect(search2.device.name).to eq("/dev/vdb")
+      expect(search3.solved?).to eq(true)
+      expect(search3.device.name).to eq("/dev/vdc")
+    end
+
+    context "and there is not unassigned device" do
+      let(:drives) do
+        [
+          {},
+          {},
+          {},
+          {}
+        ]
+      end
+
+      it "does not set a device to the drive" do
+        subject.solve(config)
+        search = config.drives[3].search
+        expect(search.solved?).to eq(true)
+        expect(search.device).to be_nil
+      end
+    end
+  end
+
+  context "if a drive has a search with a device name" do
+    let(:config_json) { { drives: drives } }
+
+    let(:drives) do
+      [
+        { search: search }
+      ]
+    end
+
+    let(:scenario) { "disks.yaml" }
+
+    context "and the device is found" do
+      let(:search) { "/dev/vdb" }
+
+      it "sets the device to the drive" do
+        subject.solve(config)
+        search = config.drives.first.search
+        expect(search.solved?).to eq(true)
+        expect(search.device.name).to eq("/dev/vdb")
+      end
+    end
+
+    context "and the device is not found" do
+      let(:search) { "/dev/vdd" }
+
+      it "does not set a device to the drive" do
+        subject.solve(config)
+        search = config.drives.first.search
+        expect(search.solved?).to eq(true)
+        expect(search.device).to be_nil
+      end
+    end
+
+    context "and the device was already assigned" do
+      let(:drives) do
+        [
+          {},
+          { search: "/dev/vda" }
+        ]
+      end
+
+      it "does not set a device to the drive" do
+        subject.solve(config)
+        search = config.drives[1].search
+        expect(search.solved?).to eq(true)
+        expect(search.device).to be_nil
+      end
+    end
+
+    context "and there is other drive with the same device" do
+      let(:drives) do
+        [
+          { search: "/dev/vdb" },
+          { search: "/dev/vdb" }
+        ]
+      end
+
+      it "only sets the device to the first drive" do
+        subject.solve(config)
+        search1, search2 = config.drives.map(&:search)
+        expect(search1.solved?).to eq(true)
+        expect(search1.device.name).to eq("/dev/vdb")
+        expect(search2.solved?).to eq(true)
+        expect(search2.device).to be_nil
+      end
+    end
+  end
+
+  context "if a partition has a search without a device name" do
+    let(:config_json) do
+      {
+        drives: [
+          { partitions: partitions }
+        ]
+      }
+    end
+
+    let(:partitions) do
+      [
+        { search: {} },
+        { search: {} },
+        { search: {} }
+      ]
+    end
+
+    let(:scenario) { "disks.yaml" }
+
+    it "sets the first unassigned partition to the config" do
+      subject.solve(config)
+      search1, search2, search3 = config.drives.first.partitions.map(&:search)
+      expect(search1.solved?).to eq(true)
+      expect(search1.device.name).to eq("/dev/vda1")
+      expect(search2.solved?).to eq(true)
+      expect(search2.device.name).to eq("/dev/vda2")
+      expect(search3.solved?).to eq(true)
+      expect(search3.device.name).to eq("/dev/vda3")
+    end
+
+    context "and there is not unassigned partition" do
+      let(:partitions) do
+        [
+          { search: {} },
+          { search: {} },
+          { search: {} },
+          { search: {} }
+        ]
+      end
+
+      it "does not set a partition to the config" do
+        subject.solve(config)
+        search = config.drives.first.partitions[3].search
+        expect(search.solved?).to eq(true)
+        expect(search.device).to be_nil
+      end
+    end
+  end
+
+  context "if a partition has a search with a device name" do
+    let(:config_json) do
+      {
+        drives: [
+          { partitions: partitions }
+        ]
+      }
+    end
+
+    let(:partitions) do
+      [
+        { search: search }
+      ]
+    end
+
+    let(:scenario) { "disks.yaml" }
+
+    search_proc = proc { |c| c.drives.first.partitions.first.search }
+
+    context "and the partition is found" do
+      let(:search) { "/dev/vda2" }
+
+      it "sets the partition to the config" do
+        subject.solve(config)
+        search = search_proc.call(config)
+        expect(search.solved?).to eq(true)
+        expect(search.device.name).to eq("/dev/vda2")
+      end
+    end
+
+    context "and the device is not found" do
+      let(:search) { "/dev/vdb1" }
+
+      it "does not set a partition to the config" do
+        subject.solve(config)
+        search = search_proc.call(config)
+        expect(search.solved?).to eq(true)
+        expect(search.device).to be_nil
+      end
+    end
+
+    context "and the device was already assigned" do
+      let(:partitions) do
+        [
+          { search: {} },
+          { search: "/dev/vda1" }
+        ]
+      end
+
+      it "does not set a partition to the config" do
+        subject.solve(config)
+        search = config.drives.first.partitions[1].search
+        expect(search.solved?).to eq(true)
+        expect(search.device).to be_nil
+      end
+    end
+
+    context "and there is other partition with the same device" do
+      let(:partitions) do
+        [
+          { search: "/dev/vda2" },
+          { search: "/dev/vda2" }
+        ]
+      end
+
+      it "only sets the partition to the first config" do
+        subject.solve(config)
+        search1, search2 = config.drives.first.partitions.map(&:search)
+        expect(search1.solved?).to eq(true)
+        expect(search1.device.name).to eq("/dev/vda2")
+        expect(search2.solved?).to eq(true)
+        expect(search2.device).to be_nil
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/config_solver_test.rb
+++ b/service/test/agama/storage/config_solver_test.rb
@@ -138,6 +138,36 @@ describe Agama::Storage::ConfigSolver do
       end
     end
 
+    context "if a volume group does not specify all the pv encryption properties" do
+      let(:config_json) do
+        {
+          volumeGroups: [
+            {
+              physicalVolumes: [
+                {
+                  generate: {
+                    encryption: {
+                      luks2: { password: "12345" }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "completes the encryption config according to the product info" do
+        subject.solve(config)
+
+        volume_group = config.volume_groups.first
+        encryption = volume_group.physical_volumes_encryption
+        expect(encryption.method).to eq(Y2Storage::EncryptionMethod::LUKS2)
+        expect(encryption.password).to eq("12345")
+        expect(encryption.pbkd_function).to eq(Y2Storage::PbkdFunction::ARGON2I)
+      end
+    end
+
     context "if a config does not specify all the filesystem properties" do
       let(:config_json) do
         {

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -83,7 +83,7 @@ describe Y2Storage::AgamaProposal do
 
   let(:config_from_json) do
     Agama::Storage::ConfigConversions::FromJSON
-      .new(config_json, product_config: product_config)
+      .new(config_json, default_paths: default_paths, mandatory_paths: mandatory_paths)
       .convert
   end
 
@@ -136,6 +136,10 @@ describe Y2Storage::AgamaProposal do
       }
     }
   end
+
+  let(:default_paths) { product_config.default_paths }
+
+  let(:mandatory_paths) { product_config.mandatory_paths }
 
   let(:issues_list) { [] }
 

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -107,30 +107,52 @@ describe Y2Storage::AgamaProposal do
         "volumes"          => ["/", "swap"],
         "volume_templates" => [
           {
-            "mount_path" => "/", "filesystem" => "btrfs", "size" => { "auto" => true },
-            "btrfs" => {
-              "snapshots" => true, "default_subvolume" => "@",
-              "subvolumes" => ["home", "opt", "root", "srv"]
+            "mount_path" => "/",
+            "filesystem" => "btrfs",
+            "size"       => { "auto" => true },
+            "btrfs"      => {
+              "snapshots"         => true,
+              "default_subvolume" => "@",
+              "subvolumes"        => ["home", "opt", "root", "srv"]
             },
-            "outline" => {
-              "required" => true, "snapshots_configurable" => true,
-              "auto_size" => {
-                "base_min" => "5 GiB", "base_max" => "10 GiB",
-                "min_fallback_for" => ["/home"], "max_fallback_for" => ["/home"],
+            "outline"    => {
+              "required"               => true,
+              "snapshots_configurable" => true,
+              "filesystems"            => ["btrfs", "xfs", "ext3", "ext4"],
+              "auto_size"              => {
+                "base_min"            => "5 GiB",
+                "base_max"            => "10 GiB",
+                "min_fallback_for"    => ["/home"],
+                "max_fallback_for"    => ["/home"],
                 "snapshots_increment" => "300%"
               }
             }
           },
           {
-            "mount_path" => "/home", "size" => { "auto" => false, "min" => "5 GiB" },
-            "filesystem" => "xfs", "outline" => { "required" => false }
+            "mount_path" => "/home",
+            "size"       => { "auto" => false, "min" => "5 GiB" },
+            "filesystem" => "xfs",
+            "outline"    => {
+              "required"    => false,
+              "filesystems" => ["xfs", "ext4"]
+            }
           },
           {
-            "mount_path" => "swap", "filesystem" => "swap",
-            "outline"    => { "required" => false }
+            "mount_path" => "swap",
+            "filesystem" => "swap",
+            "outline"    => {
+              "required"    => false,
+              "filesystems" => ["swap"]
+            }
           },
-          { "mount_path" => "", "filesystem" => "ext4",
-            "size" => { "min" => "100 MiB" } }
+          {
+            "mount_path" => "",
+            "filesystem" => "ext4",
+            "size"       => { "min" => "100 MiB" },
+            "outline"    => {
+              "filesystems" => ["xfs", "ext4"]
+            }
+          }
         ]
       }
     }
@@ -1049,7 +1071,8 @@ describe Y2Storage::AgamaProposal do
                   "filesystem" => "swap",
                   "size"       => { "auto" => true },
                   "outline"    => {
-                    "auto_size" => {
+                    "filesystems" => ["swap"],
+                    "auto_size"   => {
                       "adjust_by_ram" => true,
                       "base_min"      => "2 GiB",
                       "base_max"      => "4 GiB"

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -73,7 +73,6 @@ end
 
 describe Y2Storage::AgamaProposal do
   include Agama::RSpec::StorageHelpers
-  using Y2Storage::Refinements::SizeCasts
 
   subject(:proposal) do
     described_class.new(config, product_config: product_config, issues_list: issues_list)

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -396,7 +396,7 @@ describe Y2Storage::AgamaProposal do
         it "reports the corresponding error" do
           proposal.propose
           expect(proposal.issues_list).to include an_object_having_attributes(
-            description: /method 'luks2' is not available/,
+            description: /method 'Regular LUKS2' is not available/,
             severity:    Agama::Issue::Severity::ERROR
           )
         end
@@ -413,7 +413,7 @@ describe Y2Storage::AgamaProposal do
         it "reports the corresponding error" do
           proposal.propose
           expect(proposal.issues_list).to include an_object_having_attributes(
-            description: /'random_swap' is not a suitable method/,
+            description: /'Encryption with Volatile Random Key' is not a suitable method/,
             severity:    Agama::Issue::Severity::ERROR
           )
         end
@@ -1459,7 +1459,7 @@ describe Y2Storage::AgamaProposal do
       it "reports the corresponding error" do
         proposal.propose
         expect(proposal.issues_list).to include an_object_having_attributes(
-          description: /no LVM physical volume with alias pv2/,
+          description: /no LVM physical volume with alias 'pv2'/,
           severity:    Agama::Issue::Severity::ERROR
         )
       end
@@ -1511,7 +1511,7 @@ describe Y2Storage::AgamaProposal do
       it "reports the corresponding error" do
         proposal.propose
         expect(proposal.issues_list).to include an_object_having_attributes(
-          description: /no LVM thin pool volume with alias pool/,
+          description: /no LVM thin pool volume with alias 'pool'/,
           severity:    Agama::Issue::Severity::ERROR
         )
       end


### PR DESCRIPTION
Add support to the storage config for using a *generate* section for physical volumes.

~~~json
"physicalVolumes": [
  { "generate": ["first-disk", "second-disk"] }
]
~~~

~~~json
"physicalVolumes": [
  {
    "generate": {
      "targetDevices": ["first-disk"],
      "encryption": {
        "luks2": { "password": "12345" }
      }
    }
  }
]
~~~

The *generate* section allows to indicate the target devices in which to automatically create physical volumes, if needed. Agama will try to create physical volumes to allocate the defined logical volumes. If an *encryption* section is provided by the *generate* section, then the new physical volumes will be encrypted.

Notes:

* For now, *physicalVolumes* can contain either device aliases or a *generate*. In the future it will allow both.
* If there is more than one *generate* in the list of physical volumes, then only the first one will be considered (the rest ones are ignored). Note that the schema does not complain.
