### PR TITLE
fix(live): use gems for the default Ruby version

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jan 10 09:03:06 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Depend on Ruby's default version (gh#agama-project/agama#1872).
+
+-------------------------------------------------------------------
 Tue Dec 10 12:46:06 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - Updated config.sh to enable agama-dbus-monitor service

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -144,6 +144,8 @@
         <package name="agama-cli"/>
         <package name="agama-auto"/>
         <package name="agama-integration-tests"/>
+        <package name="rubygem(agama-yast)"/>
+        <package name="rubygem(byebug)"/>
         <package name="microos-tools"/>
         <package name="icewm-lite"/>
         <package name="xinit"/>
@@ -166,8 +168,6 @@
         <package name="grub2-branding-openSUSE" arch="aarch64,x86_64"/>
         <package name="openSUSE-repos-Leap"/>
         <package name="patterns-openSUSE-base"/>
-        <package name="ruby3.2-rubygem-agama-yast"/>
-        <package name="ruby3.2-rubygem-byebug"/>
         <package name="staging-build-key"/>
         <package name="openSUSE-build-key"/>
         <package name="MozillaFirefox-branding-openSUSE"/>
@@ -178,8 +178,6 @@
         <package name="grub2-branding-openSUSE" arch="aarch64,x86_64"/>
         <package name="openSUSE-repos-Tumbleweed"/>
         <package name="patterns-openSUSE-base"/>
-        <package name="ruby3.3-rubygem-agama-yast"/>
-        <package name="ruby3.3-rubygem-byebug"/>
         <package name="staging-build-key"/>
         <package name="openSUSE-build-key"/>
         <package name="MozillaFirefox-branding-openSUSE"/>
@@ -189,8 +187,6 @@
         <package name="agama-products-sle"/>
         <package name="grub2-branding-SLE" arch="aarch64,x86_64"/>
         <package name="patterns-sles-base"/>
-        <package name="ruby3.2-rubygem-agama-yast"/>
-        <package name="ruby3.2-rubygem-byebug"/>
         <package name="suse-build-key"/>
         <package name="MozillaFirefox-branding-SLE"/>
     </packages>


### PR DESCRIPTION
Use `rubygem(foo)` instead of `ruby3.X-rubygem-foo` to use the gems for the project's default Ruby version.

> [!WARNING]
> Not tested yet!