### PR TITLE
fix(service): fix the return value of ListRepositories

### DIFF
--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -70,8 +70,8 @@ module Agama
           # array of repository properties: pkg-bindings ID, alias, name, URL, product dir, enabled
           # and loaded flag
           dbus_method :ListRepositories, "out Result:a(issssbb)" do
-            backend.repositories.repositories.map do |repo|
-              [
+            [
+              backend.repositories.repositories.map do |repo|
                 [
                   repo.repo_id,
                   repo.repo_alias,
@@ -81,8 +81,8 @@ module Agama
                   repo.enabled?,
                   !!repo.loaded?
                 ]
-              ]
-            end
+              end
+            ]
           end
 
           # value of result hash is category, description, icon, summary and order

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 21 19:11:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the ListRepositories D-Bus method to return the proper value
+  instead of crashing the service (gh#agama-project/agama#1930).
+
+-------------------------------------------------------------------
 Mon Jan 20 16:44:45 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - The software service provides DBus API for reading the currently


### PR DESCRIPTION
## Problem

`ListRepositories` D-Bus method just crashes. It is expected to return an array with contains the
return value as its first element. However, when there are no repositories, it just returns an empty
array. It causes Ruby D-Bus to fail because it cannot serialize a `nil` value.

## Solution

Fix the return value. For comparison, you can check the following `ListPatterns` method.

## Testing

- _Tested manually_
