### PR TITLE
Move to json

### DIFF
--- a/doc/dbus/org.opensuse.Agama1.Questions.doc.xml
+++ b/doc/dbus/org.opensuse.Agama1.Questions.doc.xml
@@ -88,7 +88,7 @@ when the question is answered and the answer is successfully read.
     </method>
     <!--
       AddAnswerFile:
-      @path: Local fs path to answers file in yaml format.
+      @path: Local fs path to answers file in JSON format.
 
       Adds file with list of predefined answers that will be used to
       automatically answer matching questions.

--- a/doc/questions.md
+++ b/doc/questions.md
@@ -29,7 +29,7 @@ storage.* -> :skip. Also it is needed for matching of answers with type of gener
    Partition identification for luks password. Why: Getting data only from question text is hard and very unreadable with regexp.
    So questions need to specify some easy to match data in addition to the pure text.
    E.g. checksum and repository url for automatic repository approval.
-4. Question API has method to set answers ( TODO: lets see if it is better to get data structure or path to yaml file ). In such case if question
+4. Question API has method to set answers as path to JSON file. In such case if question
    with known answer is asked, it get immediate response.
    Why: To allow user define machine answers in advance.
 5. Questions API have property that defines if for questions without answer default one is used or if ask user.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -112,7 +112,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "subprocess",
  "thiserror",
  "tokio",
@@ -3630,19 +3629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.6.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,12 +4393,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/rust/agama-cli/src/questions.rs
+++ b/rust/agama-cli/src/questions.rs
@@ -37,7 +37,7 @@ pub enum QuestionsCommands {
     /// Please check Agama documentation for more details and examples:
     /// https://github.com/openSUSE/agama/blob/master/doc/questions.md
     Answers {
-        /// Path to a file containing the answers in YAML format.
+        /// Path to a file containing the answers in JSON format.
         path: String,
     },
     /// Prints the list of questions that are waiting for an answer in JSON format

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -15,7 +15,6 @@ zbus = { version = "3", default-features = false, features = ["tokio"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 thiserror = "1.0.64"
 serde = { version = "1.0.210", features = ["derive"] }
-serde_yaml = "0.9.34"
 cidr = { version = "0.2.3", features = ["serde"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.16"

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -32,7 +32,7 @@ pub enum QuestionsError {
     #[error("Could not read the answers file: {0}")]
     IO(std::io::Error),
     #[error("Could not deserialize the answers file: {0}")]
-    Deserialize(serde_yaml::Error),
+    Deserialize(serde_json::Error),
 }
 
 #[derive(Clone, Debug)]

--- a/rust/agama-server/src/questions/answers.rs
+++ b/rust/agama-server/src/questions/answers.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use super::QuestionsError;
 
-/// Data structure for single yaml answer. For variables specification see
+/// Data structure for single JSON answer. For variables specification see
 /// corresponding [agama_lib::questions::GenericQuestion] fields.
 /// The *matcher* part is: `class`, `text`, `data`.
 /// The *answer* part is: `answer`, `password`.
@@ -83,7 +83,7 @@ pub struct Answers {
 impl Answers {
     pub fn new_from_file(path: &str) -> Result<Self, QuestionsError> {
         let f = std::fs::File::open(path).map_err(QuestionsError::IO)?;
-        let result: Self = serde_yaml::from_reader(f).map_err(QuestionsError::Deserialize)?;
+        let result: Self = serde_json::from_reader(f).map_err(QuestionsError::Deserialize)?;
 
         Ok(result)
     }
@@ -298,18 +298,25 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_yaml() {
+    fn test_loading_json() {
         let file = r#"
-            answers:
-              - class: "without_data"
-                answer: "OK"
-              - class: "with_data"
-                data:
-                  testk: testv
-                  testk2: testv2
-                answer: "Cancel"
+            {
+                "answers": [
+                {
+                   "class": "without_data",
+                   "answer": "OK"
+                },
+                {
+                    "class": "with_data",
+                    "data": {
+                        "testk": "testv",
+                        "testk2": "testv2"
+                    },
+                    "answer": "Cancel"
+                }]
+            }
         "#;
-        let result: Answers = serde_yaml::from_str(file).expect("failed to load yaml string");
+        let result: Answers = serde_json::from_str(file).expect("failed to load JSON string");
         assert_eq!(result.answers.len(), 2);
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 14 13:53:10 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- CLI: change format for questions answers file from YAML to JSON
+  to be consistent with other commands
+  (gh#agama-project/agama#1667).
+
+-------------------------------------------------------------------
 Fri Sep 27 13:09:10 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
 
 - Fix optional network settings (gh#agama-project/agama#1641).

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -54,9 +54,9 @@ module Yast2
           data:          {}
         }
         data = { generic: question }.to_json
-        answer_yaml = Yast::Execute.locally!("agama", "questions", "ask",
+        answer_json = Yast::Execute.locally!("agama", "questions", "ask",
           stdin: data, stdout: :capture)
-        answer = JSON.parse!(answer_yaml)
+        answer = JSON.parse!(answer_json)
         answer["generic"]["answer"].to_sym
       end
 
@@ -101,9 +101,9 @@ module UI
         "data"          => {}
       }
       data = { generic: question, withPassword: {} }.to_json
-      answer_yaml = Yast::Execute.locally!("agama", "questions", "ask", stdin: data,
+      answer_json = Yast::Execute.locally!("agama", "questions", "ask", stdin: data,
 stdout: :capture)
-      answer = JSON.parse!(answer_yaml)
+      answer = JSON.parse!(answer_json)
       result = answer["generic"]["answer"].to_sym
       return nil if result == :cancel
 


### PR DESCRIPTION
Unify formats to use JSON with only exception beeing products files as it is intended to be PM oriented and rest is user oriented. Also we need translations and multiline content from yaml in products.
