### PR TITLE
Shorten Leap 16.0 installation_labels

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Nov  8 13:20:10 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Shorten Leap 16.0 installation_labels
+  Neither yast2 partitioner, nor gnome disks
+  allowed me to use openSUSE-Leap-DVD-x86_64 as
+  the label limit seems to be 16 characters
+
+-------------------------------------------------------------------
 Fri Nov  8 11:58:49 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Add installation_labels for Leap 16.0

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -35,13 +35,13 @@ software:
   installation_repositories:
     - url: https://download.opensuse.org/distribution/leap/16.0/repo/oss
   installation_labels:
-    - label: openSUSE-Leap-DVD-x86_64
+    - label: Leap-DVD-x86_64
       archs: x86_64
-    - label: openSUSE-Leap-DVD-aarch64
+    - label: Leap-DVD-aarch64
       archs: aarch64
-    - label: openSUSE-Leap-DVD-s390x
+    - label: Leap-DVD-s390x
       archs: s390
-    - label: openSUSE-Leap-DVD-ppc64le
+    - label: Leap-DVD-ppc64le
       archs: ppc
   mandatory_patterns:
     - enhanced_base # only pattern that is shared among all roles on Leap


### PR DESCRIPTION
* Labels should not exceed 16 characters
 
* Neither yast2 partitioner, nor gnome disks
  allowed me to use openSUSE-Leap-DVD-x86_64

* Use Leap-DVD-$arch to meet the length requirement
