### PR TITLE
Adapt SLES for SAP installation

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Dec  5 11:04:06 UTC 2024 - Angela Briel <abriel@suse.com>
+
+- SLES for SAP Application product:
+  Change the base_product to SLES-SAP.
+  Add SAP specific patterns for the default installation and for
+  the additional software selection.
+  (jsc#PED-11068, jsc#PED-11696)
+
+-------------------------------------------------------------------
 Tue Dec  3 11:22:09 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Temporarily disable adjusting swap to RAM size for all products

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -60,12 +60,23 @@ software:
 
   mandatory_patterns:
     - base_traditional
+    - sles_sap_enhanced_base
+    - sles_sap_base_sap_server
   optional_patterns: null # no optional pattern shared
-  user_patterns: []
+  user_patterns:
+    - sles_sap_DB
+    - sles_sap_HADB
+    - sles_sap_APP
+    - sles_sap_HAAPP
+    - sles_sap_trento_server
+    - sles_sap_trento_agent
+    - sles_sap_automation
+    - sles_sap_monitoring
+    - sles_sap_gui
   mandatory_packages:
     - NetworkManager
   optional_packages: null
-  base_product: SLES
+  base_product: SLES-SAP
 
 security:
   lsm: selinux


### PR DESCRIPTION
For SLES for SAP installations change the base_product to `SLES-SAP` and add SAP specific patterns for the default installation and for the additional software selection (jsc#PED-11068, jsc#PED-11696)