### PR TITLE
fix(web): fix TPM check when using the legacy AutoYaST mode

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 21 09:44:08 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash at the end of the installation when using a legacy
+  AutoYaST mode (gh#agama-project/agama#1927).
+
+-------------------------------------------------------------------
 Mon Jan 20 16:45:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - The software page displays a link for reloading the repositories

--- a/web/src/api/storage.ts
+++ b/web/src/api/storage.ts
@@ -32,8 +32,8 @@ import { config } from "~/api/storage/types";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const probe = (): Promise<any> => post("/api/storage/probe");
 
-const fetchConfig = (): Promise<config.Config | undefined> =>
-  get("/api/storage/config").then((config) => config.storage);
+const fetchConfig = (): Promise<config.Config | null> =>
+  get("/api/storage/config").then((config) => config.storage ?? null);
 
 /**
  * Returns the list of jobs

--- a/web/src/components/core/InstallationFinished.tsx
+++ b/web/src/components/core/InstallationFinished.tsx
@@ -79,6 +79,10 @@ const SuccessIcon = () => <Icon name="check_circle" className="icon-xxxl color-s
 // TODO: define some utility method to get the device used as root (drive, partition, logical volume).
 // TODO: use type checking for config.
 function usingTpm(config): boolean {
+  if (!config) {
+    return null;
+  }
+
   const { guided, drives = [], volumeGroups = [] } = config;
 
   if (guided !== undefined) {


### PR DESCRIPTION
## Problem

When using the legacy AutoYaST mode, the web UI crashes at the end of the installation when trying
to find our whether it is using TPM or not.

- https://github.com/agama-project/agama/issues/1918

## Solution

Properly handle that case:

* `fetchConfig` now returns `null` instead of `undefined`. According to [TanStack Query
documentation](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery), `queryFn`
*Must return a promise that will either resolve data or throw an error. The data cannot be
undefined*.
* `usingTpm` function now handles the case where the configuration is `null`.

## Testing

- *Tested manually*
