### PR TITLE
Small wireless configuration fixes

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 14 14:45:47 UTC 2024 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Get some wireless settings as optional in order to not break the
+  connections reader (gh#agama-project/agama#1753).
+
+-------------------------------------------------------------------
 Wed Nov 13 12:03:02 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Properly update the localization settings of the D-Bus services

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 14 14:42:46 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix wireless authentication initialization as well as the
+  invalidate the cached query in case of connected
+  (gh#agama-project/agama#1753).
+
+-------------------------------------------------------------------
 Wed Nov 13 12:06:41 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Several translation fixes (gh#agama-project/agama#1746):
@@ -20,7 +27,7 @@ Tue Nov  5 11:33:12 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix a crash when editing a network connection containing an
   additional IP address (gh#agama-project/agama#1728).
-  
+
 -------------------------------------------------------------------
 Mon Nov  4 20:32:29 UTC 2024 - David Diaz <dgonzalez@suse.com>
 

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Nov 14 14:42:46 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
-- Fix wireless authentication initialization as well as the
+- Fix wireless authentication initialization and
   invalidate the cached query in case of connected
   (gh#agama-project/agama#1753).
 

--- a/web/src/components/network/WifiConnectionForm.tsx
+++ b/web/src/components/network/WifiConnectionForm.tsx
@@ -55,6 +55,12 @@ const selectorOptions = security_options.map((security) => (
   <FormSelectOption key={security.value} value={security.value} label={security.label} />
 ));
 
+const securityFrom = (supported) => {
+  if (supported.includes("WPA2")) return "wpa-psk";
+  if (supported.includes("WPA1")) return "wpa-psk";
+  return "";
+};
+
 // FIXME: improve error handling. The errors props should have a key/value error
 //  and the component should show all of them, if any
 export default function WifiConnectionForm({
@@ -71,7 +77,9 @@ export default function WifiConnectionForm({
   const { mutate: updateConnection } = useConnectionMutation();
   const { mutate: updateSelectedNetwork } = useSelectedWifiChange();
   const [ssid, setSsid] = useState<string>(network.ssid);
-  const [security, setSecurity] = useState<string>(settings.security);
+  const [security, setSecurity] = useState<string>(
+    settings?.security || securityFrom(network?.security || []),
+  );
   const [password, setPassword] = useState<string>(settings.password);
   const [showErrors, setShowErrors] = useState<boolean>(Object.keys(errors).length > 0);
   const [isConnecting, setIsConnecting] = useState<boolean>(false);

--- a/web/src/components/network/WifiNetworksListPage.tsx
+++ b/web/src/components/network/WifiNetworksListPage.tsx
@@ -56,6 +56,7 @@ import {
   useRemoveConnectionMutation,
   useSelectedWifi,
   useSelectedWifiChange,
+  useNetworkConfigChanges,
   useWifiNetworks,
 } from "~/queries/network";
 import { slugify } from "~/utils";
@@ -222,11 +223,12 @@ const NetworkListItem = ({ network }) => {
  * Component for displaying a list of available Wi-Fi networks
  */
 function WifiNetworksListPage() {
+  useNetworkConfigChanges();
   const networks: WifiNetwork[] = useWifiNetworks();
   const { ssid: selectedSsid, hidden } = useSelectedWifi();
+  // FIXME: improve below type casting, if possible
   const selected = hidden
-    ? // FIXME: improve below type casting, if possible
-      (HIDDEN_NETWORK as unknown as WifiNetwork)
+    ? (HIDDEN_NETWORK as unknown as WifiNetwork)
     : networks.find((n) => n.ssid === selectedSsid);
   const { mutate: changeSelection } = useSelectedWifiChange();
 

--- a/web/src/queries/network.ts
+++ b/web/src/queries/network.ts
@@ -245,6 +245,7 @@ const useNetworkConfigChanges = () => {
           ) {
             if (current_device.state !== data.state) {
               queryClient.invalidateQueries({ queryKey: ["network"] });
+              return changeSelected.mutate({ needsAuth: false });
             }
           }
           if ([DeviceState.NEEDAUTH, DeviceState.FAILED].includes(data.state)) {


### PR DESCRIPTION
## Problem

- https://trello.com/c/5PjJQ2Vq

There are various issues detected when working on this PBI:

1. The authentication method is not selected properly
2. The form reports that auhentication failed when it is already connected.
3. Some times the labels and buttons for the selected wifi does not correspond whith the current state.
4. After a sync with master branch the backend started failing when reading wireless connections

## Solution

We have fixes some of the issues but the handle of state is quite fragile and coupled to the websockets notification in the frontend and the UI therefore we plan to do some changes in the UI (Drawer and selection of the WiFi) as well as in the backend trying to store the authentication state there being able to request the state from the backend without lostling any information in case of not subscribed to changes.

About the fixes in particular:

1. The authentication method is recognized again (removed method probably by error).
2. In case that a wireless device is activated the needAuth is also removed from the cached queries
3. To be better handled.
4. Get some of the wireless settings as optional (band, channel, bssid, hidden, pmf)

...

## Testing

- Tested manually

