### PR TITLE
Separate common files from service rubygem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,6 +63,32 @@ def live_iso?
   mount_out.match?(/^\w+ on \/ type overlay/) || mount_out.match?(/^\/dev\/mapper\/live-rw on \/ /)
 end
 
+def package_translations
+  # build the translations tarball
+  #
+  # NOTE: the following code was inspired by the
+  # packaging_rake_tasks/lib/tasks/tarball.rake file
+  #
+  # set the file time stamps according to the latest commit
+  mtime = `git show -s --format=%ci`.chomp
+  # For the reproducible output:
+  # - use the GNU format (the default POSIX format contains some time stamps)
+  # - sort the files (in a locale independent way)
+  # - set the owner and group to "root"
+  # - set the fixed modification time
+  sh("LC_ALL=C tar -c -j -f #{Shellwords.escape(package_dir)}/po.tar.bz2 --format=gnu --sort=name " \
+     "--owner=root --group=root --mtime=#{Shellwords.escape(mtime)} po/*.po")
+end
+
+def package_agama_yast_spec(gem_filename)
+  # "/foo/agama/service/agama-yast-10.devel201.gem" -> "10.devel201"
+  version = gem_filename.sub(/\.gem$/, "").sub(/.*-/, "")
+
+  spec_text = File.read("agama-yast.spec.in")
+  spec_text.gsub!("@VERSION@", version)
+  File.write(File.join(package_dir, "agama-yast.spec"), spec_text)
+end
+
 Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.opensuse.org"
   conf.obs_project = ENV["OBS_PROJECT"] || "systemsmanagement:Agama:Devel"
@@ -111,20 +137,9 @@ task package: [] do
     sh "gem2rpm --local --config #{gem2rpm} --template opensuse #{gem} > package/#{package_name}.spec"
     FileUtils.mv(gem, package_dir)
 
-    # build the translations tarball
-    #
-    # NOTE: the following code was inspired by the
-    # packaging_rake_tasks/lib/tasks/tarball.rake file
-    #
-    # set the file time stamps according to the latest commit
-    mtime = `git show -s --format=%ci`.chomp
-    # For the reproducible output:
-    # - use the GNU format (the default POSIX format contains some time stamps)
-    # - sort the files (in a locale independent way)
-    # - set the owner and group to "root"
-    # - set the fixed modification time
-    sh("LC_ALL=C tar -c -j -f #{Shellwords.escape(package_dir)}/po.tar.bz2 --format=gnu --sort=name " \
-      "--owner=root --group=root --mtime=#{Shellwords.escape(mtime)} po/*.po")
+    package_agama_yast_spec(gem)
+
+    package_translations
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -99,7 +99,7 @@ if ENV["SKIP_OSC_BUILD"] == "1"
 end
 
 # TODO: redefine :tarball instead of :package
-desc "Prepare sources for rpm build"
+desc "Prepare sources for rpm build. Invoke from service/"
 task package: [] do
   Dir.chdir(Rake.original_dir) do |dir|
     old_gems = Dir.glob(File.join(package_dir, "*.gem"))

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -137,6 +137,7 @@
         <package name="libpwquality-tools"/>
         <package name="NetworkManager"/>
         <package name="agama"/>
+        <package name="agama-yast"/>
         <package name="agama-web-ui"/>
         <package name="agama-cli"/>
         <package name="agama-auto"/>

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -1,6 +1,6 @@
 *.gem
 # the spec file is generated
