### PR TITLE
feat(rust): probe after running pre-scripts

### DIFF
--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -76,7 +76,11 @@ pub async fn run(http_client: BaseHTTPClient, subcommand: ConfigCommands) -> any
             let mut contents = String::new();
             stdin.read_to_string(&mut contents)?;
             let result: InstallSettings = serde_json::from_str(&contents)?;
-            Ok(store.store(&result).await?)
+            tokio::spawn(async move {
+                show_progress().await.unwrap();
+            });
+            store.store(&result).await?;
+            Ok(())
         }
         ConfigCommands::Edit { editor } => {
             let model = store.load().await?;

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -133,7 +133,7 @@ async fn show_progress() -> Result<(), ServiceError> {
     // wait 1 second to give other task chance to start, so progress can display something
     tokio::time::sleep(Duration::from_secs(1)).await;
     let conn = agama_lib::connection().await?;
-    let mut monitor = ProgressMonitor::new(conn).await.unwrap();
+    let mut monitor = ProgressMonitor::new(conn).await?;
     let presenter = InstallerProgress::new();
     monitor
         .run(presenter)

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -28,6 +28,7 @@ use agama_lib::{
 };
 use anyhow::Context;
 use clap::Subcommand;
+use console::style;
 use std::os::unix::process::CommandExt;
 use std::{
     fs::File,
@@ -81,18 +82,25 @@ pub enum ProfileCommands {
 
 fn validate(path: &PathBuf) -> anyhow::Result<()> {
     let validator = ProfileValidator::default_schema()?;
-    // let path = Path::new(&path);
     let result = validator
         .validate_file(path)
         .context(format!("Could not validate the profile {:?}", path))?;
     match result {
         ValidationResult::Valid => {
-            println!("The profile is valid")
+            println!(
+                "{} {}",
+                style("\u{2713}").bold().green(),
+                "The profile is valid."
+            );
         }
         ValidationResult::NotValid(errors) => {
-            eprintln!("The profile is not valid. Please, check the following errors:\n");
+            eprintln!(
+                "{} {}",
+                style("\u{2717}").bold().red(),
+                "The profile is not valid. Please, check the following errors:\n"
+            );
             for error in errors {
-                println!("* {error}")
+                println!("\t* {error}")
             }
         }
     }

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -18,6 +18,7 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
+use crate::show_progress;
 use agama_lib::{
     base_http_client::BaseHTTPClient,
     install_settings::InstallSettings,
@@ -107,6 +108,9 @@ fn evaluate(path: &Path) -> anyhow::Result<()> {
 }
 
 async fn import(url_string: String, dir: Option<PathBuf>) -> anyhow::Result<()> {
+    tokio::spawn(async move {
+        show_progress().await.unwrap();
+    });
     let url = Url::parse(&url_string)?;
     let tmpdir = TempDir::new()?; // TODO: create it only if dir is not passed
     let path = url.path();

--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -22,6 +22,7 @@
 
 pub mod http_client;
 pub use http_client::ManagerHTTPClient;
+use serde::{Deserialize, Serialize};
 
 use crate::error::ServiceError;
 use crate::proxies::ServiceStatusProxy;
@@ -29,7 +30,7 @@ use crate::{
     progress::Progress,
     proxies::{Manager1Proxy, ProgressProxy},
 };
-use serde_repr::Serialize_repr;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use tokio_stream::StreamExt;
 use zbus::Connection;
 
@@ -41,9 +42,23 @@ pub struct ManagerClient<'a> {
     status_proxy: ServiceStatusProxy<'a>,
 }
 
+/// Holds information about the manager's status.
+#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallerStatus {
+    /// Current installation phase.
+    pub phase: InstallationPhase,
+    /// Whether the service is busy.
+    pub is_busy: bool,
+    /// Whether Agama is running on Iguana.
+    pub use_iguana: bool,
+    /// Whether it is possible to start the installation.
+    pub can_install: bool,
+}
+
 /// Represents the installation phase.
 /// NOTE: does this conversion have any value?
-#[derive(Clone, Copy, Debug, PartialEq, Serialize_repr, utoipa::ToSchema)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize_repr, Deserialize_repr, utoipa::ToSchema)]
 #[repr(u32)]
 pub enum InstallationPhase {
     /// Start up phase.

--- a/rust/agama-lib/src/manager/http_client.rs
+++ b/rust/agama-lib/src/manager/http_client.rs
@@ -18,8 +18,10 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use crate::logs::LogsLists;
-use crate::{base_http_client::BaseHTTPClient, error::ServiceError};
+use crate::{
+    base_http_client::BaseHTTPClient, error::ServiceError, logs::LogsLists,
+    manager::InstallerStatus,
+};
 use reqwest::header::CONTENT_ENCODING;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -33,6 +35,7 @@ impl ManagerHTTPClient {
         Self { client: base }
     }
 
+    /// Starts a "probing".
     pub async fn probe(&self) -> Result<(), ServiceError> {
         // BaseHTTPClient did not anticipate POST without request body
         // so we pass () which is rendered as `null`
@@ -81,5 +84,12 @@ impl ManagerHTTPClient {
     /// store (/logs/store) backed HTTP API command
     pub async fn list(&self) -> Result<LogsLists, ServiceError> {
         Ok(self.client.get("/manager/logs/list").await?)
+    }
+
+    /// Returns the installer status.
+    pub async fn status(&self) -> Result<InstallerStatus, ServiceError> {
+        self.client
+            .get::<InstallerStatus>("/manager/installer")
+            .await
     }
 }

--- a/rust/agama-lib/src/scripts.rs
+++ b/rust/agama-lib/src/scripts.rs
@@ -26,6 +26,7 @@ mod model;
 mod settings;
 mod store;
 
+pub use client::ScriptsClient;
 pub use error::ScriptError;
 pub use model::*;
 pub use settings::*;

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -25,10 +25,10 @@
 //! * `manager_service` which returns the Axum service.
 //! * `manager_stream` which offers an stream that emits the manager events coming from D-Bus.
 
-use agama_lib::logs::{list as list_logs, store as store_logs, LogsLists, DEFAULT_COMPRESSION};
 use agama_lib::{
     error::ServiceError,
-    manager::{InstallationPhase, ManagerClient},
+    logs::{list as list_logs, store as store_logs, LogsLists, DEFAULT_COMPRESSION},
+    manager::{InstallationPhase, InstallerStatus, ManagerClient},
     proxies::Manager1Proxy,
 };
 use axum::{
@@ -39,7 +39,6 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use serde::Serialize;
 use std::pin::Pin;
 use tokio_stream::{Stream, StreamExt};
 use tokio_util::io::ReaderStream;
@@ -56,20 +55,6 @@ use crate::{
 pub struct ManagerState<'a> {
     dbus: zbus::Connection,
     manager: ManagerClient<'a>,
-}
-
-/// Holds information about the manager's status.
-#[derive(Clone, Serialize, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct InstallerStatus {
-    /// Current installation phase.
-    phase: InstallationPhase,
-    /// Whether the service is busy.
-    is_busy: bool,
-    /// Whether Agama is running on Iguana.
-    use_iguana: bool,
-    /// Whether it is possible to start the installation.
-    can_install: bool,
 }
 
 /// Returns a stream that emits manager related events coming from D-Bus.

--- a/rust/agama-server/src/web/docs/manager.rs
+++ b/rust/agama-server/src/web/docs/manager.rs
@@ -21,7 +21,7 @@ impl ApiDocBuilder for ManagerApiDocBuilder {
     fn components(&self) -> utoipa::openapi::Components {
         ComponentsBuilder::new()
             .schema_from::<agama_lib::manager::InstallationPhase>()
-            .schema_from::<crate::manager::web::InstallerStatus>()
+            .schema_from::<agama_lib::manager::InstallerStatus>()
             .build()
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov  7 14:20:48 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Perform a system re-probing after executing pre-scripts
+  (gh#agama-project/agama#1735).
+
+-------------------------------------------------------------------
 Mon Nov  4 07:51:55 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - Follow-up of original fix for gh#agama-project/agama#1495


### PR DESCRIPTION
## Problem

The typical use cases for pre-scripts are:

* Modifying the profile.
* Extending the installation media (adding some repository).
* Activating some hardware.

About the first use case, customers coming from AutoYaST can still use their old profiles because the pre-scripts will continue to work. For Agama, we could find a better way to modify the profile in place.

However, about the other use cases, we might need the scripts to run before system probing. The problem is that, in the single-product scenario, Agama performs the probing from the very beginning. It does not wait for a profile or the UI to start.

## Solution

Run the system probing again after running pre-scripts only if the system is already in the `config` phase.

## Drawback

As a side effect, importing a profile containing a pre-script causes the storage proposal to be lost. However, that's not a problem if the profile already contains a storage section, so it is kind of a corner case.

Moreover, the storage service should be responsible for keeping the proposal, which is out of this PR's scope.

## Testing

- *Tested manually*