### PR TITLE
Disable adjust_by_ram for swap at all products

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec  3 11:22:09 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Temporarily disable adjusting swap to RAM size for all products
+  (mitigation for gh#agama-project/agama/#1159).
+
+-------------------------------------------------------------------
 Tue Nov 12 08:19:51 UTC 2024 - Gustavo Yokoyama Ribeiro <gyribeiro@suse.com>
 
 - Add SLES for SAP Application product for SLE based products

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -130,12 +130,9 @@ storage:
     - mount_path: "swap"
       filesystem: swap
       size:
-        auto: true
+        min: 1 GiB
+        max: 2 GiB
       outline:
-        auto_size:
-          base_min: 1 GiB
-          base_max: 2 GiB
-          adjust_by_ram: true
         required: false
         filesystems:
           - swap

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -133,12 +133,9 @@ storage:
     - mount_path: "swap"
       filesystem: swap
       size:
-        auto: true
+        min: 1 GiB
+        max: 2 GiB
       outline:
-        auto_size:
-          base_min: 1 GiB
-          base_max: 2 GiB
-          adjust_by_ram: true
         required: false
         filesystems:
           - swap

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -133,12 +133,9 @@ storage:
     - mount_path: "swap"
       filesystem: swap
       size:
-        auto: true
+        min: 1 GiB
+        max: 2 GiB
       outline:
-        auto_size:
-          base_min: 1 GiB
-          base_max: 2 GiB
-          adjust_by_ram: true
         required: false
         filesystems:
           - swap

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -121,12 +121,9 @@ storage:
     - mount_path: "swap"
       filesystem: swap
       size:
-        auto: true
+        min: 1 GiB
+        max: 2 GiB
       outline:
-        auto_size:
-          base_min: 1 GiB
-          base_max: 2 GiB
-          adjust_by_ram: true
         required: false
         filesystems:
           - swap

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -185,12 +185,9 @@ storage:
     - mount_path: "swap"
       filesystem: swap
       size:
-        auto: true
+        min: 1 GiB
+        max: 2 GiB
       outline:
-        auto_size:
-          base_min: 1 GiB
-          base_max: 2 GiB
-          adjust_by_ram: true
         required: false
         filesystems:
           - swap


### PR DESCRIPTION
## Problem

As part of  #1111 we enabled `adjust_by_ram` for the swap. Only in the case of Tumbleweed and to (quoting from that PR description) "raise awareness and get feedback".

But somehow that setting ended up spreading over all products, even those in which linking the swap size to the RAM size by default doesn't seem to make much sense.

Very few people is installing the distributions in a setup where suspending to RAM is needed. On the other hand, many testers want a default set of settings that work out-of-the-box since they are not really interested in the storage setup.

## Solution

The original goal of getting feedback is achieved. So let's switch the feature back off to ease testing while we decide what the next steps will be regarding `adjust_by_ram` and its default value.
