### PR TITLE
fix(rust): use "dashed" form for systemd-firstboot keymap

### DIFF
--- a/rust/agama-server/src/l10n/model.rs
+++ b/rust/agama-server/src/l10n/model.rs
@@ -240,7 +240,7 @@ impl L10n {
                 "--locale",
                 self.locales.first().unwrap_or(&"en_US.UTF-8".to_string()),
                 "--keymap",
-                &self.keymap.to_string(),
+                &self.keymap.dashed(),
                 "--timezone",
                 &self.timezone,
             ])

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 28 07:13:17 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use the "dashed" form of the keymap identifier when calling
+  systemd-firstboot (bsc#1236174).
+
+-------------------------------------------------------------------
 Fri Jan 24 09:33:31 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Introduce a new installation phase "finish"


### PR DESCRIPTION
## Problem

When writing the keymap to be used by the target system, Agama does not uses the "dashed" form:
"es(ast)" instead of es-ast.

- [bsc#1236174](https://bugzilla.suse.com/show_bug.cgi?id=1236174)

## Solution

Use the "dashed" form in that case so systemd-firstboot is able to handle the keyboard.
