### PR TITLE
fix(rust): add jsonnet as a BuildRequires dependency

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 18 10:11:44 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add jsonnet as a BuildRequires dependency because it is needed
+  when running tests (gh#agama-project/agama#1842).
+
+-------------------------------------------------------------------
 Thu Dec 12 16:42:18 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix profile URL handling (bsc#1234362):

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -37,6 +37,7 @@ BuildRequires:  dbus-1-daemon
 BuildRequires:  clang-devel
 BuildRequires:  pkgconfig(pam)
 # required by autoinstallation
+BuildRequires:  jsonnet
 Requires:       jsonnet
 Requires:       lshw
 # required by "agama logs store"


### PR DESCRIPTION
Add `jsonnet` as a `BuildRequires` dependency because it is ran as part of our test suite. It should fix the build in OBS.
