### PR TITLE
Create slowroll.yaml

### DIFF
--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -7,7 +7,7 @@ description: 'A slightly slower rolling release of openSUSE designed to update
   less often than Tumbleweed but more often than Leap without forcing users to
   choose between "stable" and newer packages'
 icon: Slowroll.svg
-# Again, currently no translations at this time.
+# Do not manually change any translations! See README.md for more details.
 translations:
   description:
     ca:

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -1,7 +1,9 @@
 id: Slowroll
 name: Slowroll
 # ------------------------------------------------------------------------------
-# WARNING: There are currently no translations at this time!
+# WARNING: When changing the product description delete the translations located
+# at the at translations/description key below to avoid using obsolete
+# translations!!
 # ------------------------------------------------------------------------------
 description: 'A slightly slower rolling release of openSUSE designed to update
   less often than Tumbleweed but more often than Leap without forcing users to
@@ -9,29 +11,15 @@ description: 'A slightly slower rolling release of openSUSE designed to update
 icon: Slowroll.svg
 # Do not manually change any translations! See README.md for more details.
 translations:
-  description:
-    ca:
-    cs:
-    de:
-    es:
-    fr:
-    id:
-    ja:
-    nb_NO:
-    pt_BR:
-    ru:
-    sv:
-    tr:
-    zh_Hans:
 software:
-  installation_repositories: # was only able to find x86_64 at the time of writing
+  installation_repositories:
     - url: https://download.opensuse.org/slowroll/repo/oss/
       archs: x86_64
     - url: https://download.opensuse.org/slowroll/repo/non-oss/
       archs: x86_64
 
   mandatory_patterns:
-    - enhanced_base # seems to be a consistant pattern between all openSUSE versions
+    - enhanced_base
   optional_patterns: null
   user_patterns:
     - basic-desktop
@@ -82,9 +70,21 @@ storage:
           # Unified var subvolume - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html
           - path: var
             copy_on_write: false
-          # Architecture specific subvolumes (didnt see anything other than x86_64)
+          # Architecture specific subvolumes
+         - path: boot/grub2/arm64-efi
+            archs: aarch64
+          - path: boot/grub2/arm-efi
+            archs: arm
+          - path: boot/grub2/i386-pc
+            archs: x86_64
+          - path: boot/grub2/powerpc-ieee1275
+            archs: ppc,!board_powernv
+          - path: boot/grub2/s390x-emu
+            archs: s390
           - path: boot/grub2/x86_64-efi
             archs: x86_64
+          - path: boot/grub2/riscv64-efi
+            archs: riscv64
       size:
         auto: true
       outline:
@@ -140,4 +140,4 @@ storage:
           - ext3
           - ext4
           - xfs
-  
+          - vfat

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -1,0 +1,143 @@
+id: Slowroll
+name: Slowroll
+# ------------------------------------------------------------------------------
+# WARNING: There are currently no translations at this time!
+# ------------------------------------------------------------------------------
+description: 'A slightly slower rolling release of openSUSE designed to update
+  less often than Tumbleweed but more often than Leap without forcing users to
+  choose between "stable" and newer packages'
+icon: Slowroll.svg
+# Again, currently no translations at this time.
+translations:
+  description:
+    ca:
+    cs:
+    de:
+    es:
+    fr:
+    id:
+    ja:
+    nb_NO:
+    pt_BR:
+    ru:
+    sv:
+    tr:
+    zh_Hans:
+software:
+  installation_repositories: # was only able to find x86_64 at the time of writing
+    - url: https://download.opensuse.org/slowroll/repo/oss/
+      archs: x86_64
+    - url: https://download.opensuse.org/slowroll/repo/non-oss/
+      archs: x86_64
+
+  mandatory_patterns:
+    - enhanced_base # seems to be a consistant pattern between all openSUSE versions
+  optional_patterns: null
+  user_patterns:
+    - basic-desktop
+    - gnome
+    - kde
+    - yast2_basis
+    - yast2_desktop
+    - yast2_server
+    - multimedia
+    - office
+  mandatory_packages:
+    - NetworkManager
+    - openSUSE-repos-Slowroll
+  optional_packages: null
+  base_product: openSUSE
+
+security:
+  lsm: apparmor
+  available_lsms:
+    apparmor:
+      patterns:
+        - apparmor
+    selinux:
+      patterns:
+        - selinux
+      policy: enforcing
+    none:
+      patterns: null
+
+storage:
+  space_policy: delete
+  volumes:
+    - "/"
+    - "swap"
+  volume_templates:
+    - mount_path: "/"
+      filesystem: btrfs
+      btrfs:
+        snapshots: true
+        read_only: false
+        default_subvolume: "0"
+        subvolumes:
+          - path: home
+          - path: opt
+          - path: root
+          - path: srv
+          - path: usr/local
+          # Unified var subvolume - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html
+          - path: var
+            copy_on_write: false
+          # Architecture specific subvolumes (didnt see anything other than x86_64)
+          - path: boot/grub2/x86_64-efi
+            archs: x86_64
+      size:
+        auto: true
+      outline:
+        required: true
+        filesystems:
+          - btrfs
+          - ext2
+          - ext3
+          - ext4
+          - xfs
+        auto_size:
+          base_min: 5 GiB
+          base_max: 15 GiB
+          snapshots_increment: 250%
+          max_fallback_for:
+            - "/home"
+        snapshots_configurable: true
+    - mount_path: "swap"
+      filesystem: swap
+      size:
+        auto: true
+      outline:
+        auto_size:
+          base_min: 1 GiB
+          base_max: 2 GiB
+          adjust_by_ram: true
+        required: false
+        filesystems:
+          - swap
+    - mount_path: "/home"
+      filesystem: xfs
+      size:
+        auto: false
+        min: 10 GiB
+        max: unlimited
+      outline:
+        required: false
+        filesystems:
+          - btrfs
+          - ext2
+          - ext3
+          - ext4
+          - xfs
+    - filesystem: xfs
+      size:
+        auto: false
+        min: 1 GiB
+      outline:
+        required: false
+        filesystems:
+          - btrfs
+          - ext2
+          - ext3
+          - ext4
+          - xfs
+  


### PR DESCRIPTION
Slowroll.yaml is almost indentical to leap_160.yaml and tumbleweed.yaml but will eventually give users the option to install slowroll through agama. was unable to provide translations since i only speak english and i am unsure if there other arch's for slowroll besides x86_64

Slowroll is currently the only option not available to install via agama that (i believe) is not planning on using something different (like Aeon, Kalpa and Leap Micro)