### PR TITLE
fix(web): storage reprobe

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama.Storage1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Storage1.bus.xml
@@ -45,6 +45,8 @@
   <interface name="org.opensuse.Agama.Storage1">
     <method name="Probe">
     </method>
+    <method name="Reprobe">
+    </method>
     <method name="SetConfig">
       <arg name="serialized_config" direction="in" type="s"/>
       <arg name="result" direction="out" type="u"/>

--- a/doc/dbus/org.opensuse.Agama.Storage1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Storage1.doc.xml
@@ -8,6 +8,11 @@
     <method name="Probe">
     </method>
     <!--
+      Probes the system and recalculates the proposal using the current config.
+    -->
+    <method name="Reprobe">
+    </method>
+    <!--
       Sets the storage config.
     -->
     <method name="SetConfig">

--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -137,6 +137,11 @@ impl<'a> StorageClient<'a> {
     /// Runs the probing process
     pub async fn probe(&self) -> Result<(), ServiceError> {
         Ok(self.storage_proxy.probe().await?)
+    }
+
+    /// Runs the reprobing process
+    pub async fn reprobe(&self) -> Result<(), ServiceError> {
+        Ok(self.storage_proxy.reprobe().await?)
     }
 
     /// Set the storage config according to the JSON schema

--- a/rust/agama-lib/src/storage/proxies/storage1.rs
+++ b/rust/agama-lib/src/storage/proxies/storage1.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -55,6 +55,9 @@ pub trait Storage1 {
 
     /// Probe method
     fn probe(&self) -> zbus::Result<()>;
+
+    /// Reprobe method
+    fn reprobe(&self) -> zbus::Result<()>;
 
     /// Set the storage config according to the JSON schema
     fn set_config(&self, settings: &str) -> zbus::Result<u32>;

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -116,6 +116,7 @@ pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
         .route("/config", put(set_config).get(get_config))
         .route("/config_model", put(set_config_model).get(get_config_model))
         .route("/probe", post(probe))
+        .route("/reprobe", post(reprobe))
         .route("/devices/dirty", get(devices_dirty))
         .route("/devices/system", get(system_devices))
         .route("/devices/result", get(staging_devices))
@@ -240,13 +241,28 @@ async fn set_config_model(
     path = "/probe",
     context_path = "/api/storage",
     responses(
-        (status = 200, description = "Devices were probed and an initial proposal were performed"),
+        (status = 200, description = "Devices were probed and an initial proposal was performed"),
         (status = 400, description = "The D-Bus service could not perform the action")
     ),
     operation_id = "storage_probe"
 )]
 async fn probe(State(state): State<StorageState<'_>>) -> Result<Json<()>, Error> {
     Ok(Json(state.client.probe().await?))
+}
+
+/// Reprobes the storage devices.
+#[utoipa::path(
+    post,
+    path = "/reprobe",
+    context_path = "/api/storage",
+    responses(
+        (status = 200, description = "Devices were probed and the proposal was recalculated"),
+        (status = 400, description = "The D-Bus service could not perform the action")
+    ),
+    operation_id = "storage_reprobe"
+)]
+async fn reprobe(State(state): State<StorageState<'_>>) -> Result<Json<()>, Error> {
+    Ok(Json(state.client.reprobe().await?))
 }
 
 /// Gets whether the system is in a deprecated status.

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2024] SUSE LLC
+# Copyright (c) [2022-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -87,13 +87,15 @@ module Agama
         STORAGE_INTERFACE = "org.opensuse.Agama.Storage1"
         private_constant :STORAGE_INTERFACE
 
-        def probe
+        # @param keep_config [Boolean] Whether to use the current storage config for calculating
+        #   the proposal.
+        def probe(keep_config: false)
           busy_while do
             # Clean trees in advance to avoid having old objects exported in D-Bus.
             system_devices_tree.clean
             staging_devices_tree.clean
 
-            backend.probe
+            backend.probe(keep_config: keep_config)
           end
         end
 
@@ -162,6 +164,7 @@ module Agama
 
         dbus_interface STORAGE_INTERFACE do
           dbus_method(:Probe) { probe }
+          dbus_method(:Reprobe) { probe(keep_config: true) }
           dbus_method(:SetConfig, "in serialized_config:s, out result:u") do |serialized_config|
             busy_while { apply_config(serialized_config) }
           end

