### PR TITLE
Fix mandatory patterns for SLES16.0

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -2,7 +2,7 @@
 Thu Nov 07 18:25:49 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
 
 - Fix mandatory patterns for SLES16.0:
-  - fix tradicional pattern name, patterns-base-traditional package
+  - fix traditional pattern name, patterns-base-traditional package
     provides base_traditional
   - remove base pattern because base_traditional pattern requires it
   (gh#agama-project/agama#1736)

--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Nov 07 18:25:49 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
+
+- Fix mandatory patterns for SLES16.0:
+  - fix tradicional pattern name, patterns-base-traditional package
+    provides base_traditional
+  - remove base pattern because base_traditional pattern requires it
+  (gh#agama-project/agama#1736)
+
+-------------------------------------------------------------------
 Wed Nov 06 11:28:16 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
 
 - add traditional pattern to mandatory_patterns for SLES16.0 product,

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -59,8 +59,7 @@ software:
       archs: s390
 
   mandatory_patterns:
-    - traditional
-    - base
+    - base_traditional
   optional_patterns: null # no optional pattern shared
   user_patterns: []
   mandatory_packages:


### PR DESCRIPTION
- fix tradicional pattern name, patterns-base-traditional package provides base_traditional
- remove base pattern because base_traditional pattern requires it


## Problem

patterns-base-traditional package provides *base_traditional* pattern not *traditional* which was wrongly added in mandatory_patterns for SLES 16.0

```
$ rpm -qp --provides patterns-base-traditional-6.0-slfo.1.5.1.x86_64.rpm 
pattern() = base_traditional
pattern-category() = SLFO
pattern-icon() = pattern-kubic
pattern-order() = 9011
pattern-visible()
patterns-base-traditional = 6.0-slfo.1.5.1
patterns-base-traditional(x86-64) = 6.0-slfo.1.5.1
```


## Solution

In mandatory_patterns for SLES 16.0:
- replace *tradicional*  with *base_traditional*
- remove *base* pattern because *base_traditional* pattern requires it
```
$ rpm -qp --requires patterns-base-traditional-6.0-slfo.1.5.1.x86_64.rpm 
pattern() = base
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
zypper
zypper-needs-restarting

```


## Testing

- *Tested manually*