### PR TITLE
feat: add support to run pre/post scripts

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "strum",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1907,7 +1908,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -3784,6 +3785,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "subprocess"

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -18,6 +18,7 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
+use agama_lib::scripts::{ScriptsClient, ScriptsGroup};
 use clap::{Args, Parser};
 
 mod auth;
@@ -92,8 +93,17 @@ async fn probe() -> anyhow::Result<()> {
 ///
 /// Before starting, it makes sure that the manager is idle.
 ///
+/// * `client`: base HTTP client.
 /// * `manager`: the manager client.
-async fn install(manager: &ManagerClient<'_>, max_attempts: u8) -> anyhow::Result<()> {
+/// * `max_attempts`: number of attempts to start the installation.
+async fn install(
+    client: BaseHTTPClient,
+    manager: &ManagerClient<'_>,
+    max_attempts: u8,
+) -> anyhow::Result<()> {
+    let scripts = ScriptsClient::new(client);
+    scripts.run_scripts(ScriptsGroup::Pre).await?;
+
     if manager.is_busy().await {
         println!("Agama's manager is busy. Waiting until it is ready...");
     }
@@ -209,7 +219,7 @@ pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
         Commands::Profile(subcommand) => run_profile_cmd(subcommand).await?,
         Commands::Install => {
             let manager = build_manager().await?;
-            install(&manager, 3).await?
+            install(client, &manager, 3).await?
         }
         Commands::Questions(subcommand) => run_questions_cmd(client, subcommand).await?,
         // TODO: logs command was originally designed with idea that agama's cli and agama

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -18,7 +18,6 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use agama_lib::scripts::{ScriptsClient, ScriptsGroup};
 use clap::{Args, Parser};
 
 mod auth;
@@ -93,17 +92,8 @@ async fn probe() -> anyhow::Result<()> {
 ///
 /// Before starting, it makes sure that the manager is idle.
 ///
-/// * `client`: base HTTP client.
 /// * `manager`: the manager client.
-/// * `max_attempts`: number of attempts to start the installation.
-async fn install(
-    client: BaseHTTPClient,
-    manager: &ManagerClient<'_>,
-    max_attempts: u8,
-) -> anyhow::Result<()> {
-    let scripts = ScriptsClient::new(client);
-    scripts.run_scripts(ScriptsGroup::Pre).await?;
-
+async fn install(manager: &ManagerClient<'_>, max_attempts: u8) -> anyhow::Result<()> {
     if manager.is_busy().await {
         println!("Agama's manager is busy. Waiting until it is ready...");
     }
@@ -219,7 +209,7 @@ pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
         Commands::Profile(subcommand) => run_profile_cmd(subcommand).await?,
         Commands::Install => {
             let manager = build_manager().await?;
-            install(client, &manager, 3).await?
+            install(&manager, 3).await?
         }
         Commands::Questions(subcommand) => run_questions_cmd(client, subcommand).await?,
         // TODO: logs command was originally designed with idea that agama's cli and agama

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -28,6 +28,7 @@ curl = { version = "0.4.47", features = ["protocol-ftp"] }
 jsonwebtoken = "9.3.0"
 chrono = { version = "0.4.38", default-features = false, features = ["now", "std", "alloc", "clock"] }
 home = "0.5.9"
+strum = { version = "0.26.3", features = ["derive"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -54,9 +54,7 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "id"
-            ],
+            "required": ["id"],
             "properties": {
               "id": {
                 "title": "Connection ID",
@@ -79,22 +77,12 @@
               "method4": {
                 "title": "IPv4 configuration method",
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "manual",
-                  "link-local",
-                  "disabled"
-                ]
+                "enum": ["auto", "manual", "link-local", "disabled"]
               },
               "method6": {
                 "title": "IPv6 configuration method",
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "manual",
-                  "link-local",
-                  "disabled"
-                ]
+                "enum": ["auto", "manual", "link-local", "disabled"]
               },
               "gateway4": {
                 "title": "Connection gateway address",
@@ -162,12 +150,7 @@
                   "mode": {
                     "title": "Wireless network mode",
                     "type": "string",
-                    "enum": [
-                      "infrastructure",
-                      "adhoc",
-                      "mesh",
-                      "ap"
-                    ]
+                    "enum": ["infrastructure", "adhoc", "mesh", "ap"]
                   },
                   "hidden": {
                     "title": "Indicates that the wireless network is not broadcasting its SSID",
@@ -176,15 +159,12 @@
                   "band": {
                     "title": "Frequency band of the wireless network",
                     "type": "string",
-                    "enum": [
-                      "a",
-                      "bg"
-                    ]
+                    "enum": ["a", "bg"]
                   },
                   "channel": {
                     "title": "Wireless channel of the wireless network",
                     "type": "integer",
-                    "minimum" : 0
+                    "minimum": 0
                   },
                   "bssid": {
                     "title": "Only allow connection to this mac address",
@@ -195,12 +175,7 @@
                     "items": {
                       "title": "A list of group/broadcast encryption algorithms",
                       "type": "string",
-                      "enum": [
-                        "wep40",
-                        "wep104",
-                        "tkip",
-                        "ccmp"
-                      ]
+                      "enum": ["wep40", "wep104", "tkip", "ccmp"]
                     }
                   },
                   "pairwiseAlgorithms": {
@@ -208,10 +183,7 @@
                     "items": {
                       "title": "A list of pairwise encryption algorithms",
                       "type": "string",
-                      "enum": [
-                        "tkip",
-                        "ccmp"
-                      ]
+                      "enum": ["tkip", "ccmp"]
                     }
                   },
                   "wpaProtocolVersions": {
@@ -219,10 +191,7 @@
                     "items": {
                       "title": "A list of allowed WPA protocol versions",
                       "type": "string",
-                      "enum": [
-                        "wpa",
-                        "rsn"
-                      ]
+                      "enum": ["wpa", "rsn"]
                     }
                   },
                   "pmf": {
@@ -369,10 +338,7 @@
                   "peapVersion": {
                     "title": "Which PEAP version is used when PEAP is set as the EAP method in the 'eap' property",
                     "type": "string",
-                    "enum": [
-                      "0",
-                      "1"
-                    ]
+                    "enum": ["0", "1"]
                   },
                   "peapLabel": {
                     "title": "Force the use of the new PEAP label during key derivation",
@@ -406,11 +372,7 @@
           "examples": ["nots3cr3t"]
         }
       },
-      "required": [
-        "fullName",
-        "userName",
-        "password"
-      ]
+      "required": ["fullName", "userName", "password"]
     },
     "root": {
       "title": "Root authentication settings",
@@ -906,7 +868,7 @@
                             "description": "Name of a disk device.",
                             "type": "string",
                             "examples": ["/dev/vda"]
-                            }
+                          }
                         }
                       },
                       {
@@ -967,6 +929,30 @@
       "items": {
         "type": "object"
       }
+    },
+    "scripts": {
+      "title": "User-defined installation scripts",
+      "description": "User-defined scripts to run at different points of the installation",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pre": {
+          "title": "Pre-installation scripts",
+          "description": "User-defined scripts to run before the installation starts",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/script"
+          }
+        },
+        "post": {
+          "title": "Post-installation scripts",
+          "description": "User-defined scripts to run after the installation finishes",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/script"
+          }
+        }
+      }
     }
   },
   "$defs": {
@@ -1013,7 +999,12 @@
           },
           "minItems": 1,
           "maxItems": 2,
