### PR TITLE
fix(rust): fix BaseHTTPClient doc tests

### DIFF
--- a/rust/agama-lib/src/base_http_client.rs
+++ b/rust/agama-lib/src/base_http_client.rs
@@ -36,7 +36,7 @@ use crate::{auth::AuthToken, error::ServiceError};
 ///   use agama_lib::error::ServiceError;
 ///
 ///   async fn get_questions() -> Result<Vec<Question>, ServiceError> {
-///     let client = BaseHTTPClient::new()?;
+///     let client = BaseHTTPClient::default();
 ///     client.get("/questions").await
 ///   }
 /// ```


### PR DESCRIPTION
## Problem

Agama is failing to build in OBS because the tests are failing.

## Solution

After the latest changes in the `BaseHTTPClient` API, the doctests were not adapted. This PR fixes
the problem.
