### PR TITLE
fix(rust): fix the Questions proxy default path

### DIFF
--- a/rust/agama-lib/src/proxies/questions/questions.rs
+++ b/rust/agama-lib/src/proxies/questions/questions.rs
@@ -44,6 +44,7 @@ use zbus::proxy;
 #[proxy(
     default_service = "org.opensuse.Agama1",
     interface = "org.opensuse.Agama1.Questions",
+    default_path = "/org/opensuse/Agama1/Questions",
     assume_defaults = true
 )]
 pub trait Questions {

--- a/rust/agama-lib/src/storage/proxies/iscsi/initiator.rs
+++ b/rust/agama-lib/src/storage/proxies/iscsi/initiator.rs
@@ -42,6 +42,7 @@
 use zbus::proxy;
 #[proxy(
     default_service = "org.opensuse.Agama.Storage1",
+    default_path = "/org/opensuse/Agama/Storage1",
     interface = "org.opensuse.Agama.Storage1.ISCSI.Initiator",
     assume_defaults = true
 )]

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 25 19:51:20 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the default path of the D-Bus Questions object and the ISCSI
+  Initiator interface (gh#agama-project/agama#1785).
+
+-------------------------------------------------------------------
 Fri Nov 15 16:48:44 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Allow using encrypted passord for root and the first user


### PR DESCRIPTION
Fix the default path of the `Questions` D-Bus object and the `ISCSI.Initiator` interface.
