### PR TITLE
Fix bsc#1232618

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 30 18:57:26 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
+
+- sles_enhanced_base pattern was removed from SLES16, so replace
+  it with base pattern (bsc#1232618)
+
+-------------------------------------------------------------------
 Tue Oct 22 08:41:14 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Use HTTP repositories for SLES16, HTTPS does not work because

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -59,7 +59,7 @@ software:
       archs: s390
 
   mandatory_patterns:
-    - sles_enhanced_base
+    - base
   optional_patterns: null # no optional pattern shared
   user_patterns: []
   mandatory_packages:


### PR DESCRIPTION
sles_enhanced_base pattern was removed from SLES 16 and  replaced by base pattern


## Problem

sles_enhanced_base pattern was removed from SLES 16

- [bsc#1232618](https://bugzilla.suse.com/show_bug.cgi?id=1232618)

## Solution

 Replace sles_enhanced_base pattern with  base pattern


## Testing

- NA

## Screenshots

NA

