### PR TITLE
feat(rust): disable HTTP caching

### DIFF
--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -24,7 +24,12 @@ macaddr = { version = "1.0", features = ["serde_std"] }
 async-trait = "0.1.83"
 axum = { version = "0.7.7", features = ["ws"] }
 serde_json = "1.0.128"
-tower-http = { version = "0.5.2", features = ["compression-br", "fs", "trace"] }
+tower-http = { version = "0.5.2", features = [
+    "compression-br",
+    "fs",
+    "trace",
+    "set-header",
+] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-journald = "0.3.0"
 tracing = "0.1.40"

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 10 08:58:29 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Disable the browser cache setting the "Cache-Control" header to
+  "no-store" (gh#agama-project/agama#1880).
+
+-------------------------------------------------------------------
 Wed Jan  8 14:05:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for products registration (jsc#PED-11192,


### PR DESCRIPTION
## Problem

When connecting to the same machine (e.g. a server) but using a different version of Agama (e.g., you are using a new build), the browser cache could display the old UI.

## Solution

Disable the cache by setting the `no-store` value. In the future, we could prefer using a different mechanism, like the `Etag` header.

## Testing

- *Tested manually*