### PR TITLE
fix(web): ensure question are always rendered

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -98,7 +98,6 @@ jest.mock("~/context/installer", () => ({
 
 // Mock some components,
 // See https://www.chakshunyu.com/blog/how-to-mock-a-react-component-in-jest/#default-export
-jest.mock("~/components/questions/Questions", () => () => <div>Questions Mock</div>);
 jest.mock("~/components/layout/Loading", () => () => <div>Loading Mock</div>);
 jest.mock("~/components/product/ProductSelectionProgress", () => () => <div>Product progress</div>);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,7 +24,6 @@ import React from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { ServerError } from "~/components/core";
 import { Loading, PlainLayout } from "~/components/layout";
-import { Questions } from "~/components/questions";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { useInstallerClientStatus } from "~/context/installer";
 import { useProduct, useProductChanges } from "~/queries/software";
@@ -102,12 +101,7 @@ function App() {
 
   if (!language) return null;
 
-  return (
-    <>
-      <Content />
-      <Questions />
-    </>
-  );
+  return <Content />;
 }
 
 export default App;

--- a/web/src/components/layout/Layout.test.tsx
+++ b/web/src/components/layout/Layout.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+import Layout from "./Layout";
+
+jest.mock("~/components/layout/Header", () => () => <div>Header Mock</div>);
+jest.mock("~/components/layout/Sidebar", () => () => <div>Sidebar Mock</div>);
+jest.mock("~/components/core/IssuesDrawer", () => () => <div>IssuesDrawer Mock</div>);
+jest.mock("~/components/questions/Questions", () => () => <div>Questions Mock</div>);
+
+describe("Layout", () => {
+  it("renders a page with header and sidebar by default", () => {
+    plainRender(<Layout />);
+    screen.getByText("Header Mock");
+    screen.getByText("Sidebar Mock");
+  });
+
+  it("does not render the header when mountHeader=false", () => {
+    plainRender(<Layout mountHeader={false} />);
+    expect(screen.queryByText("Header Mock")).toBeNull();
+  });
+
+  it("does not render the sidebar when mountSidebar=false", () => {
+    plainRender(<Layout mountSidebar={false} />);
+    expect(screen.queryByText("Sidebar Mock")).toBeNull();
+  });
+
+  describe("when children are not given", () => {
+    it("renders router <Outlet />", () => {
+      plainRender(<Layout />);
+      // NOTE: react-router-dom/Outlet is mock at src/test-utils
+      screen.getByText("Outlet Content");
+    });
+
+    it("renders the questions component", () => {
+      plainRender(<Layout />);
+      screen.getByText("Questions Mock");
+    });
+  });
+
+  describe("when children are given", () => {
+    it("renders children instead of router <Outlet />", () => {
+      plainRender(
+        <Layout>
+          <button>Dummy testing button</button>
+        </Layout>,
+      );
+      screen.getByRole("button", { name: "Dummy testing button" });
+      // NOTE: react-router-dom/Outlet is mock at src/test-utils
+      expect(screen.queryByText("Outlet Content")).toBeNull();
+    });
+
+    it("renders the questions component", () => {
+      plainRender(<Layout />);
+      screen.getByText("Questions Mock");
+    });
+  });
+});

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -23,6 +23,7 @@
 import React, { Suspense, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { Page } from "@patternfly/react-core";
+import { Questions } from "~/components/questions";
 import Header, { HeaderProps } from "~/components/layout/Header";
 import { Loading, Sidebar } from "~/components/layout";
 import { IssuesDrawer } from "~/components/core";
@@ -50,23 +51,26 @@ const Layout = ({
   const toggleIssuesDrawer = () => setIssuesDrawerVisible(!issuesDrawerVisible);
 
   return (
-    <Page
-      isManagedSidebar
-      header={
-        mountHeader && (
-          <Header
-            showSidebarToggle={mountSidebar}
-            toggleIssuesDrawer={toggleIssuesDrawer}
-            {...headerOptions}
-          />
-        )
-      }
-      sidebar={mountSidebar && <Sidebar />}
-      notificationDrawer={<IssuesDrawer onClose={closeIssuesDrawer} />}
-      isNotificationDrawerExpanded={issuesDrawerVisible}
-    >
-      <Suspense fallback={<Loading />}>{children || <Outlet />}</Suspense>
-    </Page>
+    <>
+      <Page
+        isManagedSidebar
+        header={
+          mountHeader && (
+            <Header
+              showSidebarToggle={mountSidebar}
+              toggleIssuesDrawer={toggleIssuesDrawer}
+              {...headerOptions}
+            />
+          )
+        }
+        sidebar={mountSidebar && <Sidebar />}
+        notificationDrawer={<IssuesDrawer onClose={closeIssuesDrawer} />}
+        isNotificationDrawerExpanded={issuesDrawerVisible}
+      >
+        <Suspense fallback={<Loading />}>{children || <Outlet />}</Suspense>
+      </Page>
+      <Questions />
+    </>
   );
 };
 


### PR DESCRIPTION
Rendering questions across the app no longer works as expected after #1690 because commit f10153bd56e96c1ec6d3c64a1247d52999bd2bad, which change how the content outside the _installation settings context_ is handled, rendered by navigating to its own path instead of including it as part of `App` component.

_Mounting_ `Questions` component in `Layout` should restore the previous behavior and fix #1820.