### PR TITLE
move sles and sles4sap to own packages

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 28 16:38:26 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- packages SLES and SLES4SAP in separate packages. Keep
+  agama-products-sle that will install both.
+
+-------------------------------------------------------------------
 Fri Jan 24 06:45:45 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Change the registration property in a product's definition to a

--- a/products.d/agama-products.spec
+++ b/products.d/agama-products.spec
@@ -55,17 +55,37 @@ Definition of openSUSE products (Tumbleweed, Leap, MicroOS and Slowroll) for the
 
 %package sle
 Summary:        Definition of SLE products for the Agama installer.
+Requires:       agama-products-sles
+Requires:       agama-products-sles_sap
 
 %description sle
 SLE-based products definition for Agama installer.
 Definition of SLE-based products (e.g., SUSE Linux Enterprise Server) for the Agama installer.
 
-%files sle
+%package sles
+Summary:        Definition of SLES product for the Agama installer.
+
+%description sles
+SLES product definition for Agama installer.
+
+%files sles
 %doc README.md
 %license LICENSE
 %dir %{_datadir}/agama
 %dir %{_datadir}/agama/products.d
 %{_datadir}/agama/products.d/sles_160.yaml
+
+%package sles_sap
+Summary:        Definition of SLES for SAP product for the Agama installer.
+
+%description sles_sap
+SLES for SAP product definition for Agama installer.
+
+%files sles_sap
+%doc README.md
+%license LICENSE
+%dir %{_datadir}/agama
+%dir %{_datadir}/agama/products.d
 %{_datadir}/agama/products.d/sles_sap_160.yaml
 
 %changelog


### PR DESCRIPTION
***Do not merge yet***

## Problem

If Offline medium should be one per base product it is not possible now.


## Solution

Split sle products into own packages and for backward compatibility keep previous name of both.


## Testing

- *testing IBS build with new sources at https://build.suse.de/package/show/home:jreidinger:branches:Devel:YaST:Agama:Head/agama-products



