### PR TITLE
fix(rust): better profile URL handling

### DIFF
--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -32,7 +32,7 @@ mod questions;
 use crate::error::CliError;
 use agama_lib::base_http_client::BaseHTTPClient;
 use agama_lib::{
-    error::ServiceError, manager::ManagerClient, progress::ProgressMonitor, transfer::Transfer,
+    error::ServiceError, manager::ManagerClient, progress::ProgressMonitor, utils::Transfer,
 };
 use auth::run as run_auth_cmd;
 use commands::Commands;

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -22,7 +22,8 @@ use crate::show_progress;
 use agama_lib::{
     base_http_client::BaseHTTPClient,
     install_settings::InstallSettings,
-    profile::{AutoyastProfile, ProfileEvaluator, ProfileValidator, ValidationResult},
+    profile::{AutoyastProfileImporter, ProfileEvaluator, ProfileValidator, ValidationResult},
+    utils::FileFormat,
     utils::Transfer,
     Store as SettingsStore,
 };
@@ -114,48 +115,59 @@ async fn import(url_string: String, dir: Option<PathBuf>) -> anyhow::Result<()> 
     tokio::spawn(async move {
         show_progress().await.unwrap();
     });
+
     let url = Url::parse(&url_string)?;
     let tmpdir = TempDir::new()?; // TODO: create it only if dir is not passed
+    let work_dir = dir.unwrap_or_else(|| tmpdir.into_path());
+    let profile_path = work_dir.join("profile.json");
+
+    // Specific AutoYaST handling
     let path = url.path();
-    let output_file = if path.ends_with(".sh") {
-        "profile.sh"
-    } else if path.ends_with(".jsonnet") {
-        "profile.jsonnet"
-    } else {
-        "profile.json"
-    };
-    let output_dir = dir.unwrap_or_else(|| tmpdir.into_path());
-    let mut output_path = output_dir.join(output_file);
-    let output_fd = File::create(output_path.clone())?;
     if path.ends_with(".xml") || path.ends_with(".erb") || path.ends_with('/') {
-        // autoyast specific download and convert to json
-        AutoyastProfile::new(&url)?.read_into(output_fd)?;
+        // AutoYaST specific download and convert to JSON
+        AutoyastProfileImporter::read(&url)?.write_file(&profile_path)?;
     } else {
-        // just download profile
-        Transfer::get(&url_string, output_fd)?;
+        pre_process_profile(&url_string, &profile_path)?;
     }
 
-    // exec shell scripts
-    if output_file.ends_with(".sh") {
-        let err = Command::new("bash")
-            .args([output_path.to_str().context("Wrong path to shell script")?])
-            .exec();
-        eprintln!("Exec failed: {}", err);
+    validate(&profile_path)?;
+    store_settings(&profile_path).await?;
+
+    Ok(())
+}
+
+// Preprocess the profile.
+//
+// The profile can be a JSON or a Jsonnet file or a script.
+//
+// * If it is a JSON file, no preprocessing is needed.
+// * If it is a Jsonnet file, it is converted to JSON.
+// * If it is a script, it is executed.
+fn pre_process_profile<P: AsRef<Path>>(url_string: &str, path: P) -> anyhow::Result<()> {
+    let work_dir = path.as_ref().parent().unwrap();
+    let tmp_profile_path = work_dir.join("profile.temp");
+    let tmp_file = File::create(&tmp_profile_path)?;
+    Transfer::get(url_string, tmp_file)?;
+
+    match FileFormat::from_file(&tmp_profile_path) {
+        FileFormat::Jsonnet => {
+            let file = File::create(path)?;
+            let evaluator = ProfileEvaluator {};
+            evaluator
+                .evaluate(&tmp_profile_path, file)
+                .context("Could not evaluate the profile".to_string())?;
+        }
+        FileFormat::Script => {
+            let err = Command::new("bash").args([path.as_ref()]).exec();
+            eprintln!("Exec failed: {}", err);
+        }
+        FileFormat::Json => {
+            std::fs::rename(&tmp_profile_path, path.as_ref())?;
+        }
+        _ => {
+            return Err(anyhow::Error::msg("Unsupported file format"));
+        }
     }
-
-    // evaluate jsonnet profiles
-    if output_file.ends_with(".jsonnet") {
-        let fd = File::create(output_dir.join("profile.json"))?;
-        let evaluator = ProfileEvaluator {};
-        evaluator
-            .evaluate(&output_path, fd)
-            .context("Could not evaluate the profile".to_string())?;
-        output_path = output_dir.join("profile.json");
-    }
-
-    validate(&output_path)?;
-    store_settings(&output_path).await?;
-
     Ok(())
 }
 
@@ -168,8 +180,8 @@ async fn store_settings<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
 
 fn autoyast(url_string: String) -> anyhow::Result<()> {
     let url = Url::parse(&url_string)?;
-    let reader = AutoyastProfile::new(&url)?;
-    reader.read_into(std::io::stdout())?;
+    let importer = AutoyastProfileImporter::read(&url)?;
+    importer.write(std::io::stdout())?;
     Ok(())
 }
 

--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -23,7 +23,7 @@ use agama_lib::{
     base_http_client::BaseHTTPClient,
     install_settings::InstallSettings,
     profile::{AutoyastProfile, ProfileEvaluator, ProfileValidator, ValidationResult},
-    transfer::Transfer,
+    utils::Transfer,
     Store as SettingsStore,
 };
 use anyhow::Context;

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -23,7 +23,7 @@ use std::io;
 use thiserror::Error;
 use zbus::{self, zvariant};
 
