### PR TITLE
products.d: sles_160.yaml: Add traditional pattern to mandatory_patterns for SLES16.0 product

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 06 11:28:16 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
+
+- add traditional pattern to mandatory_patterns for SLES16.0 product,
+  it will fix missing zypper in initial installation
+  (gh#agama-project/agama#1731)
+
+-------------------------------------------------------------------
 Wed Oct 30 18:57:26 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
 
 - sles_enhanced_base pattern was removed from SLES16, so replace

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -59,6 +59,7 @@ software:
       archs: s390
 
   mandatory_patterns:
+    - traditional
     - base
   optional_patterns: null # no optional pattern shared
   user_patterns: []


### PR DESCRIPTION
It will fix missing zypper in initial installation


## Problem

zypper is missing it the default installation for SLES 16.0

## Solution

Add traditional pattern as mandatory_patterns for SLES 16.0 to have zypper installed in the default installation


## Testing

- *Tested manually*
