### PR TITLE
fix(web): make download logs actions work again

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 23 16:26:29 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Fix the link to download the logs (gh#agama-project/agama#1694).
+
+-------------------------------------------------------------------
 Wed Oct 23 15:26:29 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adapt the URL to fetch the logs (gh#agama-project/agama#1693).

--- a/web/src/components/core/LogsButton.tsx
+++ b/web/src/components/core/LogsButton.tsx
@@ -20,111 +20,17 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
-import { Alert, Button, ButtonProps } from "@patternfly/react-core";
-import { Popup } from "~/components/core";
+import React from "react";
 import { _ } from "~/i18n";
-import { useCancellablePromise } from "~/utils";
-import { fetchLogs } from "~/api/manager";
-
-const FILENAME = "agama-installation-logs.tar.gz";
 
 /**
  * Button for collecting and downloading Agama/YaST logs
  */
-const LogsButton = (props: ButtonProps) => {
-  const { cancellablePromise } = useCancellablePromise();
-  const [error, setError] = useState(null);
-  const [isCollecting, setIsCollecting] = useState(false);
-
-  /**
-   * Helper function for triggering the download automatically
-   *
-   * @note Based on the article "Programmatic file downloads in the browser" found at
-   *       https://blog.logrocket.com/programmatic-file-downloads-in-the-browser-9a5186298d5c
-   *
-   * @param {string} url - the file location to download from
-   */
-  const autoDownload = (url: string) => {
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = FILENAME;
-
-    // Click handler that releases the object URL after the element has been clicked
-    // This is required to let the browser know not to keep the reference to the file any longer
-    // See https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL
-    const clickHandler = () => {
-      setTimeout(() => {
-        URL.revokeObjectURL(url);
-        a.removeEventListener("click", clickHandler);
-      }, 150);
-    };
-
-    // Add the click event listener on the anchor element
-    a.addEventListener("click", clickHandler, false);
-
-    // Programmatically trigger a click on the anchor element
-    // Needed for make the download to happen automatically without attaching the anchor element to
-    // the DOM
-    a.click();
-  };
-
-  const collectAndDownload = () => {
-    setError(null);
-    setIsCollecting(true);
-    cancellablePromise(fetchLogs().then((response) => response.blob()))
-      .then(URL.createObjectURL)
-      .then(autoDownload)
-      .catch((error) => {
-        console.error(error);
-        setError(true);
-      })
-      .finally(() => setIsCollecting(false));
-  };
-
-  const close = () => setError(false);
-
+const LogsButton = () => {
   return (
-    <>
-      <Button
-        isInline
-        variant="link"
-        style={{ color: "white" }}
-        onClick={collectAndDownload}
-        isLoading={isCollecting}
-        isDisabled={isCollecting}
-        {...props}
-      >
-        {isCollecting ? _("Collecting logs...") : _("Download logs")}
-      </Button>
-
-      <Popup title={_("Download logs")} isOpen={isCollecting || error}>
-        {isCollecting && (
-          <Alert
-            isInline
-            isPlain
-            variant="info"
-            title={_(
-              "The browser will run the logs download as soon as they are ready. Please, be patient.",
-            )}
-          />
-        )}
-
-        {error && (
-          <Alert
-            isInline
-            isPlain
-            variant="warning"
-            title={_("Something went wrong while collecting logs. Please, try again.")}
-          />
-        )}
-        <Popup.Actions>
-          <Popup.Confirm onClick={close} autoFocus>
-            {_("Close")}
-          </Popup.Confirm>
-        </Popup.Actions>
-      </Popup>
-    </>
+    <a href="api/manager/logs.tar.gz" download>
+      {_("Download logs")}
+    </a>
   );
 };
 


### PR DESCRIPTION
## Problem 

After changes introduced in https://github.com/agama-project/agama/pull/1693, the `LogsButton` component has become obsolete and does not work as expected.

## Solution

Use an old plain HTML link pointing to the expected URL and using the [download](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) attribute.

## Additional note

Please, bear in mind that this is kind of intermediate change to make the link work again. It will be superseded (and probably improved) by the  WIP https://github.com/agama-project/agama/pull/1690

## Testing

- Tested manually
