### PR TITLE
add installation labels to sle products

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 10:43:32 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Set installation labels for SLES and SLES4SAP
+  (gh#agama-project/agama#1937)
+
+-------------------------------------------------------------------
 Mon Jan 20 10:36:19 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Set the license for SLES and SLES4SAP (jsc#PED-11987).

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -54,6 +54,15 @@ translations:
       bulutta ve uçta iş açısından kritik iş yüklerini çalıştırır.
 software:
   installation_repositories: []
+  installation_labels:
+    - label: SLES160-x86_64
+      archs: x86_64
+    - label: SLES160-arch64
+      archs: aarch64
+    - label: SLES160-s390x
+      archs: s390
+    - label: SLES160-ppc64
+      archs: ppc
 
   mandatory_patterns:
     - base_traditional

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -19,6 +19,13 @@ translations:
   description:
 software:
   installation_repositories: []
+  installation_labels:
+    - label: S4SAP160-x86_64
+      archs: x86_64
+    - label: S4SAP160-arch64
+      archs: aarch64
+    - label: S4SAP160-ppc64
+      archs: ppc
 
   mandatory_patterns:
     - base_traditional


### PR DESCRIPTION
## Problem

SLES and SLES4SAP product does not have defined installation labels, but it is needed for full medium.


## Solution

Define them as agreed.