-use crate::transfer::TransferError;
+use crate::utils::TransferError;
 
 #[derive(Error, Debug)]
 pub enum ServiceError {

--- a/rust/agama-lib/src/lib.rs
+++ b/rust/agama-lib/src/lib.rs
@@ -66,7 +66,7 @@ pub use store::Store;
 pub mod openapi;
 pub mod questions;
 pub mod scripts;
-pub mod transfer;
+pub mod utils;
 
 use crate::error::ServiceError;
 use reqwest::{header, Client};

--- a/rust/agama-lib/src/scripts/model.rs
+++ b/rust/agama-lib/src/scripts/model.rs
@@ -28,7 +28,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::transfer::Transfer;
+use crate::utils::Transfer;
 
 use super::ScriptError;
 

--- a/rust/agama-lib/src/transfer.rs
+++ b/rust/agama-lib/src/transfer.rs
@@ -27,6 +27,7 @@ impl Transfer {
     /// * `out_fd`: where to write the data.
     pub fn get(url: &str, mut out_fd: impl Write) -> TransferResult<()> {
         let mut handle = Easy::new();
+        handle.follow_location(true)?;
         handle.url(url)?;
 
         let mut transfer = handle.transfer();

--- a/rust/agama-lib/src/utils.rs
+++ b/rust/agama-lib/src/utils.rs
@@ -18,17 +18,10 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use std::io;
-use thiserror::Error;
+//! Utility module for Agama.
 
-use crate::utils::TransferError;
+mod file_format;
+mod transfer;
 
-#[derive(Error, Debug)]
-pub enum ScriptError {
-    #[error("Could not fetch the profile: '{0}'")]
-    Unreachable(#[from] TransferError),
-    #[error("I/O error: '{0}'")]
-    InputOutputError(#[from] io::Error),
-    #[error("Wrong script type")]
-    WrongScriptType,
-}
+pub use file_format::*;
+pub use transfer::*;

--- a/rust/agama-lib/src/utils/file_format.rs
+++ b/rust/agama-lib/src/utils/file_format.rs
@@ -1,0 +1,123 @@
+// Copyright (c) [2024] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+//! File format detection for Agama.
+//!
+//! It implements a simple API to detect the file formats that are relevent for Agama.
+
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+/// File formats
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum FileFormat {
+    Json,
+    Jsonnet,
+    Script,
+    Unknown,
+}
+
+const JSONNETFMT_PATH: &str = "/usr/bin/jsonnetfmt";
+
+impl FileFormat {
+    pub fn from_file(file_path: &str) -> Self {
+        let Ok(content) = std::fs::read_to_string(file_path) else {
+            return Self::Unknown;
+        };
+        Self::from_string(&content)
+    }
+
+    pub fn from_string(content: &str) -> Self {
+        if Self::is_json(content) {
+            return Self::Json;
+        } else if Self::is_jsonnet(content) {
+            return Self::Jsonnet;
+        } else if Self::is_script(content) {
+            return Self::Script;
+        }
+
+        Self::Unknown
+    }
+
+    fn is_json(content: &str) -> bool {
+        let json = serde_json::from_str::<serde_json::Value>(content);
+        json.is_ok()
+    }
+
+    fn is_jsonnet(content: &str) -> bool {
+        let child = Command::new(JSONNETFMT_PATH)
+            .args(["-"])
+            .stdin(Stdio::piped())
+            .spawn();
+
+        let Ok(mut child) = child else {
+            return false;
+        };
+
+        let Some(mut stdin) = child.stdin.take() else {
+            return false;
+        };
+
+        stdin
+            .write_all(content.as_bytes())
+            .expect("Failed to write to stdin");
+        drop(stdin);
+
+        child.wait().is_ok_and(|s| s.success())
+    }
+
+    fn is_script(content: &str) -> bool {
+        content.starts_with("#!")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FileFormat;
+
+    #[test]
+    fn test_json() {
+        let content = r#"
+            { "name:": "value"}
+            "#;
+
+        assert_eq!(FileFormat::from_string(content), FileFormat::Json);
+    }
+
+    #[test]
+    fn test_jsonnet() {
+        let content = r#"
+            { name: "value" }
+            "#;
+
+        assert_eq!(FileFormat::from_string(content), FileFormat::Jsonnet);
+    }
+
+    #[test]
+    fn test_script() {
+        let content = r#"#!/bin/bash
+            echo "Hello World"
+            "#;
+
+        assert_eq!(FileFormat::from_string(content), FileFormat::Script);
+    }
+}

--- a/rust/agama-lib/src/utils/transfer.rs
+++ b/rust/agama-lib/src/utils/transfer.rs
@@ -1,3 +1,23 @@
+// Copyright (c) [2024] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
 //! File transfer API for Agama.
 //!
 //! Implement a file transfer API which, in the future, will support Agama specific URLs. Check the


### PR DESCRIPTION
Fix for [bsc#1234362](https://bugzilla.suse.com/show_bug.cgi?id=1234362).

It fixes the behavior when importing an auto-installation profile:

* Follow redirections.
* Determine the file format from the content instead of the extension. It does not apply to AutoYaST profiles, where it still uses the extension in the URL for backward compatibility.

## Follow-up

This feature was not updated after adding the `--api`. The processing of the profile should be done at the server's side.