### PR TITLE
Fix sap pattern

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan 16 15:12:08 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Update also base product from SLES-SAP to SLES_SAP(bsc#1235956)
+
+-------------------------------------------------------------------
 Mon Jan 13 09:04:21 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update SLES4SAP ID to SLES_SAP (gh#agama-project/agama#1890).

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -37,7 +37,7 @@ software:
   mandatory_packages:
     - NetworkManager
   optional_packages: null
-  base_product: SLES-SAP
+  base_product: SLES_SAP
 
 security:
   lsm: selinux


### PR DESCRIPTION
## Problem

When selecting SLES4SAP product it won't find base product.


## Solution

After rename also base product is changed from SLES-SAP to SLES_SAP, so update base product entry.


## Testing


- *Tested manually*

Please note that for testing manually SCC still after registration returns old Alpha repo which missing system_installation fix and also old SLES-SAP product. For this reason I used for testing agama.install_url pointing to the latest internal products repo and skip registration ( so scc repos is not used ).