### PR TITLE
fix(service): better handling of script names

### DIFF
--- a/service/lib/agama/autoyast/scripts_reader.rb
+++ b/service/lib/agama/autoyast/scripts_reader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+Yast.import "URL"
 
 # :nodoc:
 module Agama
@@ -50,6 +51,7 @@ module Agama
       #
       # @return [Hash] Agama "scripts" section
       def read
+        @index = 0
         scripts = {}
           .merge(read_post_scripts)
           .merge(read_init_scripts)
@@ -100,7 +102,7 @@ module Agama
       # @param section [Hash] AutoYaST script section
       def read_script(section)
         script = {
-          "name" => section["file_name"]
+          "name" => filename_for(section)
         }
 
         if section["location"]
@@ -120,6 +122,28 @@ module Agama
       def read_post_script(section)
         read_script(section)
           .merge("chroot" => section.fetch("chrooted", false))
+      end
+
+      # Extracts the name of the script
+      #
+      # If the "filename" attribute is defined, it is used. Otherwise, it tries
+      # to infer the name from the "location" attribute. If the "location" is
+      # not defined, it uses a generic name plus the index of the script.
+      #
+      # @param section [Hash] AutoYaST script definition
+      # @return [String]
+      def filename_for(section)
+        return section["filename"] if section["filename"]
+
+        location = section["location"].to_s
+        if !location.empty?
+          url = Yast::URL.Parse(location)
+          path = File.basename(url["path"].to_s)
+          return path unless path.empty? || path == "/"
+        end
+
+        @index += 1
+        "script-#{@index}"
       end
     end
   end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 27 17:38:53 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix handling of script names from AutoYaST profiles
+  (gh#agama-project/agama#1903).
+
+-------------------------------------------------------------------
 Fri Jan 24 09:33:27 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Introduce a new installation phase "finish"

--- a/service/test/agama/autoyast/scripts_reader_test.rb
+++ b/service/test/agama/autoyast/scripts_reader_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -32,27 +32,60 @@ RSpec.shared_examples "a script reader" do |ay_section, section|
 
   context "when the script definition includes the sources" do
     let(:script) do
-      { "file_name" => "script.sh",
-        "location"  => "https://example.com/script.sh" }
+      { "filename" => "script.sh",
+        "location" => "https://example.com/script.sh" }
     end
 
     it "sets the \"url\" to the \"location\"" do
       scripts = subject.read["scripts"][section]
       expect(scripts.first).to include("url" => "https://example.com/script.sh")
     end
+
+    context "and the script filename is not specified" do
+      let(:script) do
+        { "location" => "https://example.com/script.sh" }
+      end
+
+      it "uses the path as the filename" do
+        scripts = subject.read["scripts"][section]
+        expect(scripts.first).to include("name" => "script.sh")
+      end
+
+      context "but there is no path in the URL" do
+        let(:script) do
+          { "location" => "https://example.com/" }
+        end
+
+        it "uses the script type as the filename" do
+          scripts = subject.read["scripts"][section]
+          expect(scripts.first).to include("name" => "script-1")
+        end
+      end
+    end
   end
 
   context "when the script definition specifies a location" do
     let(:script) do
       {
-        "file_name" => "script.sh",
-        "source"    => "#!/bin/bash\necho 'Hello World!'"
+        "filename" => "script.sh",
+        "source"   => "#!/bin/bash\necho 'Hello World!'"
       }
     end
 
     it "sets the \"body\" to the \"sources\"" do
       scripts = subject.read["scripts"][section]
       expect(scripts.first).to include("body" => "#!/bin/bash\necho 'Hello World!'")
+    end
+
+    context "and the script filename is not specified" do
+      let(:script) do
+        { "source" => "#!/bin/bash\necho 'Hello World!'" }
+      end
+
+      it "uses the script type as the filename" do
+        scripts = subject.read["scripts"][section]
+        expect(scripts.first).to include("name" => "script-1")
+      end
     end
   end
 end
@@ -77,9 +110,9 @@ describe Agama::AutoYaST::ScriptsReader do
       it_behaves_like "a script reader", "chroot-scripts", "post"
 
       let(:chroot_script) do
-        { "file_name" => "test.sh",
-          "chrooted"  => true,
-          "source"    => "#!/bin/bash\necho 'Hello World!'" }
+        { "filename" => "test.sh",
+          "chrooted" => true,
+          "source"   => "#!/bin/bash\necho 'Hello World!'" }
       end
 
       let(:profile) do
@@ -92,8 +125,8 @@ describe Agama::AutoYaST::ScriptsReader do
 
       context "when the \"chrooted\" option is not set" do
         let(:chroot_script) do
-          { "file_name" => "test.sh",
-            "source"    => "#!/bin/bash\necho 'Hello World!'" }
+          { "filename" => "test.sh",
+            "source"   => "#!/bin/bash\necho 'Hello World!'" }
         end
 
         it "sets the \"chroot\" option to false" do


### PR DESCRIPTION
## Problem

There are a few problems when importing an AutoYaST script:

- Agama uses `file_name` instead of `filename`.
- If `file_name` is missing, it does not propose another name, generating an invalid profile.

## Solution

Fix both problems by:

- Using the right attribute name (`filename` instead of `file_name`).
- Falling back to the basename from the location. If no location is given, propose `script-X`
  where `X` is a number.

## Testing

- _Added a new unit test_
- _Tested manually_
