### PR TITLE
fix(live): Less aggressive kernel driver cleanup

### DIFF
--- a/live/Makefile
+++ b/live/Makefile
@@ -14,6 +14,7 @@ FLAVOR = openSUSE
 # the default OBS project,
 # to use a different project run "make build OBS_PROJECT=<project>"
 OBS_PROJECT = "systemsmanagement:Agama:Devel"
+OBS_PACKAGE = "agama-installer"
 
 # files to copy from src/
 COPY_FILES = $(patsubst $(SRCDIR)/%,$(DESTDIR)/%,$(wildcard $(SRCDIR)/*))
@@ -52,7 +53,7 @@ $(DESTDIR)/%.tar.xz: % $$(shell find % -type f,l)
 
 # build the ISO locally
 build: $(DESTDIR)
-	if [ ! -e  $(DESTDIR)/.osc ]; then make clean; osc co -o $(DESTDIR) $(OBS_PROJECT) agama-installer-openSUSE; fi
+	if [ ! -e  $(DESTDIR)/.osc ]; then make clean; osc co -o $(DESTDIR) $(OBS_PROJECT) $(OBS_PACKAGE); fi
 	$(MAKE) all
 	(cd $(DESTDIR) && osc build -M $(FLAVOR) images)
 

--- a/live/root/tmp/driver_cleanup.rb
+++ b/live/root/tmp/driver_cleanup.rb
@@ -1,0 +1,93 @@
+#! /usr/bin/env ruby
+
+# This script removes not needed multimedia drivers (sound cards, TV cards,...).
+#
+# By default the script runs in safe mode and only lists the drivers to delete,
+# use the "--delete" argument to really delete the drivers.
+
+require "find"
+require "shellwords"
+
+# class holding the kernel driver data
+class Driver
+  # the driver name, full file path, dependencies
+  attr_reader :name, :path, :deps
+
+  def initialize(name, path, deps)
+    @name = name
+    @path = path
+    @deps = deps
+  end
+
+  # load the kernel driver data from the given path recursively
+  def self.find(dir)
+    drivers = []
+    puts "Scanning kernel modules in #{dir}..."
+
+    return drivers unless File.directory?(dir)
+    
+    Find.find(dir) do |path|
+      if File.file?(path) && path.end_with?(".ko", ".ko.xz", ".ko.zst")
+        name = File.basename(path).sub(/\.ko(\.xz|\.zst|)\z/, "")
+        deps = `/usr/sbin/modinfo -F depends #{path.shellescape}`.chomp.split(",")
+        drivers << Driver.new(name, path, deps)
+      end
+    end
+
+    return drivers
+  end
+end
+
+# delete the kernel drivers in these subdirectories, but keep the drivers used by
+# dependencies from other drivers
+delete = [
+  "kernel/sound", 
+  "kernel/drivers/media",
+  "kernel/drivers/staging/media"
+]
+
+# in the Live ISO there should be just one kernel installed
+dir = Dir["/lib/modules/*"].first
+
+# drivers to delete
+delete_drivers = []
+
+# scan the drivers in the delete subdirectories
+delete.each do |d|
+  delete_drivers += Driver.find(File.join(dir, d))
+end
+
+all_drivers = Driver.find(dir)
+
+# remove the possibly deleted drivers
+all_drivers.reject!{|a| delete_drivers.any?{|d| d.name == a.name}}
+
+puts "Skipping dependent drivers:"
+
+# iteratively find the dependant drivers (dependencies of dependencies...)
+loop do 
+  referenced = delete_drivers.select do |dd|
+    all_drivers.any?{|ad| ad.deps.include?(dd.name)}
+  end
+
+  # no more new dependencies, end of the dependency chain reached
+  break if referenced.empty?
+
+  puts referenced.map(&:path).sort.join("\n")
+
+  # move the referenced drivers from the "delete" list to the "keep" list
+  all_drivers += referenced
+  delete_drivers.reject!{|a| referenced.any?{|d| d.name == a.name}}
+end
+
+puts "Drivers to delete:"
+delete = ARGV[0] == "--delete"
+
+delete_drivers.each do |d|
+  if (delete)
+    puts "Deleting #{d.path}"
+    File.delete(d.path)
+  else
+    puts d.path
+  end
+end

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 28 08:58:21 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Less aggressive kernel driver cleanup, keep the multimedia
+  drivers which are needed as dependencies of other drivers
+  (usually graphic card drivers) (gh#agama-project/agama#1665)
+
+-------------------------------------------------------------------
 Wed Nov 13 12:20:23 UTC 2024 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Temporarily drop xf86-video-fbdev as it seems to be missing

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -160,10 +160,11 @@ rpm -e --nodeps alsa alsa-utils alsa-ucm-conf || true
 # and remove the drivers for sound cards and TV cards instead. Those do not
 # make sense on a server.
 du -h -s /lib/modules /lib/firmware
-# delete sound drivers
-rm -rfv /lib/modules/*/kernel/sound
-# delete TV cards and radio cards
-rm -rfv /lib/modules/*/kernel/drivers/media/
+
+# remove the multimedia drivers
+/tmp/driver_cleanup.rb --delete
+# remove the script, not needed anymore
+rm /tmp/driver_cleanup.rb
 
 # remove the unused firmware (not referenced by kernel drivers)
 /tmp/fw_cleanup.rb --delete


### PR DESCRIPTION
## Problem

- Some kernel drivers are missing on the Live ISO, some hardware might not be supported or might work only partially
- See #1665

## Solution

- Keep the multimedia drivers which are needed as dependencies of other drivers (usually graphic card drivers)
- The driver dependencies are evaluated recursively to include also dependencies of dependencies...

## Testing

- Tested manually, the Live ISO builds fine
- The built ISO image size is increased just slightly, +1MB
- The missing `cec.ko` driver originally reported in #1665 is kept in the system

Script output from Live ISO build:

```
Scanning kernel modules in /lib/modules/6.11.8-1-default/kernel/sound...
Scanning kernel modules in /lib/modules/6.11.8-1-default/kernel/drivers/media...
Scanning kernel modules in /lib/modules/6.11.8-1-default/kernel/drivers/staging/media...
Scanning kernel modules in /lib/modules/6.11.8-1-default...
Skipping dependent drivers:
/lib/modules/6.11.8-1-default/kernel/drivers/media/cec/core/cec.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/common/uvc.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/common/videobuf2/videobuf2-common.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/common/videobuf2/videobuf2-dma-sg.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/common/videobuf2/videobuf2-v4l2.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/common/videobuf2/videobuf2-vmalloc.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/rc/rc-core.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/v4l2-core/v4l2-flash-led-class.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/v4l2-core/videodev.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-pcm.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-rawmidi.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-ump.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/soc/snd-soc-core.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/soc/sof/intel/snd-sof-intel-hda-mlink.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/common/videobuf2/videobuf2-memops.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/mc/mc.ko.zst
/lib/modules/6.11.8-1-default/kernel/drivers/media/v4l2-core/v4l2-async.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-compress.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-pcm-dmaengine.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-seq-device.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/core/snd-timer.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/hda/ext/snd-hda-ext-core.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/soundcore.ko.zst
/lib/modules/6.11.8-1-default/kernel/sound/hda/snd-hda-core.ko.zst
Drivers to delete:
Deleting /lib/modules/6.11.8-1-default/kernel/sound/ac97_bus.ko.zst
Deleting /lib/modules/6.11.8-1-default/kernel/sound/core/oss/snd-mixer-oss.ko.zst
Deleting ...
```
