### PR TITLE
Add pattern sles_minimal_sap to user patterns of product SLES

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jan 20 10:30:55 UTC 2025 - Angela Briel <abriel@suse.com>
+
+- Add pattern sles_minimal_sap to the user selectable patterns list
+  of the SLES product to give the admin the chance to get a minimal
+  preparation of the operating system to run SAP workloads on plain
+  SLES.
+
+-------------------------------------------------------------------
 Thu Jan 16 15:12:08 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Update also base product from SLES-SAP to SLES_SAP(bsc#1235956)

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -61,6 +61,7 @@ software:
     - kvm_host
     - cockpit
     - sles_enhanced_base
+    - sles_minimal_sap
   mandatory_packages:
     - NetworkManager
   optional_packages: null


### PR DESCRIPTION
Add pattern sles_minimal_sap to the user selectable patterns list of the SLES product to give the admin the chance to get a minimal preparation of the operating system to run SAP workloads on plain SLES.


## Problem

Today the customer can not prepare the SLES operating system during installation for running SAP workloads, so he will run into installation and performance issues later during the SAP workload installation and runtime.


## Solution

Add a pattern to the user pattern list, which the user can select for SAP Server preparation during the installation.

