### PR TITLE
fix(rust): several schema validation fixes

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -96,8 +96,8 @@
                 "title": "The name of the network interface bound to this connection",
                 "type": "string"
               },
-              "mac-address": {
-                "title": "Custom mac-address",
+              "macAddress": {
+                "title": "Custom MAC address",
                 "description": "Can also be 'preserve', 'permanent', 'random' or 'stable'.",
                 "type": "string"
               },
@@ -149,8 +149,19 @@
                   "additionalProperties": false
                 }
               },
-              "ignore_auto_dns": {
+              "ignoreAutoDns": {
                 "description": "Whether DNS options provided via DHCP are used or not",
+                "type": "boolean"
+              },
+              "status": {
+                "title": "Connection status",
+                "description": "The status of the connection",
+                "type": "string",
+                "enum": ["up", "down", "removed"]
+              },
+              "autoconnect": {
+                "title": "Auto-connected",
+                "description": "Whether the connection should be automatically connected",
                 "type": "boolean"
               },
               "wireless": {
@@ -388,6 +399,11 @@
         },
         "hashedPassword": {
           "title": "Flag for hashed password (true) or plain text password (false or not defined)",
+          "type": "boolean"
+        },
+        "autologin": {
+          "title": "Automatic user login",
+          "description": "Whether the user should be automatically logged in (only relevant in desktop systems)",
           "type": "boolean"
         }
       },

--- a/rust/agama-lib/src/product/settings.rs
+++ b/rust/agama-lib/src/product/settings.rs
@@ -28,6 +28,8 @@ use serde::{Deserialize, Serialize};
 pub struct ProductSettings {
     /// ID of the product to install (e.g., "ALP", "Tumbleweed", etc.)
     pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub registration_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub registration_email: Option<String>,
 }

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -62,5 +62,6 @@ pub struct RootUserSettings {
     #[serde(skip_serializing)]
     pub hashed_password: Option<bool>,
     /// Root SSH public key
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ssh_public_key: Option<String>,
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Dec 19 11:39:14 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix several validation issues (gh#agama-project/agama#1845).
+
+-------------------------------------------------------------------
 Wed Dec 18 12:32:00 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Introduce a new AGAMA_LOG environment variable to control what to


### PR DESCRIPTION
## Problem

An exported profile is not valid.

```shell
# agama config show > profile.json
# agama profile validate profile.json

✗ The profile is not valid. Please, check the following errors:

	* Additional properties are not allowed ('autoconnect', 'ignoreAutoDns', 'status' were unexpected). ValidationError { instance: Object {"autoconnect": Bool(true), "id": String("Wired connection 1"), "ignoreAutoDns": Bool(false), "interface": String("enp1s0"), "method4": String("auto"), "method6": String("auto"), "status": String("up")}, kind: AdditionalProperties { unexpected: ["autoconnect", "ignoreAutoDns", "status"] }, instance_path: JSONPointer([Property("network"), Property("connections"), Index(0)]), schema_path: JSONPointer([Keyword("properties"), Property("network"), Keyword("properties"), Property("connections"), Keyword("items"), Keyword("additionalProperties")]) }
	* null is not of type "string". ValidationError { instance: Null, kind: Type { kind: Single(String) }, instance_path: JSONPointer([Property("product"), Property("registrationCode")]), schema_path: JSONPointer([Keyword("properties"), Property("product"), Keyword("properties"), Property("registrationCode"), Keyword("type")]) }
	* null is not of type "string". ValidationError { instance: Null, kind: Type { kind: Single(String) }, instance_path: JSONPointer([Property("product"), Property("registrationEmail")]), schema_path: JSONPointer([Keyword("properties"), Property("product"), Keyword("properties"), Property("registrationEmail"), Keyword("type")]) }
	* null is not of type "string". ValidationError { instance: Null, kind: Type { kind: Single(String) }, instance_path: JSONPointer([Property("root"), Property("sshPublicKey")]), schema_path: JSONPointer([Keyword("properties"), Property("root"), Keyword("properties"), Property("sshPublicKey"), Keyword("type")]) }
	* Additional properties are not allowed ('autologin' was unexpected). ValidationError { instance: Object {"autologin": Bool(false), "fullName": String(""), "hashedPassword": Bool(false), "password": String(""), "userName": String("")}, kind: AdditionalProperties { unexpected: ["autologin"] }, instance_path: JSONPointer([Property("user")]), schema_path: JSONPointer([Keyword("properties"), Property("user"), Keyword("additionalProperties")]) }
```

## Solution

Fix both the exported values and the JSON schema.

```shell
# agama config show > profile.json
# agama profile validate profile.json
✓ The profile is valid.
```
