### PR TITLE
docs: Fix broken links after moving content to web site

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -7,8 +7,8 @@ The Agama packages are available in the
 OBS project. These packages are automatically updated whenever the master branch is changed or when
 a new version is released.
 
-You can find more details the automatic OBS synchronization in the
-[obs_integration.md](doc/obs_integration.md) file.
+You can find more details the automatic OBS synchronization at
+[obs_integration.md](https://agama-project.github.io/docs/devel/obs_integration).
 
 The process to build each package is slightly different depending on the technology we are using.
 While the Ruby-based one (`rubygem-agama-yast`) is built as any other YaST package, the Agama server

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ If you have troubles or you want to know more about this feature, check our
 ## Other Resources
 
 - If you want to know how Agama works, you should read about
-  [Agama's architecture](/doc/architecture.md)
+  [Agama's architecture](https://agama-project.github.io/docs/devel/architecture)
 - If you would like to [contribute](#how-to-contribute), you might be interested in:
-  - [Running Agama from sources](./doc/running.md).
+  - [Running Agama from sources](https://agama-project.github.io/docs/devel/running).
   - [Working with Agama's web server](./rust/WEB-SERVER.md).
   - [Working with Agama's web UI](./web/README.md).
 - You can check the overall status of the project through the [status page](/STATUS.md).

--- a/autoinstallation/README.md
+++ b/autoinstallation/README.md
@@ -8,8 +8,8 @@ approach might sound familiar to AutoYaST users. On the other hand, Agama can ac
 shell script, enabling custom pre-installation workflows.
 
 Although Agama defines its own [profile format](../rust/agama-lib/share/profile.schema.json), it is
-able to partially handle AutoYaST profiles. Please, check the [AutoYaST support document](../doc/
-autoyast.md) for further information.
+able to partially handle AutoYaST profiles. Please, check the [AutoYaST support document](
+https://agama-project.github.io/docs/user/autoyast) for further information.
 
 ## Profile-based installation
 
@@ -235,7 +235,8 @@ Using the correct extension in the file name is important:
 - `.jsonnet` enables dynamic content through Jsonnet.
 - `.json` assumes the profile is just a JSON file, so no dynamic content is expected.
 - `.xml`, `.erb` or a trailing slash (`/`) indicates that you want to import an AutoYaST profile.
-  Check [autoyast.md](../doc/autoyast.doc) for further information.
+  Check the [AutoYaST support document](https://agama-project.github.io/docs/user/autoyast)
+  for further information.
 - `.sh` would be interpreted as a shell script.
 
 ## Caveats

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,7 @@
 # Agama Server
 
-According to [Agama's architecture](../doc/architecture.md) this project implements the following components:
+According to [Agama's architecture](https://agama-project.github.io/docs/devel/architecture)
+this project implements the following components:
 
 * The *Agama server*, excluding *Agama YaST* which lives in the [service](../service) directory.
 * The *Agama D-Bus service*.

--- a/service/README.md
+++ b/service/README.md
@@ -1,6 +1,7 @@
 # Agama YaST
 
-According to [Agama's architecture](../doc/architecture.md) this project implements the following components:
+According to [Agama's architecture](https://agama-project.github.io/docs/devel/architecture)
+this project implements the following components:
 
 * The *Agama YaST*, the layer build on top of YaST functionality.
 


### PR DESCRIPTION
The removal of redundant docs left some dangling links.  This commit changes the links to point to the web site.

Note: There is still a dangling link to doc/avahi.md in README.md but there is no matching documentation on the web site.

