### PR TITLE
Add autoconnect property for network connections

### DIFF
--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -203,10 +203,16 @@ pub struct NetworkConnection {
     pub mtu: u32,
     #[serde(rename = "ieee-8021x", skip_serializing_if = "Option::is_none")]
     pub ieee_8021x: Option<IEEE8021XSettings>,
+    #[serde(default = "default_true")]
+    pub autoconnect: bool,
 }
 
 fn is_zero<T: PartialEq + From<u16>>(u: &T) -> bool {
     *u == T::from(0)
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl NetworkConnection {

--- a/rust/agama-lib/src/network/settings.rs
+++ b/rust/agama-lib/src/network/settings.rs
@@ -165,44 +165,64 @@ pub struct NetworkDevice {
     pub state: DeviceState,
 }
 
+/// Represents the configuration details for a network connection
 #[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkConnection {
+    /// Unique identifier for the network connection
     pub id: String,
+    /// IPv4 method used for the network connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method4: Option<String>,
+    /// Gateway IP address for the IPv4 connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway4: Option<IpAddr>,
+    /// IPv6 method used for the network connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method6: Option<String>,
+    /// Gateway IP address for the IPv6 connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway6: Option<IpAddr>,
+    /// List of assigned IP addresses
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub addresses: Vec<IpInet>,
+    /// List of DNS server IP addresses
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub nameservers: Vec<IpAddr>,
+    /// List of search domains for DNS resolution
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub dns_searchlist: Vec<String>,
+    /// Specifies whether to ignore automatically assigned DNS settings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_auto_dns: Option<bool>,
+    /// Wireless settings for the connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireless: Option<WirelessSettings>,
+    /// Network interface associated with the connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interface: Option<String>,
+    /// Match settings for the network connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub match_settings: Option<MatchSettings>,
+    /// Identifier for the parent connection, if this connection is part of a bond
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<String>,
+    /// Bonding settings if part of a bond
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bond: Option<BondSettings>,
+    /// MAC address of the connection's interface
     #[serde(rename = "mac-address", skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
+    /// Current status of the network connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<Status>,
+    /// Maximum Transmission Unit (MTU) for the connection
     #[serde(skip_serializing_if = "is_zero", default)]
     pub mtu: u32,
+    /// IEEE 802.1X settings
     #[serde(rename = "ieee-8021x", skip_serializing_if = "Option::is_none")]
     pub ieee_8021x: Option<IEEE8021XSettings>,
+    /// Specifies if the connection should automatically connect
     #[serde(default = "default_true")]
     pub autoconnect: bool,
 }

--- a/rust/agama-server/src/network/model.rs
+++ b/rust/agama-server/src/network/model.rs
@@ -513,6 +513,7 @@ pub struct Connection {
     pub match_config: MatchConfig,
     pub config: ConnectionConfig,
     pub ieee_8021x_config: Option<IEEE8021XConfig>,
+    pub autoconnect: bool,
 }
 
 impl Connection {
@@ -584,6 +585,7 @@ impl Default for Connection {
             match_config: Default::default(),
             config: Default::default(),
             ieee_8021x_config: Default::default(),
+            autoconnect: true,
         }
     }
 }
@@ -634,6 +636,7 @@ impl TryFrom<NetworkConnection> for Connection {
         connection.ip_config.gateway6 = conn.gateway6;
         connection.interface = conn.interface;
         connection.mtu = conn.mtu;
+        connection.autoconnect = conn.autoconnect;
 
         Ok(connection)
     }
@@ -660,6 +663,7 @@ impl TryFrom<Connection> for NetworkConnection {
         let ieee_8021x: Option<IEEE8021XSettings> = conn
             .ieee_8021x_config
             .and_then(|x| IEEE8021XSettings::try_from(x).ok());
+        let autoconnect = conn.autoconnect;
 
         let mut connection = NetworkConnection {
             id,
@@ -676,6 +680,7 @@ impl TryFrom<Connection> for NetworkConnection {
             addresses,
             mtu,
             ieee_8021x,
+            autoconnect,
             ..Default::default()
         };
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 30 15:27:11 UTC 2024 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Add autoconnect property for network connections
+  (gh#agama-project/agama#1715)
+
+-------------------------------------------------------------------
 Mon Oct 28 09:24:48 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use the correct method to apply the network configuration from


### PR DESCRIPTION
## Problem

Missing autoconnect property for network connections.

## Solution

Add autoconnect property.


## Testing

- *Extended unit test*
- *Tested manually*
```bash
sudo agama auth login && AGAMA_TOKEN=`sudo agama auth show`
curl http://localhost/api/network/connections \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN" \
    -d '{ "id": "testcon", "method4": "auto", "method6": "auto", "ignoreAutoDns": false, "status": "down", "autoconnect": false }'
curl -X POST http://localhost/api/network/system/apply \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $AGAMA_TOKEN"
nmcli con show testcon
# See autoconnect set to "no".
```