### PR TITLE
Very rough reorganization of the storage UI

### DIFF
--- a/web/src/agama.js
+++ b/web/src/agama.js
@@ -100,6 +100,20 @@ agama.ngettext = function ngettext(str1, strN, n) {
   return n === 1 ? str1 : strN;
 };
 
+/**
+ * Wrapper around Intl.ListFormat to get a language-specific representation of the given list of
+ * strings.
+ *
+ * @param {string[]} list iterable list of strings to represent
+ * @param {object} options passed to the Intl.ListFormat constructor
+ * @return {string} concatenation of the original strings with the correct language-specific
+ *  separators according to the currently selected language for the Agama UI
+ */
+agama.formatList = function formatList(list, options) {
+  const formatter = new Intl.ListFormat(agama.language, options);
+  return formatter.format(list);
+};
+
 // register a global object so it can be accessed from a separate po.js script
 window.agama = agama;
 

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -23,7 +23,7 @@
 import React, {useState} from "react";
 import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
-import { useAvailableDevices, useConfigDevices } from "~/queries/storage";
+import { useDevices, useConfigDevices } from "~/queries/storage";
 import { config as type } from "~/api/storage/types";
 import { StorageDevice } from "~/types/storage";
 import { deviceSize, SPACE_POLICIES } from "~/components/storage/utils";
