### PR TITLE
Temporary fixes to UI

### DIFF
--- a/rust/agama-lib/src/storage/proxies.rs
+++ b/rust/agama-lib/src/storage/proxies.rs
@@ -88,17 +88,24 @@ trait ProposalCalculator {
 }
 
 #[dbus_proxy(
-    interface = "org.opensuse.Agama.Storage1.Proposal",
+    interface = "org.opensuse.Agama.Storage1.Devices",
     default_service = "org.opensuse.Agama.Storage1",
-    default_path = "/org/opensuse/Agama/Storage1/Proposal"
+    default_path = "/org/opensuse/Agama/Storage1"
 )]
-trait Proposal {
+trait Devices {
     /// Actions property
     #[dbus_proxy(property)]
     fn actions(
         &self,
     ) -> zbus::Result<Vec<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>>;
+}
 
+#[dbus_proxy(
+    interface = "org.opensuse.Agama.Storage1.Proposal",
+    default_service = "org.opensuse.Agama.Storage1",
+    default_path = "/org/opensuse/Agama/Storage1/Proposal"
+)]
+trait Proposal {
     /// Settings property
     #[dbus_proxy(property)]
     fn settings(

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -120,7 +120,7 @@ pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
         .route("/devices/result", get(staging_devices))
         .route("/product/volume_for", get(volume_for))
         .route("/product/params", get(product_params))
-        .route("/proposal/actions", get(actions))
+        .route("/devices/actions", get(actions))
         .route("/proposal/usable_devices", get(usable_devices))
         .route(
             "/proposal/settings",
@@ -331,7 +331,7 @@ pub struct ProductParams {
 /// Gets the actions to perform in the storage devices.
 #[utoipa::path(
     get,
-    path = "/proposal/actions",
+    path = "/devices/actions",
     context_path = "/api/storage",
     responses(
         (status = 200, description = "List of actions", body = Vec<Action>),

--- a/web/src/api/storage/proposal.ts
+++ b/web/src/api/storage/proposal.ts
@@ -40,7 +40,7 @@ const fetchDefaultVolume = (mountPath: string): Promise<Volume | undefined> => {
 
 const fetchSettings = (): Promise<ProposalSettings> => get("/api/storage/proposal/settings");
 
-const fetchActions = (): Promise<Action[]> => get("/api/storage/proposal/actions");
+const fetchActions = (): Promise<Action[]> => get("/api/storage/devices/actions");
 
 const calculate = (settings: ProposalSettingsPatch) =>
   put("/api/storage/proposal/settings", settings);

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -38,7 +38,6 @@ import { Link } from "react-router-dom";
 import { Center } from "~/components/layout";
 import { EmptyState, InstallButton, Page } from "~/components/core";
 import L10nSection from "./L10nSection";
-import StorageSection from "./StorageSection";
 import SoftwareSection from "./SoftwareSection";
 import { _ } from "~/i18n";
 import { useAllIssues } from "~/queries/issues";
@@ -116,7 +115,6 @@ const OverviewSection = () => (
   >
     <Stack hasGutter>
       <L10nSection />
-      <StorageSection />
       <SoftwareSection />
     </Stack>
   </Page.Section>

--- a/web/src/components/overview/index.js
+++ b/web/src/components/overview/index.js
@@ -23,4 +23,3 @@
 export { default as OverviewPage } from "./OverviewPage";
 export { default as L10nSection } from "./L10nSection";
 export { default as SoftwareSection } from "./SoftwareSection";
-export { default as StorageSection } from "./StorageSection";

--- a/web/src/queries/storage.ts
+++ b/web/src/queries/storage.ts
@@ -34,22 +34,13 @@ import {
   fetchActions,
   fetchDefaultVolume,
   fetchProductParams,
-  fetchSettings,
   fetchUsableDevices,
 } from "~/api/storage/proposal";
 import { useInstallerClient } from "~/context/installer";
-import { compact, uniq } from "~/utils";
-import {
-  ProductParams,
-  Volume as APIVolume,
-  ProposalSettings as APIProposalSettings,
-  ProposalTarget as APIProposalTarget,
-  ProposalSettingsPatch,
-} from "~/api/storage/types";
+import { ProductParams, Volume as APIVolume, ProposalSettingsPatch } from "~/api/storage/types";
 import {
   ProposalSettings,
   ProposalResult,
-  ProposalTarget,
   StorageDevice,
   Volume,
   VolumeTarget,
@@ -200,11 +191,6 @@ const useVolumeDevices = (): StorageDevice[] => {
   return [...availableDevices, ...mds, ...vgs];
 };
 
-const proposalSettingsQuery = {
-  queryKey: ["storage", "proposal", "settings"],
-  queryFn: fetchSettings,
-};
-
 const proposalActionsQuery = {
   queryKey: ["storage", "devices", "actions"],
   queryFn: fetchActions,
@@ -214,64 +200,9 @@ const proposalActionsQuery = {
  * Hook that returns the current proposal (settings and actions).
  */
 const useProposalResult = (): ProposalResult | undefined => {
-  const buildTarget = (value: APIProposalTarget): ProposalTarget => {
-    // FIXME: handle the case where they do not match
-    const target = value as ProposalTarget;
-    return target;
-  };
+  const { data: actions } = useSuspenseQuery(proposalActionsQuery);
 
-  /** @todo Read installation devices from D-Bus. */
-  const buildInstallationDevices = (settings: APIProposalSettings, devices: StorageDevice[]) => {
-    const findDevice = (name: string) => {
-      const device = devices.find((d) => d.name === name);
-
-      if (device === undefined) console.error("Device object not found: ", name);
-
-      return device;
-    };
-
-    // Only consider the device assigned to a volume as installation device if it is needed
-    // to find space in that device. For example, devices directly formatted or mounted are not
-    // considered as installation devices.
-    const volumes = settings.volumes.filter((vol) => {
-      const target = vol.target as VolumeTarget;
-      return [VolumeTarget.NEW_PARTITION, VolumeTarget.NEW_VG].includes(target);
-    });
-
-    const values = [
-      settings.targetDevice,
-      settings.targetPVDevices,
-      volumes.map((v) => v.targetDevice),
-    ].flat();
-
-    if (settings.configureBoot) values.push(settings.bootDevice);
-
-    const names = uniq(compact(values)).filter((d) => d.length > 0);
-
-    // #findDevice returns undefined if no device is found with the given name.
-    return compact(names.sort().map(findDevice));
-  };
-
-  const [{ data: settings }, { data: actions }] = useSuspenseQueries({
-    queries: [proposalSettingsQuery, proposalActionsQuery],
-  });
-  const systemDevices = useDevices("system", { suspense: true });
-  const { mountPoints: productMountPoints } = useProductParams({ suspense: true });
-
-  return {
-    settings: {
-      ...settings,
-      targetPVDevices: settings.targetPVDevices || [],
-      target: buildTarget(settings.target),
-      volumes: settings.volumes.map((v) => buildVolume(v, systemDevices, productMountPoints)),
-      // NOTE: strictly speaking, installation devices does not belong to the settings. It
-      // should be a separate method instead of an attribute in the settings object.
-      // Nevertheless, it was added here for simplicity and to avoid passing more props in some
-      // react components. Please, do not use settings as a jumble.
-      installationDevices: buildInstallationDevices(settings, systemDevices),
-    },
-    actions,
-  };
+  return { actions };
 };
 
 const useProposalMutation = () => {

--- a/web/src/queries/storage.ts
+++ b/web/src/queries/storage.ts
@@ -206,7 +206,7 @@ const proposalSettingsQuery = {
 };
 
 const proposalActionsQuery = {
-  queryKey: ["storage", "proposal", "actions"],
+  queryKey: ["storage", "devices", "actions"],
   queryFn: fetchActions,
 };
 


### PR DESCRIPTION
Now that we don't have a Proposal object exported at the API, this should prevent the UI from crashing right away.

Temporarily the storage page looks like this:

![storage](https://github.com/user-attachments/assets/20acb407-d598-4151-b90d-144a4daacbb3)
