### PR TITLE
Storage: Do not register issues when skipping entries at the config

### DIFF
--- a/service/lib/agama/storage/config_checker.rb
+++ b/service/lib/agama/storage/config_checker.rb
@@ -29,7 +29,7 @@ module Agama
     # Class for checking a storage config.
     #
     # TODO: Split in smaller checkers, for example: ConfigFilesystemChecker, etc.
-    class ConfigChecker # rubocop:disable Metrics/ClassLength
+    class ConfigChecker
       include Yast::I18n
 
       # @param config [Storage::Config]
@@ -81,15 +81,10 @@ module Agama
       # @return [Agama::Issue]
       def search_issue(config)
         return if !config.search || config.found_device
+        return if config.search.skip_device?
 
         if config.is_a?(Agama::Storage::Configs::Drive)
-          if config.search.skip_device?
-            warning(_("No device found for an optional drive"))
-          else
-            error(_("No device found for a mandatory drive"))
-          end
-        elsif config.search.skip_device?
-          warning(_("No device found for an optional partition"))
+          error(_("No device found for a mandatory drive"))
         else
           error(_("No device found for a mandatory partition"))
         end
@@ -468,18 +463,6 @@ module Agama
       # @return [VolumeTemplatesBuilder]
       def volume_builder
         @volume_builder ||= VolumeTemplatesBuilder.new_from_config(product_config)
-      end
-
-      # Creates a warning issue.
-      #
-      # @param message [String]
-      # @return [Issue]
-      def warning(message)
-        Agama::Issue.new(
-          message,
-          source:   Agama::Issue::Source::CONFIG,
-          severity: Agama::Issue::Severity::WARN
-        )
       end
 
       # Creates an error issue.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 24 14:44:35 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: do not report issues when intentionally skipping entries
+  at the storage config (gh#agama-project/agama#1696).
+
+-------------------------------------------------------------------
 Thu Oct 24 13:07:50 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Storage: support to match several devices with every 'search'

--- a/service/test/agama/storage/config_checker_test.rb
+++ b/service/test/agama/storage/config_checker_test.rb
@@ -21,7 +21,7 @@
 
 require_relative "./storage_helpers"
 require "agama/config"
-require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_conversions"
 require "agama/storage/config_checker"
 require "agama/storage/config_solver"
 require "y2storage"
@@ -281,13 +281,8 @@ describe Agama::Storage::ConfigChecker do
       context "and the drive should be skipped" do
         let(:if_not_found) { "skip" }
 
-        it "includes the expected issue" do
-          issues = subject.issues
-          expect(issues.size).to eq(1)
-
-          issue = issues.first
-          expect(issue.error?).to eq(false)
-          expect(issue.description).to eq("No device found for an optional drive")
+        it "does not include any issue" do
+          expect(subject.issues).to be_empty
         end
       end
 
@@ -374,13 +369,8 @@ describe Agama::Storage::ConfigChecker do
         context "and the partition should be skipped" do
           let(:if_not_found) { "skip" }
 
-          it "includes the expected issue" do
-            issues = subject.issues
-            expect(issues.size).to eq(1)
-
-            issue = issues.first
-            expect(issue.error?).to eq(false)
-            expect(issue.description).to eq("No device found for an optional partition")
+          it "does not include any issue" do
+            expect(subject.issues).to be_empty
           end
         end
 

--- a/service/test/y2storage/agama_proposal_search_test.rb
+++ b/service/test/y2storage/agama_proposal_search_test.rb
@@ -207,7 +207,7 @@ describe Y2Storage::AgamaProposal do
             expect(disk.partitions.size).to eq 1
           end
 
-          it "register a no issues about non-existent partitions" do
+          it "does not include any issue about non-existent partitions" do
             proposal.propose
             expect(proposal.issues_list).to be_empty
           end

--- a/service/test/y2storage/agama_proposal_search_test.rb
+++ b/service/test/y2storage/agama_proposal_search_test.rb
@@ -207,12 +207,9 @@ describe Y2Storage::AgamaProposal do
             expect(disk.partitions.size).to eq 1
           end
 
-          it "register a warning about non-existent partitions" do
+          it "register a no issues about non-existent partitions" do
             proposal.propose
-            expect(proposal.issues_list).to include an_object_having_attributes(
-              description: /optional partition/,
-              severity:    Agama::Issue::Severity::WARN
-            )
+            expect(proposal.issues_list).to be_empty
           end
         end
       end

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -22,7 +22,7 @@
 require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
-require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_conversions"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -484,12 +484,9 @@ describe Y2Storage::AgamaProposal do
           expect(proposal.failed?).to eq false
         end
 
-        it "registers a non-critical issue" do
+        it "does not register any issue about missing disks" do
           proposal.propose
-          expect(proposal.issues_list).to include an_object_having_attributes(
-            description: /optional drive/,
-            severity:    Agama::Issue::Severity::WARN
-          )
+          expect(proposal.issues_list).to be_empty
         end
       end
 
@@ -576,12 +573,9 @@ describe Y2Storage::AgamaProposal do
           expect(proposal.failed?).to eq false
         end
 
-        it "registers a non-critical issue" do
+        it "does not register any issue about missing partitions" do
           proposal.propose
-          expect(proposal.issues_list).to include an_object_having_attributes(
-            description: /optional partition/,
-            severity:    Agama::Issue::Severity::WARN
-          )
+          expect(proposal.issues_list).to be_empty
         end
       end
 


### PR DESCRIPTION
## Problem

At the storage configuration, it's possible to specify a section describing a device (drive, partition, volume group, logical volume, etc.) with a `search` entry to indicate such a  description corresponds to one or several previously existing device(s) that should be found in the system.

That `search` entry can contain `ifNotFound: "skip"` to indicate the description should be ignored if the corresponding devices are not found.

If that happens, a warning is added to the list of found issues with a message like "_No device found for an optional drive/partition/whatever_".

That warning looks overkill. Especially having into account the default value for `ifNotFound` is "error", which means profiles using "skip" really mean it.

## Solution

Reduce the noise by not longer generating the issue for missing optional devices.
