### PR TITLE
Increase constraint

### DIFF
--- a/rust/package/_constraints
+++ b/rust/package/_constraints
@@ -2,7 +2,7 @@
   <hardware>
     <jobs>4</jobs>
     <disk>
-      <size unit="G">20</size>
+      <size unit="G">25</size>
     </disk>
     <physicalmemory>
       <size unit="G">8</size>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Jan  9 12:52:05 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
-- Increase disk size in _constrain to fix build on ppc
+- Increase disk size in _constraints to fix build on ppc
   (gh#agama-project/agama#1876).
 
 -------------------------------------------------------------------

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -2,6 +2,7 @@
 Thu Jan  9 12:52:05 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Increase disk size in _constrain to fix build on ppc
+  (gh#agama-project/agama#1876).
 
 -------------------------------------------------------------------
 Wed Jan  8 14:05:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan  9 12:52:05 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Increase disk size in _constrain to fix build on ppc
+
+-------------------------------------------------------------------
 Wed Jan  8 14:05:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for products registration (jsc#PED-11192,


### PR DESCRIPTION
## Problem

ppc fails to build due to run out of space


## Solution

increase disk constrain to ensure there is enough space. Probably caused by that new xtask compilation task that eats another space.


## Testing

Testing in my IBS branch https://build.suse.de/package/show/home:jreidinger:branches:Devel:YaST:Agama:Head/agama