### PR TITLE
Update ruby-augeas to fix problem at CI

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.1)
-    ruby-augeas (0.5.0)
+    ruby-augeas (0.6.0)
     ruby-dbus (0.23.1)
       rexml
     simplecov (0.21.2)


### PR DESCRIPTION
## Problem

The checks at GitHub were failing for new pull requests because it was not possible to install ruby-augeas 0.5.0 at the containers.

Apparently that was triggered by a recent update of the version of the package at openSUSE Tumbleweed (it moved to 0.6.0).

## Solution

This updates `Gemfile.lock` to use the same version that is now available on Tumbleweed. Apparently that fixes CI for the new pull requests.