-/package/*.spec
+/package/rubygem*.spec
 *.rbc
 /.config
 /coverage/

--- a/service/agama-yast.spec.in
+++ b/service/agama-yast.spec.in
@@ -17,7 +17,7 @@
 
 
 Name:           agama-yast
-Version:        10.devel54
+Version:        @VERSION@
 Release:        0
 %define mod_name agama-yast
 %define mod_full_name %{mod_name}-%{version}

--- a/service/agama-yast.spec.in
+++ b/service/agama-yast.spec.in
@@ -25,6 +25,7 @@ BuildRequires:  dbus-1-common
 # "msgfmt" tool
 BuildRequires:  gettext-runtime
 Requires:       dbus-1-common
+Requires:       rubygem(agama-yast)
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  ruby-macros >= 5

--- a/service/agama-yast.spec.in
+++ b/service/agama-yast.spec.in
@@ -46,14 +46,13 @@ D-Bus service exposing some YaST features that are useful for Agama.
 %build
 
 %install
-BASE=%{mod_full_name}
-install -D -m 0644 ${BASE}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
+install -D -m 0644 %{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
 install --directory %{buildroot}%{_datadir}/dbus-1/agama-services
-install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services ${BASE}/share/org.opensuse.Agama*.service
-install -D -m 0644 ${BASE}/share/agama.service %{buildroot}%{_unitdir}/agama.service
-install -D -m 0644 ${BASE}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
+install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services %{mod_full_name}/share/org.opensuse.Agama*.service
+install -D -m 0644 %{mod_full_name}/share/agama.service %{buildroot}%{_unitdir}/agama.service
+install -D -m 0644 %{mod_full_name}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
 install --directory %{buildroot}/usr/share/agama/conf.d
-install -D -m 0644 ${BASE}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
+install -D -m 0644 %{mod_full_name}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
 
 # run a script for installing the translations
 sh "%{SOURCE2}" "%{SOURCE1}"

--- a/service/package/agama-yast.spec
+++ b/service/package/agama-yast.spec
@@ -1,16 +1,36 @@
-# ---------------
-# FIXME: SPEC header
-# simple approach: most of the files are in the binary gem anyway
+#
+# spec file for package agama-yast
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
 
 Name:           agama-yast
-Version:        10.devel155
+Version:        10.devel54
 Release:        0
-BuildRequires:  rubygem(agama-yast)
+%define mod_name agama-yast
+%define mod_full_name %{mod_name}-%{version}
 BuildRequires:  dbus-1-common
 # "msgfmt" tool
 BuildRequires:  gettext-runtime
 Requires:       dbus-1-common
-Url:            https://github.com/openSUSE/agama
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  ruby-macros >= 5
+
+URL:            https://github.com/openSUSE/agama
+Source:         %{mod_full_name}.gem
 Source1:        po.tar.bz2
 Source2:        install_translations.sh
 Summary:        YaST integration service for Agama - common files
@@ -21,22 +41,22 @@ Group:          Development/Languages/Ruby
 D-Bus service exposing some YaST features that are useful for Agama.
 
 %prep
+%{gem_unpack}
 
 %build
 
 %install
-%define mod_full_name agama-yast-*
-install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
+BASE=%{mod_full_name}
+install -D -m 0644 ${BASE}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
 install --directory %{buildroot}%{_datadir}/dbus-1/agama-services
-install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services %{gem_base}/gems/%{mod_full_name}/share/org.opensuse.Agama*.service
-install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/share/agama.service %{buildroot}%{_unitdir}/agama.service
-install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
+install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services ${BASE}/share/org.opensuse.Agama*.service
+install -D -m 0644 ${BASE}/share/agama.service %{buildroot}%{_unitdir}/agama.service
+install -D -m 0644 ${BASE}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
 install --directory %{buildroot}/usr/share/agama/conf.d
-install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
+install -D -m 0644 ${BASE}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
 
 # run a script for installing the translations
 sh "%{SOURCE2}" "%{SOURCE1}"
-
 
 %pre
 %service_add_pre agama.service

--- a/service/package/agama-yast.spec
+++ b/service/package/agama-yast.spec
@@ -1,0 +1,65 @@
+# ---------------
+# FIXME: SPEC header
+# simple approach: most of the files are in the binary gem anyway
+
+Name:           agama-yast
+Version:        10.devel155
+Release:        0
+BuildRequires:  rubygem(agama-yast)
+BuildRequires:  dbus-1-common
+# "msgfmt" tool
+BuildRequires:  gettext-runtime
+Requires:       dbus-1-common
+Url:            https://github.com/openSUSE/agama
+Source1:        po.tar.bz2
+Source2:        install_translations.sh
+Summary:        YaST integration service for Agama - common files
+License:        GPL-2.0-only
+Group:          Development/Languages/Ruby
+
+%description
+D-Bus service exposing some YaST features that are useful for Agama.
+
+%prep
+
+%build
+
+%install
+%define mod_full_name agama-yast-*
+install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
+install --directory %{buildroot}%{_datadir}/dbus-1/agama-services
+install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services %{gem_base}/gems/%{mod_full_name}/share/org.opensuse.Agama*.service
+install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/share/agama.service %{buildroot}%{_unitdir}/agama.service
+install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
+install --directory %{buildroot}/usr/share/agama/conf.d
+install -D -m 0644 %{gem_base}/gems/%{mod_full_name}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
+
+# run a script for installing the translations
+sh "%{SOURCE2}" "%{SOURCE1}"
+
+
+%pre
+%service_add_pre agama.service
+
+%post
+%service_add_post agama.service
+
+%preun
+%service_del_preun agama.service
+
+%postun
+%service_del_postun_with_restart agama.service
+
+%files
+%{_datadir}/dbus-1/agama.conf
+%dir %{_datadir}/dbus-1/agama-services
+%{_datadir}/dbus-1/agama-services/org.opensuse.Agama*.service
+%{_unitdir}/agama.service
+%{_unitdir}/agama-proxy-setup.service
+%dir %{_datadir}/agama
+%dir %{_datadir}/agama/conf.d
+%{_datadir}/agama/conf.d
+%dir /usr/share/YaST2
+/usr/share/YaST2/locale
+
+%changelog

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -9,16 +9,6 @@
   # "msgfmt" tool
   BuildRequires:  gettext-runtime
   Requires:       dbus-1-common
-:post_install: |-
-  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/agama.conf
-  install --directory %{buildroot}%{_datadir}/dbus-1/agama-services
-  install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/org.opensuse.Agama*.service
-  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/agama.service %{buildroot}%{_unitdir}/agama.service
-  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/agama-proxy-setup.service %{buildroot}%{_unitdir}/agama-proxy-setup.service
-  install --directory %{buildroot}/usr/share/agama/conf.d
-  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/conf.d/*.yaml %{buildroot}/usr/share/agama/conf.d/
-  # run a script for installing the translations
-  sh "%{SOURCE2}" "%{SOURCE1}"
 :main:
   :preamble: |-
     # Override build.rpm, see also https://github.com/openSUSE/obs-build/blob/master/configs/
@@ -75,16 +65,6 @@
     Requires:       yast2-schema
     # lsblk
     Requires:       util-linux-systemd
-  :filelist: "%{_datadir}/dbus-1/agama.conf\n
-    %dir %{_datadir}/dbus-1/agama-services\n
-    %{_datadir}/dbus-1/agama-services/org.opensuse.Agama*.service\n
-    %{_unitdir}/agama.service\n
-    %{_unitdir}/agama-proxy-setup.service\n
-    %dir %{_datadir}/agama\n
-    %dir %{_datadir}/agama/conf.d\n
-    %{_datadir}/agama/conf.d\n
-    %dir /usr/share/YaST2\n
-    /usr/share/YaST2/locale\n"
 :scripts:
   :pre: "%service_add_pre agama.service"
   :post: "%service_add_post agama.service"

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -1,13 +1,8 @@
 ---
 :sourceurl: "%{mod_full_name}.gem"
-:sources:
-  - po.tar.bz2
-  - install_translations.sh
 :preamble: |-
   %global rb_build_versions %{rb_default_ruby}
   BuildRequires:  dbus-1-common
-  # "msgfmt" tool
-  BuildRequires:  gettext-runtime
   Requires:       dbus-1-common
 :main:
   :preamble: |-
@@ -65,8 +60,3 @@
     Requires:       yast2-schema
     # lsblk
     Requires:       util-linux-systemd
-:scripts:
-  :pre: "%service_add_pre agama.service"
-  :post: "%service_add_post agama.service"
-  :preun: "%service_del_preun agama.service"
-  :postun: "%service_del_postun_with_restart agama.service"

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -8,7 +8,6 @@
   :preamble: |-
     # Override build.rpm, see also https://github.com/openSUSE/obs-build/blob/master/configs/
     %global rb_build_versions %{rb_default_ruby}
-    Provides:       agama-yast
     BuildRequires:  dbus-1-common
     Requires:       dbus-1-common
     Requires:       dbus-1-daemon

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov  5 16:11:35 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- packaging: split out files independent of Ruby version
+  from rubygem-agama-yast (gh#agama-project/agama#1677).
+
+-------------------------------------------------------------------
 Wed Oct 30 11:33:54 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: do not generate config json with search wildcard


### PR DESCRIPTION
## Problem

split out files independent of Ruby version from rubygem-agama-yast

- https://trello.com/c/yAFVjbv6/3824-3-improve-rubygem-agama-yast-packaging

## Solution

Make `rubygem-agama-yast` in OBS a *multibuild* package where `agama-yast.gem` is a source for two spec files:
- `rubygem-agama-yast.spec` via `gem2rpm.yml`, containing the ruby+gem-versioned files, as usual with Rubygems
- `agama-yast.spec` containing the common files for D-Bus and translations

https://build.opensuse.org/package/show/home:mvidner:branches:systemsmanagement:Agama:Devel/rubygem-agama-yast


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

N/A