### PR TITLE
fix(web): proper handle of the network prefix

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov  5 11:33:12 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix a crash when editing a network connection containing an
+  additional IP address (gh#agama-project/agama#1728).
+
+-------------------------------------------------------------------
 Wed Oct 30 22:26:29 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Render Install button only where it makes sense and prevent the

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -61,7 +61,7 @@ const isValidIp = (value: IPAddress["address"]) => ipaddr.IPv4.isValidFourPartDe
  * @return true if given IP is valid; false otherwise.
  */
 const isValidIpPrefix = (value: IPAddress["prefix"]) => {
-  const prefix = value as string;
+  const prefix = String(value);
 
   if (prefix.match(/^\d+$/)) {
     return parseInt(prefix) <= 32;


### PR DESCRIPTION
## Problem

The web UI crashes when you try to edit a network connection containing an additional IP address
because the prefix is not handled correctly. The `as string` construction tells TypeScript to
consider the variable as a string, but it does not do a runtime conversion.

## Solution

Cast the variable to a string at runtime.
