### PR TITLE
Support for encrypted passwords

### DIFF
--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -50,7 +50,7 @@ jobs:
       run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
     - name: Install Ruby development files and XML tooling
-      run: zypper --non-interactive install --no-recommends
+      run: zypper --non-interactive install --no-recommends --force-resolution
            gcc gcc-c++ make libopenssl-devel ruby-devel augeas-devel diff
            libxslt-devel libxml2-devel xmlstarlet 'rubygem(ruby-augeas)'
 

--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -50,7 +50,7 @@ jobs:
       run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
     - name: Install Ruby development files and XML tooling
-      run: zypper --non-interactive install --no-recommends --force-resolution
+      run: zypper --non-interactive install --no-recommends --allow-downgrade
            gcc gcc-c++ make libopenssl-devel ruby-devel augeas-devel diff
            libxslt-devel libxml2-devel xmlstarlet 'rubygem(ruby-augeas)'
 

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -391,9 +391,13 @@
           "examples": ["jane.doe"]
         },
         "password": {
-          "title": "User password",
+          "title": "User password (plain text or encrypted depending on the \"passwordEncrypted\" field)",
           "type": "string",
           "examples": ["nots3cr3t"]
+        },
+        "passwordEncrypted": {
+          "title": "Flag for encrypted password (true) or plain text password (false or not defined)",
+          "type": "boolean"
         }
       },
       "required": ["fullName", "userName", "password"]
@@ -404,8 +408,12 @@
       "additionalProperties": false,
       "properties": {
         "password": {
-          "title": "Root password",
+          "title": "Root password (plain text or encrypted depending on the \"passwordEncrypted\" field)",
           "type": "string"
+        },
+        "passwordEncrypted": {
+          "title": "Flag for encrypted password (true) or plain text password (false or not defined)",
+          "type": "boolean"
         },
         "sshPublicKey": {
           "title": "SSH public key",

--- a/rust/agama-lib/src/users/client.rs
+++ b/rust/agama-lib/src/users/client.rs
@@ -35,6 +35,8 @@ pub struct FirstUser {
     pub user_name: String,
     /// First user's password (in clear text)
     pub password: String,
+    /// Whether the password is encrypted (true) or is plain text (false)
+    pub encrypted_password: bool,
     /// Whether auto-login should enabled or not
     pub autologin: bool,
 }
@@ -46,7 +48,8 @@ impl FirstUser {
             full_name: data.0,
             user_name: data.1,
             password: data.2,
-            autologin: data.3,
+            encrypted_password: data.3,
+            autologin: data.4,
         })
     }
 }
@@ -107,6 +110,7 @@ impl<'a> UsersClient<'a> {
                 &first_user.full_name,
                 &first_user.user_name,
                 &first_user.password,
+                first_user.encrypted_password,
                 first_user.autologin,
                 std::collections::HashMap::new(),
             )

--- a/rust/agama-lib/src/users/proxies.rs
+++ b/rust/agama-lib/src/users/proxies.rs
@@ -47,6 +47,7 @@ use zbus::proxy;
 /// * full name
 /// * user name
 /// * password
+/// * encrypted_password (true = encrypted, false = plain text)
 /// * auto-login (enabled or not)
 /// * some optional and additional data
 // NOTE: Manually added to this file.
@@ -54,6 +55,7 @@ pub type FirstUser = (
     String,
     String,
     String,
+    bool,
     bool,
     std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
 );
@@ -77,6 +79,7 @@ pub trait Users1 {
         full_name: &str,
         user_name: &str,
         password: &str,
+        encrypted_password: bool,
         auto_login: bool,
         data: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
     ) -> zbus::Result<(bool, Vec<String>)>;

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -43,6 +43,8 @@ pub struct FirstUserSettings {
     pub user_name: Option<String>,
     /// First user's password (in clear text)
     pub password: Option<String>,
+    /// Whether the password is encrypted or is plain text
+    pub encrypted_password: Option<bool>,
     /// Whether auto-login should enabled or not
     pub autologin: Option<bool>,
 }
@@ -56,6 +58,9 @@ pub struct RootUserSettings {
     /// Root's password (in clear text)
     #[serde(skip_serializing)]
     pub password: Option<String>,
+    /// Whether the password is encrypted or is plain text
+    #[serde(skip_serializing)]
+    pub encrypted_password: Option<bool>,
     /// Root SSH public key
     pub ssh_public_key: Option<String>,
 }

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -47,6 +47,7 @@ impl UsersStore {
             autologin: Some(first_user.autologin),
             full_name: Some(first_user.full_name),
             password: Some(first_user.password),
+            encrypted_password: Some(first_user.encrypted_password),
         };
         let mut root_user = RootUserSettings::default();
         let ssh_public_key = self.users_client.root_ssh_key().await?;
