### PR TITLE
fix(ci): Fixed timeout in the integration test

### DIFF
--- a/puppeteer/tests/test_root_password.js
+++ b/puppeteer/tests/test_root_password.js
@@ -123,7 +123,6 @@ describe("Agama test", function () {
   });
 
   it("should optionally display the product selection dialog", async function () {
-    this.timeout(60000);
     // Either the root password setting is displayed or there is
     // the product selection page.
     const productSelectionDisplayed = await Promise.any([
@@ -155,6 +154,8 @@ describe("Agama test", function () {
   });
 
   it("should require setting the root password", async function () {
+    // increase the timeout for the whole test
+    this.timeout(60000);
     await page
       .locator("input#rootPassword")
       // refreshing the repositories before showing the password configuration might take long time


### PR DESCRIPTION
## Problem

- The integration test *sometimes* fails
- https://github.com/agama-project/agama/actions/runs/12390466733/job/34585536259

```
1) Agama test
       should require setting the root password:
     Error: Timeout of 20000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/usr/share/agama/integration-tests/tests/test_root_password.js)
      at listOnTimeout (node:internal/timers:594:[17](https://github.com/agama-project/agama/actions/runs/12390466733/job/34585536259#step:17:18))
      at process.processTimers (node:internal/timers:529:7)
```

The uploaded screenshot confirms that it the software initialization was still running:

![should_require_setting_the_root_password](https://github.com/user-attachments/assets/b74170a9-0324-433f-a060-e10c00445a6c)


## Solution

- Fix the timeout setting
