### PR TITLE
fix(build): The number of build jobs should depend on RAM size

### DIFF
--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package agama
 #
-# Copyright (c) 2023-2024 SUSE LLC
+# Copyright (c) 2023-2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,8 +12,19 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
+
+# Require at least 1.3GB RAM per each parallel job (the size is in MB)
+%define ram_per_cpu 1300
+
+# Redefine the _smp_mflags macro so it takes the amount of RAM into account
+%define _smp_mflags %([ -z "$RPM_BUILD_NCPUS" ] \\\
+  && RPM_BUILD_NCPUS="`/usr/bin/getconf _NPROCESSORS_ONLN`"; \\\
+  ram_kb="$(awk '/MemTotal/ {print $2}' /proc/meminfo)"; \\\
+  ncpus_max=$(("$ram_kb"/%ram_per_cpu/1024)); \\\
+  if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
+  if [ "$RPM_BUILD_NCPUS" -gt 1 ]; then echo "-j$RPM_BUILD_NCPUS"; fi)
 
 Name:           agama
 #               This will be set by osc services, that will run after this.
@@ -23,7 +34,7 @@ Summary:        Agama Installer
 #               If you know the license, put it's SPDX string here.
 #               Alternately, you can use cargo lock2rpmprovides to help generate this.
 License:        GPL-2.0-or-later
-Url:            https://github.com/opensuse/agama
+Url:            https://github.com/agama-project/agama
 Source0:        agama.tar
 Source1:        vendor.tar.zst
 
@@ -70,7 +81,7 @@ Version:        0
 Release:        0
 Summary:        Agama command-line interface
 License:        GPL-2.0-only
-Url:            https://github.com/opensuse/agama
+Url:            https://github.com/agama-project/agama
 
 %description -n agama-cli
 Command line program to interact with the Agama installer.
@@ -129,6 +140,9 @@ package contains a systemd service to run scripts when booting the installed sys
 # find vendor -type f -name \*.rs -exec chmod -x '{}' \;
 
 %build
+# just for debugging failures with low memory
+cat /proc/meminfo | head -n 3
+
 %{cargo_build}
 cargo run --package xtask -- manpages
 gzip out/man/*

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -16,15 +16,10 @@
 #
 
 # Require at least 1.3GB RAM per each parallel job (the size is in MB)
-%define ram_per_cpu 1300
+%global _smp_tasksize_proc 1300
 
 # Redefine the _smp_mflags macro so it takes the amount of RAM into account
-%define _smp_mflags %([ -z "$RPM_BUILD_NCPUS" ] \\\
-  && RPM_BUILD_NCPUS="`/usr/bin/getconf _NPROCESSORS_ONLN`"; \\\
-  ram_kb="$(awk '/MemTotal/ {print $2}' /proc/meminfo)"; \\\
-  ncpus_max=$(("$ram_kb"/%ram_per_cpu/1024)); \\\
-  if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
-  if [ "$RPM_BUILD_NCPUS" -gt 1 ]; then echo "-j$RPM_BUILD_NCPUS"; fi)
+%define _smp_mflags "-j%{getncpus:proc}"
 
 Name:           agama
 #               This will be set by osc services, that will run after this.


### PR DESCRIPTION
## Problem

- Package build fails in OBS with OOM killer
- https://build.suse.de/package/live_build_log/Devel:YaST:Agama:Head/agama/SLES-16.0/s390x

## Details

Sometimes the build might fail in OBS because Rust compilation requires huge amount of RAM. The problem happens when running many parallel jobs on a machine with not enough RAM. The build on S390 failed when running 8 jobs with 8GB RAM.

Originally I wanted to increase the requirement for RAM in the `_constraints` file from 8GB to 16GB. But that would decrease the number of available workers significantly, esp. on exotic archs like s390. And in most cases the workers run 4 or 8 jobs so requiring 16GB would be an overkill.

## Solution

So to decrease the needed amount of RAM decrease the maximum number of parallel jobs.

My experimental run `/usr/bin/time -v cargo build -j1` showed maximum used memory 1.1GB on x86_64. The compilation on S390 failed with 1GB per job. To be on the safe side let's require 1.3GB per job, different architectures might require more and we need to also leave something for the system and other services.

That means with 8GB RAM it should run at most 6 parallel jobs. That should hopefully avoid triggering the OOM killer.

## Notes

- We can adjust the RAM per job constant later if needed, this initial value is rather an experimental value, let's see how it will work.
- If some architecture needs quite different amount of RAM we can make the setting arch dependent using the `%ifarch` macro.