### PR TITLE
fix: do not freeze when downloading the logs

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 23 15:25:36 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the action to download the logs (gh#agama-project/agama#1693).
+
+-------------------------------------------------------------------
 Tue Oct 22 09:46:41 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improve OpenAPI specification generation (gh#agama-project/agama#1564):

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 23 15:26:29 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Adapt the URL to fetch the logs (gh#agama-project/agama#1693).
+
+-------------------------------------------------------------------
 Fri Oct 11 09:46:02 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Workaround the "not found" problem in the products selection page

--- a/web/src/api/manager.ts
+++ b/web/src/api/manager.ts
@@ -42,6 +42,6 @@ const finishInstallation = () => post("/api/manager/finish");
 /**
  * Returns the binary content of the YaST logs file.
  */
-const fetchLogs = () => get("/api/manager/logs");
+const fetchLogs = () => get("/api/manager/logs.tar.gz");
 
 export { startProbing, startInstallation, finishInstallation, fetchLogs };


### PR DESCRIPTION
## Problem

If you try to download the logs using the web UI, `agama-web-server` gets unresponsive.

## Solution

- Use `tokio::process::Command` to download the logs.
- Rename the endpoint to reflect the file format.

## To do

- The UI is not properly adapted yet but @dgdavid is working on it.
