### PR TITLE
Correctly select the base product to install (bsc#1235931)

### DIFF
--- a/service/lib/agama/software/proposal.rb
+++ b/service/lib/agama/software/proposal.rb
@@ -86,8 +86,10 @@ module Agama
       # @return [Boolean]
       def calculate
         initialize_target
-        select_base_product
         @proposal = Yast::Packages.Proposal(force_reset = true, reinit = false, _simple = true)
+        # select the base product after running the Packages.Proposal, the force_reset = true
+        # option would reset the selection and a random product would be selected by the solver
+        select_base_product
         solve_dependencies
 
         valid?

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan 16 17:30:03 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Correctly select the base product to install (bsc#1235931)
+
+-------------------------------------------------------------------
 Wed Jan 15 14:26:11 UTC 2025 - José Iván López González <jlopez@suse.com>
 
  - Add missing gems to the gemspec file


### PR DESCRIPTION
## Problem

- A different product is installed in the target system than selected initially
- https://bugzilla.suse.com/show_bug.cgi?id=1235931

## Details

- The product was selected but later a reset was called so the selection was lost
- Then the solver selected a random product to satisfy the dependencies

## Solution

- Just select the product later, after resetting the selection

## Testing

- Tested manually, it fixes t he problem
