### PR TITLE
fix(autoinstallation): Import the user settings sooner to avoid stuck web UI

### DIFF
--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -104,6 +104,11 @@ impl Store {
             }
         }
 
+        // import the users (esp. the root password) before initializing software,
+        // if software fails the Web UI would be stuck in the root password dialog
+        if let Some(user) = &settings.user {
+            self.users.store(user).await?;
+        }
         if let Some(network) = &settings.network {
             self.network.store(network).await?;
         }
@@ -118,9 +123,6 @@ impl Store {
         }
         if let Some(software) = &settings.software {
             self.software.store(software).await?;
-        }
-        if let Some(user) = &settings.user {
-            self.users.store(user).await?;
         }
         if settings.storage.is_some() || settings.storage_autoyast.is_some() {
             self.storage.store(&settings.into()).await?

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 22 14:49:56 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Added a workaround for stuck web UI when importing auto
+  installation profile with unreachable software repository
+  (gh#agama-project/agama#1933)
+
+-------------------------------------------------------------------
 Mon Jan 20 16:44:02 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - The web server provides /api/software/repositories endpoint


### PR DESCRIPTION


## Problem

- When the repository initialization fails fast in the autoinstallation mode the root password might not be imported yet and the web UI is stuck in the root password popup.

![agama-broken-user-config](https://github.com/user-attachments/assets/fcd9bb0c-8dd4-4b65-bcec-b0075301c4de)


## Solution

- Import the user setting earlier so if the repository refresh fails the password is already set and the web UI automatically goes  to the overview page.


## Testing

- Tested manually with locally built Live ISO


## Screenshots

- The web UI displays the overview page

![agama-fixed-user-config-overview](https://github.com/user-attachments/assets/0f5f95a8-d6fd-464d-b913-f2c3c61f5db7)

- After switching to the software page the initial repository error is displayed

![agama-fixed-user-config](https://github.com/user-attachments/assets/d28c90cb-a4aa-4ba7-85d2-f9a9a564b5c6)

