### PR TITLE
AgamaProposal: Honor DiskAnalyzer candidate devices when searching drives

### DIFF
--- a/service/lib/agama/storage/config_solver.rb
+++ b/service/lib/agama/storage/config_solver.rb
@@ -32,11 +32,14 @@ module Agama
     # example, the sizes of a partition config taking into account its fallbacks, assigning a
     # specific device when a config has a search, etc.
     class ConfigSolver
-      # @param devicegraph [Y2Storage::Devicegraph]
-      # @param product_config [Agama::Config]
-      def initialize(devicegraph, product_config)
+      # @param devicegraph [Y2Storage::Devicegraph] initial layout of the system
+      # @param product_config [Agama::Config] configuration of the product to install
+      # @param disk_analyzer [Y2Storage::DiskAnalyzer, nil] optional extra information about the
+      #   initial layout of the system
+      def initialize(devicegraph, product_config, disk_analyzer: nil)
         @devicegraph = devicegraph
         @product_config = product_config
+        @disk_analyzer = disk_analyzer
       end
 
       # Solves the config according to the product and the system.
@@ -47,7 +50,7 @@ module Agama
       def solve(config)
         ConfigEncryptionSolver.new(product_config).solve(config)
         ConfigFilesystemSolver.new(product_config).solve(config)
-        ConfigSearchSolver.new(devicegraph).solve(config)
+        ConfigSearchSolver.new(devicegraph, disk_analyzer).solve(config)
         # Sizes must be solved once the searches are solved.
         ConfigSizeSolver.new(devicegraph, product_config).solve(config)
       end
@@ -59,6 +62,9 @@ module Agama
 
       # @return [Agama::Config]
       attr_reader :product_config
+
+      # @return [Y2Storage::DiskAnalyzer, nil]
+      attr_reader :disk_analyzer
     end
   end
 end

--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -93,7 +93,7 @@ module Y2Storage
     # @raise [NoDiskSpaceError] if there is no enough space to perform the installation
     def calculate_proposal
       Agama::Storage::ConfigSolver
-        .new(initial_devicegraph, product_config)
+        .new(initial_devicegraph, product_config, disk_analyzer: disk_analyzer)
         .solve(config)
 
       issues = Agama::Storage::ConfigChecker

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 14 13:26:23 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: honor the candidate devices from DiskAnalyzer when
+  matching drives (gh#agama-project/agama#1765).
+
+-------------------------------------------------------------------
 Wed Nov 13 12:14:06 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when trying to change the language of the storage


### PR DESCRIPTION
## Problem

When searching drives, the initial implementation of `AgamaProposal` uses all disk (or disk-like devices, to be precise) in the system.

That is ok as a first attempt, but we always knew we might need to refine that a bit.

Now that we are working on the new interface for storage configuration, fully based on `AgamaProposal`, the fact that `AgamaProposal` can choose a disk that is not considered by `DiskAnalyzer` to be an installation candidate feels a bit odd.

## Solution

For the time being (and with minimal code changes), this adapts the `AgamaProposal` algorithm to filter out disks that are skipped by `DiskAnalyzer`. That typically means the disks from which the installer is running, disks that contain installation repositories, etc.

We may need to refine that in the future again. But for now that's the most consistent behavior we can adopt without taking big decisions.

## Testing

Added a new unit test

Manual testing done by @joseivanlopez.