### PR TITLE
change product description for SLES4SAP (bsc#1235023)

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan  6 14:41:28 UTC 2025 - Angela Briel <abriel@suse.com>
+
+- SLES for SAP Application product:
+  Change product description.
+  (bsc#1235023)
+
+-------------------------------------------------------------------
 Thu Dec  5 11:04:06 UTC 2024 - Angela Briel <abriel@suse.com>
 
 - SLES for SAP Application product:

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -1,54 +1,18 @@
 id: SLES_SAP_16.0
-name: SUSE Linux Enterprise Server for SAP Applications 16.0 Alpha
+name: SUSE Linux Enterprise Server for SAP Applications 16.0 Beta
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located
 # at the at translations/description key below to avoid using obsolete
 # translations!!
 # ------------------------------------------------------------------------------
-description: "An open, reliable, compliant, and future-proof Linux Server choice
-  that ensures the enterprise's business continuity. It is the secure and
-  adaptable OS for long-term supported, innovation-ready infrastructure running
-  business-critical workloads on-premises, in the cloud, and at the edge."
+description: "The leading OS for a secure and reliable SAP platform.
+Endorsed for SAP deployments, SUSE Linux Enterprise Server for SAP Applications
+futureproofs the SAP project, offers uninterrupted business, and minimizes
+operational risks and costs."
 icon: SUSE.svg
 # Do not manually change any translations! See README.md for more details.
 translations:
   description:
-    ca: Una opció de servidor de Linux oberta, fiable, compatible i a prova del
-      futur que garanteix la continuïtat del negoci de l'empresa. És el sistema
-      operatiu segur i adaptable per a una infraestructura amb suport a llarg
-      termini i preparada per a la innovació que executa càrregues de treball
-      crítiques per a l'empresa a les instal·lacions, al núvol i a l'última.
-    cs: Otevřená, spolehlivá, kompatibilní a perspektivní volba linuxového serveru,
-      která zajišťuje kontinuitu podnikání podniku. Je to bezpečný a
-      přizpůsobivý operační systém pro dlouhodobě podporovanou infrastrukturu
-      připravenou na inovace, na které běží kritické podnikové úlohy v lokálním
-      prostředí, v cloudu i na okraji sítě.
-    de: Ein offener, zuverlässiger, kompatibler und zukunftssicherer Linux-Server,
-      der die Geschäftskontinuität des Unternehmens gewährleistet. Es ist das
-      sichere und anpassungsfähige Betriebssystem für eine langfristig
-      unterstützte, innovationsbereite Infrastruktur, auf der geschäftskritische
-      Arbeitslasten vor Ort, in der Cloud und am Netzwerkrand ausgeführt werden.
-    es: Una opción de servidor Linux abierta, confiable, compatible y preparada para
-      el futuro que garantiza la continuidad del negocio de la empresa. Es el
-      sistema operativo seguro y adaptable para una infraestructura lista para
-      la innovación y con soporte a largo plazo que ejecuta cargas de trabajo
-      críticas para el negocio en las instalaciones, en la nube y en el borde.
-    ja: オープンで信頼性が高く、各種の標準にも準拠し、将来性とビジネスの継続性を支援する Linux
-      サーバです。長期のサポートが提供されていることから、安全性と順応性に優れ、オンプレミスからクラウド、エッジ環境に至るまで、様々な場所で重要なビジネス処理をこなすことのできる革新性の高いインフラストラクチャです。
-    pt_BR: Uma escolha de servidor Linux aberta, confiável, compatível e à prova do
-      futuro que garante a continuidade dos negócios da empresa. É o SO seguro e
-      adaptável para infraestrutura com suporte de longo prazo e pronta para
-      inovação, executando cargas de trabalho críticas para os negócios no
-      local, na nuvem e na borda.
-    sv: Ett öppet, pålitligt, kompatibelt och framtidssäkert Linux-serverval som
-      säkerställer företagets affärskontinuitet. Det är det säkra och
-      anpassningsbara operativsystemet för långsiktigt stödd, innovationsfärdig
-      infrastruktur som kör affärskritiska arbetsbelastningar på plats, i molnet
-      och vid kanten.
-    tr: İşletmenin iş sürekliliğini garanti eden açık, güvenilir, uyumlu ve geleceğe
-      dönük bir Linux Sunucu seçeneği. Uzun vadeli desteklenen, inovasyona hazır
-      altyapı için güvenli ve uyarlanabilir işletim sistemidir. Şirket içinde,
-      bulutta ve uçta iş açısından kritik iş yüklerini çalıştırır.
 software:
   installation_repositories:
     # Use plain HTTP repositories, HTTPS does not work without importing the SSL


### PR DESCRIPTION
## Problem

The description of the product SLES for SAP 16 is the same as for the product SLES 16
see https://bugzilla.suse.com/show_bug.cgi?id=1235023

## Solution

Changed the description for  product SLES for SAP 16 after discussion with PM.

Not sure about the part with the translation. Please drop me a note if anything is missing.