@@ -77,6 +78,7 @@ impl UsersStore {
             full_name: settings.full_name.clone().unwrap_or_default(),
             autologin: settings.autologin.unwrap_or_default(),
             password: settings.password.clone().unwrap_or_default(),
+            encrypted_password: settings.encrypted_password.clone().unwrap_or_default(),
             ..Default::default()
         };
         self.users_client.set_first_user(&first_user).await?;
@@ -84,9 +86,11 @@ impl UsersStore {
     }
 
     async fn store_root_user(&self, settings: &RootUserSettings) -> Result<(), ServiceError> {
+        let encrypted_password = settings.encrypted_password.clone().unwrap_or_default();
+
         if let Some(root_password) = &settings.password {
             self.users_client
-                .set_root_password(root_password, false)
+                .set_root_password(root_password, encrypted_password)
                 .await?;
         }
 
@@ -126,6 +130,7 @@ mod test {
                     "fullName": "Tux",
                     "userName": "tux",
                     "password": "fish",
+                    "encryptedPassword": false,
                     "autologin": true
                 }"#,
                 );
@@ -150,11 +155,13 @@ mod test {
             full_name: Some("Tux".to_owned()),
             user_name: Some("tux".to_owned()),
             password: Some("fish".to_owned()),
+            encrypted_password: Some(false),
             autologin: Some(true),
         };
         let root_user = RootUserSettings {
             // FIXME this is weird: no matter what HTTP reports, we end up with None
             password: None,
+            encrypted_password: None,
             ssh_public_key: Some("keykeykey".to_owned()),
         };
         let expected = UserSettings {
@@ -179,7 +186,7 @@ mod test {
             when.method(PUT)
                 .path("/api/users/first")
                 .header("content-type", "application/json")
-                .body(r#"{"fullName":"Tux","userName":"tux","password":"fish","autologin":true}"#);
+                .body(r#"{"fullName":"Tux","userName":"tux","password":"fish","encryptedPassword":false,"autologin":true}"#);
             then.status(200);
         });
         // note that we use 2 requests for root
@@ -205,10 +212,12 @@ mod test {
             full_name: Some("Tux".to_owned()),
             user_name: Some("tux".to_owned()),
             password: Some("fish".to_owned()),
+            encrypted_password: Some(false),
             autologin: Some(true),
         };
         let root_user = RootUserSettings {
             password: Some("1234".to_owned()),
+            encrypted_password: Some(false),
             ssh_public_key: Some("keykeykey".to_owned()),
         };
         let settings = UserSettings {

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -90,7 +90,8 @@ async fn first_user_changed_stream(
                     full_name: user.0,
                     user_name: user.1,
                     password: user.2,
-                    autologin: user.3,
+                    encrypted_password: user.3,
+                    autologin: user.4,
                 };
                 return Some(Event::FirstUserChanged(user_struct));
             }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 15 16:48:44 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Allow using encrypted passord for root and the first user
+  (gh#agama-project/agama#1771)
+
+-------------------------------------------------------------------
 Thu Nov 14 14:45:47 UTC 2024 - Knut Alejandro Anderssen González <kanderssen@suse.com>
 
 - Get some wireless settings as optional in order to not break the

--- a/service/.rubocop.yml
+++ b/service/.rubocop.yml
@@ -28,3 +28,6 @@ Lint/UselessAssignment:
 # be less strict
 Metrics/AbcSize:
   Max: 32
+
+Metrics/ParameterLists:
+  Max: 6

--- a/service/lib/agama/autoyast/root_reader.rb
+++ b/service/lib/agama/autoyast/root_reader.rb
@@ -41,6 +41,8 @@ module Agama
         return {} unless root_user
 
         hsh = { "password" => root_user.password.value.to_s }
+        hsh["passwordEncrypted"] = true if root_user.password.value.encrypted?
+
         public_key = root_user.authorized_keys.first
         hsh["sshPublicKey"] = public_key if public_key
         { "root" => hsh }

--- a/service/lib/agama/autoyast/user_reader.rb
+++ b/service/lib/agama/autoyast/user_reader.rb
@@ -45,6 +45,9 @@ module Agama
           "fullName" => user.gecos.first.to_s,
           "password" => user.password.value.to_s
         }
+
+        hsh["passwordEncrypted"] = true if user.password.value.encrypted?
+
         { "user" => hsh }
       end
 

--- a/service/lib/agama/users.rb
+++ b/service/lib/agama/users.rb
@@ -99,15 +99,21 @@ module Agama
     # @param full_name [String]
     # @param user_name [String]
     # @param password [String]
+    # @param encrypted_password [Boolean] true = encrypted password, false = plain text password
     # @param auto_login [Boolean]
     # @param _data [Hash]
     # @return [Array] the list of fatal issues found
-    def assign_first_user(full_name, user_name, password, auto_login, _data)
+    def assign_first_user(full_name, user_name, password, encrypted_password, auto_login, _data)
       remove_first_user
 
       user = Y2Users::User.new(user_name)
       user.gecos = [full_name]
-      user.password = Y2Users::Password.create_plain(password)
+      user.password = if encrypted_password
+        Y2Users::Password.create_encrypted(password)
+      else
+        Y2Users::Password.create_plain(password)
+      end
+
       fatal_issues = user.issues.map.select(&:error?)
       return fatal_issues.map(&:message) unless fatal_issues.empty?
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 15 16:48:44 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Allow using encrypted passord for root and the first user
+  (gh#agama-project/agama#1771)
+
+-------------------------------------------------------------------
 Thu Nov 14 15:34:17 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Storage: fixed bug when existing partitions were searched at the

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Nov 15 16:48:44 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
-- Allow using encrypted passord for root and the first user
+- Allow using encrypted password for root and the first user
   (gh#agama-project/agama#1771)
 
 -------------------------------------------------------------------

--- a/service/test/agama/dbus/users_test.rb
+++ b/service/test/agama/dbus/users_test.rb
@@ -24,6 +24,7 @@ require "agama/dbus/interfaces/issues"
 require "agama/dbus/interfaces/service_status"
 require "agama/dbus/users"
 require "agama/users"
+require "y2users"
 
 describe Agama::DBus::Users do
   subject { described_class.new(backend, logger) }
@@ -69,16 +70,18 @@ describe Agama::DBus::Users do
       let(:user) { nil }
 
       it "returns default data" do
-        expect(subject.first_user).to eq(["", "", "", false, {}])
+        expect(subject.first_user).to eq(["", "", "", false, false, {}])
       end
     end
 
     context "if there is an user" do
+      let(:password) { Y2Users::Password.create_encrypted("12345") }
       let(:user) do
         instance_double(Y2Users::User,
           full_name:        "Test user",
           name:             "test",
-          password_content: "12345")
+          password:         password,
+          password_content: password.value.to_s)
       end
 
       before do
@@ -86,7 +89,7 @@ describe Agama::DBus::Users do
       end
 
       it "returns the first user data" do
-        expect(subject.first_user).to eq(["Test user", "test", "12345", true, {}])
+        expect(subject.first_user).to eq(["Test user", "test", password.value.to_s, true, true, {}])
       end
     end
   end

--- a/service/test/agama/users_test.rb
+++ b/service/test/agama/users_test.rb
@@ -81,7 +81,7 @@ describe Agama::Users do
   describe "#assign_first_user" do
     context "when the options given do not present any issue" do
       it "adds the user to the user's configuration" do
-        subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+        subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
         user = users_config.users.by_name("jane")
         expect(user.full_name).to eq("Jane Doe")
         expect(user.password).to eq(Y2Users::Password.create_plain("12345"))
@@ -89,11 +89,11 @@ describe Agama::Users do
 
       context "when a first user exists" do
         before do
-          subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+          subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
         end
 
         it "replaces the user with the new one" do
-          subject.assign_first_user("John Doe", "john", "12345", false, {})
+          subject.assign_first_user("John Doe", "john", "12345", false, false, {})
 
           user = users_config.users.by_name("jane")
           expect(user).to be_nil
@@ -104,23 +104,23 @@ describe Agama::Users do
       end
 
       it "returns an empty array of issues" do
-        issues = subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+        issues = subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
         expect(issues).to be_empty
       end
     end
 
     context "when the given arguments presents some critical error" do
       it "does not add the user to the config" do
-        subject.assign_first_user("Jonh Doe", "john", "", false, {})
+        subject.assign_first_user("Jonh Doe", "john", "", false, false, {})
         user = users_config.users.by_name("john")
         expect(user).to be_nil
-        subject.assign_first_user("Ldap user", "ldap", "12345", false, {})
+        subject.assign_first_user("Ldap user", "ldap", "12345", false, false, {})
         user = users_config.users.by_name("ldap")
         expect(user).to be_nil
       end
 
       it "returns an array with all the issues" do
-        issues = subject.assign_first_user("Root user", "root", "12345", false, {})
+        issues = subject.assign_first_user("Root user", "root", "12345", false, false, {})
         expect(issues.size).to eql(1)
       end
     end
@@ -128,7 +128,7 @@ describe Agama::Users do
 
   describe "#remove_first_user" do
     before do
-      subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+      subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
     end
 
     it "removes the already defined first user" do
@@ -156,7 +156,7 @@ describe Agama::Users do
     end
 
     it "writes system and installer defined users" do
-      subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+      subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
 
       expect(Y2Users::Linux::Writer).to receive(:new) do |target_config, _old_config|
         user_names = target_config.users.map(&:name)
@@ -196,7 +196,7 @@ describe Agama::Users do
 
       context "when a first user is defined" do
         before do
-          subject.assign_first_user("Jane Doe", "jdoe", "123456", false, {})
+          subject.assign_first_user("Jane Doe", "jdoe", "123456", false, false, {})
         end
 
         it "returns an empty list" do

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 15 16:48:44 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Set the plain text password flag when setting the root and first
+  user password (gh#agama-project/agama#1771)
+
+-------------------------------------------------------------------
 Thu Nov 14 14:42:46 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix wireless authentication initialization and

--- a/web/src/components/users/FirstUserForm.tsx
+++ b/web/src/components/users/FirstUserForm.tsx
@@ -134,6 +134,10 @@ export default function FirstUserForm() {
 
     if (!changePassword) {
       delete user.password;
+    } else {
+      // the web UI only supports plain text passwords, this resets the flag if an encrypted
+      // password was previously set from CLI
+      user.encryptedPassword = false;
     }
     delete user.passwordConfirmation;
     user.autologin = !!user.autologin;

--- a/web/src/components/users/RootPasswordPopup.jsx
+++ b/web/src/components/users/RootPasswordPopup.jsx
@@ -55,7 +55,9 @@ export default function RootPasswordPopup({ title = _("Root password"), isOpen, 
   const accept = async (e) => {
     e.preventDefault();
     // TODO: handle errors
-    if (password !== "") await setRootUser.mutateAsync({ password });
+    // the web UI only supports plain text passwords, this resets the flag if an encrypted password
+    // was previously set from CLI
+    if (password !== "") await setRootUser.mutateAsync({ password, passwordEncrypted: false });
     close();
   };
 

--- a/web/src/components/users/RootPasswordPopup.test.jsx
+++ b/web/src/components/users/RootPasswordPopup.test.jsx
@@ -75,7 +75,10 @@ describe("when it is open", () => {
     expect(confirmButton).toBeEnabled();
     await user.click(confirmButton);
 
-    expect(mockRootUserMutation.mutateAsync).toHaveBeenCalledWith({ password });
+    expect(mockRootUserMutation.mutateAsync).toHaveBeenCalledWith({
+      password,
+      passwordEncrypted: false,
+    });
     expect(onCloseCallback).toHaveBeenCalled();
   });
 

--- a/web/src/queries/users.ts
+++ b/web/src/queries/users.ts
@@ -83,11 +83,12 @@ const useFirstUserChanges = () => {
 
     return client.onEvent((event) => {
       if (event.type === "FirstUserChanged") {
-        const { fullName, userName, password, autologin, data } = event;
+        const { fullName, userName, password, passwordEncrypted, autologin, data } = event;
         queryClient.setQueryData(["users", "firstUser"], {
           fullName,
           userName,
           password,
+          passwordEncrypted,
           autologin,
           data,
         });
@@ -122,7 +123,7 @@ const useRootUserMutation = () => {
 };
 
 /**
- * Listens for first user changes.
+ * Listens for root user changes.
  */
 const useRootUserChanges = () => {
   const client = useInstallerClient();
@@ -138,6 +139,7 @@ const useRootUserChanges = () => {
           const newRoot = { ...oldRoot };
           if (password !== undefined) {
             newRoot.password = password;
+            newRoot.encryptedPassword = false;
           }
 
           if (sshkey) {

--- a/web/src/types/users.ts
+++ b/web/src/types/users.ts
@@ -24,11 +24,13 @@ type FirstUser = {
   fullName: string;
   userName: string;
   password: string;
+  encryptedPassword: boolean;
   autologin: boolean;
 };
 
 type RootUser = {
   password: boolean;
+  encryptedPassword: boolean;
   sshkey: string;
 };
 


### PR DESCRIPTION
## Problem

- The Agama autoinstallation and CLI accept the first user and the root passwords only in plain text
- That's insecure, everybody who can access the installation profile knows the root password

## Solution

- Support passing an already encrypted (hashed) password in the profile
- Similar to AutoYaST, an additional `encryptedPassword` boolean flag is used to determine whether the specified password is encrypted (`true` value) or plain text (`false` value or missing in the profile)

## Notes

- The web UI allows specifying only plain text passwords
- Encrypted passwords are long and hard to type and they need to be encrypted externally

## Features

- Adapted schema definition
- Adapted the AutoYaST conversion tool
- When an encrypted password is set from Agama CLI then web UI resets the flag back to plain text (it supports only plain text passwords)

## Testing

- Tested manually (both root user and first user), tested the AutoYaST profile conversion
- Updated unit tests
