### PR TITLE
Ignore generated OpenAPI data

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -7,3 +7,6 @@
 
 # Agama configuration file
 /etc/agama.d
+
+# Generated OpenAPI data
+/out/


### PR DESCRIPTION
- To have a clean git checkout after running `cargo xtask openapi`