@@ -173,12 +173,12 @@ function DriveEditor({ drive, driveDevice }: DriveEditorProps) {
 
 export default function ConfigEditor() {
   const drives = useConfigDevices();
-  const availableDevices = useAvailableDevices();
+  const devices = useDevices("system", { suspense: true });
 
   return (
     <List isPlain isBordered>
       {drives.map((drive, i) => {
-        const device = availableDevices.find((d) => d.name === drive.name);
+        const device = devices.find((d) => d.name === drive.name);
 
         return <DriveEditor key={i} drive={drive} driveDevice={device} />
       })}

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, {useState} from "react";
+import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+import { useAvailableDevices, useConfigDevices } from "~/queries/storage";
+import { config as type } from "~/api/storage/types";
+import { StorageDevice } from "~/types/storage";
+import { deviceSize, SPACE_POLICIES } from "~/components/storage/utils";
+import * as driveUI from "~/components/storage/utils/drive";
+import { typeDescription, contentDescription } from "~/components/storage/utils/device";
+import {
+  Button,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  List,
+  ListItem,
+  Label,
+  Stack,
+  StackItem,
+  Split,
+  SplitItem,
+  MenuToggle,
+  Dropdown,
+  DropdownList,
+  DropdownItem
+} from "@patternfly/react-core";
+import { generate as generateDevices } from "~/storage/model/config";
+
+type DriveEditorProps = { drive: type.DriveElement, driveDevice: StorageDevice };
+type PartitionsProps = { drive: type.DriveElement };
+
+function Partitions({ drive }: PartitionsProps) {
+  return driveUI.contentDescription(drive);
+};
+
+function DriveEditor({ drive, driveDevice }: DriveEditorProps) {
+  const DriveHeader = () => {
+    // TRANSLATORS: Header a so-called drive at the storage configuration. %s is the drive identifier
+    // like 'vdb' or any alias set by the user
+    const text = sprintf(_("Disk %s"), driveUI.label(drive));
+
+    return <h4>{text}</h4>;
+  };
+
+  // FIXME: do this i18n friendly, responsive and all that
+  const DeviceDescription = () => {
+    const data = [
+      driveDevice.name,
+      deviceSize(driveDevice.size),
+      typeDescription(driveDevice),
+      driveDevice.model
+    ];
+    const usefulData = [...new Set(data)].filter((d) => d && d !== "");
+
+    return <span>{usefulData.join(" ")}</span>;
+  };
+
+  const ContentDescription = () => {
+    const content = contentDescription(driveDevice);
+
+    return content && <span>{content}</span>;
+    // <FilesystemLabel item={driveDevice} />
+  };
+
+  const SpacePolicy = () => {
+    const currentPolicy = driveUI.spacePolicyEntry(drive);
+    const [isOpen, setIsOpen] = useState(false);
+    const onToggleClick = () => {
+      setIsOpen(!isOpen);
+    };
+
+    const PolicyItem = ({policy}) => {
+      return (
+        <DropdownItem
+          isSelected={policy.id === currentPolicy.id}
+          description={policy.description}
+        >
+          {policy.label}
+        </DropdownItem>
+      );
+    };
+
+    return (
+      <span>
+        {driveUI.oldContentActionsDescription(drive)}
+        <Dropdown
+          shouldFocusToggleOnSelect
+          isOpen={isOpen}
+          onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+          toggle={(toggleRef: React.Ref<MenuToggleElemet>) => (
+            <MenuToggle
+              ref={toggleRef}
+              onClick={onToggleClick}
+              isExpanded={isOpen}
+              variant="plain"
+            >
+              {_("Change")}
+            </MenuToggle>
+          )}
+        >
+          <DropdownList>
+            {SPACE_POLICIES.map((policy) => <PolicyItem policy={policy} />)}
+          </DropdownList>
+        </Dropdown>
+      </span>
+    );
+  };
+
+  return (
+    <ListItem>
+      <Stack>
+        <StackItem>
+          <DriveHeader />
+        </StackItem>
+        <StackItem>
+          <DescriptionList isHorizontal isCompact horizontalTermWidthModifier={{ default: '14ch'}}>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{_("Device")}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <DeviceDescription />
+                <Button variant="link">Change device</Button>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{_("Current Content")}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Stack>
+                  <StackItem>
+                    <ContentDescription />
+                    {driveDevice.systems.map((s) => <Label isCompact>{s}</Label>)}
+                  </StackItem>
+                  <StackItem>
+                    <SpacePolicy />
+                  </StackItem>
+                </Stack>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{_("New content")}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Partitions drive={drive} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </StackItem>
+      </Stack>
+    </ListItem>
+  );
+};
+
+export default function ConfigEditor() {
+  const drives = useConfigDevices();
+  const availableDevices = useAvailableDevices();
+
+  return (
+    <List isPlain isBordered>
+      {drives.map((drive, i) => {
+        const device = availableDevices.find((d) => d.name === drive.name);
+
+        return <DriveEditor key={i} drive={drive} driveDevice={device} />
+      })}
+    </List>
+  );
+}

--- a/web/src/components/storage/DeviceSelectorTable.tsx
+++ b/web/src/components/storage/DeviceSelectorTable.tsx
@@ -46,36 +46,7 @@ const DeviceInfo = ({ item }: { item: PartitionSlot | StorageDevice }) => {
   if (!device) return null;
 
   const DeviceType = () => {
-    let type: string;
-
-    switch (device.type) {
-      case "multipath": {
-        // TRANSLATORS: multipath device type
-        type = _("Multipath");
-        break;
-      }
-      case "dasd": {
-        // TRANSLATORS: %s is replaced by the device bus ID
-        type = sprintf(_("DASD %s"), device.busId);
-        break;
-      }
-      case "md": {
-        // TRANSLATORS: software RAID device, %s is replaced by the RAID level, e.g. RAID-1
-        type = sprintf(_("Software %s"), device.level.toUpperCase());
-        break;
-      }
-      case "disk": {
-        if (device.sdCard) {
-          type = _("SD Card");
-        } else {
-          const technology = device.transport || device.bus;
-          type = technology
-            ? // TRANSLATORS: %s is substituted by the type of disk like "iSCSI" or "SATA"
-              sprintf(_("%s disk"), technology)
-            : _("Disk");
-        }
-      }
-    }
+    const type = typeDescription(device);
 
     return type && <div>{type}</div>;
   };
@@ -133,27 +104,10 @@ const DeviceExtendedDetails = ({ item }: { item: PartitionSlot | StorageDevice }
 
   if (!device || ["partition", "lvmLv"].includes(device.type)) return <DeviceDetails item={item} />;
 
-  // TODO: there is a lot of room for improvement here, but first we would need
-  // device.description (comes from YaST) to be way more granular
   const Description = () => {
-    if (device.partitionTable) {
-      const type = device.partitionTable.type.toUpperCase();
-      const numPartitions = device.partitionTable.partitions.length;
-
-      // TRANSLATORS: disk partition info, %s is replaced by partition table
-      // type (MS-DOS or GPT), %d is the number of the partitions
-      return sprintf(_("%s with %d partitions"), type, numPartitions);
-    }
-
-    if (!!device.model && device.model === device.description) {
-      // TRANSLATORS: status message, no existing content was found on the disk,
-      // i.e. the disk is completely empty
-      return _("No content found");
-    }
-
     return (
       <div>
-        {device.description} <FilesystemLabel item={device} />
+        {contentDescription(device)} <FilesystemLabel item={device} />
       </div>
     );
   };
@@ -164,7 +118,7 @@ const DeviceExtendedDetails = ({ item }: { item: PartitionSlot | StorageDevice }
     const System = ({ system }) => {
       const isWindows = /windows/i.test(system);
 
-      if (isWindows) return;
+      if (isWindows) return <div>{system}</div>;
 
       return (
         <div>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -24,8 +24,9 @@ import React, { useRef } from "react";
 import { Grid, GridItem, Stack } from "@patternfly/react-core";
 import { Page, Drawer } from "~/components/core/";
 import ProposalResultSection from "./ProposalResultSection";
+import ConfigEditor from "./ConfigEditor";
 import ProposalActionsSummary from "~/components/storage/ProposalActionsSummary";
-import { ProposalActionsDialog } from "~/components/storage";
+import EncryptionField from "~/components/storage/EncryptionField"
 import { _ } from "~/i18n";
 import { toValidationError } from "~/utils";
 import { useIssues } from "~/queries/issues";
@@ -86,32 +87,28 @@ export default function ProposalPage() {
 
       <Page.Content>
         <Grid hasGutter>
-          <GridItem sm={12}>
-            <Drawer
-              ref={drawerRef}
-              panelHeader={<h4>{_("Planned Actions")}</h4>}
-              panelContent={<ProposalActionsDialog actions={actions} />}
+          <GridItem sm={12} xl={8}>
+            <Page.Section
+              title={_("Installation Devices")}
+              description={_("Structure of the new system, including disks to use and additional devices like LVM volume groups.")}
             >
-              <Stack hasGutter>
-                <ProposalActionsSummary
-                  system={systemDevices}
-                  staging={stagingDevices}
-                  errors={errors}
-                  actions={actions}
-                  // @ts-expect-error: we do not know how to specify the type of
-                  // drawerRef properly and TS does not find the "open" property
-                  onActionsClick={drawerRef.current?.open}
-                  isLoading={false}
-                />
-                <ProposalResultSection
-                  system={systemDevices}
-                  staging={stagingDevices}
-                  actions={actions}
-                  errors={errors}
-                  isLoading={false}
-                />
-              </Stack>
-            </Drawer>
+              <ConfigEditor />
+            </Page.Section>
+          </GridItem>
+          <GridItem sm={12} xl={4}>
+            <EncryptionField
+              password={""}
+              isLoading={false}
+            />
+          </GridItem>
+          <GridItem sm={12}>
+            <ProposalResultSection
+              system={systemDevices}
+              staging={stagingDevices}
+              actions={actions}
+              errors={errors}
+              isLoading={false}
+            />
           </GridItem>
         </Grid>
       </Page.Content>

--- a/web/src/components/storage/ProposalResultSection.tsx
+++ b/web/src/components/storage/ProposalResultSection.tsx
@@ -20,12 +20,13 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
-import { Skeleton, Stack } from "@patternfly/react-core";
+import React, { useState } from "react";
+import { Alert, ExpandableSection, Skeleton, Stack } from "@patternfly/react-core";
 import { EmptyState, Page } from "~/components/core";
 import DevicesManager from "~/components/storage/DevicesManager";
 import ProposalResultTable from "~/components/storage/ProposalResultTable";
-import { _ } from "~/i18n";
+import { ProposalActionsDialog } from "~/components/storage";
+import { _, n_ } from "~/i18n";
 import { Action, StorageDevice } from "~/types/storage";
 import { ValidationError } from "~/types/issues";
 
@@ -43,6 +44,65 @@ const ResultSkeleton = () => (
   </Stack>
 );
 
+/**
+ * Renders information about delete actions
+ */
+const DeletionsInfo = ({ manager }: { manager: DevicesManager }) => {
+  let label;
+  const systems = manager.deletedSystems();
+  const deleteActions = manager.actions.filter((a) => a.delete && !a.subvol).length;
+  const hasDeleteActions = deleteActions !== 0;
+
+  if (!hasDeleteActions) return;
+
+  // TRANSLATORS: %d will be replaced by the amount of destructive actions
+  label = sprintf(
+    n_(
+      "There is %d destructive action planned",
+      "There are %d destructive actions planned",
+      deleteActions,
+    ),
+    deleteActions
+  );
+
+  // FIXME: building the string by pieces like this is not i18n-friendly
+  if (systems.length) {
+    // FIXME: Use the Intl.ListFormat instead of the `join(", ")` used below.
+    // Most probably, a `listFormat` or similar wrapper should live in src/i18n.js or so.
+    // Read https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
+    label = sprintf(_("%s affecting %s"), label, systems.join(", "));
+  }
+
+  return (
+    <Alert variant="warning" isPlain isInline title={label} />
+  );
+};
+
+export type ActionsListProps = {
+  manager: DevicesManager;
+};
+
+function ActionsList({ manager }: ActionsListProps) {
+  const actions = manager.actions;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toggleText = isExpanded ?
+    _("Collapse the list of planned actions") : sprintf(_("Check the %d planned actions"), actions.length);
+
+  return (
+    <Stack>
+      <DeletionsInfo manager={manager} />
+      <ExpandableSection
+        isIndented
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded(!isExpanded)}
+        toggleText={toggleText}
+      >
+        <ProposalActionsDialog actions={actions} />
+      </ExpandableSection>
+    </Stack>
+  );
+};
+
 export type ProposalResultSectionProps = {
   system?: StorageDevice[];
   staging?: StorageDevice[];
@@ -58,14 +118,19 @@ export default function ProposalResultSection({
   errors = [],
   isLoading = false,
 }: ProposalResultSectionProps) {
+  const devicesManager = new DevicesManager(system, staging, actions);
+
   return (
     <Page.Section
-      title={_("Final layout")}
-      description={_("The systems will be configured as displayed below.")}
+      title={_("Result")}
+      description={_("During installation, several actions will be performed to setup the layout shown at the table below.")}
     >
       {isLoading && <ResultSkeleton />}
       {errors.length === 0 ? (
-        <ProposalResultTable devicesManager={new DevicesManager(system, staging, actions)} />
+        <Stack>
+          <ActionsList manager={devicesManager} />
+          <ProposalResultTable devicesManager={devicesManager} />
+        </Stack>
       ) : (
         <EmptyState
           icon="error"

--- a/web/src/components/storage/ProposalResultSection.tsx
+++ b/web/src/components/storage/ProposalResultSection.tsx
@@ -26,7 +26,7 @@ import { EmptyState, Page } from "~/components/core";
 import DevicesManager from "~/components/storage/DevicesManager";
 import ProposalResultTable from "~/components/storage/ProposalResultTable";
 import { ProposalActionsDialog } from "~/components/storage";
-import { _, n_ } from "~/i18n";
+import { _, n_, formatList } from "~/i18n";
 import { Action, StorageDevice } from "~/types/storage";
 import { ValidationError } from "~/types/issues";
 
@@ -55,23 +55,29 @@ const DeletionsInfo = ({ manager }: { manager: DevicesManager }) => {
 
   if (!hasDeleteActions) return;
 
-  // TRANSLATORS: %d will be replaced by the amount of destructive actions
-  label = sprintf(
-    n_(
-      "There is %d destructive action planned",
-      "There are %d destructive actions planned",
-      deleteActions,
-    ),
-    deleteActions
-  );
-
   // FIXME: building the string by pieces like this is not i18n-friendly
   if (systems.length) {
-    // FIXME: Use the Intl.ListFormat instead of the `join(", ")` used below.
-    // Most probably, a `listFormat` or similar wrapper should live in src/i18n.js or so.
-    // Read https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
-    label = sprintf(_("%s affecting %s"), label, systems.join(", "));
-  }
+    label = sprintf(
+      // TRANSLATORS: %d will be replaced by the amount of destructive actions and %s will be replaced
+      // by a formatted list of affected systems like "Windows and openSUSE Tumbleweed".
+      n_(
+        "There is %d destructive action planned affecting %s",
+        "There are %d destructive actions planned affecting %s",
+        deleteActions,
+      ),
+      deleteActions, formatList(systems)
+    );
+  } else {
+    label = sprintf(
+      // TRANSLATORS: %d will be replaced by the amount of destructive actions
+      n_(
+        "There is %d destructive action planned",
+        "There are %d destructive actions planned",
+        deleteActions,
+      ),
+      deleteActions
+    );
+  };
 
   return (
     <Alert variant="warning" isPlain isInline title={label} />

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -31,7 +31,7 @@
  */
 
 import xbytes from "xbytes";
-import { N_ } from "~/i18n";
+import { _, N_ } from "~/i18n";
 import { PartitionSlot, StorageDevice, Volume } from "~/types/storage";
 
 /**
@@ -258,6 +258,16 @@ const volumeLabel = (volume: Volume): string =>
  */
 const gib: (value: number) => number = (value): number => value * 1024 ** 3;
 
+/**
+ * Formats a mount path within a sentence in a i18n-friendly way.
+ */
+const formattedPath = (path: string): string => {
+  // TRANSLATORS: sub-string used to represent a path like "/" or "/var". %s is replaced by the path
+  // itself, the rest of the string (quotation marks in the English case) is used to encapsulate the
+  // path in a bigger sentence like 'Create partitions for "/" and "/var"'.
+  return sprintf(_("\"%s\""), path);
+};
+
 export {
   DEFAULT_SIZE_UNIT,
   SIZE_METHODS,
@@ -268,6 +278,7 @@ export {
   deviceLabel,
   deviceChildren,
   deviceSize,
+  formattedPath,
   gib,
   parseToBytes,
   splitSize,

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -46,7 +46,7 @@ export type SpacePolicy = {
   id: string;
   label: string;
   description: string;
-  summaryLabels: string[];
+  summaryLabel: string;
 };
 
 export type SizeMethod = "auto" | "fixed" | "range";
@@ -71,42 +71,25 @@ const SPACE_POLICIES: SpacePolicy[] = [
   {
     id: "delete",
     label: N_("Delete current content"),
-    description: N_("All partitions will be removed and any data in the disks will be lost."),
-    summaryLabels: [
-      // TRANSLATORS: This is presented next to the label "Find space", so the whole sentence
-      // would read as "Find space deleting current content". Keep it short
-      N_("deleting current content"),
-    ],
+    summaryLabel: N_("All content will be deleted."),
+    description: N_("Any existing partition will be removed and all data in the disk will be lost."),
   },
   {
     id: "resize",
     label: N_("Shrink existing partitions"),
+    summaryLabel: N_("Some existing partitions may be shrunk."),
     description: N_("The data is kept, but the current partitions will be resized as needed."),
-    summaryLabels: [
-      // TRANSLATORS: This is presented next to the label "Find space", so the whole sentence
-      // would read as "Find space shrinking partitions". Keep it short.
-      N_("shrinking partitions"),
-    ],
   },
   {
     id: "keep",
     label: N_("Use available space"),
+    summaryLabel: N_("Content will be kept."),
     description: N_("The data is kept. Only the space not assigned to any partition will be used."),
-    summaryLabels: [
-      // TRANSLATORS: This is presented next to the label "Find space", so the whole sentence
-      // would read as "Find space without modifying any partition". Keep it short.
-      N_("without modifying any partition"),
-    ],
   },
   {
     id: "custom",
     label: N_("Custom"),
     description: N_("Select what to do with each partition."),
-    summaryLabels: [
-      // TRANSLATORS: This is presented next to the label "Find space", so the whole sentence
-      // would read as "Find space with custom actions". Keep it short.
-      N_("with custom actions"),
-    ],
   },
 ];
 
@@ -173,10 +156,17 @@ const parseToBytes = (size: string | number): number => {
 };
 
 /**
+ * Base name for a full path
+ */
+const baseName = (name: string): string => {
+  return name.split("/").pop();
+};
+
+/**
  * Base name of a device.
  */
 const deviceBaseName = (device: StorageDevice): string => {
-  return device.name.split("/").pop();
+  return baseName(device.name);
 };
 
 /**
@@ -273,6 +263,7 @@ export {
   SIZE_METHODS,
   SIZE_UNITS,
   SPACE_POLICIES,
+  baseName,
   deviceBaseName,
   deviceLabel,
   deviceChildren,

--- a/web/src/components/storage/utils/device.tsx
+++ b/web/src/components/storage/utils/device.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+import { StorageDevice } from "~/types/storage";
+
+/*
+ * Description of the device type.
+ */
+const typeDescription = (device: StorageDevice): string | undefined => {
+  let type: string;
+
+  switch (device.type) {
+    case "multipath": {
+      // TRANSLATORS: multipath device type
+      type = _("Multipath");
+      break;
+    }
+    case "dasd": {
+      // TRANSLATORS: %s is replaced by the device bus ID
+      type = sprintf(_("DASD %s"), device.busId);
+      break;
+    }
+    case "md": {
+      // TRANSLATORS: software RAID device, %s is replaced by the RAID level, e.g. RAID-1
+      type = sprintf(_("Software %s"), device.level.toUpperCase());
+      break;
+    }
+    case "disk": {
+      if (device.sdCard) {
+        type = _("SD Card");
+      } else {
+        const technology = device.transport || device.bus;
+        type = technology
+          ? // TRANSLATORS: %s is substituted by the type of disk like "iSCSI" or "SATA"
+            sprintf(_("%s disk"), technology)
+          : _("Disk");
+      }
+    }
+  }
+
+  return type;
+};
+
+/*
+ * Description of the device.
+ *
+ * TODO: there is a lot of room for improvement here, but first we would need
+ * device.description (comes from YaST) to be way more granular
+ */
+const contentDescription = (device: StorageDevice): string => {
+  if (device.partitionTable) {
+    const type = device.partitionTable.type.toUpperCase();
+    const numPartitions = device.partitionTable.partitions.length;
+
+    // TRANSLATORS: disk partition info, %s is replaced by partition table
+    // type (MS-DOS or GPT), %d is the number of the partitions
+    return sprintf(_("%s with %d partitions"), type, numPartitions);
+  }
+
+  if (!!device.model && device.model === device.description) {
+    // TRANSLATORS: status message, no existing content was found on the disk,
+    // i.e. the disk is completely empty
+    return _("No content found");
+  }
+
+  if (device.description === "") return;
+
+  return device.description;
+};
+
+export {
+  typeDescription,
+  contentDescription
+};

--- a/web/src/components/storage/utils/drive.tsx
+++ b/web/src/components/storage/utils/drive.tsx
@@ -22,10 +22,9 @@
 
 // @ts-check
 
-import { _ } from "~/i18n";
+import { _, n_, formatList } from "~/i18n";
 import { DriveElement } from "~/api/storage/types";
-import { SpacePolicy, SPACE_POLICIES, baseName } from "~/components/storage/utils";
-
+import { SpacePolicy, SPACE_POLICIES, baseName, formattedPath } from "~/components/storage/utils";
 
 /**
  * String to identify the drive.
@@ -68,7 +67,7 @@ const resizeTextFor = (partitions) => {
 
 /**
  * FIXME: right now, this considers only the case in which the drive is going to be partitioned. If
- * its directly used (as LVM PV, as MD member, to host a filesystem...) the content wil be deleted
+ * it's directly used (as LVM PV, as MD member, to host a filesystem...) the content wil be deleted
  * anyways. That must be properly stated.
  */
 const oldContentActionsDescription = (drive: DriveElement): string => {
@@ -97,9 +96,6 @@ const oldContentActionsDescription = (drive: DriveElement): string => {
 /**
  * FIXME: right now, this considers only the case in which the drive is going to host some formatted
  * partitions.
- *
- * FIXME: We probably want to format the mount points a bit (eg. use "root" for "/" or use some
- * markup).
  */
 const contentDescription = (drive: DriveElement): string => {
   const partitions = drive.partitions.filter((p) => !p.name)
@@ -107,10 +103,18 @@ const contentDescription = (drive: DriveElement): string => {
   // FIXME: this is one of the several cases we need to handle better
   if (partitions.length === 0) return "";
 
-  // FIXME: Use the Intl.ListFormat instead of the `join(", ")` used below.
-  // Most probably, a `listFormat` or similar wrapper should live in src/i18n.js or so.
-  // Read https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
-  return sprintf(_("New partitions will be created for %s"), partitions.map((p) => p.mountPath).join(", "));
+
+  const mountPaths = partitions.map((p) => formattedPath(p.mountPath));
+  return sprintf(
+    // TRANSLATORS: %s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
+    // single mount point in the singular case).
+    n_(
+      "A new partition will be created for %s",
+      "New partitions will be created for %s",
+      mountPaths.length
+    ),
+    formatList(mountPaths)
+  );
 };
 
 export {

--- a/web/src/components/storage/utils/drive.tsx
+++ b/web/src/components/storage/utils/drive.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import { _ } from "~/i18n";
+import { DriveElement } from "~/api/storage/types";
+import { SpacePolicy, SPACE_POLICIES, baseName } from "~/components/storage/utils";
+
+
+/**
+ * String to identify the drive.
+ */
+const label = (drive: DriveElement): string => {
+  if (drive.alias) return drive.alias;
+
+  return baseName(drive.name);
+};
+
+const spacePolicyEntry = (drive: DriveElement): SpacePolicy => {
+  return SPACE_POLICIES.find((p) => p.id === drive.spacePolicy);
+}
+
+const deleteTextFor = (partitions) => {
+  const mandatory = partitions.filter((p) => p.delete).length;
+  const onDemand = partitions.filter((p) => p.deleteIfNeeded).length;
+
+  if (mandatory === 0 && onDemand === 0) return;
+  if (mandatory === 1 && onDemand === 0) return _("A partition will be deleted.");
+  if (mandatory === 1) return _("At least one partition will be deleted.");
+  if (mandatory > 1) return _("Several partitions will be deleted.");
+  if (onDemand === 1) return _("A partition may be deleted.");
+
+  return _("Some partitions may be deleted.");
+};
+
+/**
+ * FIXME: right now, this considers only a particular case because the information from the model is
+ * incomplete.
+ */
+const resizeTextFor = (partitions) => {
+  const count = partitions.filter((p) => p.size?.min === 0).length;
+
+  if (count === 0) return;
+  if (count === 1) return _("A partition may be shrunk.");
+
+  return _("Some partitions may be shrunk.");
+};
+
+/**
+ * FIXME: right now, this considers only the case in which the drive is going to be partitioned. If
+ * its directly used (as LVM PV, as MD member, to host a filesystem...) the content wil be deleted
+ * anyways. That must be properly stated.
+ */
+const oldContentActionsDescription = (drive: DriveElement): string => {
+  const policyLabel = spacePolicyEntry(drive).summaryLabel;
+
+  if (policyLabel) return _(policyLabel);
+
+
+  const partitions = drive.partitions.filter((p) => p.name);
+  const deleteText = deleteTextFor(partitions);
+  const resizeText = resizeTextFor(partitions);
+
+  if (deleteText && resizeText) {
+    // TRANSLATORS: this simply concatenates the two sentences that describe what is going to happen
+    // with partitions. The first %s corresponds to deleted partitions and the second one to resized
+    // ones.
+    return sprintf(_("%s %s"), deleteText, resizeText);
+  }
+
+  if (deleteText) return deleteText;
+  if (resizeText) return resizeText;
+
+  return _(SPACE_POLICIES.find((p) => p.id === "keep").summaryLabel);
+};
+
+/**
+ * FIXME: right now, this considers only the case in which the drive is going to host some formatted
+ * partitions.
+ *
+ * FIXME: We probably want to format the mount points a bit (eg. use "root" for "/" or use some
+ * markup).
+ */
+const contentDescription = (drive: DriveElement): string => {
+  const partitions = drive.partitions.filter((p) => !p.name)
+
+  // FIXME: this is one of the several cases we need to handle better
+  if (partitions.length === 0) return "";
+
+  // FIXME: Use the Intl.ListFormat instead of the `join(", ")` used below.
+  // Most probably, a `listFormat` or similar wrapper should live in src/i18n.js or so.
+  // Read https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
+  return sprintf(_("New partitions will be created for %s"), partitions.map((p) => p.mountPath).join(", "));
+};
+
+export {
+  label,
+  spacePolicyEntry,
+  oldContentActionsDescription,
+  contentDescription
+};

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -138,4 +138,15 @@ const N_ = (str) => str;
  */
 const Nn_ = (str1, strN, n) => (n === 1 ? str1 : strN);
 
-export { _, n_, N_, Nn_ };
+/**
+ * Wrapper around Intl.ListFormat to get a language-specific representation of the given list of
+ * strings.
+ *
+ * @param {string[]} list iterable list of strings to represent
+ * @param {object} options passed to the Intl.ListFormat constructor
+ * @return {string} concatenation of the original strings with the correct language-specific
+ *  separators according to the currently selected language for the Agama UI
+ */
+const formatList = (list, options = {}) => agama.formatList(list, options);
+
+export { _, n_, N_, Nn_, formatList };


### PR DESCRIPTION
This replaces #1742 (it was impossible to resurrect and/or re-target that PR since its base branch was deleted).

Currently this looks like this:

![datos1](https://github.com/user-attachments/assets/63496c9b-a8ad-4c92-83bc-52aecac3fcd1)

![datos2](https://github.com/user-attachments/assets/1c254840-6488-4d8a-ba8d-c175ccdd43e3)

But that's just temporal. This is not a proposal about the information that should be displayed and how. It's just an attempt to throw all possible information in the UI so @dgdavid has real data to do his magic.

In fact, I would like each device entry to be way more compact. Let's play with Gimp to show what I mean!

![datos-compactos](https://github.com/user-attachments/assets/ec2fa83d-683e-4cb5-996a-1c6f413f266b)