-          "examples": [[1024, "current"], ["1 GiB", "5 GiB"], [1024, "2 GiB"], ["2 GiB"]]
+          "examples": [
+            [1024, "current"],
+            ["1 GiB", "5 GiB"],
+            [1024, "2 GiB"],
+            ["2 GiB"]
+          ]
         },
         {
           "title": "Size range",
@@ -1206,8 +1197,22 @@
         {
           "title": "File system type",
           "enum": [
-            "bcachefs", "btrfs", "exfat", "ext2", "ext3", "ext4", "f2fs", "jfs",
-            "nfs", "nilfs2", "ntfs", "reiserfs", "swap", "tmpfs", "vfat", "xfs"
+            "bcachefs",
+            "btrfs",
+            "exfat",
+            "ext2",
+            "ext3",
+            "ext4",
+            "f2fs",
+            "jfs",
+            "nfs",
+            "nilfs2",
+            "ntfs",
+            "reiserfs",
+            "swap",
+            "tmpfs",
+            "vfat",
+            "xfs"
           ]
         },
         {
@@ -1330,7 +1335,15 @@
               },
               "id": {
                 "title": "Partition ID",
-                "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "bios_boot"]
+                "enum": [
+                  "linux",
+                  "swap",
+                  "lvm",
+                  "raid",
+                  "esp",
+                  "prep",
+                  "bios_boot"
+                ]
               },
               "size": {
                 "title": "Partition size",
@@ -1394,6 +1407,28 @@
     "lvStripeSize": {
       "title": "Stripe size",
       "$ref": "#/$defs/sizeValue"
+    },
+    "script": {
+      "title": "User-defined installation script",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Script name, to be used as file name",
+          "type": "string"
+        },
+        "body": {
+          "title": "Script content",
+          "description": "Script content, starting with the shebang",
+          "type": "string"
+        },
+        "url": {
+          "title": "Script URL",
+          "description": "URL to fetch the script from"
+        }
+      },
+      "required": ["name"],
+      "oneOf": [{ "required": ["body"] }, { "required": ["url"] }]
     }
   }
 }

