### PR TITLE
Resolve search sections that match several devices

### DIFF
--- a/rust/agama-lib/share/examples/storage/drives.json
+++ b/rust/agama-lib/share/examples/storage/drives.json
@@ -67,9 +67,7 @@
             "deleteIfNeeded": true
           },
           {
-            "search": {
-              "ifNotFound": "skip"
-            },
+            "search": "*",
             "delete": true
           },
           {

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1029,6 +1029,11 @@
       "type": "string",
       "examples": ["/dev/vda", "/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9"]
     },
+    "searchAll": {
+      "title": "Search all devices",
+      "description": "Shortcut to match all devices if there is any (equivalent to specify no conditions and to skip the entry if no device is found).",
+      "const": "*"
+    },
     "searchByName": {
       "title": "Search by name condition",
       "type": "object",
@@ -1042,6 +1047,9 @@
     },
     "search": {
       "anyOf": [
+        {
+          "$ref": "#/$defs/searchAll"
+        },
         {
           "$ref": "#/$defs/searchName"
         },

--- a/service/lib/agama/storage/config_conversions.rb
+++ b/service/lib/agama/storage/config_conversions.rb
@@ -26,6 +26,9 @@ module Agama
   module Storage
     # Conversions for the storage config.
     module ConfigConversions
+      # Reserved string for Configs::Search meaning 'match all devices if there is any'
+      SEARCH_ANYTHING_STRING = "*"
+      private_constant :SEARCH_ANYTHING_STRING
     end
   end
 end

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
@@ -41,27 +41,20 @@ module Agama
           # @see Base#conversions
           # @return [Hash]
           def conversions
+            return convert_string if search_json.is_a?(String)
+
             {
-              name:         convert_name,
-              if_not_found: convert_not_found
+              name:         search_json.dig(:condition, :name),
+              max:          search_json[:max],
+              if_not_found: search_json[:ifNotFound]&.to_sym
             }
           end
 
-          # @return [String, nil]
-          def convert_name
-            return search_json if search_json.is_a?(String)
+          # @return [String]
+          def convert_string
+            return { if_not_found: :skip } if search_json == SEARCH_ANYTHING_STRING
 
-            search_json.dig(:condition, :name)
-          end
-
-          # @return [Symbol, nil]
-          def convert_not_found
-            return if search_json.is_a?(String)
-
-            value = search_json[:ifNotFound]
-            return unless value
-
-            value.to_sym
+            { name: search_json }
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
@@ -33,13 +33,22 @@ module Agama
             Configs::Search
           end
 
+          # @see Base#convert
+          def convert
+            converted = super
+            return SEARCH_ANYTHING_STRING if converted.is_a?(Hash) && anything?(converted)
+
+            converted
+          end
+
         private
 
           # @see Base#conversions
           def conversions
             {
               condition:  convert_condition,
-              ifNotFound: config.if_not_found.to_s
+              ifNotFound: config.if_not_found.to_s,
+              max:        config.max
             }
           end
 
@@ -49,6 +58,14 @@ module Agama
             return unless name
 
             { name: name }
+          end
+
+          # Whether the search can be aliased with the special "*" string
+          def anything?(search_hash)
+            [
+              { ifNotFound: "skip" },
+              { condition: {}, ifNotFound: "skip" }
+            ].include?(search_hash.compact)
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
@@ -35,10 +35,9 @@ module Agama
 
           # @see Base#convert
           def convert
-            converted = super
-            return SEARCH_ANYTHING_STRING if converted.is_a?(Hash) && anything?(converted)
+            return SEARCH_ANYTHING_STRING if config.all_if_any?
 
-            converted
+            super
           end
 
         private
@@ -58,14 +57,6 @@ module Agama
             return unless name
 
             { name: name }
-          end
-
-          # Whether the search can be aliased with the special "*" string
-          def anything?(search_hash)
-            [
-              { ifNotFound: "skip" },
-              { condition: {}, ifNotFound: "skip" }
-            ].include?(search_hash.compact)
           end
         end
       end

--- a/service/lib/agama/storage/configs/drive.rb
+++ b/service/lib/agama/storage/configs/drive.rb
@@ -48,7 +48,7 @@ module Agama
         def initialize
           @partitions = []
           # All drives are expected to match a real device in the system, so let's ensure a search.
-          @search = Search.new
+          @search = Search.new.tap { |s| s.max = 1 }
         end
 
         # Whether the drive definition contains partition definitions

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -37,6 +37,12 @@ module Agama
         # @return [:create, :skip, :error]
         attr_accessor :if_not_found
 
+        # Optional max number of devices to match
+        #
+        # return [Integer, nil] nil means no limit, ie. all devices that meet the condition are
+        #   matched
+        attr_accessor :max
+
         # Constructor
         def initialize
           @solved = false
@@ -61,7 +67,7 @@ module Agama
         # Whether the search does not define any specific condition.
         #
         # @return [Boolean]
-        def any_device?
+        def always_match?
           name.nil?
         end
 

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -71,6 +71,13 @@ module Agama
           name.nil?
         end
 
+        # Whether the search matches all the available devices, skipping if none is found
+        #
+        # @return [Boolean]
+        def all_if_any?
+          always_match? && max.nil? && if_not_found == :skip
+        end
+
         # Whether the section containing the search should be skipped
         #
         # @return [Boolean]

--- a/service/lib/agama/storage/configs/with_search.rb
+++ b/service/lib/agama/storage/configs/with_search.rb
@@ -35,6 +35,14 @@ module Agama
         def found_device
           search&.device
         end
+
+        # Creates a deep copy of the config element
+        #
+        # Needed when a search returns multiple devices and the configuration needs to be replicated
+        # for each one.
+        def copy
+          Marshal.load(Marshal.dump(self))
+        end
       end
     end
   end

--- a/service/lib/y2storage/proposal/agama_vg_planner.rb
+++ b/service/lib/y2storage/proposal/agama_vg_planner.rb
@@ -59,8 +59,8 @@ module Y2Storage
       # @param config [Agama::Storage::Config]
       # @return [Array<String>]
       def devices_for_pvs(vg_config, config)
-        drives = vg_config.physical_volumes_devices.map do |dev_alias|
-          config.drives.find { |d| d.alias?(dev_alias) }
+        drives = vg_config.physical_volumes_devices.flat_map do |dev_alias|
+          config.drives.select { |d| d.alias?(dev_alias) }
         end.compact
 
         drives.map { |d| d.found_device.name }

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 24 13:07:50 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: support to match several devices with every 'search'
+  section (gh#agama-project/agama#1691).
+
+-------------------------------------------------------------------
 Tue Oct 22 09:48:57 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: extend schema to allow selecting TPM FDE as encryption

--- a/service/test/agama/storage/config_checker_test.rb
+++ b/service/test/agama/storage/config_checker_test.rb
@@ -244,8 +244,8 @@ describe Agama::Storage::ConfigChecker do
 
   before do
     mock_storage(devicegraph: scenario)
-    # To speed-up the tests
-    allow(Y2Storage::EncryptionMethod::TPM_FDE)
+    # To speed-up the tests. Use #allow_any_instance because #allow introduces marshaling problems
+    allow_any_instance_of(Y2Storage::EncryptionMethod::TpmFde)
       .to(receive(:possible?))
       .and_return(true)
   end

--- a/service/test/agama/storage/config_checker_test.rb
+++ b/service/test/agama/storage/config_checker_test.rb
@@ -255,6 +255,8 @@ describe Agama::Storage::ConfigChecker do
       # Solves the config before checking.
       devicegraph = Y2Storage::StorageManager.instance.probed
 
+      allow(Y2Storage::BlkDevice).to receive(:find_by_any_name)
+
       Agama::Storage::ConfigSolver
         .new(devicegraph, product_config)
         .solve(config)

--- a/service/test/agama/storage/config_conversions/from_json_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_test.rb
@@ -21,7 +21,7 @@
 
 require_relative "../../../test_helper"
 require "agama/config"
-require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_conversions"
 require "y2storage/encryption_method"
 require "y2storage/filesystems/mount_by_type"
 require "y2storage/filesystems/type"
@@ -107,6 +107,18 @@ shared_examples "with search" do |config_proc|
     end
   end
 
+  context "with an asterisk" do
+    let(:search) { "*" }
+
+    it "sets #search to the expected value" do
+      config = config_proc.call(subject.convert)
+      expect(config.search).to be_a(Agama::Storage::Configs::Search)
+      expect(config.search.name).to be_nil
+      expect(config.search.if_not_found).to eq(:skip)
+      expect(config.search.max).to be_nil
+    end
+  end
+
   context "with a search section" do
     let(:search) do
       {
@@ -120,6 +132,24 @@ shared_examples "with search" do |config_proc|
       expect(config.search).to be_a(Agama::Storage::Configs::Search)
       expect(config.search.name).to eq("/dev/vda1")
       expect(config.search.if_not_found).to eq(:skip)
+      expect(config.search.max).to be_nil
+    end
+  end
+
+  context "with a search section including a max" do
+    let(:search) do
+      {
+        ifNotFound: "error",
+        max:        3
+      }
+    end
+
+    it "sets #search to the expected value" do
+      config = config_proc.call(subject.convert)
+      expect(config.search).to be_a(Agama::Storage::Configs::Search)
+      expect(config.search.name).to be_nil
+      expect(config.search.if_not_found).to eq(:error)
+      expect(config.search.max).to eq 3
     end
   end
 end

--- a/service/test/agama/storage/config_conversions/to_json_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_test.rb
@@ -20,8 +20,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
-require "agama/storage/config_conversions/from_json"
-require "agama/storage/config_conversions/to_json"
+require "agama/storage/config_conversions"
 require "y2storage/refinements"
 
 using Y2Storage::Refinements::SizeCasts
@@ -93,7 +92,8 @@ shared_examples "with search" do |result_scope|
   let(:search) do
     {
       condition:  { name: "/dev/vda1" },
-      ifNotFound: "skip"
+      ifNotFound: "skip",
+      max:        2
     }
   end
 
@@ -104,7 +104,8 @@ shared_examples "with search" do |result_scope|
     expect(search_json).to eq(
       {
         condition:  { name: "/dev/vda1" },
-        ifNotFound: "skip"
+        ifNotFound: "skip",
+        max:        2
       }
     )
   end
@@ -143,6 +144,17 @@ shared_examples "with search" do |result_scope|
           }
         )
       end
+    end
+  end
+
+  context "if there are no conditions or limits and errors should be skipped" do
+    let(:search) { { ifNotFound: "skip" } }
+
+    it "generates a wildcard" do
+      config_json = result_scope.call(subject.convert)
+      search_json = config_json[:search]
+
+      expect(search_json).to eq "*"
     end
   end
 end
@@ -633,9 +645,7 @@ describe Agama::Storage::ConfigConversions::ToJSON do
         drives_json = subject.convert[:drives]
 
         default_drive_json = {
-          search:     {
-            ifNotFound: "error"
-          },
+          search:     { ifNotFound: "error", max: 1 },
           partitions: []
         }
 
@@ -658,9 +668,7 @@ describe Agama::Storage::ConfigConversions::ToJSON do
           search_json = drive_json[:search]
 
           expect(search_json).to eq(
-            {
-              ifNotFound: "error"
-            }
+            { ifNotFound: "error", max: 1 }
           )
         end
       end

--- a/service/test/y2storage/agama_proposal_search_test.rb
+++ b/service/test/y2storage/agama_proposal_search_test.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../agama/storage/storage_helpers"
+require "agama/config"
+require "agama/storage/config"
+require "agama/storage/config_conversions"
+require "y2storage"
+require "y2storage/agama_proposal"
+
+describe Y2Storage::AgamaProposal do
+  using Y2Storage::Refinements::SizeCasts
+  include Agama::RSpec::StorageHelpers
+
+  subject(:proposal) do
+    described_class.new(config, issues_list: issues_list)
+  end
+
+  let(:config) { config_from_json }
+
+  let(:config_from_json) do
+    Agama::Storage::ConfigConversions::FromJSON
+      .new(config_json)
+      .convert
+  end
+
+  let(:issues_list) { [] }
+
+  before do
+    mock_storage(devicegraph: scenario)
+    # To speed-up the tests
+    allow(Y2Storage::EncryptionMethod::TPM_FDE).to receive(:possible?).and_return(true)
+  end
+
+  let(:scenario) { "disks.yaml" }
+
+  describe "#propose" do
+    context "when searching several disks at once and using them as LVM targetDevices" do
+      let(:config_json) do
+        {
+          drives:       [
+            { search: { max: 2 }, alias: "first-two" }
+          ],
+          volumeGroups: [
+            {
+              name:            "system",
+              physicalVolumes: [
+                { generate: { targetDevices: ["first-two"] } }
+              ],
+              logicalVolumes:  [
+                {
+                  name:       "root",
+                  size:       "55 GiB",
+                  filesystem: { path: "/" }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "extends the LVM over all the chosen disks if needed" do
+        devicegraph = proposal.propose
+
+        system = devicegraph.find_by_name("/dev/system")
+        expect(system.lvm_pvs.map { |pv| pv.blk_device.partitionable.name })
+          .to contain_exactly("/dev/vda", "/dev/vdb")
+      end
+    end
+
+    context "when searching several disks at once and using them as LVM PVs" do
+      let(:config_json) do
+        {
+          drives:       [
+            {
+              partitions: [
+                { search: "/dev/vda1" },
+                { search: "*", alias: "rest" }
+              ]
+            }
+          ],
+          volumeGroups: [
+            {
+              name:            "system",
+              physicalVolumes: ["rest"],
+              logicalVolumes:  [
+                {
+                  name:       "root",
+                  size:       "10 GiB",
+                  filesystem: { path: "/" }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "uses all the disks as physical volumes" do
+        probed = Y2Storage::StorageManager.instance.probed
+        vda2_sid = probed.find_by_name("/dev/vda2").sid
+        vda3_sid = probed.find_by_name("/dev/vda3").sid
+
+        devicegraph = proposal.propose
+
+        system = devicegraph.find_by_name("/dev/system")
+        expect(system.lvm_pvs.map(&:blk_device).map(&:sid)).to contain_exactly(vda2_sid, vda3_sid)
+      end
+    end
+
+    context "when marking several partitions for resizing" do
+      let(:config_json) do
+        {
+          boot:   { configure: false },
+          drives: [
+            {
+              search:     disk_name,
+              partitions: [
+                { search: search, size: { min: 0, max: "current" } },
+                { size: "25 GiB", filesystem: { path: "/" } }
+              ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow_any_instance_of(Y2Storage::Partition)
+          .to(receive(:detect_resize_info))
+          .and_return(resize_info)
+      end
+
+      let(:resize_info) do
+        instance_double(
+          Y2Storage::ResizeInfo, resize_ok?: true,
+          min_size: Y2Storage::DiskSize::GiB(4), max_size: Y2Storage::DiskSize::GiB(35)
+        )
+      end
+
+      shared_examples "resize" do
+        it "resizes several partitions if needed" do
+          probed = Y2Storage::StorageManager.instance.probed
+          vda2_size = probed.find_by_name("/dev/vda2").size
+          vda3_size = probed.find_by_name("/dev/vda3").size
+
+          devicegraph = proposal.propose
+
+          expect(devicegraph.find_by_name("/dev/vda2").size).to be < vda2_size
+          expect(devicegraph.find_by_name("/dev/vda3").size).to be < vda3_size
+        end
+      end
+
+      context "using an empty search to match the partitions" do
+        let(:search) { {} }
+
+        context "if there are several partitions at the disk" do
+          let(:disk_name) { "/dev/vda" }
+
+          include_examples "resize"
+        end
+
+        context "if there are no partitions in the disk" do
+          let(:disk_name) { "/dev/vdc" }
+
+          it "register an error and returns nil" do
+            expect(proposal.propose).to be_nil
+            expect(proposal.issues_list).to include an_object_having_attributes(
+              description: /mandatory partition/,
+              severity:    Agama::Issue::Severity::ERROR
+            )
+          end
+        end
+      end
+
+      context "using asterisk as the search to match the partitions" do
+        let(:search) { "*" }
+
+        context "if there are several partitions at the disk" do
+          let(:disk_name) { "/dev/vda" }
+
+          include_examples "resize"
+        end
+
+        context "if there are no partitions in the disk" do
+          let(:disk_name) { "/dev/vdc" }
+
+          it "processes the proposal" do
+            devicegraph = proposal.propose
+            disk = devicegraph.find_by_name(disk_name)
+            expect(disk.partitions.size).to eq 1
+          end
+
+          it "register a warning about non-existent partitions" do
+            proposal.propose
+            expect(proposal.issues_list).to include an_object_having_attributes(
+              description: /optional partition/,
+              severity:    Agama::Issue::Severity::WARN
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The search functionality described at `auto_storage.md` is pretty powerful. But the current implementation only allows to:

- search by name
- return 0 or 1 devices per search

## Solution

This implements several parts of the missing functionality, like:

- Ability to match more than one device per `search` section
- Limit the number of matches by using `max`.

This pull request does not add the ability to use other conditions or matching order beyond `name`. So it's only possible to search either for a device with a given name, either for all the devices sorted by name. The syntax for the latter would be this (a search with no conditions):

```
{ "search": {} }
```

For readability, the following alternative syntax is also introduced at this pull request:

```
{ "search": "*" }
```

The new default for drive entries (if omitted) becomes:

```
{ "search": { "max": 1 } }
```

If several devices match with a given `search` section, the corresponding configuration containing the `search` is replicated as many times as needed. Eg. in a system with two disks, the following config...

```
{
  "storage": {
    "drives": [
      { "search": "*" }
    ]
  }
}
```

...is expanded into:

```
{
  "storage": {
    "drives": [
      { "search": "*" },
      { "search": "*" }
    ]
  }
}
```

This also makes sure everything keeps working when an `alias` is used together with a `search` that matches several devices (so all the resulting config objects share the same alias).

## Testing

- Adapted existing unit tests and added a new ones regarding the `search` functionality
- Added a new unit test to check that resolving a config into several ones (potentially with a shared alias) works as expected.
