### PR TITLE
fix(storage): recover config if needed

### DIFF
--- a/service/lib/agama/dbus/clients/storage.rb
+++ b/service/lib/agama/dbus/clients/storage.rb
@@ -24,6 +24,7 @@ require "agama/dbus/clients/with_service_status"
 require "agama/dbus/clients/with_locale"
 require "agama/dbus/clients/with_progress"
 require "agama/dbus/clients/with_issues"
+require "json"
 
 module Agama
   module DBus
@@ -60,6 +61,22 @@ module Agama
         # Cleans-up the storage stuff after installation
         def finish
           dbus_object.Finish
+        end
+
+        # Gets the current storage config.
+        #
+        # @return [Hash]
+        def config
+          serialized_config = dbus_object.GetConfig
+          JSON.parse(serialized_config, symbolize_names: true)
+        end
+
+        # Sets the storage config.
+        #
+        # @param config [Hash]
+        def config=(config)
+          serialized_config = JSON.pretty_generate(config)
+          dbus_object.SetConfig(serialized_config)
         end
 
       private

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 20 15:05:11 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Hotfix to avoid losing the storage config with auto installation
+  (bsc#1234711).
+
+-------------------------------------------------------------------
 Fri Dec 20 12:18:56 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Add bootloader dbus interface to allow to set if bootloader


### PR DESCRIPTION
## Problem

In autoinstallation, the storage config could be set before probing storage. If so, the probing action overwrites the config that was set from the autoinstall profile.

https://bugzilla.suse.com/show_bug.cgi?id=1234711

## Solution

Hotfix for ensuring the storage config is preserved when doing probing for first time. A better solution should be provided for a correct management of the services and precedences.

## Testing

Manually tested.
