### PR TITLE
Activate multipath in case of forced by the user and fix environment file typo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@
 root = true
 
 # 2 space indentation
-[{*.sh}]
+[*.sh]
 indent_style = space
 indent_size = 2

--- a/rust/share/agama-web-server.service
+++ b/rust/share/agama-web-server.service
@@ -6,7 +6,7 @@ After=network-online.target agama.service agama-hostname.service
 BindsTo=agama.service
 
 [Service]
-EnvironmentFile=-"/etc/agama.d/cmdline.conf"
+EnvironmentFile=-/etc/agama.d/cmdline.conf
 Environment="AGAMA_LOG=debug,zbus=info"
 Type=notify
 ExecStart=/usr/bin/agama-web-server serve --address :::80 --address2 :::443

--- a/service/lib/agama/storage/callbacks/activate_multipath.rb
+++ b/service/lib/agama/storage/callbacks/activate_multipath.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/question"
+require "y2storage"
 
 module Agama
   module Storage
@@ -42,6 +43,7 @@ module Agama
         # @param looks_like_real_multipath [Boolean] see {Callbacks::Activate#multipath}.
         # @return [Boolean]
         def call(looks_like_real_multipath)
+          return true if Y2Storage::StorageEnv.instance.forced_multipath?
           return false unless looks_like_real_multipath
 
           questions_client.ask(question) do |question_client|

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan  9 12:21:40 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Activate multipath in case it is forced by the user 
+  (gh#agama-project/agama#1875).
+
+-------------------------------------------------------------------
 Wed Jan  8 14:05:53 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for products registration (jsc#PED-11192,

--- a/service/share/agama.service
+++ b/service/share/agama.service
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 Type=forking
 ExecStart=/usr/bin/agamactl --daemon
-EnviromentFile=-/etc/agama.d/cmdline.conf
+EnvironmentFile=-/etc/agama.d/cmdline.conf
 PIDFile=/run/agama/bus.pid
 User=root
 TimeoutStopSec=5


### PR DESCRIPTION
## Problem

- The agama service have a typo in the EnvironmentFile variable name.
- Agama is not checking if the user is forcing multipath through a environment variable.

## Solution

Fix the typo and check if multipath is forced.


## Testing

- *Tested manually*
