### PR TITLE
fix(service): add missing gems

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,13 +1,17 @@
 PATH
   remote: .
   specs:
-    agama-yast (11)
+    agama-yast (11.devel4)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
+      csv (~> 3.3)
       eventmachine (~> 1.2.7)
       fast_gettext (~> 2.3.0)
+      logger (~> 1.6)
       nokogiri (~> 1.15)
+      ostruct (~> 0.6.1)
+      prime (~> 0.1.3)
       rexml (~> 3.2)
       ruby-dbus (>= 0.23.1, < 1.0)
 
@@ -22,14 +26,23 @@ GEM
       cfa (~> 1.0)
     cheetah (1.0.0)
       abstract_method (~> 1.2)
+    csv (3.3.2)
     diff-lcs (1.5.1)
     docile (1.4.1)
     eventmachine (1.2.7)
     fast_gettext (2.3.0)
-    nokogiri (1.16.7-x86_64-linux)
+    forwardable (1.3.3)
+    logger (1.6.5)
+    mini_portile2 (2.8.8)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.1)
     packaging_rake_tasks (1.5.4)
       rake
+    prime (0.1.3)
+      forwardable
+      singleton
     racc (1.8.1)
     rake (13.0.6)
     rexml (3.2.9)
@@ -57,6 +70,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
+    singleton (0.3.0)
     strscan (3.1.0)
     yard (0.9.36)
 

--- a/service/agama-yast.gemspec
+++ b/service/agama-yast.gemspec
@@ -59,4 +59,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "~> 1.15"
   spec.add_dependency "rexml", "~> 3.2"
   spec.add_dependency "ruby-dbus", ">= 0.23.1", "< 1.0"
+  spec.add_dependency "csv", "~> 3.3"
+  spec.add_dependency "prime", "~> 0.1.3"
+  spec.add_dependency "logger", "~> 1.6"
+  spec.add_dependency "ostruct", "~> 0.6.1"
 end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 15 14:26:11 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+ - Add missing gems to the gemspec file
+  (gh#agama-project/agama#1899).
+
+-------------------------------------------------------------------
 Fri Jan 10 21:22:00 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 11


### PR DESCRIPTION
## Problem

*csv* does not belong to the ruby standard library since ruby 3.4. The gem is still installed as part of the ruby 3.4 package, but the CI task for running unit tests fails because the code is executed via bundle. 

## Solution

Add the required gems to the gemspec file.
