### PR TITLE
Rename "encrypted password" to "hashed password"

### DIFF
--- a/live/root/etc/systemd/system/live-password-cmdline.service
+++ b/live/root/etc/systemd/system/live-password-cmdline.service
@@ -9,7 +9,7 @@ Before=agama-web-server.service
 Before=live-password-dialog.service
 Before=live-password-systemd.service
 
-# plain text password or encrypted password passed via kernel command line
+# plain text password or hashed password passed via kernel command line
 ConditionKernelCommandLine=|live.password
 ConditionKernelCommandLine=|live.password_hash
 

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -382,12 +382,12 @@
           "examples": ["jane.doe"]
         },
         "password": {
-          "title": "User password (plain text or encrypted depending on the \"encryptedPassword\" field)",
+          "title": "User password (plain text or hashed depending on the \"hashedPassword\" field)",
           "type": "string",
           "examples": ["nots3cr3t"]
         },
-        "encryptedPassword": {
-          "title": "Flag for encrypted password (true) or plain text password (false or not defined)",
+        "hashedPassword": {
+          "title": "Flag for hashed password (true) or plain text password (false or not defined)",
           "type": "boolean"
         }
       },
@@ -399,11 +399,11 @@
       "additionalProperties": false,
       "properties": {
         "password": {
-          "title": "Root password (plain text or encrypted depending on the \"encryptedPassword\" field)",
+          "title": "Root password (plain text or hashed depending on the \"hashedPassword\" field)",
           "type": "string"
         },
-        "encryptedPassword": {
-          "title": "Flag for encrypted password (true) or plain text password (false or not defined)",
+        "hashedPassword": {
+          "title": "Flag for hashed password (true) or plain text password (false or not defined)",
           "type": "boolean"
         },
         "sshPublicKey": {

--- a/rust/agama-lib/src/users/client.rs
+++ b/rust/agama-lib/src/users/client.rs
@@ -35,8 +35,8 @@ pub struct FirstUser {
     pub user_name: String,
     /// First user's password (in clear text)
     pub password: String,
-    /// Whether the password is encrypted (true) or is plain text (false)
-    pub encrypted_password: bool,
+    /// Whether the password is hashed (true) or is plain text (false)
+    pub hashed_password: bool,
     /// Whether auto-login should enabled or not
     pub autologin: bool,
 }
@@ -48,7 +48,7 @@ impl FirstUser {
             full_name: data.0,
             user_name: data.1,
             password: data.2,
-            encrypted_password: data.3,
+            hashed_password: data.3,
             autologin: data.4,
         })
     }
@@ -73,12 +73,8 @@ impl<'a> UsersClient<'a> {
     }
 
     /// SetRootPassword method
-    pub async fn set_root_password(
-        &self,
-        value: &str,
-        encrypted: bool,
-    ) -> Result<u32, ServiceError> {
-        Ok(self.users_proxy.set_root_password(value, encrypted).await?)
+    pub async fn set_root_password(&self, value: &str, hashed: bool) -> Result<u32, ServiceError> {
+        Ok(self.users_proxy.set_root_password(value, hashed).await?)
     }
 
     pub async fn remove_root_password(&self) -> Result<u32, ServiceError> {
@@ -110,7 +106,7 @@ impl<'a> UsersClient<'a> {
                 &first_user.full_name,
                 &first_user.user_name,
                 &first_user.password,
-                first_user.encrypted_password,
+                first_user.hashed_password,
                 first_user.autologin,
                 std::collections::HashMap::new(),
             )

--- a/rust/agama-lib/src/users/http_client.rs
+++ b/rust/agama-lib/src/users/http_client.rs
@@ -58,15 +58,11 @@ impl UsersHTTPClient {
 
     /// SetRootPassword method.
     /// Returns 0 if successful (always, for current backend)
-    pub async fn set_root_password(
-        &self,
-        value: &str,
-        encrypted: bool,
-    ) -> Result<u32, ServiceError> {
+    pub async fn set_root_password(&self, value: &str, hashed: bool) -> Result<u32, ServiceError> {
         let rps = RootPatchSettings {
             sshkey: None,
             password: Some(value.to_owned()),
-            encrypted_password: Some(encrypted),
+            hashed_password: Some(hashed),
         };
         let ret = self.client.patch("/users/root", &rps).await?;
         Ok(ret)
@@ -84,7 +80,7 @@ impl UsersHTTPClient {
         let rps = RootPatchSettings {
             sshkey: Some(value.to_owned()),
             password: None,
-            encrypted_password: None,
+            hashed_password: None,
         };
         let ret = self.client.patch("/users/root", &rps).await?;
         Ok(ret)

--- a/rust/agama-lib/src/users/model.rs
+++ b/rust/agama-lib/src/users/model.rs
@@ -35,6 +35,6 @@ pub struct RootPatchSettings {
     pub sshkey: Option<String>,
     /// empty string here means remove password for root
     pub password: Option<String>,
-    /// specify if patched password is provided in encrypted form
-    pub encrypted_password: Option<bool>,
+    /// specify if patched password is provided in plain text (default) or hashed
+    pub hashed_password: Option<bool>,
 }

--- a/rust/agama-lib/src/users/proxies.rs
+++ b/rust/agama-lib/src/users/proxies.rs
@@ -47,7 +47,7 @@ use zbus::proxy;
 /// * full name
 /// * user name
 /// * password
-/// * encrypted_password (true = encrypted, false = plain text)
+/// * hashed_password (true = hashed, false = plain text)
 /// * auto-login (enabled or not)
 /// * some optional and additional data
 // NOTE: Manually added to this file.
@@ -79,13 +79,13 @@ pub trait Users1 {
         full_name: &str,
         user_name: &str,
         password: &str,
-        encrypted_password: bool,
+        hashed_password: bool,
         auto_login: bool,
         data: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
     ) -> zbus::Result<(bool, Vec<String>)>;
 
     /// SetRootPassword method
-    fn set_root_password(&self, value: &str, encrypted: bool) -> zbus::Result<u32>;
+    fn set_root_password(&self, value: &str, hashed: bool) -> zbus::Result<u32>;
 
     /// SetRootSSHKey method
     #[zbus(name = "SetRootSSHKey")]

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -43,8 +43,8 @@ pub struct FirstUserSettings {
     pub user_name: Option<String>,
     /// First user's password (in clear text)
     pub password: Option<String>,
-    /// Whether the password is encrypted or is plain text
-    pub encrypted_password: Option<bool>,
+    /// Whether the password is hashed or is plain text
+    pub hashed_password: Option<bool>,
     /// Whether auto-login should enabled or not
     pub autologin: Option<bool>,
 }
@@ -58,9 +58,9 @@ pub struct RootUserSettings {
     /// Root's password (in clear text)
     #[serde(skip_serializing)]
     pub password: Option<String>,
-    /// Whether the password is encrypted or is plain text
+    /// Whether the password is hashed or is plain text
     #[serde(skip_serializing)]
-    pub encrypted_password: Option<bool>,
+    pub hashed_password: Option<bool>,
     /// Root SSH public key
     pub ssh_public_key: Option<String>,
 }

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -90,7 +90,7 @@ async fn first_user_changed_stream(
                     full_name: user.0,
                     user_name: user.1,
                     password: user.2,
-                    encrypted_password: user.3,
+                    hashed_password: user.3,
                     autologin: user.4,
                 };
                 return Some(Event::FirstUserChanged(user_struct));
@@ -243,7 +243,7 @@ async fn patch_root(
         } else {
             state
                 .users
-                .set_root_password(&password, config.encrypted_password == Some(true))
+                .set_root_password(&password, config.hashed_password == Some(true))
                 .await?
         }
     }

--- a/service/lib/agama/autoyast/root_reader.rb
+++ b/service/lib/agama/autoyast/root_reader.rb
@@ -41,7 +41,7 @@ module Agama
         return {} unless root_user
 
         hsh = { "password" => root_user.password.value.to_s }
-        hsh["encryptedPassword"] = true if root_user.password.value.encrypted?
+        hsh["hashedPassword"] = true if root_user.password.value.encrypted?
 
         public_key = root_user.authorized_keys.first
         hsh["sshPublicKey"] = public_key if public_key

--- a/service/lib/agama/autoyast/user_reader.rb
+++ b/service/lib/agama/autoyast/user_reader.rb
@@ -46,7 +46,7 @@ module Agama
           "password" => user.password.value.to_s
         }
 
-        hsh["encryptedPassword"] = true if user.password.value.encrypted?
+        hsh["hashedPassword"] = true if user.password.value.encrypted?
 
         { "user" => hsh }
       end

--- a/service/lib/agama/dbus/users.rb
+++ b/service/lib/agama/dbus/users.rb
@@ -58,7 +58,7 @@ module Agama
       USERS_INTERFACE = "org.opensuse.Agama.Users1"
       private_constant :USERS_INTERFACE
 
-      FUSER_SIG = "in FullName:s, in UserName:s, in Password:s, in EncryptedPassword:b, " \
+      FUSER_SIG = "in FullName:s, in UserName:s, in Password:s, in HashedPassword:b, " \
                   "in AutoLogin:b, in data:a{sv}"
       private_constant :FUSER_SIG
 
@@ -70,9 +70,9 @@ module Agama
         dbus_reader :first_user, "(sssbba{sv})"
 
         dbus_method :SetRootPassword,
-          "in Value:s, in Encrypted:b, out result:u" do |value, encrypted|
+          "in Value:s, in Hashed:b, out result:u" do |value, hashed|
           logger.info "Setting Root Password"
-          backend.assign_root_password(value, encrypted)
+          backend.assign_root_password(value, hashed)
 
           dbus_properties_changed(USERS_INTERFACE, { "RootPasswordSet" => !value.empty? }, [])
           0
@@ -99,10 +99,10 @@ module Agama
           # It returns an Struct with the first field with the result of the operation as a boolean
           # and the second parameter as an array of issues found in case of failure
           FUSER_SIG + ", out result:(bas)" do
-            |full_name, user_name, password, encrypted_password, auto_login, data|
+            |full_name, user_name, password, hashed_password, auto_login, data|
           logger.info "Setting first user #{full_name}"
           user_issues = backend.assign_first_user(full_name, user_name, password,
-            encrypted_password, auto_login, data)
+            hashed_password, auto_login, data)
 
           if user_issues.empty?
             dbus_properties_changed(USERS_INTERFACE, { "FirstUser" => first_user }, [])

--- a/service/lib/agama/users.rb
+++ b/service/lib/agama/users.rb
@@ -60,8 +60,8 @@ module Agama
       !root_ssh_key.empty?
     end
 
-    def assign_root_password(value, encrypted)
-      pwd = if encrypted
+    def assign_root_password(value, hashed)
+      pwd = if hashed
         Y2Users::Password.create_encrypted(value)
       else
         Y2Users::Password.create_plain(value)
@@ -99,16 +99,16 @@ module Agama
     # @param full_name [String]
     # @param user_name [String]
     # @param password [String]
-    # @param encrypted_password [Boolean] true = encrypted password, false = plain text password
+    # @param hashed_password [Boolean] true = hashed password, false = plain text password
     # @param auto_login [Boolean]
     # @param _data [Hash]
     # @return [Array] the list of fatal issues found
-    def assign_first_user(full_name, user_name, password, encrypted_password, auto_login, _data)
+    def assign_first_user(full_name, user_name, password, hashed_password, auto_login, _data)
       remove_first_user
 
       user = Y2Users::User.new(user_name)
       user.gecos = [full_name]
-      user.password = if encrypted_password
+      user.password = if hashed_password
         Y2Users::Password.create_encrypted(password)
       else
         Y2Users::Password.create_plain(password)

--- a/service/test/agama/users_test.rb
+++ b/service/test/agama/users_test.rb
@@ -37,15 +37,15 @@ describe Agama::Users do
   describe "#assign_root_password" do
     let(:root_user) { instance_double(Y2Users::User) }
 
-    context "when the password is encrypted" do
-      it "sets the password as encrypted" do
-        subject.assign_root_password("encrypted", true)
+    context "when the password is hashed" do
+      it "sets the password as hashed" do
+        subject.assign_root_password("hashed", true)
         root_user = users_config.users.root
-        expect(root_user.password).to eq(Y2Users::Password.create_encrypted("encrypted"))
+        expect(root_user.password).to eq(Y2Users::Password.create_encrypted("hashed"))
       end
     end
 
-    context "when the password is not encrypted" do
+    context "when the password is not hashed" do
       it "sets the password in clear text" do
         subject.assign_root_password("12345", false)
         root_user = users_config.users.root

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -110,7 +110,7 @@ describe("App", () => {
     });
 
     mockProducts = [tumbleweed, microos];
-    mockRootUser = { password: true, encryptedPassword: false, sshkey: "FAKE-SSH-KEY" };
+    mockRootUser = { password: true, hashedPassword: false, sshkey: "FAKE-SSH-KEY" };
   });
 
   afterEach(() => {
@@ -165,7 +165,7 @@ describe("App", () => {
 
       describe("when there are no authentication method for root user", () => {
         beforeEach(() => {
-          mockRootUser = { password: false, encryptedPassword: false, sshkey: "" };
+          mockRootUser = { password: false, hashedPassword: false, sshkey: "" };
         });
 
         it("redirects to root user edition", async () => {
@@ -176,7 +176,7 @@ describe("App", () => {
 
       describe("when only root password is set", () => {
         beforeEach(() => {
-          mockRootUser = { password: true, encryptedPassword: false, sshkey: "" };
+          mockRootUser = { password: true, hashedPassword: false, sshkey: "" };
         });
         it("renders the application content", async () => {
           installerRender(<App />, { withL10n: true });
@@ -186,7 +186,7 @@ describe("App", () => {
 
       describe("when only root SSH public key is set", () => {
         beforeEach(() => {
-          mockRootUser = { password: false, encryptedPassword: false, sshkey: "FAKE-SSH-KEY" };
+          mockRootUser = { password: false, hashedPassword: false, sshkey: "FAKE-SSH-KEY" };
         });
         it("renders the application content", async () => {
           installerRender(<App />, { withL10n: true });

--- a/web/src/components/users/FirstUserForm.tsx
+++ b/web/src/components/users/FirstUserForm.tsx
@@ -135,9 +135,9 @@ export default function FirstUserForm() {
     if (!changePassword) {
       delete user.password;
     } else {
-      // the web UI only supports plain text passwords, this resets the flag if an encrypted
+      // the web UI only supports plain text passwords, this resets the flag if a hashed
       // password was previously set from CLI
-      user.encryptedPassword = false;
+      user.hashedPassword = false;
     }
     delete user.passwordConfirmation;
     user.autologin = !!user.autologin;

--- a/web/src/components/users/RootAuthMethodsPage.test.tsx
+++ b/web/src/components/users/RootAuthMethodsPage.test.tsx
@@ -53,7 +53,7 @@ describe("RootAuthMethodsPage", () => {
     await user.click(acceptButton);
     expect(mockRootUserMutation.mutateAsync).toHaveBeenCalledWith({
       password: "t0ps3cr3t",
-      encryptedPassword: false,
+      hashedPassword: false,
     });
 
     // After submitting the data, it must navigate

--- a/web/src/components/users/RootAuthMethodsPage.tsx
+++ b/web/src/components/users/RootAuthMethodsPage.tsx
@@ -52,7 +52,7 @@ function RootAuthMethodsPage() {
     e.preventDefault();
     if (isEmpty(password)) return;
 
-    await setRootUser.mutateAsync({ password, encryptedPassword: false });
+    await setRootUser.mutateAsync({ password, hashedPassword: false });
 
     navigate(location.state?.from || PATHS.root, { replace: true });
   };

--- a/web/src/components/users/RootPasswordPopup.jsx
+++ b/web/src/components/users/RootPasswordPopup.jsx
@@ -55,9 +55,9 @@ export default function RootPasswordPopup({ title = _("Root password"), isOpen, 
   const accept = async (e) => {
     e.preventDefault();
     // TODO: handle errors
-    // the web UI only supports plain text passwords, this resets the flag if an encrypted password
+    // the web UI only supports plain text passwords, this resets the flag if a hashed password
     // was previously set from CLI
-    if (password !== "") await setRootUser.mutateAsync({ password, encryptedPassword: false });
+    if (password !== "") await setRootUser.mutateAsync({ password, hashedPassword: false });
     close();
   };
 

--- a/web/src/components/users/RootPasswordPopup.test.jsx
+++ b/web/src/components/users/RootPasswordPopup.test.jsx
@@ -77,7 +77,7 @@ describe("when it is open", () => {
 
     expect(mockRootUserMutation.mutateAsync).toHaveBeenCalledWith({
       password,
-      encryptedPassword: false,
+      hashedPassword: false,
     });
     expect(onCloseCallback).toHaveBeenCalled();
   });

--- a/web/src/queries/users.ts
+++ b/web/src/queries/users.ts
@@ -83,12 +83,12 @@ const useFirstUserChanges = () => {
 
     return client.onEvent((event) => {
       if (event.type === "FirstUserChanged") {
-        const { fullName, userName, password, encryptedPassword, autologin, data } = event;
+        const { fullName, userName, password, hashedPassword, autologin, data } = event;
         queryClient.setQueryData(["users", "firstUser"], {
           fullName,
           userName,
           password,
-          encryptedPassword,
+          hashedPassword,
           autologin,
           data,
         });
@@ -155,7 +155,7 @@ const useRootUserChanges = () => {
           const newRoot = { ...oldRoot };
           if (password !== undefined) {
             newRoot.password = password;
-            newRoot.encryptedPassword = false;
+            newRoot.hashedPassword = false;
           }
 
           if (sshkey) {

--- a/web/src/types/users.ts
+++ b/web/src/types/users.ts
@@ -24,19 +24,19 @@ type FirstUser = {
   fullName: string;
   userName: string;
   password: string;
-  encryptedPassword: boolean;
+  hashedPassword: boolean;
   autologin: boolean;
 };
 
 type RootUser = {
   password: boolean;
-  encryptedPassword: boolean;
+  hashedPassword: boolean;
   sshkey: string;
 };
 
 type RootUserChanges = {
   password: string;
-  encryptedPassword: boolean;
+  hashedPassword: boolean;
   sshkey: string;
 };
 


### PR DESCRIPTION
- As discussed on the review meeting, technically it is not an encryption (because the decryption part is missing) but hashing. That's the correct term.

## Testing

- Updated unit tests
- Tested manually

```console
# agama config show | jq .user
{
  "fullName": "Agama",
  "userName": "agama",
  "password": "$5$t3gRfqthxk7ZsJw.$gpduJASf12Xk8aPtIllniJAwhbhlYvLcEUH0.4P9MWA",
  "hashedPassword": true,
  "autologin": false
}
```