### PR TITLE
fix: adapt setup scripts to run properly on distrobox

### DIFF
--- a/setup-services.sh
+++ b/setup-services.sh
@@ -149,7 +149,7 @@ $SUDO $ZYPPER install \
   cd $MYDIR/rust
   cargo build
 
-  ln -st /usr/bin $MYDIR/rust/target/debug/agama{,*server}
+  ln -sft /usr/bin $MYDIR/rust/target/debug/agama{,*server}
 )
 
 # - D-Bus configuration

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -117,14 +117,15 @@ fi
       sed -e '/gemspec/a gem "ruby-dbus", path: "/checkout-ruby-dbus"' -i Gemfile
   fi
 
-  if [ -n "$CI" ]; then
+  if [ -n "${CI:-}" ] || [ -n "${DISTROBOX_ENTER_PATH:-}" ]; then
     # in CI reuse the pre-installed system gems from RPMs
     bundle config set --local disable_shared_gems 0
+    sudo bundle install
   else
     bundle config set --local path 'vendor/bundle'
+    bundle install
   fi
 
-  bundle install
 )
 
 # Rust service, CLI and auto-installation.

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -150,7 +150,7 @@ $SUDO $ZYPPER install \
   cd $MYDIR/rust
   cargo build
 
-  ln -sft /usr/bin $MYDIR/rust/target/debug/agama{,*server}
+  sudo ln -sft /usr/bin $MYDIR/rust/target/debug/agama{,*server}
 )
 
 # - D-Bus configuration

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -117,7 +117,7 @@ fi
       sed -e '/gemspec/a gem "ruby-dbus", path: "/checkout-ruby-dbus"' -i Gemfile
   fi
 
-  if [ -n "${CI:-}" ] || [ -n "${DISTROBOX_ENTER_PATH:-}" ]; then
+  if [ -n "${CI:-}" ]; then
     # in CI reuse the pre-installed system gems from RPMs
     bundle config set --local disable_shared_gems 0
     sudo bundle install

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -42,6 +42,7 @@ ZYPPER="zypper --non-interactive -v"
 $SUDO $ZYPPER install \
   gcc \
   gcc-c++ \
+  git \
   make \
   openssl-devel \
   ruby-devel \
@@ -137,6 +138,7 @@ $SUDO $ZYPPER install \
   gzip \
   jsonnet \
   lshw \
+  NetworkManager \
   pam-devel \
   python-langtable-data \
   tar \

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -120,7 +120,7 @@ fi
   if [ -n "${CI:-}" ]; then
     # in CI reuse the pre-installed system gems from RPMs
     bundle config set --local disable_shared_gems 0
-    sudo bundle install
+    $SUDO bundle install
   else
     bundle config set --local path 'vendor/bundle'
     bundle install
@@ -150,7 +150,7 @@ $SUDO $ZYPPER install \
   cd $MYDIR/rust
   cargo build
 
-  sudo ln -sft /usr/bin $MYDIR/rust/target/debug/agama{,*server}
+  $SUDO ln -sft /usr/bin $MYDIR/rust/target/debug/agama{,*server}
 )
 
 # - D-Bus configuration

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -195,7 +195,19 @@ $SUDO mkdir -p /usr/share/agama/products.d
 $SUDO cp -f $MYDIR/products.d/*.yaml /usr/share/agama/products.d
 
 # - Make sure NetworkManager is running
-$SUDO systemctl start NetworkManager
+if [ -n "${DISTROBOX_ENTER_PATH:-}" ]; then
+  AGAMA_WEB_SERVER_SVC="/usr/lib/systemd/system/agama-web-server.service"
+  grep -q DBUS_SYSTEM_BUS_ADDRESS $AGAMA_WEB_SERVER_SVC || $SUDO sed -i \
+    -e '/\[Service\]/a Environment="DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/run/dbus/system_bus_socket"' \
+    $AGAMA_WEB_SERVER_SVC
+
+  AGAMA_SVC="/usr/lib/systemd/system/agama.service"
+  grep -q DBUS_SYSTEM_BUS_ADDRESS $AGAMA_SVC || $SUDO sed -i \
+    -e '/\[Service\]/a Environment="DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/run/dbus/system_bus_socket"' \
+    $AGAMA_SVC
+else
+  $SUDO systemctl start NetworkManager
+fi
 
 # systemd reload and start of service
 (


### PR DESCRIPTION
Due to a problem with [ruby-augeas](https://rubygems.org/gems/augeas) and Ruby 3.3, the setup script does not work anymore. In our continuous integration we decided to use the system libraries, which causes bundler to install software into `/usr/lib`. Of course, we do not want that behavior everywhere.

Alternatively, this PR adapts the script to work using distrobox. The setup is rather simple:

```
distrobox create --root --init --image tumbleweed --name agama
distrobox enter --root agama
./setup.sh
```

The script detects that it is running on distrobox and it workarounds the augeas problem like in our continuous integration.

Please, see #1685 for more context.