### PR TITLE
fix(service): Fixed shell injection vulnerability in the internal API

### DIFF
--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -19,6 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "shellwords"
+
 require "yast"
 require "agama/config"
 require "agama/network"
@@ -236,7 +238,7 @@ module Agama
     #
     # @return [String] path to created archive
     def collect_logs(path: nil)
-      opt = "-d #{path}" unless path.nil? || path.empty?
+      opt = "-d #{path.shellescape}" unless path.nil? || path.empty?
 
       `agama logs store #{opt}`.strip
     end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 14 14:52:26 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed shell injection vulnerability in the internal API
+  (gh#agama-project/agama#1668)
+
+-------------------------------------------------------------------
 Tue Oct  8 12:25:08 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Storage: added support for automatic creation of physical volumes


### PR DESCRIPTION
## Problem

- https://github.com/agama-project/agama/security/code-scanning/2

## Solution

- Escape the path parameter so the special shell characters do not cause problems

## Details

- The problem is only in the internal implementation, the DBus service just uses the default (does not allow to pass the parameter)
- But it potentially could be a problem in the future when we change the API so let's fix it, the fix is trivial anyway