### PR TITLE
fix(web): display the "finished" page

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 04 20:32:29 UTC 2024 - David Diaz <dgonzalez@suse.com>
+
+- Add missing subscription to avoid Agama getting stuck at the installation
+  progress when the installation finishes
+  (gh#agama-project/agama#1726, gh#agama-project/agama#1727).
+
+-------------------------------------------------------------------
 Wed Oct 30 22:26:29 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Render Install button only where it makes sense and prevent the

--- a/web/src/components/core/InstallationProgress.tsx
+++ b/web/src/components/core/InstallationProgress.tsx
@@ -26,10 +26,11 @@ import ProgressReport from "./ProgressReport";
 import { InstallationPhase } from "~/types/status";
 import { ROOT as PATHS } from "~/routes/paths";
 import { Navigate } from "react-router-dom";
-import { useInstallerStatus } from "~/queries/status";
+import { useInstallerStatus, useInstallerStatusChanges } from "~/queries/status";
 
 function InstallationProgress() {
   const { isBusy, phase } = useInstallerStatus({ suspense: true });
+  useInstallerStatusChanges();
 
   if (phase !== InstallationPhase.Install) {
     return <Navigate to={PATHS.root} replace />;


### PR DESCRIPTION
## Problem

The "Installation Finished" page is not shown when the installation finishes. It seems to be related
to latest changes regarding the application layout. Now, the `App` component is not always on top.

## Solution

Listen for status changes in the installation progress page.

## Testing

- Tested manually
