### PR TITLE
fix(storage): reprobe and recalculate proposal

### DIFF
--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -88,7 +88,13 @@ module Agama
         private_constant :STORAGE_INTERFACE
 
         def probe
-          busy_while { backend.probe }
+          busy_while do
+            # Clean trees in advance to avoid having old objects exported in D-Bus.
+            system_devices_tree.clean
+            staging_devices_tree.clean
+
+            backend.probe
+          end
         end
 
         # Applies the given serialized config according to the JSON schema.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 10 15:44:30 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Objects from the D-Bus trees representing the storage devices are
+  removed before performing the probing. It prevents a segmentation
+  fault by accessing to old objects (gh#agama-project/agama#1884).
+
+-------------------------------------------------------------------
 Thu Jan  9 12:21:40 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Activate multipath in case it is forced by the user 

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 10 15:56:35 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Add storage reprobing and recalculate proposal when going back to
+  either the proposal page or the devices selector if the system
+  is deprecated (gh#agama-project/agama#1884).
+
+-------------------------------------------------------------------
 Fri Jan 10 13:46:42 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Drop the feature for deregistering a product

--- a/web/src/api/storage.ts
+++ b/web/src/api/storage.ts
@@ -32,8 +32,6 @@ import { config } from "~/api/storage/types";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const probe = (): Promise<any> => post("/api/storage/probe");
 
-export { probe };
-
 const fetchConfig = (): Promise<config.Config | undefined> =>
   get("/api/storage/config").then((config) => config.storage);
 
@@ -57,8 +55,8 @@ const findStorageJob = (id: string): Promise<Job | undefined> =>
  */
 const refresh = async (): Promise<void> => {
   const settings = await fetchSettings();
-  await probe();
-  await calculate(settings);
+  await probe().catch(console.log);
+  await calculate(settings).catch(console.log);
 };
 
-export { fetchConfig, fetchStorageJobs, findStorageJob, refresh };
+export { probe, fetchConfig, fetchStorageJobs, findStorageJob, refresh };

--- a/web/src/components/storage/DeviceSelection.tsx
+++ b/web/src/components/storage/DeviceSelection.tsx
@@ -27,11 +27,17 @@ import { Page } from "~/components/core";
 import { DeviceSelectorTable } from "~/components/storage";
 import DevicesTechMenu from "./DevicesTechMenu";
 import { ProposalTarget, StorageDevice } from "~/types/storage";
-import { useAvailableDevices, useProposalMutation, useProposalResult } from "~/queries/storage";
+import {
+  useAvailableDevices,
+  useProposalMutation,
+  useProposalResult,
+  useRefresh,
+} from "~/queries/storage";
 import { deviceChildren } from "~/components/storage/utils";
 import { compact } from "~/utils";
 import a11y from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 import { _ } from "~/i18n";
+import { Loading } from "~/components/layout";
 
 const SELECT_DISK_ID = "select-disk";
 const CREATE_LVM_ID = "create-lvm";
@@ -53,10 +59,16 @@ export default function DeviceSelection() {
   const availableDevices = useAvailableDevices();
   const updateProposal = useProposalMutation();
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [state, setState] = useState<DeviceSelectionState>({});
 
   const isTargetDisk = state.target === ProposalTarget.DISK;
   const isTargetNewLvmVg = state.target === ProposalTarget.NEW_LVM_VG;
+
+  useRefresh({
+    onStart: () => setIsLoading(true),
+    onFinish: () => setIsLoading(false),
+  });
 
   useEffect(() => {
     if (state.target !== undefined) return;
@@ -117,6 +129,8 @@ by default as [logical volumes of a new LVM Volume Group]. The corresponding \
 physical volumes will be created on demand as new partitions at the selected \
 devices.",
   ).split(/[[\]]/);
+
+  if (isLoading) return <Loading />;
 
   return (
     <Page>

--- a/web/src/components/storage/ISCSIPage.tsx
+++ b/web/src/components/storage/ISCSIPage.tsx
@@ -24,6 +24,7 @@ import { Grid, GridItem } from "@patternfly/react-core";
 import React from "react";
 import { Page } from "~/components/core";
 import { InitiatorSection, TargetsSection } from "~/components/storage/iscsi";
+import { STORAGE as PATHS } from "~/routes/paths";
 import { _ } from "~/i18n";
 
 export default function ISCSIPage() {
@@ -42,6 +43,11 @@ export default function ISCSIPage() {
           </GridItem>
         </Grid>
       </Page.Content>
+      <Page.Actions>
+        <Page.Action variant="secondary" navigateTo={PATHS.targetDevice}>
+          {_("Back to device selection")}
+        </Page.Action>
+      </Page.Actions>
     </Page>
   );
 }


### PR DESCRIPTION
## Problem

The device selector allows going to iSCSI, zFCP and DASD pages in order to activate/deactivate devices. But the system is not reprobed when going back to the device selector.

## Solution

Add hook for reprobing and recalculating the storage proposal. The hook is used by the proposal page and the device selector. Both components are shown as loading meanwhile the reprobing is being done. 

Note: The install button prevents to install if the system is deprecated.

Note: This is a temporary solution. Dealing with deprecated system, reprobing, etc should be done in a more realiable way after Agama 11.