### PR TITLE
Temporarily drop xf86-video-fbdev

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 13 12:20:23 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Temporarily drop xf86-video-fbdev as it seems to be missing
+  in the repo
+  (gh#agama-project/agama#1752)
+
+-------------------------------------------------------------------
 Wed Nov 13 10:29:31 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Add common xf86-video drives + x86-input for tablets

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -152,7 +152,6 @@
         <package name="xf86-input-libinput" />
         <package name="xf86-input-wacom" arch="aarch64,x86_64,ppc64le"/>
         <package name="xf86-video-amdgpu" arch="x86_64"/>
-        <package name="xf86-video-fbdev" arch="x86_64"/>
         <package name="xf86-video-intel" arch="x86_64"/>
         <package name="xf86-video-nv" arch="x86_64"/>
         <package name="xf86-video-qxl" arch="x86_64"/>


### PR DESCRIPTION
Build fails on missing -fbdev driver. Let's temporarily drop it