### PR TITLE
service: Workaround for error on s390x

### DIFF
--- a/service/lib/agama/storage/proposal_strategies/guided.rb
+++ b/service/lib/agama/storage/proposal_strategies/guided.rb
@@ -62,6 +62,9 @@ module Agama
 
         # @see Base#issues
         def issues
+          # Returning [] in case of a missing proposal is a workaround (the scenario should
+          # not happen). But this class is not expected to live long.
+          return [] unless storage_manager.proposal
           return [] unless storage_manager.proposal.failed?
 
           [target_device_issue, missing_devices_issue].compact


### PR DESCRIPTION
## Problem

As described at #1818, there seems to be a problem when installing at s390x and starting with no available disks. See [this comment](https://github.com/agama-project/agama/issues/1818#issuecomment-2527658289) at the original issue.

After visiting the DASD section and activating+formatting a device, the backend fails and the UI becomes barely usable.

The error is produced when checking `storage_manager.proposal` after re-probing the system and trying an (unsuccessful) proposal.

## Solution

This pull request does not implement a real fix, but a workaround that has proven to be useful in that case. It allowed the installation to continue successfully at the reported scenario.

I tried to fix the real root of the issue, but I was unable to find out why `storage_manager.proposal` was nil at that point.

But since we are rewriting the approach to the storage proposal, the whole `ProposalStrategies::Guided` class is going to disappear so it makes little sense to invest more time.

I will keep the original issue open and will create a Trello card to track it, so we check whether the new implementation of the storage proposal (still under development) is reliable in that situation.

## Testing

Verified with manual testing. Going further would be wasting resources right now.