### PR TITLE
Fix network method

### DIFF
--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -84,7 +84,7 @@ impl NetworkClient {
         // trying to be tricky here. If something breaks then we need a put method on
         // BaseHTTPClient which doesn't require a serialiable object for the body
         self.client
-            .put_void(&format!("/network/system/apply").as_str(), &())
+            .post_void(&format!("/network/system/apply").as_str(), &())
             .await?;
 
         Ok(())

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 28 09:24:48 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use the correct method to apply the network configuration from
+  the CLI (gh#agama-project/agama#1701).
+
+-------------------------------------------------------------------
 Wed Oct 23 15:25:36 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the action to download the logs (gh#agama-project/agama#1693).


### PR DESCRIPTION
## Problem

See #1701. The CLI uses a PUT instead of a POST when applying the network configuration.

## Solution

Use the correct HTTP verb when applying the network configuration.

## Testing

- Tested manually