### PR TITLE
Fix storage config

### DIFF
--- a/service/lib/agama/dbus/clients/storage.rb
+++ b/service/lib/agama/dbus/clients/storage.rb
@@ -67,7 +67,8 @@ module Agama
         #
         # @return [Hash]
         def config
-          serialized_config = dbus_object.GetConfig
+          # Use storage iface to avoid collision with bootloader iface
+          serialized_config = dbus_object[STORAGE_IFACE].GetConfig
           JSON.parse(serialized_config, symbolize_names: true)
         end
 
@@ -76,7 +77,8 @@ module Agama
         # @param config [Hash]
         def config=(config)
           serialized_config = JSON.pretty_generate(config)
-          dbus_object.SetConfig(serialized_config)
+          # Use storage iface to avoid collision with bootloader iface
+          dbus_object[STORAGE_IFACE].SetConfig(serialized_config)
         end
 
       private

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 23 18:40:01 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix collision between hotfix and new bootlaoder dbus interface
+  (gh#agama-project/agama#1852)
+
+-------------------------------------------------------------------
 Fri Dec 20 15:05:11 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Hotfix to avoid losing the storage config with auto installation


### PR DESCRIPTION
## Problem

There is collision between https://github.com/agama-project/agama/pull/1848 and https://github.com/agama-project/agama/pull/1840 where bootloader adds another interface with Get/SetConfig on Storage service. This result that generic access no longer works and needs access via specific interface.

reported on slack https://suse.slack.com/archives/C02TLF25571/p1734924853266999

## Solution

Change code to avoid ambitious code.


## Testing

- *Tested manually*
