### PR TITLE
PoC for the online demo

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,8 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
+import React, { useState } from "react";
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { ServerError } from "~/components/core";
 import { Loading, PlainLayout } from "~/components/layout";
@@ -35,6 +36,8 @@ import { useDeprecatedChanges } from "~/queries/storage";
 import { ROOT, PRODUCT } from "~/routes/paths";
 import { InstallationPhase } from "~/types/status";
 
+import { _ } from "~/i18n";
+
 /**
  * Main application component.
  */
@@ -44,6 +47,7 @@ function App() {
   const { connected, error } = useInstallerClientStatus();
   const { selectedProduct, products } = useProduct();
   const { language } = useInstallerL10n();
+  const [isOpen, setIsOpen] = useState(true);
   useL10nConfigChanges();
   useProductChanges();
   useIssuesChanges();
@@ -89,8 +93,33 @@ function App() {
 
   if (!language) return null;
 
+  // TRANSLATORS: the text in square brackets [] is a clickable link
+  const [msgStart, msgLink, msgEnd] = _(
+    "The demo runs in read-only mode, you cannot change any values and the installation cannot \
+be started. To find more details about Agama check the [home page].",
+  ).split(/[[\]]/);
+
+  const alert =
+    process.env.AGAMA_DEMO && isOpen ? (
+      <Alert
+        variant="warning"
+        title={_("This is Agama installer online demo.")}
+        timeout={12000}
+        actionClose={<AlertActionCloseButton onClose={() => setIsOpen(false)} />}
+      >
+        <p>
+          {msgStart}
+          <a href="https://agama-project.github.io/" rel="noreferrer" target="_blank">
+            {msgLink}
+          </a>
+          {msgEnd}
+        </p>
+      </Alert>
+    ) : null;
+
   return (
     <>
+      {alert}
       <Content />
       <Questions />
     </>

--- a/web/src/api/http.ts
+++ b/web/src/api/http.ts
@@ -22,9 +22,28 @@
 
 import axios from "axios";
 
+let demo_data;
+if (process.env.AGAMA_DEMO) {
+  demo_data = await import(process.env.AGAMA_DEMO);
+}
+
 const http = axios.create({
   responseType: "json",
 });
+
+function mock_response(method: string, url: string) {
+  console.info("Demo mode, ignoring request", method, url);
+
+  return Promise.resolve({
+    data: {},
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: {
+      headers: {},
+    },
+  });
+}
 
 /**
  * Retrieves the object from given URL
@@ -32,7 +51,16 @@ const http = axios.create({
  * @param url - HTTP URL
  * @return data from the response body
  */
-const get = (url: string) => http.get(url).then(({ data }) => data);
+const get = (url: string) => {
+  if (process.env.AGAMA_DEMO) {
+    if (!(url in demo_data)) {
+      console.error("Missing demo data for REST API path", url);
+    }
+    return Promise.resolve(demo_data[url]);
+  } else {
+    return http.get(url).then(({ data }) => data);
+  }
+};
 
 /**
  * Performs a PATCH request with the given URL and data
@@ -40,7 +68,8 @@ const get = (url: string) => http.get(url).then(({ data }) => data);
  * @param url - endpoint URL
  * @param data - Request payload
  */
-const patch = (url: string, data?: object) => http.patch(url, data);
+const patch = (url: string, data?: object) =>
+  process.env.AGAMA_DEMO ? mock_response("PATCH", url) : http.patch(url, data);
 
 /**
  * Performs a PUT request with the given URL and data
@@ -48,7 +77,8 @@ const patch = (url: string, data?: object) => http.patch(url, data);
  * @param url - endpoint URL
  * @param data - request payload
  */
-const put = (url: string, data: object) => http.put(url, data);
+const put = (url: string, data: object) =>
+  process.env.AGAMA_DEMO ? mock_response("PUT", url) : http.put(url, data);
 
 /**
  * Performs a POST request with the given URL and data
@@ -56,7 +86,8 @@ const put = (url: string, data: object) => http.put(url, data);
  * @param url - endpoint URL
  * @param data - request payload
  */
-const post = (url: string, data?: object) => http.post(url, data);
+const post = (url: string, data?: object) =>
+  process.env.AGAMA_DEMO ? mock_response("POST", url) : http.post(url, data);
 
 /**
  * Performs a DELETE request on the given URL
@@ -64,6 +95,7 @@ const post = (url: string, data?: object) => http.post(url, data);
  * @param url - endpoint URL
  * @param data - request payload
  */
-const del = (url: string) => http.delete(url);
+const del = (url: string) =>
+  process.env.AGAMA_DEMO ? mock_response("DELETE", url) : http.delete(url);
 
 export { get, patch, post, put, del };

--- a/web/src/client/ws.js
+++ b/web/src/client/ws.js
@@ -82,10 +82,13 @@ class WSClient {
   }
 
   isConnected() {
+    if (process.env.AGAMA_DEMO) return true;
     return this.wsState() === SocketStates.CONNECTED;
   }
 
   buildClient() {
+    if (process.env.AGAMA_DEMO) return null;
+
     const client = new WebSocket(this.url);
     client.onopen = () => {
       console.log("Websocket connected");

--- a/web/src/context/auth.jsx
+++ b/web/src/context/auth.jsx
@@ -49,7 +49,7 @@ const AuthErrors = Object.freeze({
  * @param {React.ReactNode} [props.children] - content to display within the provider
  */
 function AuthProvider({ children }) {
-  const [isLoggedIn, setIsLoggedIn] = useState(undefined);
+  const [isLoggedIn, setIsLoggedIn] = useState(process.env.AGAMA_DEMO ? true : undefined);
   const [error, setError] = useState(null);
 
   const login = useCallback(async (password) => {
@@ -79,19 +79,21 @@ function AuthProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    fetch("/api/auth", {
-      headers: { "Content-Type": "application/json" },
-    })
-      .then((response) => {
-        setIsLoggedIn(response.status === 200);
-        if (response.status >= 500 && response.status < 600) {
-          setError(AuthErrors.SERVER);
-        }
-        if (response.status >= 400 && response.status < 500) {
-          setError(AuthErrors.AUTH);
-        }
+    if (!process.env.AGAMA_DEMO) {
+      fetch("/api/auth", {
+        headers: { "Content-Type": "application/json" },
       })
-      .catch(() => setIsLoggedIn(false));
+        .then((response) => {
+          setIsLoggedIn(response.status === 200);
+          if (response.status >= 500 && response.status < 600) {
+            setError(AuthErrors.SERVER);
+          }
+          if (response.status >= 400 && response.status < 500) {
+            setError(AuthErrors.AUTH);
+          }
+        })
+        .catch(() => setIsLoggedIn(false));
+    }
   }, []);
 
   return (

--- a/web/src/context/installer.jsx
+++ b/web/src/context/installer.jsx
@@ -77,7 +77,7 @@ function useInstallerClientStatus() {
  */
 function InstallerClientProvider({ children, client = null }) {
   const [value, setValue] = useState(client);
-  const [connected, setConnected] = useState(false);
+  const [connected, setConnected] = useState(process.env.AGAMA_DEMO !== undefined);
   const [error, setError] = useState(false);
 
   useEffect(() => {

--- a/web/src/context/installerL10n.tsx
+++ b/web/src/context/installerL10n.tsx
@@ -194,7 +194,7 @@ function reload(newLanguage: string) {
  */
 function InstallerL10nProvider({ children }: { children?: React.ReactNode }) {
   const { connected } = useInstallerClientStatus();
-  const [language, setLanguage] = useState(undefined);
+  const [language, setLanguage] = useState(process.env.AGAMA_DEMO ? "en-us" : undefined);
   const [keymap, setKeymap] = useState(undefined);
 
   const syncBackendLanguage = useCallback(async () => {

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -40,6 +40,7 @@ const copy_files = [
   "./src/index.html",
   // TODO: consider using something more complete like https://github.com/jantimon/favicons-webpack-plugin
   "./src/assets/favicon.svg",
+  "./src/languages.json",
   { from: "./src/assets/products/*.svg", to: "assets/logos/[name][ext]" },
 ];
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -54,7 +54,7 @@ const plugins = [
   // the current value of the environment variable, that variable is set to
   // "true" when running the development server ("npm run server")
   // https://webpack.js.org/plugins/environment-plugin/
-  new webpack.EnvironmentPlugin({ WEBPACK_SERVE: null, LOCAL_CONNECTION: null }),
+  new webpack.EnvironmentPlugin({ WEBPACK_SERVE: null, LOCAL_CONNECTION: null, AGAMA_DEMO: null }),
 ].filter(Boolean);
 
 if (eslint) {


### PR DESCRIPTION
# Prototype for the online demo

This is a prototype for building a completely static Agama demo.

We have some screenshots on the home page and in the documentation but it would be better to have some real site with working Agama so people can try it live.

The problem is that Agama needs a real system for probing hardware and so on. But we could simply run it on some real system, dump the collected REST API responses and then just replay them on the demo site.

That means the demo would be read-only and all changes done by user would be ignored. But I think that for the demo purposes it would be good enough.

## Deployed demo

You can try the deployed code at https://agama-online-demo.surge.sh.

There are still some small glitches (changing the installed product gets stuck, you need to reload the page manually) but in general it works fine.

## How to reproduce the build

- First compile with AGAMA_DEMO=record
- Login to Agama, click all sections, go to all subpages to trigger all HTTP requests
- From development console save the `window.agama_demo` value to `src/api/demo.json` file
- Compile with AGAMA_DEMO=replay to build a static site with the recorded data

## Improvements

- Handle better some corner cases (starting installation, product selection...)
- It would be nice to collect the REST API responses automatically, clicking around in a real browser is error prone.
- It would be nice to define the target testing system or even have a script which creates the same virtual machine. If you collect the data on a different machine you will get different proposal (very likely with different partitioning). This should be a reproducible process.