### PR TITLE
refactor(web): do not allow unregistering a product

### DIFF
--- a/web/src/api/software.ts
+++ b/web/src/api/software.ts
@@ -67,11 +67,6 @@ const updateConfig = (config: SoftwareConfig) => put("/api/software/config", con
 const register = ({ key, email }: { key: string; email?: string }) =>
   post("/api/software/registration", { key, email });
 
-/**
- * Request deregistering selected product
- */
-const deregister = () => del("/api/software/registration");
-
 export {
   fetchConfig,
   fetchPatterns,
@@ -80,5 +75,4 @@ export {
   fetchRegistration,
   updateConfig,
   register,
-  deregister,
 };

--- a/web/src/components/product/ProductRegistrationPage.test.tsx
+++ b/web/src/components/product/ProductRegistrationPage.test.tsx
@@ -42,12 +42,10 @@ const sle: Product = {
 let selectedProduct: Product;
 let registrationInfoMock: RegistrationInfo;
 const registerMutationMock = jest.fn();
-const deregisterMutationMock = jest.fn();
 
 jest.mock("~/queries/software", () => ({
   ...jest.requireActual("~/queries/software"),
   useRegisterMutation: () => ({ mutate: registerMutationMock }),
-  useDeregisterMutation: () => ({ mutate: deregisterMutationMock }),
   useRegistration: (): ReturnType<typeof useRegistration> => registrationInfoMock,
   useProduct: (): ReturnType<typeof useProduct> => {
     return {
@@ -126,13 +124,6 @@ describe("ProductRegistrationPage", () => {
       await user.click(visibilityCodeToggler);
       expect(screen.queryByText("INTERNAL-USE-ONLY-1234-5678")).toBeNull();
       screen.getByText(/\*?5678/);
-    });
-
-    it("allows deregistering the product", async () => {
-      const { user } = installerRender(<ProductRegistrationPage />);
-      const deregisterButton = screen.getByRole("button", { name: "deregister" });
-      await user.click(deregisterButton);
-      expect(deregisterMutationMock).toHaveBeenCalled();
     });
 
     //   describe("but at registration path already", () => {

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -39,12 +39,7 @@ import {
 import { Page, PasswordInput } from "~/components/core";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 import spacingStyles from "@patternfly/react-styles/css/utilities/Spacing/spacing";
-import {
-  useProduct,
-  useRegistration,
-  useRegisterMutation,
-  useDeregisterMutation,
-} from "~/queries/software";
+import { useProduct, useRegistration, useRegisterMutation } from "~/queries/software";
 import { isEmpty, mask } from "~/utils";
 import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
@@ -55,29 +50,15 @@ const EMAIL_LABEL = "Email";
 
 const RegisteredProductSection = () => {
   const { selectedProduct: product } = useProduct();
-  const { mutate: deregister } = useDeregisterMutation();
   const registration = useRegistration();
   const [showCode, setShowCode] = useState(false);
   const toggleCodeVisibility = () => setShowCode(!showCode);
-
-  const footer = _("For using a different registration code, please %s the product first.");
-  const deregisterButtonLabel = _("deregister");
-  const [footerStart, footerEnd] = footer.split("%s");
 
   return (
     <Page.Section
       title={_("Product registered")}
       description={sprintf(_("%s has been registered with below information."), product.name)}
       pfCardProps={{ isCompact: false }}
-      actions={
-        <p>
-          {footerStart}{" "}
-          <Button onClick={() => deregister()} variant="link" isInline>
-            {deregisterButtonLabel}
-          </Button>{" "}
-          {footerEnd}
-        </p>
-      }
     >
       <DescriptionList className={spacingStyles.myMd}>
         <DescriptionListGroup>

--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -39,7 +39,6 @@ import {
   SoftwareProposal,
 } from "~/types/software";
 import {
-  deregister,
   fetchConfig,
   fetchPatterns,
   fetchProducts,
@@ -134,25 +133,6 @@ const useRegisterMutation = () => {
 
   const query = {
     mutationFn: register,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["software/registration"] });
-      startProbing();
-    },
-  };
-  return useMutation(query);
-};
-
-/**
- * Hook that builds a mutation for deregistering a product
- *
- * @note it would trigger a general probing as a side-effect when mutation
- * includes a product.
- */
-const useDeregisterMutation = () => {
-  const queryClient = useQueryClient();
-
-  const query = {
-    mutationFn: deregister,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["software/registration"] });
       startProbing();
@@ -286,5 +266,4 @@ export {
   useProposalChanges,
   useRegistration,
   useRegisterMutation,
-  useDeregisterMutation,
 };


### PR DESCRIPTION
The action for revoking a product registration is actually not needed. Let's drop it until there is a real need in order to keep the UI more clean.