### PR TITLE
fix(web): use right  type for icon name at core/EmptyState

### DIFF
--- a/web/src/components/core/EmptyState.jsx
+++ b/web/src/components/core/EmptyState.jsx
@@ -34,7 +34,7 @@ import {
 import { Icon } from "~/components/layout";
 
 /**
- * @typedef {import("~/components/layout/Icon").IconName} IconName
+ * @typedef {import("~/components/layout/Icon").IconProps} IconProps
  * @typedef {import("@patternfly/react-core").EmptyStateProps} EmptyStateProps
  * @typedef {import("@patternfly/react-core").EmptyStateHeaderProps} EmptyStateHeaderProps
  */
@@ -48,7 +48,7 @@ import { Icon } from "~/components/layout";
  *
  * @param {object} props
  * @param {string} props.title
- * @param {IconName} props.icon
+ * @param {IconProps["name"]} props.icon
  * @param {string} [props.color="color-100"]
  * @param {EmptyStateHeaderProps["headingLevel"]} [props.headingLevel="h4"]
  * @param {boolean} [props.noPadding=false]

--- a/web/src/components/core/EmptyState.tsx
+++ b/web/src/components/core/EmptyState.tsx
@@ -20,8 +20,6 @@
  * find current contact information at www.suse.com.
  */
 
-// @ts-check
-
 import React from "react";
 import {
   EmptyState,
@@ -30,14 +28,21 @@ import {
   Stack,
   EmptyStateFooter,
   EmptyStateActions,
+  EmptyStateProps,
+  EmptyStateHeaderProps,
 } from "@patternfly/react-core";
 import { Icon } from "~/components/layout";
+import { IconProps } from "../layout/Icon";
 
-/**
- * @typedef {import("~/components/layout/Icon").IconProps} IconProps
- * @typedef {import("@patternfly/react-core").EmptyStateProps} EmptyStateProps
- * @typedef {import("@patternfly/react-core").EmptyStateHeaderProps} EmptyStateHeaderProps
- */
+type EmptyStateWrapperProps = {
+  title: string;
+  icon: IconProps["name"];
+  color?: string;
+  headingLevel?: EmptyStateHeaderProps["headingLevel"];
+  noPadding?: boolean;
+  actions?: React.ReactNode;
+  children?: React.ReactNode;
+};
 
 /**
  * Convenient wrapper for easing the use of PF/EmptyState component
@@ -46,15 +51,6 @@ import { Icon } from "~/components/layout";
  * directly when dealing with a very specific UI use case and more freedom is
  * needed.
  *
- * @param {object} props
- * @param {string} props.title
- * @param {IconProps["name"]} props.icon
- * @param {string} [props.color="color-100"]
- * @param {EmptyStateHeaderProps["headingLevel"]} [props.headingLevel="h4"]
- * @param {boolean} [props.noPadding=false]
- * @param {React.ReactNode} [props.actions]
- * @param {React.ReactNode} [props.children]
- * @param {EmptyStateProps} [props.rest]
  * @todo write documentation
  */
 export default function EmptyStateWrapper({
@@ -66,7 +62,7 @@ export default function EmptyStateWrapper({
   actions,
   children,
   ...rest
-}) {
+}: Partial<EmptyStateProps> & EmptyStateWrapperProps) {
   // @ts-ignore
   if (noPadding) rest.className = [rest.className, "no-padding"].join(" ").trim();
 

--- a/web/src/components/layout/Icon.tsx
+++ b/web/src/components/layout/Icon.tsx
@@ -152,7 +152,7 @@ const icons = {
 
 const PREDEFINED_SIZES = ["xxxs", "xxs", "xs", "s", "m", "l", "xl", "xxl", "xxxl"];
 
-type IconProps = React.SVGAttributes<SVGElement> & {
+export type IconProps = React.SVGAttributes<SVGElement> & {
   /** Name of the desired icon */
   name: keyof typeof icons;
   /** Size used for both, width and height.It can be a CSS unit or one of PREDEFINED_SIZES */

--- a/web/src/components/storage/zfcp/ZFCPPage.tsx
+++ b/web/src/components/storage/zfcp/ZFCPPage.tsx
@@ -84,7 +84,6 @@ const NoDisksFound = () => {
     <EmptyState
       title={_("No zFCP disks found.")}
       icon="warning"
-      // @ts-expect-error: core/EmptyState props are not well defined
       variant="sm"
       actions={
         activeController && (


### PR DESCRIPTION
## Problem

Unfortunately, https://github.com/agama-project/agama/pull/1690 broken a type import at core/EmptyState component that has been cough [by OBS](https://build.opensuse.org/package/live_build_log/systemsmanagement:Agama:Devel/agama-web-ui/openSUSE_Tumbleweed/x86_64)


## Solution

To use the right type (https://github.com/agama-project/agama/commit/d9554b145904d0eb2883d61b8f1cd4d7f0c6e9dd) and take the opportunity for migrating the component to TypeScript (https://github.com/agama-project/agama/commit/9719d0b201e7f1d861062e18fd9748a3e9c50373) which makes possible to get rid of a `@ts-expect-error` directive (https://github.com/agama-project/agama/commit/749db9e4d9c2a49d2c6b0ebb601d0ed1ae0dc961)

## Testing

Tested manually by running `NODE_ENV=production npm run build`
