### PR TITLE
PoC: Use CSS modules for the Agama components

### DIFF
--- a/web/src/assets/styles/app.scss
+++ b/web/src/assets/styles/app.scss
@@ -26,16 +26,6 @@ button.remove-link:hover {
   color: var(--pf-v5-c-button--m-danger--BackgroundColor);
 }
 
-.first-username-dropdown {
-  position: absolute;
-  width: 100%;
-}
-
-.first-username-wrapper {
-  position: relative;
-  width: 100%;
-}
-
 #productSelectionForm {
   input[type="radio"] {
     align-self: center;

--- a/web/src/components/users/FirstUserForm.module.scss
+++ b/web/src/components/users/FirstUserForm.module.scss
@@ -1,0 +1,9 @@
+.dropdown {
+  position: absolute;
+  width: 100%;
+}
+
+.wrapper {
+  position: relative;
+  width: 100%;
+}

--- a/web/src/components/users/FirstUserForm.tsx
+++ b/web/src/components/users/FirstUserForm.tsx
@@ -43,6 +43,7 @@ import { _ } from "~/i18n";
 import { suggestUsernames } from "~/components/users/utils";
 import { useFirstUser, useFirstUserMutation } from "~/queries/users";
 import { FirstUser } from "~/types/users";
+import * as styles from "./FirstUserForm.module.scss";
 
 const UsernameSuggestions = ({
   isOpen = false,
@@ -56,7 +57,7 @@ const UsernameSuggestions = ({
   return (
     <Menu
       aria-label={_("Username suggestion dropdown")}
-      className="first-username-dropdown"
+      className={styles.dropdown}
       onMouseEnter={() => setInsideDropDown(true)}
       onMouseLeave={() => setInsideDropDown(false)}
     >
@@ -233,11 +234,7 @@ export default function FirstUserForm() {
                     />
                   </FormGroup>
 
-                  <FormGroup
-                    className="first-username-wrapper"
-                    fieldId="userName"
-                    label={_("Username")}
-                  >
+                  <FormGroup className={styles.wrapper} fieldId="userName" label={_("Username")}>
                     <TextInput
                       id="userName"
                       name="userName"


### PR DESCRIPTION
## CSS modules

When working with Docusaurus I learned about the [CSS modules](https://github.com/css-modules/css-modules).

With the current implementation it is very hard to find the CSS related to the component code. For example the `FirstUserForm` component defines its CSS style in `assets/styles/app.scss` file somewhere in the middle. That's quite difficult to find.

## Pros and cons

CSS modules have several advantages:

- It allows using simple and short CSS names. To avoid conflicts we use `agama-` prefix or long names like `first-username-dropdown`. That's not nice.
- It has local scope, it avoids conflicts in CSS rules. You can decrease the chance for a conflict using a prefix but you cannot completely avoid it.  Webpack generates unique names for the CSS modules which guarantees that a conflict can never happen.
- The CSS and the JS code live next to each other, it is easy to find the related CSS. If you delete a component it is easy to delete the related CSS.

Of course, there also some disadvantages

- When inspecting the page elements you see CSS classes like `Iv3X764_hcFfxZFNQLEm` from which is not obvious what was the original name. Fortunately CSS modules support source mapping properly so you can get the original name and the exact location in the source file quite easily in the browser devtools.
- That might be problematic for the future Agama plugins. On the other hand I expect that the CSS modules will mostly contain layout fixes. Color theming, etc... will be still defined in the global CSS with known names. So I guess you should not need to change the base CSS modules from plugins.

## Notes

- The HMR (Hot Module Replacement) works fine as with normal CSS or JS files. After changing the CSS module file in editor the webpage is automatically updated when using the Webpack development server.
- CSS modules should be used only for the components. The global styles, PatternFly overrides, theming, etc... should be done as it is now.

## Proof of concept

In this example I moved the the CSS for the `FirstUserForm` component to separate `FirstUserForm.module.scss` file. We could do the same for the other components as well.