### PR TITLE
feat(rust): add support for auto-installation "init" scripts

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -306,30 +306,13 @@
                     "items": {
                       "title": "List of EAP methods used",
                       "type": "string",
-                      "enum": [
-                        "leap",
-                        "md5",
-                        "tls",
-                        "peap",
-                        "ttls",
-                        "pwd",
-                        "fast"
-                      ]
+                      "enum": ["leap", "md5", "tls", "peap", "ttls", "pwd", "fast"]
                     }
                   },
                   "phase2Auth": {
                     "title": "Phase 2 inner auth method",
                     "type": "string",
-                    "enum": [
-                      "pap",
-                      "chap",
-                      "mschap",
-                      "mschapv2",
-                      "gtc",
-                      "otp",
-                      "md5",
-                      "tls"
-                    ]
+                    "enum": ["pap", "chap", "mschap", "mschapv2", "gtc", "otp", "md5", "tls"]
                   },
                   "identity": {
                     "title": "Identity string, often for example the user's login name",
@@ -985,10 +968,7 @@
       "examples": [1024, 2048]
     },
     "sizeValue": {
-      "anyOf": [
-        { "$ref": "#/$defs/sizeString" },
-        { "$ref": "#/$defs/sizeInteger" }
-      ]
+      "anyOf": [{ "$ref": "#/$defs/sizeString" }, { "$ref": "#/$defs/sizeInteger" }]
     },
     "sizeValueWithCurrent": {
       "anyOf": [
@@ -1015,12 +995,7 @@
           },
           "minItems": 1,
           "maxItems": 2,
-          "examples": [
-            [1024, "current"],
-            ["1 GiB", "5 GiB"],
-            [1024, "2 GiB"],
-            ["2 GiB"]
-          ]
+          "examples": [[1024, "current"], ["1 GiB", "5 GiB"], [1024, "2 GiB"], ["2 GiB"]]
         },
         {
           "title": "Size range",
@@ -1378,15 +1353,7 @@
               },
               "id": {
                 "title": "Partition ID",
-                "enum": [
-                  "linux",
-                  "swap",
-                  "lvm",
-                  "raid",
-                  "esp",
-                  "prep",
-                  "bios_boot"
-                ]
+                "enum": ["linux", "swap", "lvm", "raid", "esp", "prep", "bios_boot"]
               },
               "size": {
                 "title": "Partition size",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -28,6 +28,14 @@
           "items": {
             "$ref": "#/$defs/script"
           }
+        },
+        "init": {
+          "title": "Init scripts",
+          "description": "User-defined scripts to run booting the installed system",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/script"
+          }
         }
       }
     },

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -40,6 +40,7 @@ use super::ScriptError;
 pub enum ScriptsGroup {
     Pre,
     Post,
+    Init,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -68,10 +68,7 @@ impl Script {
     /// * `workdir`: where to write assets (script, logs and exit code).
     pub async fn run(&self, workdir: &Path) -> Result<(), ScriptError> {
         let dir = workdir.join(self.group.to_string());
-
         let path = dir.join(&self.name);
-        self.write(&path).await?;
-
         let output = process::Command::new(&path).output()?;
 
         let stdout_log = dir.join(format!("{}.log", &self.name));
@@ -128,8 +125,13 @@ impl ScriptsRepository {
     /// Adds a new script to the repository.
     ///
     /// * `script`: script to add.
-    pub fn add(&mut self, script: Script) {
+    pub async fn add(&mut self, script: Script) -> Result<(), ScriptError> {
+        let workdir = self.workdir.join(script.group.to_string());
+        std::fs::create_dir_all(&workdir)?;
+        let path = workdir.join(&script.name);
+        script.write(&path).await?;
         self.scripts.push(script);
+        Ok(())
     }
 
     /// Removes all the scripts from the repository.
@@ -142,8 +144,6 @@ impl ScriptsRepository {
     /// They run in the order they were added to the repository. If does not return an error
     /// if running a script fails, although it logs the problem.
     pub async fn run(&self, group: ScriptsGroup) -> Result<(), ScriptError> {
-        let workdir = self.workdir.join(group.to_string());
-        std::fs::create_dir_all(&workdir)?;
         let scripts: Vec<_> = self.scripts.iter().filter(|s| s.group == group).collect();
         for script in scripts {
             if let Err(error) = script.run(&self.workdir).await {
@@ -188,7 +188,7 @@ mod test {
             },
             group: ScriptsGroup::Pre,
         };
-        repo.add(script);
+        repo.add(script).await.unwrap();
 
         let script = repo.scripts.first().unwrap();
         assert_eq!("test".to_string(), script.name);
@@ -205,7 +205,7 @@ mod test {
             source: ScriptSource::Text { body },
             group: ScriptsGroup::Pre,
         };
-        repo.add(script);
+        repo.add(script).await.unwrap();
         repo.run(ScriptsGroup::Pre).await.unwrap();
 
         repo.scripts.first().unwrap();

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -26,14 +26,14 @@ use super::{Script, ScriptSource};
 #[serde(rename_all = "camelCase")]
 pub struct ScriptsConfig {
     /// User-defined pre-installation scripts
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub pre: Vec<ScriptConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre: Option<Vec<ScriptConfig>>,
     /// User-defined post-installation scripts
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub post: Vec<ScriptConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post: Option<Vec<ScriptConfig>>,
     /// User-defined init scripts
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub init: Vec<ScriptConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init: Option<Vec<ScriptConfig>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -31,6 +31,9 @@ pub struct ScriptsConfig {
     /// User-defined post-installation scripts
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub post: Vec<ScriptConfig>,
+    /// User-defined init scripts
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub init: Vec<ScriptConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -42,14 +42,10 @@ impl ScriptsStore {
     pub async fn load(&self) -> Result<ScriptsConfig, ServiceError> {
         let scripts = self.scripts.scripts().await?;
 
-        let pre = Self::to_script_configs(&scripts, ScriptsGroup::Pre);
-        let post = Self::to_script_configs(&scripts, ScriptsGroup::Post);
-        let init = Self::to_script_configs(&scripts, ScriptsGroup::Init);
-
         Ok(ScriptsConfig {
-            pre: if pre.is_empty() { None } else { Some(pre) },
-            post: if post.is_empty() { None } else { Some(post) },
-            init: if init.is_empty() { None } else { Some(init) },
+            pre: Self::to_script_configs(&scripts, ScriptsGroup::Pre),
+            post: Self::to_script_configs(&scripts, ScriptsGroup::Post),
+            init: Self::to_script_configs(&scripts, ScriptsGroup::Init),
         })
     }
 
@@ -96,11 +92,17 @@ impl ScriptsStore {
         }
     }
 
-    fn to_script_configs(scripts: &[Script], group: ScriptsGroup) -> Vec<ScriptConfig> {
-        scripts
+    fn to_script_configs(scripts: &[Script], group: ScriptsGroup) -> Option<Vec<ScriptConfig>> {
+        let configs: Vec<_> = scripts
             .iter()
             .filter(|s| s.group == group)
             .map(|s| s.into())
-            .collect()
+            .collect();
+
+        if configs.is_empty() {
+            return None;
+        }
+
+        Some(configs)
     }
 }

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -74,9 +74,6 @@ impl ScriptsStore {
             }
         }
 
-        // TODO: find a better play to run the scripts (before probing).
-        self.client.run_scripts(ScriptsGroup::Pre).await?;
-
         Ok(())
     }
 

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -39,6 +39,7 @@ impl ScriptsStore {
         Ok(ScriptsConfig {
             pre: Self::to_script_configs(&scripts, ScriptsGroup::Pre),
             post: Self::to_script_configs(&scripts, ScriptsGroup::Post),
+            init: Self::to_script_configs(&scripts, ScriptsGroup::Init),
         })
     }
 

--- a/rust/agama-lib/src/software/http_client.rs
+++ b/rust/agama-lib/src/software/http_client.rs
@@ -22,6 +22,8 @@ use crate::software::model::SoftwareConfig;
 use crate::{base_http_client::BaseHTTPClient, error::ServiceError};
 use std::collections::HashMap;
 
+use super::model::{ResolvableParams, ResolvableType};
+
 pub struct SoftwareHTTPClient {
     client: BaseHTTPClient,
 }
@@ -73,5 +75,23 @@ impl SoftwareHTTPClient {
             patterns: Some(patterns),
         };
         self.set_config(&config).await
+    }
+
+    /// Sets a resolvable list
+    pub async fn set_resolvables(
+        &self,
+        name: &str,
+        r#type: ResolvableType,
+        names: &[&str],
+        optional: bool,
+    ) -> Result<(), ServiceError> {
+        let path = format!("/software/resolvables/{}", name);
+        let options = ResolvableParams {
+            names: names.iter().map(|n| n.to_string()).collect(),
+            r#type,
+            optional,
+        };
+        self.client.put_void(&path, &options).await?;
+        Ok(())
     }
 }

--- a/rust/agama-lib/src/software/model.rs
+++ b/rust/agama-lib/src/software/model.rs
@@ -80,3 +80,23 @@ impl TryFrom<u32> for RegistrationRequirement {
         }
     }
 }
+
+/// Software resolvable type (package or pattern).
+#[derive(Deserialize, Serialize, strum::Display, utoipa::ToSchema)]
+#[strum(serialize_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
+pub enum ResolvableType {
+    Package = 0,
+    Pattern = 1,
+}
+
+/// Resolvable list specification.
+#[derive(Deserialize, Serialize, utoipa::ToSchema)]
+pub struct ResolvableParams {
+    /// List of resolvables.
+    pub names: Vec<String>,
+    /// Resolvable type.
+    pub r#type: ResolvableType,
+    /// Whether the resolvables are optional or not.
+    pub optional: bool,
+}

--- a/rust/agama-lib/src/software/proxies/proposal.rs
+++ b/rust/agama-lib/src/software/proxies/proposal.rs
@@ -42,6 +42,7 @@
 use zbus::proxy;
 #[proxy(
     default_service = "org.opensuse.Agama.Software1",
+    default_path = "/org/opensuse/Agama/Software1/Proposal",
     interface = "org.opensuse.Agama.Software1.Proposal",
     assume_defaults = true
 )]

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -94,10 +94,10 @@ impl Store {
     pub async fn store(&self, settings: &InstallSettings) -> Result<(), ServiceError> {
         if let Some(scripts) = &settings.scripts {
             self.scripts.store(scripts).await?;
-        }
 
-        if settings.scripts.as_ref().is_some_and(|s| !s.pre.is_empty()) {
-            self.run_pre_scripts().await?;
+            if scripts.pre.as_ref().is_some_and(|s| !s.is_empty()) {
+                self.run_pre_scripts().await?;
+            }
         }
 
         if let Some(network) = &settings.network {

--- a/rust/agama-server/src/scripts/web.rs
+++ b/rust/agama-server/src/scripts/web.rs
@@ -110,7 +110,7 @@ async fn remove_scripts(
     state: State<ScriptsState>,
 ) -> Result<impl IntoResponse, ScriptServiceError> {
     let mut scripts = state.scripts.write().await;
-    scripts.clear();
+    scripts.clear()?;
     Ok(())
 }
 

--- a/rust/agama-server/src/scripts/web.rs
+++ b/rust/agama-server/src/scripts/web.rs
@@ -81,7 +81,7 @@ async fn add_script(
     Json(script): Json<Script>,
 ) -> Result<impl IntoResponse, ScriptServiceError> {
     let mut scripts = state.scripts.write().await;
-    scripts.add(script);
+    scripts.add(script).await?;
     Ok(())
 }
 

--- a/rust/agama-server/src/web/docs/software.rs
+++ b/rust/agama-server/src/web/docs/software.rs
@@ -40,14 +40,7 @@ impl ApiDocBuilder for SoftwareApiDocBuilder {
             .path_from::<crate::software::web::__path_products>()
             .path_from::<crate::software::web::__path_proposal>()
             .path_from::<crate::software::web::__path_set_config>()
-            // .path(
-            //     "/api/software/issues/software",
-            //     issues_path("List of software-related issues", "software_issues"),
-            // )
-            // .path(
-            //     "/api/software/issues/product",
-            //     issues_path("List of product-related issues", "product_issues"),
-            // )
+            .path_from::<crate::software::web::__path_set_resolvables>()
             .build()
     }
 
@@ -58,6 +51,8 @@ impl ApiDocBuilder for SoftwareApiDocBuilder {
             .schema_from::<agama_lib::software::Pattern>()
             .schema_from::<agama_lib::software::model::RegistrationInfo>()
             .schema_from::<agama_lib::software::model::RegistrationParams>()
+            .schema_from::<agama_lib::software::model::ResolvableParams>()
+            .schema_from::<agama_lib::software::model::ResolvableType>()
             .schema_from::<agama_lib::software::SelectedBy>()
             .schema_from::<agama_lib::software::model::SoftwareConfig>()
             .schema_from::<crate::software::web::SoftwareProposal>()

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 28 11:07:58 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for auto-installation "init" scripts
+  (gh#agama-project/agama#1788).
+
+-------------------------------------------------------------------
 Mon Nov 25 19:51:20 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the default path of the D-Bus Questions object and the ISCSI

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -146,7 +146,8 @@ install -m 0644 %{_builddir}/agama/share/agama.libsonnet %{buildroot}%{_datadir}
 install --directory %{buildroot}%{_datadir}/dbus-1/agama-services
 install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services %{_builddir}/agama/share/org.opensuse.Agama1.service
 install -D -m 0644 %{_builddir}/agama/share/agama-web-server.service %{buildroot}%{_unitdir}/agama-web-server.service
-install -D -m 0644 %{_builddir}/agama/share/agama-scripts.sh %{buildroot}%{_bindir}/agama-scripts.sh
+install -D -d -m 0755 %{buildroot}%{_libexecdir}
+install -D -m 0755 %{_builddir}/agama/share/agama-scripts.sh %{buildroot}%{_libexecdir}/agama-scripts.sh
 install -D -m 0644 %{_builddir}/agama/share/agama-scripts.service %{buildroot}%{_unitdir}/agama-scripts.service
 
 # install manpages
@@ -229,6 +230,6 @@ echo $PATH
 
 %files -n agama-scripts
 %{_unitdir}/agama-scripts.service
-%{_bindir}/agama-scripts.sh
+%{_libexecdir}/agama-scripts.sh
 
 %changelog

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -115,6 +115,13 @@ The OpenAPI Specification (OAS) allows describing an HTTP API in an standard and
 language-agnostic way. This package contains the specification for Agama's HTTP
 API.
 
+%package -n agama-scripts
+Summary:        Agama support for running user-defined scripts
+
+%description -n agama-scripts
+The Agama installer supports running user-defined scripts during and after the installation. This
+package contains a systemd service to run scripts when booting the installed system.
+
 %prep
 %autosetup -a1 -n agama
 # Remove exec bits to prevent an issue in fedora shebang checking. Uncomment only if required.
@@ -139,6 +146,8 @@ install -m 0644 %{_builddir}/agama/share/agama.libsonnet %{buildroot}%{_datadir}
 install --directory %{buildroot}%{_datadir}/dbus-1/agama-services
 install -m 0644 --target-directory=%{buildroot}%{_datadir}/dbus-1/agama-services %{_builddir}/agama/share/org.opensuse.Agama1.service
 install -D -m 0644 %{_builddir}/agama/share/agama-web-server.service %{buildroot}%{_unitdir}/agama-web-server.service
+install -D -m 0644 %{_builddir}/agama/share/agama-scripts.sh %{buildroot}%{_bindir}/agama-scripts.sh
+install -D -m 0644 %{_builddir}/agama/share/agama-scripts.service %{buildroot}%{_unitdir}/agama-scripts.service
 
 # install manpages
 mkdir -p %{buildroot}%{_mandir}/man1
@@ -165,14 +174,26 @@ echo $PATH
 %pre
 %service_add_pre agama-web-server.service
 
+%pre -n agama-scripts
+%service_add_pre agama-scripts.service
+
 %post
 %service_add_post agama-web-server.service
+
+%post -n agama-scripts
+%service_add_post agama-scripts.service
 
 %preun
 %service_del_preun agama-web-server.service
 
+%preun -n agama-scripts
+%service_del_preun agama-scripts.service
+
 %postun
 %service_del_postun_with_restart agama-web-server.service
+
+%postun -n agama-scripts
+%service_del_postun_with_restart agama-scripts.service
 
 %files
 %doc README.md
@@ -205,5 +226,9 @@ echo $PATH
 %dir %{_datadir}/agama
 %dir %{_datadir}/agama/openapi
 %{_datadir}/agama/openapi/*.json
+
+%files -n agama-scripts
+%{_unitdir}/agama-scripts.service
+%{_bindir}/agama-scripts.sh
 
 %changelog

--- a/rust/share/agama-scripts.service
+++ b/rust/share/agama-scripts.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Agama init scripts
+After=remote-fs.target network-online.target time-sync.target mail-transfer-agent.target hwscan.service ypbind.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
+Before=display-manager.service systemd-user-sessions.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=TERM=linux
+ExecStartPre=-/usr/bin/plymouth --hide-splash
+ExecStart=/usr/bin/agama-scripts.sh
+RemainAfterExit=yes
+TimeoutSec=0
+
+[Install]
+WantedBy=default.target

--- a/rust/share/agama-scripts.service
+++ b/rust/share/agama-scripts.service
@@ -10,7 +10,7 @@ Wants=network-online.target
 Type=oneshot
 Environment=TERM=linux
 ExecStartPre=-/usr/bin/plymouth --hide-splash
-ExecStart=/usr/bin/agama-scripts.sh
+ExecStart=/usr/libexec/agama-scripts.sh
 RemainAfterExit=yes
 TimeoutSec=0
 

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -20,7 +20,7 @@
 
 # This script runs the user-defined Agama init scripts.
 
-WORKDIR="/run/agama/scripts/init"
+WORKDIR="/var/log/agama-installation/scripts/init"
 
 systemctl disable agama-scripts.service
 

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -1,0 +1,43 @@
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 2 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# This script runs the user-defined Agama init scripts.
+
+WORKDIR="/run/agama/scripts/init"
+
+systemctl disable agama-scripts.service
+
+if [ ! -d "$WORKDIR" ]; then
+    exit 1
+fi
+
+for script in  `find $WORKDIR -type f`; do
+    CONTINUE=1
+done
+
+if [ -z "$CONTINUE" ]; then
+    exit 0
+fi
+
+for script in  `find $WORKDIR -type f |sort`; do
+    echo -n "Executing Agama auto-installation script: $script"
+    BASENAME=`basename $script`
+    . $script > $WORKDIR/$BASENAME.log 2>&1
+done


### PR DESCRIPTION
Add support for running custom-defined scripts during the first boot of the installed system. The scripts are executed by a special `agama-scripts` service, which is included in a package that is installed on the target system *only* if an init-script was included in the profile.

Agama will not complain if the package is available yet. We should enable this behavior when we 1) submit the package and 2) improve software error reporting.