### PR TITLE
live: config.sh: ignore non-existent translations if already missing

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Nov  5 12:41:19 UTC 2024 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- config.sh: ignore non-existent translations if already missing.
+
+-------------------------------------------------------------------
 Fri Sep 20 11:44:43 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 10

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -137,7 +137,7 @@ ls -1 "${IGNORE_OPTS[@]}" -I "en_US*" -I "C.*" /usr/lib/locale/ | xargs -I% sh -
 
 # delete unused translations (MO files)
 for t in zypper gettext-runtime p11-kit; do
-    rm /usr/share/locale/*/LC_MESSAGES/$t.mo
+    rm -f /usr/share/locale/*/LC_MESSAGES/$t.mo
 done
 du -h -s /usr/{share,lib}/locale/
 


### PR DESCRIPTION
## Problem

Some packages (e.g. gettext-runtime) might not be installed, and if missing the glob would not be evaluated and rm would fail.


## Solution

Let's use `rm -f` instead.


## Testing

- *Tested manually*
