### PR TITLE
Drop yast from Leap 16 selection

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan  7 12:57:13 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Drop yast from Leap 16.0 software selection
+  code-o-o#leap/features#173
+
+
+-------------------------------------------------------------------
 Mon Jan  6 14:41:28 UTC 2025 - Angela Briel <abriel@suse.com>
 
 - SLES for SAP Application product:

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -50,9 +50,6 @@ software:
     - basic_desktop
     - gnome
     - kde
-    - yast2_basis
-    - yast2_desktop
-    - yast2_server
     - multimedia
     - office
   mandatory_packages:


### PR DESCRIPTION
I'd like to cleanup Leap 16.0 from yast and start from beginning only with yqpkg
Of course we'd still be inheriting whatever yast libs and ruibygems are in SLES for Agama.

https://code.opensuse.org/leap/features/issue/173

 Mentioned patters are removed in https://build.opensuse.org/staging_workflows/openSUSE:Leap:16.0/staging_projects/openSUSE:Leap:16.0:Staging:A