### PR TITLE
Use AgamaProposal for the initial storage proposal

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -6,7 +6,7 @@ Tue Oct 22 08:41:14 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
   (gh#agama-project/agama#1688)
 
 -------------------------------------------------------------------
-Tru Oct 17 21:58:46 UTC 2024 - WesfunOfficial <93811710+WesfunOfficial@users.noreply.github.com>
+Thu Oct 17 21:58:46 UTC 2024 - WesfunOfficial <93811710+WesfunOfficial@users.noreply.github.com>
 
 - Added Slowroll to the product list (gh#agama-project/agama#1674)
 

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -7,6 +7,30 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "scripts": {
+      "title": "User-defined installation scripts",
+      "description": "User-defined scripts to run at different points of the installation",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pre": {
+          "title": "Pre-installation scripts",
+          "description": "User-defined scripts to run before the installation starts",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/script"
+          }
+        },
+        "post": {
+          "title": "Post-installation scripts",
+          "description": "User-defined scripts to run after the installation finishes",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/script"
+          }
+        }
+      }
+    },
     "software": {
       "title": "Software settings",
       "type": "object",
@@ -928,30 +952,6 @@
       "type": "array",
       "items": {
         "type": "object"
-      }
-    },
-    "scripts": {
-      "title": "User-defined installation scripts",
-      "description": "User-defined scripts to run at different points of the installation",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "pre": {
-          "title": "Pre-installation scripts",
-          "description": "User-defined scripts to run before the installation starts",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/script"
-          }
-        },
-        "post": {
-          "title": "Post-installation scripts",
-          "description": "User-defined scripts to run after the installation finishes",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/script"
-          }
-        }
       }
     }
   },

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -84,7 +84,7 @@ impl NetworkClient {
         // trying to be tricky here. If something breaks then we need a put method on
         // BaseHTTPClient which doesn't require a serialiable object for the body
         self.client
-            .put_void(&format!("/network/system/apply").as_str(), &())
+            .post_void(&format!("/network/system/apply").as_str(), &())
             .await?;
 
         Ok(())

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 28 09:24:48 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use the correct method to apply the network configuration from
+  the CLI (gh#agama-project/agama#1701).
+
+-------------------------------------------------------------------
 Thu Oct 24 14:19:46 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: extend the HTTP API to allow getting the solved storage

--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.1)
-    ruby-augeas (0.5.0)
+    ruby-augeas (0.6.0)
     ruby-dbus (0.23.1)
       rexml
     simplecov (0.21.2)

--- a/service/lib/agama/storage/config_checker.rb
+++ b/service/lib/agama/storage/config_checker.rb
@@ -29,7 +29,7 @@ module Agama
     # Class for checking a storage config.
     #
     # TODO: Split in smaller checkers, for example: ConfigFilesystemChecker, etc.
-    class ConfigChecker # rubocop:disable Metrics/ClassLength
+    class ConfigChecker
       include Yast::I18n
 
       # @param config [Storage::Config]
@@ -81,15 +81,10 @@ module Agama
       # @return [Agama::Issue]
       def search_issue(config)
         return if !config.search || config.found_device
+        return if config.search.skip_device?
 
         if config.is_a?(Agama::Storage::Configs::Drive)
-          if config.search.skip_device?
-            warning(_("No device found for an optional drive"))
-          else
-            error(_("No device found for a mandatory drive"))
-          end
-        elsif config.search.skip_device?
-          warning(_("No device found for an optional partition"))
+          error(_("No device found for a mandatory drive"))
         else
           error(_("No device found for a mandatory partition"))
         end
@@ -468,18 +463,6 @@ module Agama
       # @return [VolumeTemplatesBuilder]
       def volume_builder
         @volume_builder ||= VolumeTemplatesBuilder.new_from_config(product_config)
-      end
-
-      # Creates a warning issue.
-      #
-      # @param message [String]
-      # @return [Issue]
-      def warning(message)
-        Agama::Issue.new(
-          message,
-          source:   Agama::Issue::Source::CONFIG,
-          severity: Agama::Issue::Severity::WARN
-        )
       end
 
       # Creates an error issue.

--- a/service/lib/agama/storage/config_reader.rb
+++ b/service/lib/agama/storage/config_reader.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/config_conversions"
+
+module Agama
+  module Storage
+    # Reader for the initial storage config
+    class ConfigReader
+      # @param agama_config [Agama::Config]
+      def initialize(agama_config)
+        @agama_config = agama_config
+      end
+
+      # Generates a storage config from the Agama control file.
+      #
+      # @return [Storage::Config]
+      def read
+        ConfigConversions::FromJSON.new(json, default_paths: default_paths).convert
+      end
+
+    private
+
+      # @return [Agama::Config]
+      attr_reader :agama_config
+
+      # Default filesystem paths from the Agama control file
+      #
+      # @return [Array<String>]
+      def default_paths
+        @default_paths ||= agama_config.default_paths
+      end
+
+      # Default policy to make space from the Agama control file
+      #
+      # @return [String]
+      def space_policy
+        @space_policy ||= agama_config.data.dig("storage", "space_policy")
+      end
+
+      # Whether the Agama control file specifies that LVM must be used by default
+      #
+      # @return [Boolean]
+      def lvm?
+        return @lvm unless @lvm.nil?
+
+        @lvm = !!agama_config.data.dig("storage", "lvm")
+      end
+
+      # JSON representation of the initial storage config
+      #
+      # @return [Hash]
+      def json
+        lvm? ? json_for_lvm : json_for_disk
+      end
+
+      # @see #json
+      #
+      # @return [Hash]
+      def json_for_disk
+        {
+          drives: [
+            { partitions: [partition_for_existing, volumes_generator].compact }
+          ]
+        }
+      end
+
+      # @see #json
+      #
+      # @return [Hash]
+      def json_for_lvm
+        {
+          drives:       [
+            {
+              alias:      "target",
+              partitions: [partition_for_existing].compact
+            }
+          ],
+          volumeGroups: [
+            {
+              name:            "system",
+              physicalVolumes: [{ generate: ["target"] }],
+              logicalVolumes:  [volumes_generator]
+            }
+          ]
+        }
+      end
+
+      # JSON piece to generate default filesystems as partitions or logical volumes
+      #
+      # @return [Hash]
+      def volumes_generator
+        { generate: "default" }
+      end
+
+      # JSON piece to specify what to do with existing partitions
+      #
+      # @return [Hash, nil] nil if no actions are to be performed
+      def partition_for_existing
+        return unless ["delete", "resize"].include?(space_policy)
+
+        partition = { search: "*" }
+
+        if space_policy == "delete"
+          partition[:delete] = true
+        else
+          partition[:size] = { min: 0, max: "current" }
+        end
+
+        partition
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -29,7 +29,7 @@ require "agama/storage/proposal_settings"
 require "agama/storage/callbacks"
 require "agama/storage/iscsi/manager"
 require "agama/storage/finisher"
-require "agama/storage/proposal_settings_reader"
+require "agama/storage/config_reader"
 require "agama/issue"
 require "agama/with_locale"
 require "agama/with_issues"
@@ -216,8 +216,8 @@ module Agama
 
       # Calculates the proposal using the settings from the config file.
       def calculate_proposal
-        settings = ProposalSettingsReader.new(config).read
-        proposal.calculate_guided(settings)
+        settings = ConfigReader.new(config).read
+        proposal.calculate_agama(settings)
       end
 
       # Adds the required packages to the list of resolvables to install

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 24 14:44:35 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: do not report issues when intentionally skipping entries
+  at the storage config (gh#agama-project/agama#1696).
+
+-------------------------------------------------------------------
 Thu Oct 24 14:18:28 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Storage: extend the D-Bus API to allow getting the solved storage

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 28 15:30:25 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: use AgamaProposal for the initial storage setup during
+  system probing (gh#agama-project/agama#1699).
+
+-------------------------------------------------------------------
 Thu Oct 24 14:44:35 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Storage: do not report issues when intentionally skipping entries

--- a/service/test/agama/storage/config_checker_test.rb
+++ b/service/test/agama/storage/config_checker_test.rb
@@ -21,7 +21,7 @@
 
 require_relative "./storage_helpers"
 require "agama/config"
-require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_conversions"
 require "agama/storage/config_checker"
 require "agama/storage/config_solver"
 require "y2storage"
@@ -281,13 +281,8 @@ describe Agama::Storage::ConfigChecker do
       context "and the drive should be skipped" do
         let(:if_not_found) { "skip" }
 
-        it "includes the expected issue" do
-          issues = subject.issues
-          expect(issues.size).to eq(1)
-
-          issue = issues.first
-          expect(issue.error?).to eq(false)
-          expect(issue.description).to eq("No device found for an optional drive")
+        it "does not include any issue" do
+          expect(subject.issues).to be_empty
         end
       end
 
@@ -374,13 +369,8 @@ describe Agama::Storage::ConfigChecker do
         context "and the partition should be skipped" do
           let(:if_not_found) { "skip" }
 
-          it "includes the expected issue" do
-            issues = subject.issues
-            expect(issues.size).to eq(1)
-
-            issue = issues.first
-            expect(issue.error?).to eq(false)
-            expect(issue.description).to eq("No device found for an optional partition")
+          it "does not include any issue" do
+            expect(subject.issues).to be_empty
           end
         end
 

--- a/service/test/agama/storage/config_reader_test.rb
+++ b/service/test/agama/storage/config_reader_test.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "agama/config"
+require "agama/storage/device_settings"
+require "agama/storage/config_reader"
+require "y2storage"
+
+describe Agama::Storage::ConfigReader do
+  let(:agama_config) { Agama::Config.new(config_data) }
+
+  subject { described_class.new(agama_config) }
+
+  describe "#read" do
+    let(:lvm) { false }
+    let(:space_policy) { "delete" }
+    let(:config_data) do
+      {
+        "storage" => {
+          "lvm"              => lvm,
+          "space_policy"     => space_policy,
+          "encryption"       => {
+            "method"        => "luks2",
+            "pbkd_function" => "argon2id"
+          },
+          "volumes"          => ["/", "swap"],
+          "volume_templates" => [
+            {
+              "mount_path" => "/",
+              "outline"    => { "required" => true }
+            },
+            {
+              "mount_path" => "/home",
+              "outline"    => { "required" => false }
+            },
+            {
+              "mount_path" => "swap",
+              "outline"    => { "required" => false }
+            }
+          ]
+        }
+      }
+    end
+
+    it "generates the corresponding storage configuration" do
+      config = subject.read
+      expect(config).to be_a(Agama::Storage::Config)
+      expect(config.drives.size).to eq 1
+    end
+
+    context "if lvm is disabled" do
+      let(:lvm) { false }
+
+      it "applies the space policy to the first drive and places the default volumes there" do
+        config = subject.read
+        expect(config.drives.size).to eq 1
+
+        partitions = config.drives.first.partitions
+        expect(partitions).to contain_exactly(
+          an_object_having_attributes(
+            search: an_instance_of(Agama::Storage::Configs::Search), filesystem: nil
+          ),
+          an_object_having_attributes(
+            search: nil, filesystem: an_object_having_attributes(path: "/")
+          ),
+          an_object_having_attributes(
+            search: nil, filesystem: an_object_having_attributes(path: "swap")
+          )
+        )
+      end
+    end
+
+    context "if lvm is enabled" do
+      let(:lvm) { true }
+
+      it "applies the space policy to the first drive" do
+        config = subject.read
+        expect(config.drives.size).to eq 1
+
+        partitions = config.drives.first.partitions
+        expect(partitions.size).to eq 1
+        partition = partitions.first
+        expect(partition.search).to be_a Agama::Storage::Configs::Search
+      end
+
+      it "places the default volumes at a new LVM over the first disk" do
+        config = subject.read
+        expect(config.volume_groups.size).to eq 1
+        vg = config.volume_groups.first
+        disk_alias = config.drives.first.alias
+        expect(vg.physical_volumes_devices).to contain_exactly disk_alias
+
+        expect(vg.logical_volumes).to contain_exactly(
+          an_object_having_attributes(filesystem: an_object_having_attributes(path: "/")),
+          an_object_having_attributes(filesystem: an_object_having_attributes(path: "swap"))
+        )
+      end
+    end
+
+    context "if the space policy is unknown" do
+      let(:space_policy) { nil }
+
+      it "generates no partitition config to match existing partitions" do
+        config = subject.read
+        partitions = config.drives.first.partitions
+        expect(partitions).to_not include(
+          an_object_having_attributes(search: an_instance_of(Agama::Storage::Configs::Search))
+        )
+      end
+    end
+
+    context "if the space policy is 'keep'" do
+      let(:space_policy) { "keep" }
+
+      it "generates no partitition config to match existing partitions" do
+        config = subject.read
+        partitions = config.drives.first.partitions
+        expect(partitions).to_not include(
+          an_object_having_attributes(search: an_instance_of(Agama::Storage::Configs::Search))
+        )
+      end
+    end
+
+    context "if the space policy is 'delete'" do
+      let(:space_policy) { "delete" }
+
+      it "generates a partitition config to delete existing partitions" do
+        config = subject.read
+        partitions = config.drives.first.partitions
+        expect(partitions).to include(
+          an_object_having_attributes(search: an_instance_of(Agama::Storage::Configs::Search))
+        )
+
+        search_part = partitions.find(&:search)
+        expect(search_part.delete).to eq true
+        expect(search_part.search.name).to be_nil
+        expect(search_part.search.if_not_found).to eq :skip
+      end
+    end
+
+    context "if the space policy is 'resize'" do
+      let(:space_policy) { "resize" }
+
+      it "generates a partitition config to shrink existing partitions" do
+        config = subject.read
+        partitions = config.drives.first.partitions
+        expect(partitions).to include(
+          an_object_having_attributes(search: an_instance_of(Agama::Storage::Configs::Search))
+        )
+
+        search_part = partitions.find(&:search)
+        expect(search_part.delete).to eq false
+        expect(search_part.size).to have_attributes(
+          default: false, min: Y2Storage::DiskSize.zero, max: nil
+        )
+        expect(search_part.search.name).to be_nil
+        expect(search_part.search.if_not_found).to eq :skip
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -163,8 +163,7 @@ describe Agama::Storage::Manager do
 
       allow(proposal).to receive(:issues).and_return(proposal_issues)
       allow(proposal).to receive(:available_devices).and_return(devices)
-      allow(proposal).to receive(:settings).and_return(settings)
-      allow(proposal).to receive(:calculate_guided)
+      allow(proposal).to receive(:calculate_agama)
 
       allow(config).to receive(:pick_product)
       allow(iscsi).to receive(:activate)
@@ -172,8 +171,8 @@ describe Agama::Storage::Manager do
       allow(iscsi).to receive(:probe)
       allow(y2storage_manager).to receive(:probe)
 
-      allow_any_instance_of(Agama::Storage::ProposalSettingsReader).to receive(:read)
-        .and_return(config_settings)
+      allow_any_instance_of(Agama::Storage::ConfigReader).to receive(:read)
+        .and_return(storage_config)
     end
 
     let(:raw_devicegraph) do
@@ -186,8 +185,7 @@ describe Agama::Storage::Manager do
 
     let(:devices) { [disk1, disk2] }
 
-    let(:settings) { Agama::Storage::ProposalSettings.new }
-    let(:config_settings) { Agama::Storage::ProposalSettings.new }
+    let(:storage_config) { Agama::Storage::Config.new }
 
     let(:disk1) { instance_double(Y2Storage::Disk, name: "/dev/vda") }
     let(:disk2) { instance_double(Y2Storage::Disk, name: "/dev/vdb") }
@@ -206,7 +204,7 @@ describe Agama::Storage::Manager do
       end
       expect(iscsi).to receive(:probe)
       expect(y2storage_manager).to receive(:probe)
-      expect(proposal).to receive(:calculate_guided).with(config_settings)
+      expect(proposal).to receive(:calculate_agama).with(storage_config)
       storage.probe
     end
 

--- a/service/test/y2storage/agama_proposal_search_test.rb
+++ b/service/test/y2storage/agama_proposal_search_test.rb
@@ -207,12 +207,9 @@ describe Y2Storage::AgamaProposal do
             expect(disk.partitions.size).to eq 1
           end
 
-          it "register a warning about non-existent partitions" do
+          it "does not include any issue about non-existent partitions" do
             proposal.propose
-            expect(proposal.issues_list).to include an_object_having_attributes(
-              description: /optional partition/,
-              severity:    Agama::Issue::Severity::WARN
-            )
+            expect(proposal.issues_list).to be_empty
           end
         end
       end

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -22,7 +22,7 @@
 require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
-require "agama/storage/config_conversions/from_json"
+require "agama/storage/config_conversions"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -484,12 +484,9 @@ describe Y2Storage::AgamaProposal do
           expect(proposal.failed?).to eq false
         end
 
-        it "registers a non-critical issue" do
+        it "does not register any issue about missing disks" do
           proposal.propose
-          expect(proposal.issues_list).to include an_object_having_attributes(
-            description: /optional drive/,
-            severity:    Agama::Issue::Severity::WARN
-          )
+          expect(proposal.issues_list).to be_empty
         end
       end
 
@@ -576,12 +573,9 @@ describe Y2Storage::AgamaProposal do
           expect(proposal.failed?).to eq false
         end
 
-        it "registers a non-critical issue" do
+        it "does not register any issue about missing partitions" do
           proposal.propose
-          expect(proposal.issues_list).to include an_object_having_attributes(
-            description: /optional partition/,
-            severity:    Agama::Issue::Severity::WARN
-          )
+          expect(proposal.issues_list).to be_empty
         end
       end
 


### PR DESCRIPTION
We decided to stop relying on the YaST proposal and always use the new so-called `AgamaProposal` both for the auto-installation and for the interactive one.

This makes that change effective by generating an initial storage configuration that fulfills the product settings and executing `AgamaProposal` for it during the storage probing phase.

## Bonus

This includes a merge of `master` into the feature branch. To keep things in sync and, even more important, to get some fixes from there.