### PR TITLE
fixup: Separate common files from service rubygem

### DIFF
--- a/service/package/_multibuild
+++ b/service/package/_multibuild
@@ -1,0 +1,6 @@
+<multibuild>
+  <!-- don't repeat the base package name, it is implied
+  <flavor>rubygem-agama-yast</flavor>
+  -->
+  <flavor>agama-yast</flavor>
+</multibuild>


### PR DESCRIPTION
Oops, a file was only in my OSC working copy but not in git, missing from #1677
