### PR TITLE
fix(web): warn the user when using the new storage settings

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 10 13:22:27 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not allow changing the storage setup when Agama is using the
+  new storage settings (gh#agama-project/agama#1881).
+
+-------------------------------------------------------------------
 Wed Jan  8 16:07:13 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for products registration (jsc#PED-11192,

--- a/web/src/api/storage/proposal.ts
+++ b/web/src/api/storage/proposal.ts
@@ -38,9 +38,12 @@ const fetchDefaultVolume = (mountPath: string): Promise<Volume | undefined> => {
   return get(`/api/storage/product/volume_for?mount_path=${path}`);
 };
 
-const fetchSettings = (): Promise<ProposalSettings> => get("/api/storage/proposal/settings");
+// NOTE: the settings might not exist.
+const fetchSettings = (): Promise<ProposalSettings> =>
+  get("/api/storage/proposal/settings").catch(() => null);
 
-const fetchActions = (): Promise<Action[]> => get("/api/storage/proposal/actions");
+// NOTE: the actions might not exist.
+const fetchActions = (): Promise<Action[]> => get("/api/storage/proposal/actions").catch(() => []);
 
 const calculate = (settings: ProposalSettingsPatch) =>
   put("/api/storage/proposal/settings", settings);

--- a/web/src/components/overview/StorageSection.test.tsx
+++ b/web/src/components/overview/StorageSection.test.tsx
@@ -31,15 +31,30 @@ const mockAvailableDevices = [
 ];
 
 const mockResultSettings = { target: "disk", targetDevice: "/dev/sda", spacePolicy: "delete" };
+let mockProposalResult;
 
 jest.mock("~/queries/storage", () => ({
   ...jest.requireActual("~/queries/storage"),
   useAvailableDevices: () => mockAvailableDevices,
-  useProposalResult: () => ({
+  useProposalResult: () => mockProposalResult,
+}));
+
+beforeEach(() => {
+  mockProposalResult = {
     settings: mockResultSettings,
     actions: [],
-  }),
-}));
+  };
+});
+
+describe("when using the new storage settings", () => {
+  beforeEach(() => (mockProposalResult = undefined));
+
+  it("renders a warning message", () => {
+    plainRender(<StorageSection />);
+
+    expect(screen.getByText("Install using an advanced configuration.")).toBeInTheDocument();
+  });
+});
 
 describe("when there is a proposal", () => {
   beforeEach(() => {

--- a/web/src/components/overview/StorageSection.tsx
+++ b/web/src/components/overview/StorageSection.tsx
@@ -118,7 +118,7 @@ export default function StorageSection() {
   if (result === undefined) {
     return (
       <Content>
-        <Text>{_("Install using an advanced method.")}</Text>
+        <Text>{_("Install using an advanced configuration.")}</Text>
       </Content>
     );
   }

--- a/web/src/components/overview/StorageSection.tsx
+++ b/web/src/components/overview/StorageSection.tsx
@@ -115,7 +115,13 @@ export default function StorageSection() {
   const availableDevices = useAvailableDevices();
   const result = useProposalResult();
 
-  if (result === undefined) return;
+  if (result === undefined) {
+    return (
+      <Content>
+        <Text>{_("Install using an advanced method.")}</Text>
+      </Content>
+    );
+  }
 
   const label = (deviceName) => {
     const device = availableDevices.find((d) => d.name === deviceName);

--- a/web/src/components/storage/BootSelection.tsx
+++ b/web/src/components/storage/BootSelection.tsx
@@ -53,16 +53,16 @@ export default function BootSelectionDialog() {
   };
 
   const [state, setState] = useState<BootSelectionState>({ load: false });
-  const { settings } = useProposalResult();
+  const proposal = useProposalResult();
   const availableDevices = useAvailableDevices();
   const updateProposal = useProposalMutation();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (state.load) return;
+    if (state.load || !proposal.settings) return;
 
     let selectedOption: string;
-    const { bootDevice, configureBoot, defaultBootDevice } = settings;
+    const { bootDevice, configureBoot, defaultBootDevice } = proposal.settings;
 
     if (!configureBoot) {
       selectedOption = BOOT_DISABLED_ID;
@@ -82,7 +82,7 @@ export default function BootSelectionDialog() {
       availableDevices,
       selectedOption,
     });
-  }, [availableDevices, settings, state.load]);
+  }, [availableDevices, proposal, state.load]);
 
   if (!state.load) return;
 
@@ -97,7 +97,7 @@ export default function BootSelectionDialog() {
       bootDevice: state.selectedOption === BOOT_MANUAL_ID ? state.bootDevice.name : undefined,
     };
 
-    await updateProposal.mutateAsync({ ...settings, ...newSettings });
+    await updateProposal.mutateAsync({ ...proposal.settings, ...newSettings });
     navigate("..");
   };
 

--- a/web/src/components/storage/DeviceSelection.tsx
+++ b/web/src/components/storage/DeviceSelection.tsx
@@ -49,7 +49,7 @@ type DeviceSelectionState = {
  * @component
  */
 export default function DeviceSelection() {
-  const { settings } = useProposalResult();
+  const proposal = useProposalResult();
   const availableDevices = useAvailableDevices();
   const updateProposal = useProposalMutation();
   const navigate = useNavigate();
@@ -63,11 +63,13 @@ export default function DeviceSelection() {
 
     // FIXME: move to a state/reducer
     setState({
-      target: settings.target,
-      targetDevice: availableDevices.find((d) => d.name === settings.targetDevice),
-      targetPVDevices: availableDevices.filter((d) => settings.targetPVDevices?.includes(d.name)),
+      target: proposal.settings.target,
+      targetDevice: availableDevices.find((d) => d.name === proposal.settings.targetDevice),
+      targetPVDevices: availableDevices.filter((d) =>
+        proposal.settings.targetPVDevices?.includes(d.name),
+      ),
     });
-  }, [settings, availableDevices, state.target]);
+  }, [proposal, availableDevices, state.target]);
 
   const selectTargetDisk = () => setState({ ...state, target: ProposalTarget.DISK });
   const selectTargetNewLvmVG = () => setState({ ...state, target: ProposalTarget.NEW_LVM_VG });
@@ -86,7 +88,7 @@ export default function DeviceSelection() {
       targetPVDevices: isTargetNewLvmVg ? state.targetPVDevices.map((d) => d.name) : [],
     };
 
-    updateProposal.mutateAsync({ ...settings, ...newSettings });
+    updateProposal.mutateAsync({ ...proposal.settings, ...newSettings });
     navigate("..");
   };
 

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -54,7 +54,7 @@ const StorageWarning = () => (
     <Page.Content>
       <EmptyState
         title={_(
-          "The system layout was set up using a explicit configuration that cannot be modified with the current version of this visual interface. This limitation will be removed in a future version of Agama.",
+          "The system layout was set up using a advanced configuration that cannot be modified with the current version of this visual interface. This limitation will be removed in a future version of Agama.",
         )}
         icon="warning"
       />

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -22,7 +22,7 @@
 
 import React, { useRef } from "react";
 import { Grid, GridItem, Stack } from "@patternfly/react-core";
-import { Page, Drawer } from "~/components/core/";
+import { Page, Drawer, EmptyState } from "~/components/core/";
 import ProposalTransactionalInfo from "./ProposalTransactionalInfo";
 import ProposalSettingsSection from "./ProposalSettingsSection";
 import ProposalResultSection from "./ProposalResultSection";
@@ -45,6 +45,22 @@ import {
 } from "~/queries/storage";
 import { useQueryClient } from "@tanstack/react-query";
 import { refresh } from "~/api/storage";
+
+const StorageWarning = () => (
+  <Page>
+    <Page.Header>
+      <h2>{_("Storage")}</h2>
+    </Page.Header>
+    <Page.Content>
+      <EmptyState
+        title={_(
+          "The system layout was set up using a explicit configuration that cannot be modified with the current version of this visual interface. This limitation will be removed in a future version of Agama.",
+        )}
+        icon="warning"
+      />
+    </Page.Content>
+  </Page>
+);
 
 /**
  * Which UI item is being changed by user
@@ -78,7 +94,7 @@ export default function ProposalPage() {
   const volumeDevices = useVolumeDevices();
   const volumeTemplates = useVolumeTemplates();
   const { encryptionMethods } = useProductParams({ suspense: true });
-  const { actions, settings } = useProposalResult();
+  const proposal = useProposalResult();
   const updateProposal = useProposalMutation();
   const deprecated = useDeprecated();
   const queryClient = useQueryClient();
@@ -94,6 +110,10 @@ export default function ProposalPage() {
   const errors = useIssues("storage")
     .filter((s) => s.severity === IssueSeverity.Error)
     .map(toValidationError);
+
+  if (proposal === undefined) return <StorageWarning />;
+
+  const { settings, actions } = proposal;
 
   const changeSettings = async (changing, updated: object) => {
     const newSettings = { ...settings, ...updated };

--- a/web/src/queries/storage.ts
+++ b/web/src/queries/storage.ts
@@ -269,6 +269,8 @@ const useProposalResult = (): ProposalResult | undefined => {
   const systemDevices = useDevices("system", { suspense: true });
   const { mountPoints: productMountPoints } = useProductParams({ suspense: true });
 
+  if (settings === null) return undefined;
+
   return {
     settings: {
       ...settings,


### PR DESCRIPTION
## Problem

Agama's web UI does not support the new storage settings yet. Instead of crashing,
it should offer a meaningful message to the user.

## Solution

Detect when the settings are not available and display an error instead of crashing.

## Testing

- *Tested manually*


## Screenshots

<details>
<summary>Overview page</summary>

![Captura desde 2025-01-10 12-17-25](https://github.com/user-attachments/assets/1d48e4e1-e8a8-46e1-b928-6bc9507549cb)
</details>

<details>
<summary>Storage page</summary>

![Captura desde 2025-01-10 12-17-31](https://github.com/user-attachments/assets/f98efe4b-25ce-4c6a-ab75-a0e3ad66a75d)
</details>


