### PR TITLE
refactor(rust): introduce a new "transfer" module

### DIFF
--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -30,9 +30,9 @@ mod progress;
 mod questions;
 
 use crate::error::CliError;
-use agama_lib::error::ServiceError;
-use agama_lib::manager::ManagerClient;
-use agama_lib::progress::ProgressMonitor;
+use agama_lib::{
+    error::ServiceError, manager::ManagerClient, progress::ProgressMonitor, transfer::Transfer,
+};
 use auth::run as run_auth_cmd;
 use commands::Commands;
 use config::run as run_config_cmd;
@@ -158,7 +158,7 @@ pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
         Commands::Questions(subcommand) => run_questions_cmd(subcommand).await?,
         Commands::Logs(subcommand) => run_logs_cmd(subcommand).await?,
         Commands::Auth(subcommand) => run_auth_cmd(subcommand).await?,
-        Commands::Download { url } => crate::profile::download(&url, std::io::stdout())?,
+        Commands::Download { url } => Transfer::get(&url, std::io::stdout())?,
     };
 
     Ok(())

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -18,11 +18,12 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use curl;
 use serde_json;
 use std::io;
 use thiserror::Error;
 use zbus::{self, zvariant};
+
+use crate::transfer::TransferError;
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
@@ -66,12 +67,14 @@ pub enum ServiceError {
     // Specific error when something does not work as expected, but it is not user fault
     #[error("Internal error. Please report a bug and attach logs. Details: {0}")]
     InternalError(String),
+    #[error("Could not read the file: '{0}'")]
+    CouldNotTransferFile(#[from] TransferError),
 }
 
 #[derive(Error, Debug)]
 pub enum ProfileError {
     #[error("Could not read the profile")]
-    Unreachable(#[from] curl::Error),
+    Unreachable(#[from] TransferError),
     #[error("Jsonnet evaluation failed:\n{0}")]
     EvaluationError(String),
     #[error("I/O error")]

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -63,6 +63,7 @@ pub mod proxies;
 mod store;
 pub use store::Store;
 pub mod questions;
+pub mod transfer;
 use crate::error::ServiceError;
 use reqwest::{header, Client};
 

--- a/rust/agama-lib/src/transfer.rs
+++ b/rust/agama-lib/src/transfer.rs
@@ -1,0 +1,37 @@
+//! File transfer API for Agama.
+//!
+//! Implement a file transfer API which, in the future, will support Agama specific URLs. Check the
+//! YaST document about [URL handling in the
+//! installer](https://github.com/yast/yast-installation/blob/master/doc/url.md) for further
+//! information.
+//!
+//! At this point, it only supports those schemes supported by CURL.
+
+use std::io::Write;
+
+use curl::easy::Easy;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct TransferError(#[from] curl::Error);
+pub type TransferResult<T> = Result<T, TransferError>;
+
+/// File transfer API
+pub struct Transfer {}
+
+impl Transfer {
+    /// Retrieves and writes the data from an URL
+    ///
+    /// * `url`: URL to get the data from.
+    /// * `out_fd`: where to write the data.
+    pub fn get(url: &str, mut out_fd: impl Write) -> TransferResult<()> {
+        let mut handle = Easy::new();
+        handle.url(url)?;
+
+        let mut transfer = handle.transfer();
+        transfer.write_function(|buf| Ok(out_fd.write(buf).unwrap()))?;
+        transfer.perform()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Introduce a new `transfer` module containing an API to download files.
- The idea is to extend this API in the future to support other [URL
  types](https://github.com/yast/yast-installation/blob/master/doc/url.md).
- This module replaces the old "download" function.