--- a/rust/agama-lib/src/install_settings.rs
+++ b/rust/agama-lib/src/install_settings.rs
@@ -23,7 +23,7 @@
 //! This module implements the mechanisms to load and store the installation settings.
 use crate::{
     localization::LocalizationSettings, network::NetworkSettings, product::ProductSettings,
-    software::SoftwareSettings, users::UserSettings,
+    scripts::ScriptsConfig, software::SoftwareSettings, users::UserSettings,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -55,6 +55,8 @@ pub struct InstallSettings {
     pub network: Option<NetworkSettings>,
     #[serde(default)]
     pub localization: Option<LocalizationSettings>,
+    #[serde(default)]
+    pub scripts: Option<ScriptsConfig>,
 }
 
 impl InstallSettings {

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -63,6 +63,7 @@ pub mod proxies;
 mod store;
 pub use store::Store;
 pub mod questions;
+pub mod scripts;
 pub mod transfer;
 use crate::error::ServiceError;
 use reqwest::{header, Client};

--- a/rust/agama-lib/src/scripts.rs
+++ b/rust/agama-lib/src/scripts.rs
@@ -26,7 +26,6 @@ mod model;
 mod settings;
 mod store;
 
-pub use client::ScriptsClient;
 pub use error::ScriptError;
 pub use model::*;
 pub use settings::*;

--- a/rust/agama-lib/src/scripts.rs
+++ b/rust/agama-lib/src/scripts.rs
@@ -18,17 +18,15 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-pub mod cert;
-pub mod dbus;
-pub mod error;
-pub mod l10n;
-pub mod logs;
-pub mod manager;
-pub mod network;
-pub mod questions;
-pub mod scripts;
-pub mod software;
-pub mod storage;
-pub mod users;
-pub mod web;
-pub use web::service;
+//! Implements support for handling the user-defined scripts.
+
+mod client;
+mod error;
+mod model;
+mod settings;
+mod store;
+
+pub use error::ScriptError;
+pub use model::*;
+pub use settings::*;
+pub use store::ScriptsStore;

--- a/rust/agama-lib/src/scripts.rs
+++ b/rust/agama-lib/src/scripts.rs
@@ -26,6 +26,7 @@ mod model;
 mod settings;
 mod store;
 
+pub use client::ScriptsClient;
 pub use error::ScriptError;
 pub use model::*;
 pub use settings::*;

--- a/rust/agama-lib/src/scripts/client.rs
+++ b/rust/agama-lib/src/scripts/client.rs
@@ -47,8 +47,7 @@ impl ScriptsClient {
     }
 
     pub async fn scripts(&self) -> Result<Vec<Script>, ServiceError> {
-        let scripts = self.client.get("/scripts").await?;
-        Ok(scripts)
+        self.client.get("/scripts").await
     }
 
     /// Remove all the user-defined scripts.

--- a/rust/agama-lib/src/scripts/client.rs
+++ b/rust/agama-lib/src/scripts/client.rs
@@ -46,6 +46,7 @@ impl ScriptsClient {
         self.client.post_void("/scripts/run", &group).await
     }
 
+    /// Returns the user-defined scripts.
     pub async fn scripts(&self) -> Result<Vec<Script>, ServiceError> {
         self.client.get("/scripts").await
     }

--- a/rust/agama-lib/src/scripts/client.rs
+++ b/rust/agama-lib/src/scripts/client.rs
@@ -1,0 +1,53 @@
+// Copyright (c) [2024] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use crate::{base_http_client::BaseHTTPClient, error::ServiceError};
+
+use super::{Script, ScriptsGroup};
+
+/// HTTP client to interact with scripts.
+pub struct ScriptsClient {
+    client: BaseHTTPClient,
+}
+
+impl ScriptsClient {
+    pub fn new(base: BaseHTTPClient) -> Self {
+        Self { client: base }
+    }
+
+    /// Adds a script to the given group.
+    ///
+    /// * `script`: script's definition.
+    pub async fn add_script(&self, script: &Script) -> Result<(), ServiceError> {
+        self.client.post_void("/scripts", &script).await
+    }
+
+    /// Runs user defined scripts of the given group.
+    ///
+    /// * `group`: group of the scripts to run
+    pub async fn run_scripts(&self, group: ScriptsGroup) -> Result<(), ServiceError> {
+        self.client.post_void("/scripts/run", &group).await
+    }
+
+    pub async fn scripts(&self) -> Result<Vec<Script>, ServiceError> {
+        let scripts = self.client.get("/scripts").await?;
+        Ok(scripts)
+    }
+}

--- a/rust/agama-lib/src/scripts/client.rs
+++ b/rust/agama-lib/src/scripts/client.rs
@@ -39,7 +39,7 @@ impl ScriptsClient {
         self.client.post_void("/scripts", &script).await
     }
 
-    /// Runs user defined scripts of the given group.
+    /// Runs user-defined scripts of the given group.
     ///
     /// * `group`: group of the scripts to run
     pub async fn run_scripts(&self, group: ScriptsGroup) -> Result<(), ServiceError> {
@@ -49,5 +49,10 @@ impl ScriptsClient {
     pub async fn scripts(&self) -> Result<Vec<Script>, ServiceError> {
         let scripts = self.client.get("/scripts").await?;
         Ok(scripts)
+    }
+
+    /// Remove all the user-defined scripts.
+    pub async fn delete_scripts(&self) -> Result<(), ServiceError> {
+        self.client.delete_void("/scripts").await
     }
 }

--- a/rust/agama-lib/src/scripts/error.rs
+++ b/rust/agama-lib/src/scripts/error.rs
@@ -18,17 +18,15 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-pub mod cert;
-pub mod dbus;
-pub mod error;
-pub mod l10n;
-pub mod logs;
-pub mod manager;
-pub mod network;
-pub mod questions;
-pub mod scripts;
-pub mod software;
-pub mod storage;
-pub mod users;
-pub mod web;
-pub use web::service;
+use std::io;
+use thiserror::Error;
+
+use crate::transfer::TransferError;
+
+#[derive(Error, Debug)]
+pub enum ScriptError {
+    #[error("Could not fetch the profile: '{0}'")]
+    Unreachable(#[from] TransferError),
+    #[error("I/O error: '{0}'")]
+    InputOutputError(#[from] io::Error),
+}

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -41,6 +41,7 @@ pub enum ScriptsGroup {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum ScriptSource {
     /// Script's body.
     Text { body: String },

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -136,7 +136,8 @@ impl ScriptsRepository {
 
     /// Runs the scripts in the given group.
     ///
-    /// They run in the order they were added to the repository.
+    /// They run in the order they were added to the repository. If does not return an error
+    /// if running a script fails, although it logs the problem.
     pub async fn run(&self, group: ScriptsGroup) -> Result<(), ScriptError> {
         let workdir = self.workdir.join(group.to_string());
         std::fs::create_dir_all(&workdir)?;

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -179,7 +179,9 @@ mod test {
 
         let script = Script {
             name: "test".to_string(),
-            source: ScriptSource::Text("".to_string()),
+            source: ScriptSource::Text {
+                body: "".to_string(),
+            },
             group: ScriptsGroup::Pre,
         };
         repo.add(script);
@@ -196,7 +198,7 @@ mod test {
 
         let script = Script {
             name: "test".to_string(),
-            source: ScriptSource::Text(body),
+            source: ScriptSource::Text { body },
             group: ScriptsGroup::Pre,
         };
         repo.add(script);

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -56,7 +56,7 @@ pub struct Script {
 impl Script {
     /// Runs the script and returns the output.
     ///
-    /// * `path`: where to write assets (script, logs and exit code).
+    /// * `workdir`: where to write assets (script, logs and exit code).
     pub async fn run(&self, workdir: &Path) -> Result<(), ScriptError> {
         let dir = workdir.join(self.group.to_string());
 

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -1,0 +1,209 @@
+// Copyright (c) [2024] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use std::{
+    fs,
+    io::Write,
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+    process,
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::transfer::Transfer;
+
+use super::ScriptError;
+
+#[derive(Debug, Clone, Copy, PartialEq, strum::Display, Serialize, Deserialize)]
+#[strum(serialize_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
+pub enum ScriptsGroup {
+    Pre,
+    Post,
+}
+
+/// Represents a script to run as part of the installation process.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Script {
+    /// Script's name.
+    pub name: String,
+    /// Script's body. Either the body or the URL must be specified.
+    pub body: Option<String>,
+    /// URL to get the script from. Either the body or the URL must be specified.
+    pub url: Option<String>,
+    /// Script's group
+    pub group: ScriptsGroup,
+}
+
+impl Script {
+    /// Runs the script and returns the output.
+    ///
+    /// * `path`: where to write assets (script, logs and exit code).
+    pub async fn run(&self, workdir: &Path) -> Result<(), ScriptError> {
+        let dir = workdir.join(self.group.to_string());
+
+        let path = dir.join(&self.name);
+        self.write(&path).await?;
+
+        let output = process::Command::new(&path).output()?;
+
+        let stdout_log = dir.join(format!("{}.log", &self.name));
+        fs::write(stdout_log, output.stdout)?;
+
+        let stderr_log = dir.join(format!("{}.err", &self.name));
+        fs::write(stderr_log, output.stderr)?;
+
+        let status_file = dir.join(format!("{}.out", &self.name));
+        fs::write(status_file, output.status.to_string())?;
+
+        Ok(())
+    }
+
+    /// Writes the script to the file system.
+    ///
+    /// * `path`: path to write the script to.
+    async fn write<P: AsRef<Path>>(&self, path: P) -> Result<(), ScriptError> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o500)
+            .open(&path)?;
+
+        if let Some(url) = &self.url {
+            Transfer::get(url, file)?;
+        } else if let Some(body) = &self.body {
+            write!(file, "{}", &body)?;
+        }
+        // FIXME: else: invalid script definition
+
+        Ok(())
+    }
+}
+
+/// Manages a set of installation scripts.
+///
+/// It offers an API to add and execute installation scripts.
+pub struct ScriptsRepository {
+    workdir: PathBuf,
+    pub scripts: Vec<Script>,
+}
+
+impl ScriptsRepository {
+    /// Builds a new repository.
+    ///
+    /// * `workdir`: directory to store the scripts.
+    pub fn new<P: AsRef<Path>>(workdir: P) -> ScriptsRepository {
+        ScriptsRepository {
+            workdir: PathBuf::from(workdir.as_ref()),
+            ..Default::default()
+        }
+    }
+
+    /// Adds a new script to the repository.
+    ///
+    /// * `script`: script to add.
+    pub fn add(&mut self, script: Script) {
+        self.scripts.push(script);
+    }
+
+    /// Removes all the scripts from the repository.
+    pub fn clear(&mut self) {
+        self.scripts.clear();
+    }
+
+    /// Runs the scripts in the given group.
+    ///
+    /// They run in the order they were added to the repository.
+    pub async fn run(&self, group: ScriptsGroup) -> Result<(), ScriptError> {
+        let workdir = self.workdir.join(group.to_string());
+        std::fs::create_dir_all(&workdir)?;
+        let scripts: Vec<_> = self.scripts.iter().filter(|s| s.group == group).collect();
+        for script in scripts {
+            script.run(&self.workdir).await?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for ScriptsRepository {
+    fn default() -> Self {
+        Self {
+            workdir: PathBuf::from("/run/agama/scripts"),
+            scripts: vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tempfile::TempDir;
+    use tokio::test;
+
+    use crate::scripts::Script;
+
+    use super::{ScriptsGroup, ScriptsRepository};
+
+    #[test]
+    async fn test_add_script() {
+        let tmp_dir = TempDir::with_prefix("scripts-").expect("a temporary directory");
+        let mut repo = ScriptsRepository::new(&tmp_dir);
+
+        let script = Script {
+            name: "test".to_string(),
+            body: Some("".to_string()),
+            url: None,
+            group: ScriptsGroup::Pre,
+        };
+        repo.add(script);
+
+        let script = repo.scripts.first().unwrap();
+        assert_eq!("test".to_string(), script.name);
+    }
+
+    #[test]
+    async fn test_run_scripts() {
+        let tmp_dir = TempDir::with_prefix("scripts-").expect("a temporary directory");
+        let mut repo = ScriptsRepository::new(&tmp_dir);
+        let body = "#!/bin/bash\necho hello\necho error >&2".to_string();
+
+        let script = Script {
+            name: "test".to_string(),
+            body: Some(body),
+            url: None,
+            group: ScriptsGroup::Pre,
+        };
+        repo.add(script);
+        repo.run(ScriptsGroup::Pre).await.unwrap();
+
+        repo.scripts.first().unwrap();
+
+        let path = &tmp_dir.path().join("pre").join("test.log");
+        let body: Vec<u8> = std::fs::read(&path).unwrap();
+        let body = String::from_utf8(body).unwrap();
+        assert_eq!("hello\n", body);
+
+        let path = &tmp_dir.path().join("pre").join("test.err");
+        let body: Vec<u8> = std::fs::read(&path).unwrap();
+        let body = String::from_utf8(body).unwrap();
+        assert_eq!("error\n", body);
+    }
+}

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -138,7 +138,13 @@ impl ScriptsRepository {
         std::fs::create_dir_all(&workdir)?;
         let scripts: Vec<_> = self.scripts.iter().filter(|s| s.group == group).collect();
         for script in scripts {
-            script.run(&self.workdir).await?;
+            if let Err(error) = script.run(&self.workdir).await {
+                log::error!(
+                    "Failed to run user-defined script '{}': {:?}",
+                    &script.name,
+                    error
+                );
+            }
         }
         Ok(())
     }

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -20,6 +20,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::ScriptSource;
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScriptsConfig {
@@ -36,10 +38,7 @@ pub struct ScriptsConfig {
 pub struct ScriptConfig {
     /// Script's name.
     pub name: String,
-    /// Script's body. Either the body or the URL must be specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
-    /// URL to get the script from. Either the body or the URL must be specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    /// Script's source
+    #[serde(flatten)]
+    pub source: ScriptSource,
 }

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -18,17 +18,23 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-pub mod cert;
-pub mod dbus;
-pub mod error;
-pub mod l10n;
-pub mod logs;
-pub mod manager;
-pub mod network;
-pub mod questions;
-pub mod scripts;
-pub mod software;
-pub mod storage;
-pub mod users;
-pub mod web;
-pub use web::service;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScriptsConfig {
+    pub pre: Vec<ScriptConfig>,
+    pub post: Vec<ScriptConfig>,
+}
+
+// FIXME: it is just the same than ScriptConfig.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScriptConfig {
+    /// Script's name.
+    pub name: String,
+    /// Script's body. Either the body or the URL must be specified.
+    pub body: Option<String>,
+    /// URL to get the script from. Either the body or the URL must be specified.
+    pub url: Option<String>,
+}

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -20,7 +20,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::ScriptSource;
+use super::{Script, ScriptSource};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -23,18 +23,23 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScriptsConfig {
+    /// User-defined pre-installation scripts
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pre: Vec<ScriptConfig>,
+    /// User-defined post-installation scripts
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub post: Vec<ScriptConfig>,
 }
 
-// FIXME: it is just the same than ScriptConfig.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScriptConfig {
     /// Script's name.
     pub name: String,
     /// Script's body. Either the body or the URL must be specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
     /// URL to get the script from. Either the body or the URL must be specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -42,3 +42,12 @@ pub struct ScriptConfig {
     #[serde(flatten)]
     pub source: ScriptSource,
 }
+
+impl From<&Script> for ScriptConfig {
+    fn from(value: &Script) -> Self {
+        ScriptConfig {
+            name: value.name.clone(),
+            source: value.source.clone(),
+        }
+    }
+}

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -48,6 +48,8 @@ impl ScriptsStore {
     }
 
     pub async fn store(&self, settings: &ScriptsConfig) -> Result<(), ServiceError> {
+        self.client.delete_scripts().await?;
+
         for pre in &settings.pre {
             self.client
                 .add_script(&Self::to_script(pre, ScriptsGroup::Pre))

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -57,6 +57,8 @@ impl ScriptsStore {
                 .await?;
         }
 
+        self.client.run_scripts(ScriptsGroup::Pre).await?;
+
         Ok(())
     }
 

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -61,8 +61,6 @@ impl ScriptsStore {
                 .await?;
         }
 
-        self.client.run_scripts(ScriptsGroup::Pre).await?;
-
         Ok(())
     }
 

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -33,10 +33,6 @@ impl ScriptsStore {
         }
     }
 
-    pub fn new_with_client(client: ScriptsClient) -> Result<Self, ServiceError> {
-        Ok(Self { client })
-    }
-
     pub async fn load(&self) -> Result<ScriptsConfig, ServiceError> {
         let scripts = self.client.scripts().await?;
 

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -78,14 +78,7 @@ impl ScriptsStore {
         scripts
             .iter()
             .filter(|s| s.group == group)
-            .map(Self::to_script_config)
+            .map(|s| s.into())
             .collect()
-    }
-
-    fn to_script_config(script: &Script) -> ScriptConfig {
-        ScriptConfig {
-            name: script.name.clone(),
-            source: script.source.clone(),
-        }
     }
 }

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -1,0 +1,92 @@
+// Copyright (c) [2024] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use crate::{base_http_client::BaseHTTPClient, error::ServiceError};
+
+use super::{client::ScriptsClient, settings::ScriptsConfig, Script, ScriptConfig, ScriptsGroup};
+
+pub struct ScriptsStore {
+    client: ScriptsClient,
+}
+
+impl ScriptsStore {
+    pub fn new(client: BaseHTTPClient) -> Self {
+        Self {
+            client: ScriptsClient::new(client),
+        }
+    }
+
+    pub fn new_with_client(client: ScriptsClient) -> Result<Self, ServiceError> {
+        Ok(Self { client })
+    }
+
+    pub async fn load(&self) -> Result<ScriptsConfig, ServiceError> {
+        // TODO: Ok(self.client.scripts().await.unwrap())
+        let scripts = self.client.scripts().await?;
+
+        Ok(ScriptsConfig {
+            pre: Self::to_script_configs(&scripts, ScriptsGroup::Pre),
+            post: Self::to_script_configs(&scripts, ScriptsGroup::Post),
+        })
+    }
+
+    pub async fn store(&self, settings: &ScriptsConfig) -> Result<(), ServiceError> {
+        for pre in &settings.pre {
+            self.client
+                .add_script(&Self::to_script(pre, ScriptsGroup::Pre))
+                .await?;
+        }
+
+        for post in &settings.post {
+            self.client
+                .add_script(&Self::to_script(post, ScriptsGroup::Post))
+                .await?;
+        }
+
+        self.client.run_scripts(ScriptsGroup::Pre).await?;
+
+        Ok(())
+    }
+
+    fn to_script(config: &ScriptConfig, group: ScriptsGroup) -> Script {
+        Script {
+            name: config.name.clone(),
+            url: config.url.clone(),
+            body: config.body.clone(),
+            group,
+        }
+    }
+
+    fn to_script_configs(scripts: &[Script], group: ScriptsGroup) -> Vec<ScriptConfig> {
+        scripts
+            .iter()
+            .filter(|s| s.group == group)
+            .map(Self::to_script_config)
+            .collect()
+    }
+
+    fn to_script_config(script: &Script) -> ScriptConfig {
+        ScriptConfig {
+            name: script.name.clone(),
+            url: script.url.clone(),
+            body: script.body.clone(),
+        }
+    }
+}

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -57,6 +57,7 @@ impl ScriptsStore {
                 .await?;
         }
 
+        // TODO: find a better play to run the scripts (before probing).
         self.client.run_scripts(ScriptsGroup::Pre).await?;
 
         Ok(())

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -38,7 +38,6 @@ impl ScriptsStore {
     }
 
     pub async fn load(&self) -> Result<ScriptsConfig, ServiceError> {
-        // TODO: Ok(self.client.scripts().await.unwrap())
         let scripts = self.client.scripts().await?;
 
         Ok(ScriptsConfig {
@@ -70,8 +69,7 @@ impl ScriptsStore {
     fn to_script(config: &ScriptConfig, group: ScriptsGroup) -> Script {
         Script {
             name: config.name.clone(),
-            url: config.url.clone(),
-            body: config.body.clone(),
+            source: config.source.clone(),
             group,
         }
     }
@@ -87,8 +85,7 @@ impl ScriptsStore {
     fn to_script_config(script: &Script) -> ScriptConfig {
         ScriptConfig {
             name: script.name.clone(),
-            url: script.url.clone(),
-            body: script.body.clone(),
+            source: script.source.clone(),
         }
     }
 }

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -83,13 +83,13 @@ impl Store {
         if let Some(network) = &settings.network {
             self.network.store(network).await?;
         }
+        if let Some(scripts) = &settings.scripts {
+            self.scripts.store(scripts).await?;
+        }
         // order is important here as network can be critical for connection
         // to registration server and selecting product is important for rest
         if let Some(product) = &settings.product {
             self.product.store(product).await?;
-        }
-        if let Some(scripts) = &settings.scripts {
-            self.scripts.store(scripts).await?;
         }
         // ordering: localization after product as some product may miss some locales
         if let Some(localization) = &settings.localization {

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -26,7 +26,7 @@ use crate::error::ServiceError;
 use crate::install_settings::InstallSettings;
 use crate::{
     localization::LocalizationStore, network::NetworkStore, product::ProductStore,
-    software::SoftwareStore, storage::StorageStore, users::UsersStore,
+    scripts::ScriptsStore, software::SoftwareStore, storage::StorageStore, users::UsersStore,
 };
 
 /// Struct that loads/stores the settings from/to the D-Bus services.
@@ -42,6 +42,7 @@ pub struct Store {
     software: SoftwareStore,
     storage: StorageStore,
     localization: LocalizationStore,
+    scripts: ScriptsStore,
 }
 
 impl Store {
@@ -53,6 +54,7 @@ impl Store {
             product: ProductStore::new(http_client.clone())?,
             software: SoftwareStore::new(http_client.clone())?,
             storage: StorageStore::new(http_client.clone())?,
+            scripts: ScriptsStore::new(http_client),
         })
     }
 
@@ -64,6 +66,7 @@ impl Store {
             user: Some(self.users.load().await?),
             product: Some(self.product.load().await?),
             localization: Some(self.localization.load().await?),
+            scripts: Some(self.scripts.load().await?),
             ..Default::default()
         };
 
@@ -85,6 +88,9 @@ impl Store {
         if let Some(product) = &settings.product {
             self.product.store(product).await?;
         }
+        if let Some(scripts) = &settings.scripts {
+            self.scripts.store(scripts).await?;
+        }
         // ordering: localization after product as some product may miss some locales
         if let Some(localization) = &settings.localization {
             self.localization.store(localization).await?;
@@ -98,6 +104,7 @@ impl Store {
         if settings.storage.is_some() || settings.storage_autoyast.is_some() {
             self.storage.store(&settings.into()).await?
         }
+
         Ok(())
     }
 }

--- a/rust/agama-server/src/scripts.rs
+++ b/rust/agama-server/src/scripts.rs
@@ -18,17 +18,4 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-pub mod cert;
-pub mod dbus;
-pub mod error;
-pub mod l10n;
-pub mod logs;
-pub mod manager;
-pub mod network;
-pub mod questions;
-pub mod scripts;
-pub mod software;
-pub mod storage;
-pub mod users;
 pub mod web;
-pub use web::service;

--- a/rust/agama-server/src/scripts/web.rs
+++ b/rust/agama-server/src/scripts/web.rs
@@ -1,0 +1,137 @@
+// Copyright (c) [2024] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use std::sync::Arc;
+
+use agama_lib::{
+    error::ServiceError,
+    scripts::{Script, ScriptError, ScriptsGroup, ScriptsRepository},
+};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use thiserror::Error;
+use tokio::sync::RwLock;
+
+#[derive(Clone, Default)]
+struct ScriptsState {
+    scripts: Arc<RwLock<ScriptsRepository>>,
+}
+
+#[derive(Error, Debug)]
+#[error("Script error: {0}")]
+struct ScriptServiceError(#[from] ScriptError);
+
+impl IntoResponse for ScriptServiceError {
+    fn into_response(self) -> Response {
+        let body = json!({
+            "error": self.to_string()
+        });
+        (StatusCode::BAD_REQUEST, Json(body)).into_response()
+    }
+}
+
+/// Sets up and returns the axum service for the auto-installation scripts.
+pub async fn scripts_service() -> Result<Router, ServiceError> {
+    let state = ScriptsState::default();
+    let router = Router::new()
+        .route(
+            "/",
+            get(list_scripts).post(add_script).delete(remove_scripts),
+        )
+        .route("/run", post(run_scripts))
+        .with_state(state);
+    Ok(router)
+}
+
+#[utoipa::path(
+    post,
+    path = "/",
+    context_path = "/api/scripts",
+    request_body(content = ScriptConfig, description = "Script definition"),
+    responses(
+        (status = 200, description = "The script was added.")
+    )
+)]
+async fn add_script(
+    state: State<ScriptsState>,
+    Json(script): Json<Script>,
+) -> Result<impl IntoResponse, ScriptServiceError> {
+    let mut scripts = state.scripts.write().await;
+    scripts.add(script);
+    Ok(())
+}
+
+#[utoipa::path(
+    get,
+    path = "/",
+    context_path = "/api/scripts",
+    responses(
+        (status = 200, description = "Defined scripts.")
+    )
+)]
+async fn list_scripts(state: State<ScriptsState>) -> Json<Vec<Script>> {
+    let repo = state.scripts.read().await;
+    Json(repo.scripts.to_vec())
+}
+
+#[utoipa::path(
+    delete,
+    path = "/",
+    context_path = "/api/scripts",
+    responses(
+        (status = 200, description = "The scripts have been removed.")
+    )
+)]
+async fn remove_scripts(
+    state: State<ScriptsState>,
+) -> Result<impl IntoResponse, ScriptServiceError> {
+    let mut scripts = state.scripts.write().await;
+    scripts.clear();
+    Ok(())
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct RunScriptParams {
+    group: ScriptsGroup,
+}
+
+#[utoipa::path(
+    post,
+    path = "/run",
+    context_path = "/api/scripts",
+    responses(
+        (status = 200, description = "The scripts were successfully executed.")
+    )
+)]
+async fn run_scripts(
+    state: State<ScriptsState>,
+    Json(group): Json<ScriptsGroup>,
+) -> Result<(), ScriptServiceError> {
+    let scripts = state.scripts.write().await;
+    scripts.run(group).await?;
+    Ok(())
+}

--- a/rust/agama-server/src/scripts/web.rs
+++ b/rust/agama-server/src/scripts/web.rs
@@ -132,6 +132,8 @@ async fn run_scripts(
     Json(group): Json<ScriptsGroup>,
 ) -> Result<(), ScriptServiceError> {
     let scripts = state.scripts.write().await;
-    scripts.run(group).await?;
+    if let Err(error) = scripts.run(group).await {
+        tracing::error!("Could not run user-defined scripts: {error}");
+    }
     Ok(())
 }

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -30,6 +30,7 @@ use crate::{
     manager::web::{manager_service, manager_stream},
     network::{web::network_service, NetworkManagerAdapter},
     questions::web::{questions_service, questions_stream},
+    scripts::web::scripts_service,
     software::web::{software_service, software_streams},
     storage::web::{storage_service, storage_streams},
     users::web::{users_service, users_streams},
@@ -82,6 +83,7 @@ where
         .add_service("/network", network_service(network_adapter, events).await?)
         .add_service("/questions", questions_service(dbus.clone()).await?)
         .add_service("/users", users_service(dbus.clone()).await?)
+        .add_service("/scripts", scripts_service().await?)
         .with_config(config)
         .build();
     Ok(router)

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 16 15:07:33 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for running user-defined scripts before and after the
+  installation (gh#agama-project/agama#1673).
+
+-------------------------------------------------------------------
 Wed Oct 16 07:55:27 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - Implemented option for providing remote API address for the CLI

--- a/service/lib/agama/http.rb
+++ b/service/lib/agama/http.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  # Namespace for HTTP-related code
+  module HTTP
+  end
+end
+
+require "agama/http/clients"

--- a/service/lib/agama/http/clients.rb
+++ b/service/lib/agama/http/clients.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module HTTP
+    # Namespace for HTTP clients
+    module Clients
+    end
+  end
+end
+
+require "agama/http/clients/scripts"

--- a/service/lib/agama/http/clients/scripts.rb
+++ b/service/lib/agama/http/clients/scripts.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "uri"
+require "net/http"
+
+module Agama
+  module HTTP
+    module Clients
+      # HTTP client to interact with the scripts API.
+      class Scripts
+        def initialize
+          @base_url = "http://localhost/api"
+        end
+
+        # Runs the scripts
+        def run(group)
+          Net::HTTP.post(uri("/api/scripts/run"), group, headers)
+        end
+
+      private
+
+        def uri(path)
+          URI.join(@base_url, path)
+        end
+
+        def headers
+          @headers = {
+            Accept:        "application/json",
+            Authorization: "Bearer #{auth_token}"
+          }
+        end
+
+        def auth_token
+          File.read("/run/agama/token")
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/http/clients/scripts.rb
+++ b/service/lib/agama/http/clients/scripts.rb
@@ -21,6 +21,7 @@
 
 require "uri"
 require "net/http"
+require "json"
 
 module Agama
   module HTTP
@@ -28,12 +29,12 @@ module Agama
       # HTTP client to interact with the scripts API.
       class Scripts
         def initialize
-          @base_url = "http://localhost/api"
+          @base_url = "http://localhost/api/"
         end
 
         # Runs the scripts
         def run(group)
-          Net::HTTP.post(uri("/api/scripts/run"), group, headers)
+          Net::HTTP.post(uri("scripts/run"), group.to_json, headers)
         end
 
       private
@@ -44,8 +45,8 @@ module Agama
 
         def headers
           @headers = {
-            Accept:        "application/json",
-            Authorization: "Bearer #{auth_token}"
+            "Content-Type": "application/json",
+            Authorization:  "Bearer #{auth_token}"
           }
         end
 

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -209,12 +209,27 @@ module Agama
 
       # Step to copy the installation logs
       class CopyLogsStep < Step
+        SCRIPTS_DIR = "/run/agama/scripts"
+
         def label
           "Copying logs"
         end
 
         def run
           wfm_write("copy_logs_finish")
+          copy_agama_scripts
+        end
+
+      private
+
+        def copy_agama_scripts
+          return unless Dir.exist?(SCRIPTS_DIR)
+
+          Yast.import "Installation"
+          require "fileutils"
+          logs_dir = File.join(Yast::Installation.destdir, "var", "log", "agama")
+          FileUtils.mkdir_p(logs_dir)
+          FileUtils.cp_r(SCRIPTS_DIR, logs_dir)
         end
       end
 

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -80,6 +80,7 @@ module Agama
           IguanaStep.new(logger),
           SnapshotsStep.new(logger),
           CopyLogsStep.new(logger),
+          PostScripts.new(logger),
           UnmountStep.new(logger)
         ]
       end
@@ -214,6 +215,19 @@ module Agama
 
         def run
           wfm_write("copy_logs_finish")
+        end
+      end
+
+      # Executes post-installation scripts
+      class PostScripts < Step
+        def label
+          "Running user-defined scripts"
+        end
+
+        def run
+          require "agama/http"
+          client = Agama::HTTP::Clients::Scripts.new
+          client.run("post")
         end
       end
 

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -227,7 +227,7 @@ module Agama
 
           Yast.import "Installation"
           require "fileutils"
-          logs_dir = File.join(Yast::Installation.destdir, "var", "log", "agama")
+          logs_dir = File.join(Yast::Installation.destdir, "var", "log", "agama-installation")
           FileUtils.mkdir_p(logs_dir)
           FileUtils.cp_r(SCRIPTS_DIR, logs_dir)
         end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 16 15:09:31 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for running user-defined scripts after the
+  installation (gh#agama-project/agama#1673).
+
+-------------------------------------------------------------------
 Mon Oct 14 14:52:26 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed shell injection vulnerability in the internal API

--- a/service/test/agama/http/clients/scripts_test.rb
+++ b/service/test/agama/http/clients/scripts_test.rb
@@ -33,9 +33,9 @@ describe Agama::HTTP::Clients::Scripts do
   describe "#run" do
     it "calls the end-point to run the scripts" do
       url = URI("http://localhost/api/scripts/run")
-      expect(Net::HTTP).to receive(:post).with(url, "post", {
-        Accept:        "application/json",
-        Authorization: "Bearer 123456"
+      expect(Net::HTTP).to receive(:post).with(url, "post".to_json, {
+        "Content-Type": "application/json",
+        Authorization:  "Bearer 123456"
       })
       scripts.run("post")
     end

--- a/service/test/agama/http/clients/scripts_test.rb
+++ b/service/test/agama/http/clients/scripts_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "agama/http/clients/scripts"
+
+describe Agama::HTTP::Clients::Scripts do
+  subject(:scripts) { described_class.new }
+
+  before do
+    allow(File).to receive(:read).with("/run/agama/token")
+      .and_return("123456")
+  end
+
+  describe "#run" do
+    it "calls the end-point to run the scripts" do
+      url = URI("http://localhost/api/scripts/run")
+      expect(Net::HTTP).to receive(:post).with(url, "post", {
+        Accept:        "application/json",
+        Authorization: "Bearer 123456"
+      })
+      scripts.run("post")
+    end
+  end
+end

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -350,7 +350,8 @@ describe Agama::Storage::Manager do
 
       it "copies the artifacts to the installed system" do
         storage.finish
-        expect(File).to exist(File.join(tmp_dir, "mnt", "var", "log", "agama", "scripts"))
+        expect(File).to exist(File.join(tmp_dir, "mnt", "var", "log", "agama-installation",
+          "scripts"))
       end
     end
 


### PR DESCRIPTION
This is the first implementation of pre/post-installation scripts. They are not as capable as their AutoYaST counterparts, but the idea is to evolve them in the future.

## Specifying a script

> [!WARNING]
> JSON does not support multiline values (a.k.a. blocks) but Jsonnet does it. Perhaps we should consider using Jsonnet in the `agama config edit` command.

```jsonnet
{
  scripts: {
    pre: [
      {
         name: "say-hi",
         body: |||
           #!/bin/bash
           echo "before starting the installation"
         |||
      }
    ]
  }
}
```

> [!NOTE]
> What about having a plain list where each script has a `type` (or `group`) like `pre`, `post`, etc.?

## When scripts get executed

* Pre-scripts: when loading a profile. We plan to do [some improvements](https://trello.com/c/PiOGzXSn/584-agama-running-pre-scripts-in-the-right-place) to support the single-product case properly.
* Post-scripts: after the installation.

## Implementation details

The scripting support is written in Rust and does not use the YaST scripts code anymore. We will rewrite the Manager in Rust (at least the Agama-specific part) in the future, and the scripting support will be part of that.

## Future

Agama scripts will gain additional features soon:

* Running in a `chroot`.
* Better error handling if the shebang line is not present.
* Running after the first boot.

## Pending tasks

- [x] Extend the JSON schema
- [x] Copy the resulting files to the installed system
- [x] Add some logging
- [x] Clean-up the old scripts when reloading a profile

