### PR TITLE
feat(i18n): In local installation by default use the EFI locale

### DIFF
--- a/live/root/root/.icewm/startup
+++ b/live/root/root/.icewm/startup
@@ -5,5 +5,21 @@ TOKEN_FILE=/run/agama/token
 TOKEN=$(cat $TOKEN_FILE)
 PREFS=$HOME/.mozilla/firefox/profile/user.js
 
-sed -e "s/__HOMEPAGE__/http:\/\/localhost\/login?token=$TOKEN/" $PREFS.template > $PREFS
+# read the system locale from EFI if present
+LANG_FILE=/sys/firmware/efi/efivars/PlatformLang-8be4df61-93ca-11d2-aa0d-00e098032b8c
+
+# file exists and is not empty
+if [ -s  "$LANG_FILE" ]; then
+  # skip the first 4 bytes (the EFI attributes), keep only the characters allowed in a language code,
+  # especially remove the trailing null byte
+  EFI_LANG=$(cat "$LANG_FILE" | tail -c +5 | tr -cd "[_a-zA-Z-]")
+
+  if [ -n "$EFI_LANG" ]; then
+    # escape & because it has a special meaning in sed replacement
+    LANG_QUERY="\\&lang=$EFI_LANG"
+  fi
+fi
+
+sed -e "s/__HOMEPAGE__/http:\/\/localhost\/login?token=$TOKEN$LANG_QUERY/" $PREFS.template > $PREFS
+
 firefox --kiosk --profile $HOME/.mozilla/firefox/profile

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  7 09:15:02 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- In local installation prefer the language configured in the
+  UEFI firmware
+
+-------------------------------------------------------------------
 Fri Feb  7 08:21:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Implemented media check functionality (bsc#1236103)

--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -100,10 +100,12 @@ pub async fn login(
 pub struct LoginFromQueryParams {
     /// Token to use for authentication.
     token: String,
+    /// Requested locale
+    lang: String,
 }
 
 #[utoipa::path(get, path = "/login", responses(
-    (status = 301, description = "Injects the authentication cookie if correct and redirects to the web UI")
+    (status = 307, description = "Injects the authentication cookie if correct and redirects to the web UI")
 ))]
 pub async fn login_from_query(
     State(state): State<ServiceState>,
@@ -120,7 +122,21 @@ pub async fn login_from_query(
         );
     }
 
-    headers.insert(header::LOCATION, HeaderValue::from_static("/"));
+    // the redirection path
+    let mut target = String::from("/");
+
+    // keep the "lang" URL query if it was present in the original request
+    if !&params.lang.is_empty() {
+        target.push_str(format!("?lang={}", params.lang).as_str());
+    }
+
+    let location = HeaderValue::from_str(target.as_str());
+
+    headers.insert(
+        header::LOCATION,
+        location.unwrap_or(HeaderValue::from_static("/")),
+    );
+
     (StatusCode::TEMPORARY_REDIRECT, headers)
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb  7 11:03:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Forward the "lang" URL query parameter when redirecting in the
+  "/login" endpoint (this allows to define the default language
+  in the Firefox configuration file in local installation)
+
+-------------------------------------------------------------------
 Thu Feb  6 12:52:11 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Describe licenses API in OpenAPI documentation


### PR DESCRIPTION
## Problem

- In a local installation Agama by default always uses the English language in the UI.
- But in a remote installation it uses the language configured in the browser.
- It would be nice to have something similar also in a local installation and read the preferred language directly from the system.

## Solution

- Use the language configured in the EFI firmware

### Advantages

- Allows using the user preferred language also in a local installation

### Disadvantages

- Works only with EFI firmware (i.e. does not work on S390)
- The list of supported languages is firmware dependent. Some firmware might support few languages (the VirtualBox EFI firmware supports only English or French), some might support quite a lot of languages (my Asus board offers 7 additional languages besides the English default) and some firmware might implement none (just using the English default).
- For users it might not be obvious which language is actually configured in the firmware. At boot time firmware usually displays a splash screen with vendor logo without any hint about the selected language. This might be confusing if you buy a second hand laptop and the previous user used some exotic language...

Although it has some drawbacks and probably only very few users will benefit from this feature I still find it pretty cool. :sunglasses: 
If we later get some bug reports about this feature we can easily disable it. But I'd like to give it a try... :muscle: 

To get a list of languages supported by your firmware run

    cat /sys/firmware/efi/efivars/PlatformLangCodes-* | tail -c +5 | tr -cd '[:print:]'

## Notes

- When connecting remotely it still prefers the browser language, this change only affects the local installation
- The later "welcome screen" will allow changing the language in the very first dialog. So if the EFI default is not what the user would like to see then it can be changed easily.

## Testing

- Tested manually in VirtualBox which allows selecting between English (default) and French, see the screenshots and the recording below.

## Screenshots

After selecting the French language in the firmware...

![agama-efi-language-selection](https://github.com/user-attachments/assets/d4eed917-584a-4a0c-a220-3a16767d5f08)

... you will see Agama in French as well. (OK, not all descriptions are translated...)

![agama-efi-language](https://github.com/user-attachments/assets/c734ca35-4aff-4912-8275-84580aa6d9a3)


## Recording

[agama-efi-language-screen0.webm](https://github.com/user-attachments/assets/5c1d4ca5-aec5-4bab-addf-bb8df8d7435f)

Note: For some reason the Chrome browser does not play the video well for me, right-clicking and selecting "Open video in a new tab" works fine though. And Firefox is OK...
