### PR TITLE
fix(web): do not allow changing product after registering one

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 13 11:11:49 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Do not allow changing selected product after registering one
+  (related to gh#agama-project/agama#1891).
+
+-------------------------------------------------------------------
 Fri Jan 10 21:22:02 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 11

--- a/web/src/components/core/ChangeProductLink.test.tsx
+++ b/web/src/components/core/ChangeProductLink.test.tsx
@@ -24,8 +24,9 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { PRODUCT as PATHS } from "~/routes/paths";
-import { Product } from "~/types/software";
+import { Product, RegistrationInfo } from "~/types/software";
 import ChangeProductLink from "./ChangeProductLink";
+import { useRegistration } from "~/queries/software";
 
 const tumbleweed: Product = {
   id: "Tumbleweed",
@@ -43,9 +44,11 @@ const microos: Product = {
 };
 
 let mockUseProduct: { products: Product[]; selectedProduct?: Product };
+let registrationInfoMock: RegistrationInfo;
 
 jest.mock("~/queries/software", () => ({
   useProduct: () => mockUseProduct,
+  useRegistration: (): ReturnType<typeof useRegistration> => registrationInfoMock,
 }));
 
 describe("ChangeProductLink", () => {
@@ -58,6 +61,17 @@ describe("ChangeProductLink", () => {
       installerRender(<ChangeProductLink />);
       const link = screen.getByRole("link", { name: "Change product" });
       expect(link).toHaveAttribute("href", PATHS.changeProduct);
+    });
+
+    describe("but a product is registered", () => {
+      beforeEach(() => {
+        registrationInfoMock = { key: "INTERNAL-USE-ONLY-1234-5678", email: "" };
+      });
+
+      it("renders nothing", () => {
+        const { container } = installerRender(<ChangeProductLink />);
+        expect(container).toBeEmptyDOMElement();
+      });
     });
   });
 

--- a/web/src/components/core/ChangeProductLink.tsx
+++ b/web/src/components/core/ChangeProductLink.tsx
@@ -22,17 +22,20 @@
 
 import React from "react";
 import { Link, LinkProps } from "react-router-dom";
-import { useProduct } from "~/queries/software";
+import { useProduct, useRegistration } from "~/queries/software";
 import { PRODUCT as PATHS } from "~/routes/paths";
 import { _ } from "~/i18n";
+import { isEmpty } from "~/utils";
 
 /**
  * Link for navigating to the selection product.
  */
 export default function ChangeProductLink({ children, ...props }: Omit<LinkProps, "to">) {
   const { products } = useProduct();
+  const registration = useRegistration();
 
   if (products.length <= 1) return null;
+  if (!isEmpty(registration?.key)) return null;
 
   return (
     <Link to={PATHS.changeProduct} {...props}>

--- a/web/src/components/product/ProductSelectionPage.test.tsx
+++ b/web/src/components/product/ProductSelectionPage.test.tsx
@@ -24,8 +24,8 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender, mockNavigateFn } from "~/test-utils";
 import { ProductSelectionPage } from "~/components/product";
-import { Product } from "~/types/software";
-import { useProduct } from "~/queries/software";
+import { Product, RegistrationInfo } from "~/types/software";
+import { useProduct, useRegistration } from "~/queries/software";
 
 jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
   <div>ProductRegistrationAlert Mock</div>
@@ -50,6 +50,7 @@ const microOs: Product = {
 };
 
 let mockSelectedProduct: Product;
+let registrationInfoMock: RegistrationInfo;
 
 jest.mock("~/queries/software", () => ({
   ...jest.requireActual("~/queries/software"),
@@ -61,11 +62,24 @@ jest.mock("~/queries/software", () => ({
   },
   useProductChanges: () => jest.fn(),
   useConfigMutation: () => ({ mutate: mockConfigMutation }),
+  useRegistration: (): ReturnType<typeof useRegistration> => registrationInfoMock,
 }));
 
 describe("ProductSelectionPage", () => {
   beforeEach(() => {
     mockSelectedProduct = tumbleweed;
+    registrationInfoMock = { key: "", email: "" };
+  });
+
+  describe("when there is a registration code set", () => {
+    beforeEach(() => {
+      registrationInfoMock = { key: "INTERNAL-USE-ONLY-1234-5678", email: "" };
+    });
+
+    it("navigates to root path", async () => {
+      installerRender(<ProductSelectionPage />);
+      await screen.findByText("Navigating to /");
+    });
   });
 
   describe("when there is a product already selected", () => {

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -34,14 +34,16 @@ import {
   FormGroup,
   Button,
 } from "@patternfly/react-core";
+import { Navigate, useNavigate } from "react-router-dom";
 import { Page } from "~/components/core";
 import { Center } from "~/components/layout";
-import { useConfigMutation, useProduct } from "~/queries/software";
+import { useConfigMutation, useProduct, useRegistration } from "~/queries/software";
 import pfTextStyles from "@patternfly/react-styles/css/utilities/Text/text";
 import pfRadioStyles from "@patternfly/react-styles/css/components/Radio/radio";
 import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
-import { useNavigate } from "react-router-dom";
+import { PATHS } from "~/router";
+import { isEmpty } from "~/utils";
 
 const ResponsiveGridItem = ({ children }) => (
   <GridItem sm={10} smOffset={1} lg={8} lgOffset={2} xl={6} xlOffset={3}>
@@ -97,9 +99,12 @@ const BackLink = () => {
 
 function ProductSelectionPage() {
   const setConfig = useConfigMutation();
+  const registration = useRegistration();
   const { products, selectedProduct } = useProduct({ suspense: true });
   const [nextProduct, setNextProduct] = useState(selectedProduct);
   const [isLoading, setIsLoading] = useState(false);
+
+  if (!isEmpty(registration?.key)) return <Navigate to={PATHS.root} />;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Problem

Although it is not possible to change a product after registering one, web interface still rendering the _Change product_ action and does not redirect to the root path when users try to navigates to the product selection.

## Solution

Check if there is a registration code set for both, 

* Do not render the change product action
* Navigates to root path in case the user reach the selection product path.

## Testing

- Added a new unit test
- Manually tested by @jreidinger
---

Related to 

  * https://github.com/agama-project/agama/issues/1891
  * https://github.com/agama-project/agama/pull/1882
