### PR TITLE
AgamaProposal: fix bug when partitions are searched but not managed

### DIFF
--- a/service/lib/y2storage/proposal/agama_devices_creator.rb
+++ b/service/lib/y2storage/proposal/agama_devices_creator.rb
@@ -125,11 +125,17 @@ module Y2Storage
       def process_existing_partitionables
         partitions = partitions_for_existing(planned_devices)
 
-        # Check whether there is any chance of getting an unwanted order for the planned partitions
-        # within a disk
-        space_result = space_maker.provide_space(
-          original_graph, partitions: partitions, volume_groups: automatic_vgs
-        )
+        begin
+          # Check whether there is any chance of getting an unwanted order for the planned
+          # partitions within a disk
+          space_result = space_maker.provide_space(
+            original_graph, partitions: partitions, volume_groups: automatic_vgs
+          )
+        rescue Error => e
+          log.info "SpaceMaker was not able to find enough space: #{e}"
+          raise NoDiskSpaceError
+        end
+
         self.devicegraph = space_result[:devicegraph]
         distribution = space_result[:partitions_distribution]
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 14 15:34:17 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Storage: fixed bug when existing partitions were searched at the
+  config but not deleted or resized (gh#agama-project/agama#1767).
+
+-------------------------------------------------------------------
 Thu Nov 14 13:26:23 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Storage: honor the candidate devices from DiskAnalyzer when

--- a/service/test/agama/storage/proposal_test.rb
+++ b/service/test/agama/storage/proposal_test.rb
@@ -580,7 +580,7 @@ describe Agama::Storage::Proposal do
         subject.calculate_agama(config)
 
         expect(subject.issues).to include(
-          an_object_having_attributes(description: /A problem ocurred/)
+          an_object_having_attributes(description: /Cannot accommodate/)
         )
       end
     end

--- a/service/test/y2storage/agama_proposal_search_test.rb
+++ b/service/test/y2storage/agama_proposal_search_test.rb
@@ -214,5 +214,30 @@ describe Y2Storage::AgamaProposal do
         end
       end
     end
+
+    context "when searching existing partitions but not specifying any action on them" do
+      let(:config_json) do
+        {
+          boot:   { configure: false },
+          drives: [
+            {
+              search:     "/dev/vda",
+              partitions: [
+                { search: "*" },
+                { size: "20 GiB", filesystem: { path: "/" } }
+              ]
+            }
+          ]
+        }
+      end
+
+      # Regression test. In the past the proposal tried to resize some partitions due to the
+      # search "*" without actions.
+      it "no partitions are deleted or resized" do
+        expect_any_instance_of(Y2Storage::Partition).to_not receive(:detect_resize_info)
+        # There is no way to make 20 GiB fit without resizing or deleting
+        expect { proposal.propose }.to raise_error(Y2Storage::NoDiskSpaceError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

When a drive was configured with an empty search for partitions like this (in which there is no configuration about deleting or resizing the found partitions)...

```json
{
  "storage": {
    "drives": [
      {
        "partitions": [
          { "search": "*" },
          { "filesystem": { "path": "/" } }
        ]
      }
    ]
  } 
} 
```

...all the matched pre-existing partitions are considered as candidates to be shrunk. 

## Solution

With this fix, partitions with no actions do not generate any SpaceMaker action.

## Bonus

`AgamaProposal` now returns an exception of type `Y2Storage::NoDiskSpaceError` when the SpaceMaker fails to find space. That was the documented behavior, but a generic `Y2Storage::Error` was returned instead.

## Testing

- Added a new unit test
- Tested manually