### PR TITLE
fix(web): close issues drawer when users click on a section

### DIFF
--- a/web/src/components/core/IssuesDrawer.test.tsx
+++ b/web/src/components/core/IssuesDrawer.test.tsx
@@ -114,6 +114,11 @@ describe("IssuesDrawer", () => {
       expect(usersLink).toHaveAttribute("href", "/users");
       within(usersIssues).getByText("Users Fake Issue");
 
+      // onClose should be called when user clicks on a section too for ensuring
+      // drawer gets closed even when navigation is not needed.
+      await user.click(usersLink);
+      expect(onCloseFn).toHaveBeenCalled();
+
       const closeButton = screen.getByRole("button", { name: "Close" });
       await user.click(closeButton);
       expect(onCloseFn).toHaveBeenCalled();

--- a/web/src/components/core/IssuesDrawer.tsx
+++ b/web/src/components/core/IssuesDrawer.tsx
@@ -71,7 +71,7 @@ const IssuesDrawer = forwardRef(({ onClose }: { onClose: () => void }, ref) => {
               <section key={idx} aria-labelledby={ariaLabelId}>
                 <Stack hasGutter>
                   <h4 id={ariaLabelId}>
-                    <Link variant="link" isInline to={`/${scope}`}>
+                    <Link variant="link" isInline onClick={onClose} to={`/${scope}`}>
                       {scopeHeaders[scope]}
                     </Link>
                   </h4>


### PR DESCRIPTION
## Problem

During the presentation of the [new location for the pre-installation checks](https://github.com/agama-project/agama/pull/1778) at a team meeting on December 9th, it was discovered that the drawer doesn't close when users click on the section they are currently viewing.

## Solution

 As a quick fix, the onClose callback is triggered when users click on section names. This addresses the issue in a simple way until having time to consider other behavior options, such as not rendering the current section as a link in the drawer but using different elements to hint users they are already on that section.


## Testing

- Added a new unit test
- Tested manually

