### PR TITLE
Fix typo in `agama profile import --help` (bsc#1235827)

### DIFF
--- a/rust/agama-cli/src/profile.rs
+++ b/rust/agama-cli/src/profile.rs
@@ -72,7 +72,7 @@ pub enum ProfileCommands {
     /// installation. Unless there is a need to inject additional commands between processing
     /// use this command instead of set of underlying commands.
     Import {
-        /// Profile's URL. Supports the same schemas than te "download" command plus
+        /// Profile's URL. Supports the same schemas as the "download" command plus
         /// AutoYaST specific ones. Supported files are json, jsonnet, sh for Agama profiles and ERB, XML, and rules/classes directories
         /// for AutoYaST support.
         url: String,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan 16 09:32:00 UTC 2025 - Martin Vidner <mvidner@suse.com>
+
+- Fix typo in `agama profile import --help` (bsc#1235827)
+
+-------------------------------------------------------------------
 Fri Jan 10 21:22:01 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 11


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1235827

This help output has a typo "te" next to a grammar mistake:

> qa2-141-81:~ # agama profile import --help                                                                                  
> ...
> Arguments:
>   <URL>
>           Profile's URL. Supports the same schemas than te "download" command plus AutoYaST specific
>           ones. Supported files are json, jsonnet, sh for Agama profiles and ERB, XML, and
>           rules/classes directories for AutoYaST support
>  

## Solution

Fix typo. Note that it looks like code comment, but the CLI library shows it to the user.

## Testing

Rare case where I dare admit no testing

## Screenshots

No
