### PR TITLE
fix: prevent reaching the congratulations screen during installation

### DIFF
--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -67,6 +67,8 @@ pub enum InstallationPhase {
     Config,
     /// Installation phase.
     Install,
+    /// Finished installation phase.
+    Finish,
 }
 
 impl TryFrom<u32> for InstallationPhase {
@@ -77,6 +79,7 @@ impl TryFrom<u32> for InstallationPhase {
             0 => Ok(Self::Startup),
             1 => Ok(Self::Config),
             2 => Ok(Self::Install),
+            3 => Ok(Self::Finish),
             _ => Err(ServiceError::UnknownInstallationPhase(value)),
         }
     }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 24 09:33:31 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Introduce a new installation phase "finish"
+  (gh#agama-project/agama#1616).
+
+-------------------------------------------------------------------
 Fri Jan 24 06:43:05 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Change the registration property in a product's definition to a

--- a/service/lib/agama/dbus/clients/manager.rb
+++ b/service/lib/agama/dbus/clients/manager.rb
@@ -63,6 +63,8 @@ module Agama
             InstallationPhase::CONFIG
           when DBus::Manager::INSTALL_PHASE
             InstallationPhase::INSTALL
+          when DBus::Manager::FINISH_PHASE
+            InstallationPhase::FINISH
           end
         end
 

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -58,6 +58,7 @@ module Agama
       STARTUP_PHASE = 0
       CONFIG_PHASE = 1
       INSTALL_PHASE = 2
+      FINISH_PHASE = 3
 
       dbus_interface MANAGER_INTERFACE do
         dbus_method(:Probe, "") { config_phase }
@@ -111,7 +112,8 @@ module Agama
         [
           { "id" => STARTUP_PHASE, "label" => "startup" },
           { "id" => CONFIG_PHASE,  "label" => "config" },
-          { "id" => INSTALL_PHASE, "label" => "install" }
+          { "id" => INSTALL_PHASE, "label" => "install" },
+          { "id" => FINISH_PHASE, "label"  => "finish" }
         ]
       end
 
@@ -122,6 +124,7 @@ module Agama
         return STARTUP_PHASE if backend.installation_phase.startup?
         return CONFIG_PHASE if backend.installation_phase.config?
         return INSTALL_PHASE if backend.installation_phase.install?
+        return FINISH_PHASE if backend.installation_phase.finish?
       end
 
       # States whether installation runs on iguana

--- a/service/lib/agama/installation_phase.rb
+++ b/service/lib/agama/installation_phase.rb
@@ -27,6 +27,7 @@ module Agama
     STARTUP = "startup"
     CONFIG = "config"
     INSTALL = "install"
+    FINISH = "finish"
 
     def initialize
       @on_change_callbacks = []
@@ -51,6 +52,13 @@ module Agama
     # @return [Boolean]
     def install?
       value == INSTALL
+    end
+
+    # Whether the current installation phase value is finish
+    #
+    # @return [Boolean]
+    def finish?
+      value == FINISH
     end
 
     # Sets the installation phase value to startup
@@ -80,6 +88,16 @@ module Agama
     # @return [self]
     def install
       change_to(INSTALL)
+      self
+    end
+
+    # Sets the installation phase value to finish
+    #
+    # @note Callbacks are called.
+    #
+    # @return [self]
+    def finish
+      change_to(FINISH)
       self
     end
 

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -144,6 +144,7 @@ module Agama
       logger.error "Installation error: #{e.inspect}. Backtrace: #{e.backtrace}"
     ensure
       service_status.idle
+      installation_phase.finish
       finish_progress
     end
     # rubocop:enable Metrics/AbcSize

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 24 09:33:27 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Introduce a new installation phase "finish"
+  (gh#agama-project/agama#1616).
+
+-------------------------------------------------------------------
 Fri Jan 24 06:42:00 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use the availability of the base product to determine whether a

--- a/service/test/agama/dbus/clients/manager_test.rb
+++ b/service/test/agama/dbus/clients/manager_test.rb
@@ -99,6 +99,14 @@ describe Agama::DBus::Clients::Manager do
         expect(subject.current_installation_phase).to eq(Agama::InstallationPhase::INSTALL)
       end
     end
+
+    context "when the current phase is finish" do
+      let(:current_phase) { Agama::DBus::Manager::FINISH_PHASE }
+
+      it "returns the install phase value" do
+        expect(subject.current_installation_phase).to eq(Agama::InstallationPhase::FINISH)
+      end
+    end
   end
 
   include_examples "service status"

--- a/service/test/agama/dbus/manager_test.rb
+++ b/service/test/agama/dbus/manager_test.rb
@@ -157,7 +157,7 @@ describe Agama::DBus::Manager do
   describe "#installation_phases" do
     it "includes all possible values for the installation phase" do
       labels = subject.installation_phases.map { |i| i["label"] }
-      expect(labels).to contain_exactly("startup", "config", "install")
+      expect(labels).to contain_exactly("startup", "config", "install", "finish")
     end
 
     it "associates 'startup' with the id 0" do
@@ -173,6 +173,11 @@ describe Agama::DBus::Manager do
     it "associates 'install' with the id 2" do
       install = subject.installation_phases.find { |i| i["label"] == "install" }
       expect(install["id"]).to eq(described_class::INSTALL_PHASE)
+    end
+
+    it "associates 'finish' with the id 3" do
+      install = subject.installation_phases.find { |i| i["label"] == "finish" }
+      expect(install["id"]).to eq(described_class::FINISH_PHASE)
     end
   end
 

--- a/service/test/agama/installation_phase_test.rb
+++ b/service/test/agama/installation_phase_test.rb
@@ -95,6 +95,28 @@ describe Agama::InstallationPhase do
     end
   end
 
+  describe "finish?" do
+    context "if the installation phase is finish" do
+      before do
+        subject.finish
+      end
+
+      it "returns true" do
+        expect(subject.finish?).to eq(true)
+      end
+    end
+
+    context "if the installation phase is not finish" do
+      before do
+        subject.config
+      end
+
+      it "returns false" do
+        expect(subject.finish?).to eq(false)
+      end
+    end
+  end
+
   describe "#startup" do
     it "sets the installation phase to startup" do
       subject.startup

--- a/service/test/agama/manager_test.rb
+++ b/service/test/agama/manager_test.rb
@@ -20,7 +20,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "../test_helper"
-require_relative "./with_progress_examples"
+require_relative "with_progress_examples"
 require "agama/manager"
 require "agama/config"
 require "agama/issue"
@@ -115,9 +115,10 @@ describe Agama::Manager do
   end
 
   describe "#install_phase" do
-    it "sets the installation phase to install" do
+    it "sets the installation phase to install and later to finish" do
+      expect(subject.installation_phase).to receive(:install)
       subject.install_phase
-      expect(subject.installation_phase.install?).to eq(true)
+      expect(subject.installation_phase.finish?).to eq(true)
     end
 
     it "calls #propose on proxy and software modules" do

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 24 09:34:24 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use the "finish" to decide whether to navigate to the
+  congratulations screen (gh#agama-project/agama#1616).
+
+-------------------------------------------------------------------
 Fri Jan 24 06:43:52 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use the "missing_registration" issue to determine whether to show

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -215,7 +215,7 @@ describe("App", () => {
     });
   });
 
-  describe("on the idle finish phase", () => {
+  describe("on the finish phase", () => {
     beforeEach(() => {
       mockClientStatus.phase = InstallationPhase.Finish;
       mockSelectedProduct = tumbleweed;

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -203,10 +203,9 @@ describe("App", () => {
     });
   });
 
-  describe("on the busy installation phase", () => {
+  describe("on the installation phase", () => {
     beforeEach(() => {
       mockClientStatus.phase = InstallationPhase.Install;
-      mockClientStatus.isBusy = true;
       mockSelectedProduct = tumbleweed;
     });
 
@@ -216,10 +215,9 @@ describe("App", () => {
     });
   });
 
-  describe("on the idle installation phase", () => {
+  describe("on the idle finish phase", () => {
     beforeEach(() => {
-      mockClientStatus.phase = InstallationPhase.Install;
-      mockClientStatus.isBusy = false;
+      mockClientStatus.phase = InstallationPhase.Finish;
       mockSelectedProduct = tumbleweed;
     });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -55,11 +55,11 @@ function App() {
   const Content = () => {
     if (error) return <ServerError />;
 
-    if (phase === InstallationPhase.Install && isBusy) {
+    if (phase === InstallationPhase.Install) {
       return <Navigate to={ROOT.installationProgress} />;
     }
 
-    if (phase === InstallationPhase.Install && !isBusy) {
+    if (phase === InstallationPhase.Finish) {
       return <Navigate to={ROOT.installationFinished} />;
     }
 

--- a/web/src/components/core/InstallationFinished.test.tsx
+++ b/web/src/components/core/InstallationFinished.test.tsx
@@ -29,7 +29,7 @@ import { Encryption } from "~/api/storage/types/config";
 
 jest.mock("~/queries/status", () => ({
   ...jest.requireActual("~/queries/status"),
-  useInstallerStatus: () => ({ isBusy: false, useIguana: false, phase: 2, canInstall: false }),
+  useInstallerStatus: () => ({ isBusy: false, useIguana: false, phase: 3, canInstall: false }),
 }));
 
 type storageConfigType = "guided" | "raw";

--- a/web/src/components/core/InstallationFinished.tsx
+++ b/web/src/components/core/InstallationFinished.tsx
@@ -100,15 +100,11 @@ function usingTpm(config): boolean {
 }
 
 function InstallationFinished() {
-  const { phase, isBusy, useIguana } = useInstallerStatus({ suspense: true });
+  const { phase, useIguana } = useInstallerStatus({ suspense: true });
   const config = useConfig();
 
-  if (phase !== InstallationPhase.Install) {
+  if (phase !== InstallationPhase.Finish) {
     return <Navigate to={PATHS.root} />;
-  }
-
-  if (isBusy) {
-    return <Navigate to={PATHS.installationProgress} />;
   }
 
   return (

--- a/web/src/components/core/InstallationProgress.test.tsx
+++ b/web/src/components/core/InstallationProgress.test.tsx
@@ -27,7 +27,6 @@ import { InstallationPhase } from "~/types/status";
 import InstallationProgress from "./InstallationProgress";
 import { ROOT } from "~/routes/paths";
 
-let isBusy = false;
 let phase = InstallationPhase.Install;
 const mockInstallerStatusChanges = jest.fn();
 
@@ -35,7 +34,7 @@ jest.mock("~/components/core/ProgressReport", () => () => <div>ProgressReport Mo
 
 jest.mock("~/queries/status", () => ({
   ...jest.requireActual("~/queries/status"),
-  useInstallerStatus: () => ({ isBusy, phase }),
+  useInstallerStatus: () => ({ phase }),
   useInstallerStatusChanges: () => mockInstallerStatusChanges(),
 }));
 
@@ -56,27 +55,14 @@ describe("InstallationProgress", () => {
     });
   });
 
-  describe("when installer in the installation phase and busy", () => {
+  describe("when installer in the installation phase", () => {
     beforeEach(() => {
       phase = InstallationPhase.Install;
-      isBusy = true;
     });
 
     it("renders progress report", () => {
       installerRender(<InstallationProgress />);
       screen.getByText("ProgressReport Mock");
-    });
-  });
-
-  describe("when installer in the installation phase but not busy", () => {
-    beforeEach(() => {
-      phase = InstallationPhase.Install;
-      isBusy = false;
-    });
-
-    it("redirect to installation finished path", async () => {
-      installerRender(<InstallationProgress />);
-      await screen.findByText(`Navigating to ${ROOT.installationFinished}`);
     });
   });
 });

--- a/web/src/components/core/InstallationProgress.tsx
+++ b/web/src/components/core/InstallationProgress.tsx
@@ -29,15 +29,11 @@ import { Navigate } from "react-router-dom";
 import { useInstallerStatus, useInstallerStatusChanges } from "~/queries/status";
 
 function InstallationProgress() {
-  const { isBusy, phase } = useInstallerStatus({ suspense: true });
+  const { phase } = useInstallerStatus({ suspense: true });
   useInstallerStatusChanges();
 
   if (phase !== InstallationPhase.Install) {
     return <Navigate to={PATHS.root} replace />;
-  }
-
-  if (!isBusy) {
-    return <Navigate to={PATHS.installationFinished} replace />;
   }
 
   return <ProgressReport title={_("Installing the system, please wait...")} />;

--- a/web/src/types/status.ts
+++ b/web/src/types/status.ts
@@ -27,6 +27,7 @@ enum InstallationPhase {
   Startup = 0,
   Config = 1,
   Install = 2,
+  Finish = 3,
 }
 
 /*


### PR DESCRIPTION
## Problem

Agama determines in which point of the installation it is by the combination of two values: the
installation phase (startup, config and install) and the isBusy flag. This method has proven to be
rather fragile.

One of the typical issues is jumping into the "congratulations" screen
when the installation is not even finished. See #1616.

Although we mitigated this problem, it recently appear in our QA testing.

## Solution

Let's introduce a new phase, "finish", which indicates that the installation is finished. As simple
as that. So we do not need a combination of two values anymore at that point. We plan to extend this
approach to other parts.

## Testing

- _Added a new unit test_
- _Tested manually_
