### PR TITLE
fix(web): App uses the Suspense API while loading the selected product

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
   const location = useLocation();
   const { isBusy, phase } = useInstallerStatus({ suspense: true });
   const { connected, error } = useInstallerClientStatus();
-  const { selectedProduct, products } = useProduct();
+  const { selectedProduct, products } = useProduct({ suspense: true });
   const { language } = useInstallerL10n();
   const { password: isRootPasswordDefined, sshkey: rootSSHKey } = useRootUser();
   useL10nConfigChanges();


### PR DESCRIPTION
## Problem

The <App/> component does not wait for the information about the selected product to be loaded.
In some corner cases, it may redirect to the software selection page even if it is not needed.

## Solution

Use the Suspense API to be sure that the product is not selected before redirecting to the product
selection page automatically.

## Testing

- *Tested manually*
