### PR TITLE
Fixed typo in the SLES product name (bsc#1231663)

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct 17 08:16:42 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed typo in the SLES product name (bsc#1231663)
+
+-------------------------------------------------------------------
 Tue Sep 24 09:30:26 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update products translations (gh#openSUSE/agama#1607).

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -1,5 +1,5 @@
 id: SLES_16.0
-name: SUSE Linux Enteprise Server 16.0 Alpha
+name: SUSE Linux Enterprise Server 16.0 Alpha
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located
 # at the at translations/description key below to avoid using obsolete


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1231663
- A typo in the product name

## Solution

- The typo is fixed