### PR TITLE
live: Drop patterns-yast-yast2_basis requirement

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 15 16:53:28 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Drop patterns-yast-yast2_basis requirement
+  yast packages should be installed per package and not as
+  a whole pattern.
+  (gh#agama-project/agama#1893).
+
+-------------------------------------------------------------------
 Fri Jan 10 21:22:03 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 11

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -134,7 +134,6 @@
         <package name="blog" arch="s390x" />
         <package name="libblogger2" arch="s390x" />
         <package name="xauth"/>
-        <package name="patterns-yast-yast2_basis"/>
         <package name="MozillaFirefox"/>
         <package name="libpwquality-tools"/>
         <package name="NetworkManager"/>


### PR DESCRIPTION
## Problem

patterns-yast is not available in SLFO/SLE16.

## Solution

~~Added a requirement for the pattern only when using the openSUSE, openSUSE-PXE, Leap and Leap-PXE profiles.~~

As suggested by Josef below, dropped it entirely on openSUSE as well as the whole pattern shouldn't be installed at all.