### PR TITLE
fix(rust): upgrade rustc dependency to 1.81

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-# IpAddr::to_canonical is stable since 1.75
-rust-version = "1.75"
+# required by zbus 5
+rust-version = "1.81"
 edition = "2021"

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec  2 11:29:46 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Upgrade rustc dependency to version 1.81 because it is needed by
+  zbus 5 (gh#agama-project/agama#1797).
+
+-------------------------------------------------------------------
 Sun Dec  1 21:53:21 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Rename flag to set password as encrypted


### PR DESCRIPTION
zbus 5 requires rustc 1.81 or higher. This PR updates bumps the rustc dependency from 1.75 o 1.81 to
meet this requirement.