--- a/web/src/api/storage/proposal.ts
+++ b/web/src/api/storage/proposal.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2024] SUSE LLC
+ * Copyright (c) [2024-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -20,38 +20,10 @@
  * find current contact information at www.suse.com.
  */
 
-import { get, put } from "../http";
-import {
-  Action,
-  ProductParams,
-  ProposalSettings,
-  ProposalSettingsPatch,
-  Volume,
-} from "~/api/storage/types";
-
-const fetchUsableDevices = (): Promise<number[]> => get(`/api/storage/proposal/usable_devices`);
-
-const fetchProductParams = (): Promise<ProductParams> => get("/api/storage/product/params");
-
-const fetchDefaultVolume = (mountPath: string): Promise<Volume | undefined> => {
-  const path = encodeURIComponent(mountPath);
-  return get(`/api/storage/product/volume_for?mount_path=${path}`);
-};
-
-// NOTE: the settings might not exist.
-const fetchSettings = (): Promise<ProposalSettings> =>
-  get("/api/storage/proposal/settings").catch(() => null);
-
-const fetchActions = (): Promise<Action[]> => get("/api/storage/devices/actions");
+import { put } from "../http";
+import { ProposalSettingsPatch } from "~/api/storage/types";
 
 const calculate = (settings: ProposalSettingsPatch) =>
   put("/api/storage/proposal/settings", settings);
 
-export {
-  fetchUsableDevices,
-  fetchProductParams,
-  fetchDefaultVolume,
-  fetchSettings,
-  fetchActions,
-  calculate,
-};
+export { calculate };

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2024] SUSE LLC
+ * Copyright (c) [2024-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -33,6 +33,12 @@ export default function ConfigEditor() {
     <List isPlain>
       {model.drives.map((drive, i) => {
         const device = devices.find((d) => d.name === drive.name);
+
+        /**
+         * @fixme Make DriveEditor to work when the device is not found (e.g., after disabling
+         * a iSCSI device).
+         */
+        if (device === undefined) return null;
 
         return (
           <ListItem key={i}>

--- a/web/src/components/storage/DeviceSelection.tsx
+++ b/web/src/components/storage/DeviceSelection.tsx
@@ -27,17 +27,11 @@ import { Page } from "~/components/core";
 import { DeviceSelectorTable } from "~/components/storage";
 import DevicesTechMenu from "./DevicesTechMenu";
 import { ProposalTarget, StorageDevice } from "~/types/storage";
-import {
-  useAvailableDevices,
-  useProposalMutation,
-  useProposalResult,
-  useRefresh,
-} from "~/queries/storage";
+import { useAvailableDevices, useProposalMutation, useProposalResult } from "~/queries/storage";
 import { deviceChildren } from "~/components/storage/utils";
 import { compact } from "~/utils";
 import a11y from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 import { _ } from "~/i18n";
-import { Loading } from "~/components/layout";
 
 const SELECT_DISK_ID = "select-disk";
 const CREATE_LVM_ID = "create-lvm";
@@ -59,16 +53,10 @@ export default function DeviceSelection() {
   const availableDevices = useAvailableDevices();
   const updateProposal = useProposalMutation();
   const navigate = useNavigate();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [state, setState] = useState<DeviceSelectionState>({});
 
   const isTargetDisk = state.target === ProposalTarget.DISK;
   const isTargetNewLvmVg = state.target === ProposalTarget.NEW_LVM_VG;
-
-  useRefresh({
-    onStart: () => setIsLoading(true),
-    onFinish: () => setIsLoading(false),
-  });
 
   useEffect(() => {
     if (state.target !== undefined) return;
@@ -129,8 +117,6 @@ by default as [logical volumes of a new LVM Volume Group]. The corresponding \
 physical volumes will be created on demand as new partitions at the selected \
 devices.",
   ).split(/[[\]]/);
-
-  if (isLoading) return <Loading />;
 
   return (
     <Page>

--- a/web/src/components/storage/ISCSIPage.tsx
+++ b/web/src/components/storage/ISCSIPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2023-2024] SUSE LLC
+ * Copyright (c) [2023-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -44,8 +44,8 @@ export default function ISCSIPage() {
         </Grid>
       </Page.Content>
       <Page.Actions>
-        <Page.Action variant="secondary" navigateTo={PATHS.targetDevice}>
-          {_("Back to device selection")}
+        <Page.Action variant="secondary" navigateTo={PATHS.root}>
+          {_("Back")}
         </Page.Action>
       </Page.Actions>
     </Page>


### PR DESCRIPTION
## Problem

If the system is set as deprecated (e.g., after activating iSCSI devices), then the web client automatically reprobes the storage devices and recalculates the proposal. That is done by 3 different calls (fetch config, probe, and set config). This makes the process very unreliable if more than one reprobing is done at the same time. As side effect, the current storage config could be lost, getting the initial storage proposal instead.

## Solution

Add a new D-Bus method for reprobing in an atomic way. The system is set as "no deprecated" at the end of the action. Now clients can simultaneously call to reprobe without any risk.
