### PR TITLE
fix(products): enable Slowroll for x86_64 only and add the logo

### DIFF
--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -6,9 +6,10 @@ archs: x86_64
 # at the at translations/description key below to avoid using obsolete
 # translations!!
 # ------------------------------------------------------------------------------
-description: 'A slightly slower rolling release of openSUSE designed to update
-  less often than Tumbleweed but more often than Leap without forcing users to
-  choose between "stable" and newer packages'
+description:
+  'An experimental and slightly slower rolling release of openSUSE designed
+  to update less often than Tumbleweed but more often than Leap without forcing users
+  to choose between "stable" and newer packages.'
 icon: Slowroll.svg
 # Do not manually change any translations! See README.md for more details.
 translations:
@@ -72,7 +73,7 @@ storage:
           - path: var
             copy_on_write: false
           # Architecture specific subvolumes
-         - path: boot/grub2/arm64-efi
+          - path: boot/grub2/arm64-efi
             archs: aarch64
           - path: boot/grub2/arm-efi
             archs: arm

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -1,5 +1,6 @@
 id: Slowroll
 name: Slowroll
+archs: x86_64
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located
 # at the at translations/description key below to avoid using obsolete

--- a/web/src/assets/products/Slowroll.svg
+++ b/web/src/assets/products/Slowroll.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100%"
+   height="100%"
+   viewBox="0 0 512 512"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg6"><metadata
+   id="metadata12"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs10" />
+    <g
+   transform="matrix(48,0,0,48,-92720,-3188)"
+   id="g4">
+        <path
+   d="m 1933.8,71 c 0,-1.766 1.43,-3.2 3.2,-3.2 1.77,0 3.2,1.434 3.2,3.2 0,1.766 -1.43,3.2 -3.2,3.2 -1.77,0 -3.2,-1.434 -3.2,-3.2 z m 6,0 c 0,-1.545 -1.25,-2.8 -2.8,-2.8 -1.55,0 -2.8,1.255 -2.8,2.8 0,1.104 0.9,2 2,2 1.1,0 2,-0.896 2,-2 0,-0.662 -0.54,-1.2 -1.2,-1.2 -0.66,0 -1.2,0.538 -1.2,1.2 0,0.441 0.36,0.8 0.8,0.8 0.11,0 0.2,0.09 0.2,0.2 0,0.11 -0.09,0.2 -0.2,0.2 -0.66,0 -1.2,-0.538 -1.2,-1.2 0,-0.883 0.72,-1.6 1.6,-1.6 0.88,0 1.6,0.717 1.6,1.6 0,1.325 -1.07,2.4 -2.4,2.4 -0.32,0 -0.62,-0.061 -0.9,-0.173 0.47,0.359 1.06,0.573 1.7,0.573 1.55,0 2.8,-1.255 2.8,-2.8 z"
+   style="fill:#41c3d3"
+   id="path2" />
+    </g>
+<text
+   xml:space="preserve"
+   style="font-size:80px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;fill:#73ba25;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;"
+   x="252.89401"
+   y="457.59872"
+   id="text839"><tspan
+     id="tspan837"
+     x="252.89401"
+     y="457.59872"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:80px;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-align:center;text-anchor:middle;fill:#73ba25;fill-opacity:1;stroke:none;">Slowroll</tspan></text><text
+   xml:space="preserve"
+   style="font-size:16px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="105.01997"
+   y="268.58987"
+   id="text843"><tspan
+     id="tspan841"
+     x="105.01997"
+     y="268.58987"></tspan></text></svg>


### PR DESCRIPTION
#1674 added Slowroll to the list of products to install. Thanks @WesfunOfficial. However, given that
only x86_64 repositories are available, we should limit it to this architecture. Additionally I took
the opportunity to add the logo.
