### PR TITLE
fix(web): restore cancel behavior at product selection page

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan  8 13:12:44 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Show the cancel action at product selection page only when
+  a product is already selected (gh#agama-project/agama#1881).
+
+-------------------------------------------------------------------
 Fri Dec 20 12:53:41 UTC 2024 - David Diaz <dgonzalez@suse.com>
 
 - Fix netmask handling to avoid a silent connection form error

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -139,7 +139,7 @@ function ProductSelectionPage() {
         </Center>
       </Page.Content>
       <Page.Actions>
-        <BackLink />
+        {selectedProduct && !isLoading && <BackLink />}
         <Page.Submit
           form="productSelectionForm"
           isDisabled={isSelectionDisabled}


### PR DESCRIPTION
## Problem

The `Cancel` action at product selection page should be only rendered if there is a product already selected. By mistake, such a behavior was drop in https://github.com/agama-project/agama/pull/1769, when sticking actions to the bottom of the page.

## Solution

Restore the conditional rendering for the mentioned action and add a unit test to be aware if come change breaks it again.

## Testing

- Added a new unit test
- Tested manually
