### PR TITLE
Add support for translating ifcfg kernel cmdline argument to ip

### DIFF
--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/README
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/README
@@ -4,3 +4,20 @@ dracut agama-cmdline module
 This module writes any agama configuration given through the kernel cmdline
 to its own cmdline conf file copying it to the sysroot.
 
+It also tries to translate the linuxrc ifcfg kernel cmdline argument to the
+corresponding ip one but only basic scenarios are supported.
+
+## Supported examples
+
+  ifcfg=*=dhcp
+  ip=dhcp
+
+  ifcfg=eth0=dhcp
+  ip=eth0:dhcp
+
+  ifcfg=eth0.10=192.168.0.100/24,192.168.0.1
+  vlan=eth0.10:eth0 ip=192.168.0.100::192.168.0.1:24::eth0.10
+
+  ifcfg="eth0=192.168.0.33/24 10.0.0.100/24,192.168.0.1,192.168.0.1 10.0.0.1,suse.de"
+  ip=192.168.0.33::192.168.0.1:24::eth0 nameserver=192.168.0.1 nameserver=10.0.0.1 ip=10.0.0.100:::24::eth0
+

--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network-compat.sh
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network-compat.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+
+[ -e /dracut-state.sh ] && . /dracut-state.sh
+
+. /lib/dracut-lib.sh
+. /lib/net-lib.sh
+
+ifcfg_to_ip() {
+  local ip
+  local v="${2}",
+  local interface="$1"
+  local mac="$3"
+  local conf_path="/etc/cmdline.d/40-agama-network.conf"
+  set --
+  while [ -n "$v" ]; do
+    set -- "$@" "${v%%,*}"
+    v=${v#*,}
+  done
+
+  if [[ $# -eq 0 ]]; then
+    echo "IFCFG 0 options given, must be wrong"
+    return 1
+  fi
+
+  ### See https://en.opensuse.org/SDB:Linuxrc#Network_Config
+  # ifcfg=<interface_spec>=[try,]dhcp*,[rfc2132,]OPTION1=value1,OPTION2=value2...
+  if str_starts "$1" "dhcp"; then
+    autoconf="$1"
+    if [ "$autoconf" = "dhcp4" ]; then
+      echo "AUTOCONF"
+      autoconf="dhcp"
+    fi
+    case $autoconf in
+    "dhcp" | "dhcp6")
+      if [ "$interface" = "*" ]; then
+        echo "ip=${1}" >>"/etc/cmdline.d/40-agama-network.conf"
+      else
+        echo "ip=${interface}:${1}" >>$conf_path
+      fi
+      ;;
+    *)
+      echo "No supported option ${1}"
+      ;;
+    esac
+
+    return 0
+  fi
+
+  # ifcifg=<interface_spec>=ip,gateway,nameserver,domain
+  if strglob "$1" "*.*.*.*/*"; then
+    [[ -n "$2" ]] && gateway=$2
+    [[ -n "$3" ]] && nameserver=$3
+    [[ -n "$4" ]] && domain=$4
+
+    ip="$1 "
+    set --
+    while [ -n "$ip" ]; do
+      set -- "$@" "${ip%% *}"
+      ip="${ip#* }"
+    done
+
+    ## TODO: IP is a LIST_IP
+    ip="$1"
+    mask=${ip##*/}
+    ip=${ip%%/*}
+    shift
+
+    ## Configure the first interface, the gateway must belong to the same network
+    echo "ip=${ip}::${gateway}:$mask::${interface}" >>$conf_path
+
+    ## Configure multiple addresses for the same interface
+    while [[ $# -gt 0 ]]; do
+      ip="$1"
+      mask=${ip##*/}
+      ip=${ip%%/*}
+      echo "ip=${ip}:::$mask::${interface}" >>$conf_path
+      shift
+    done
+
+    ## Configure nameservers
+    if [[ -n $nameserver ]]; then
+      nameserver="$nameserver "
+      while [ -n "$nameserver" ]; do
+        echo "nameserver=${nameserver%% *}" >>$conf_path
+        nameserver="${nameserver#* }"
+      done
+    fi
+  fi
+
+  return 0
+}
+
+translate_ifcfg() {
+  local i
+  local first
+  local match
+  local vlan
+  local phydevice
+  local conf_path="/etc/cmdline.d/40-agama-network.conf"
+
+  while read i; do
+    set --
+    echo "### Processing $i ###"
+    set -- "$@" "${i%%=*}"
+    options="${i#*=}"
+    pattern="$1"
+    first=0
+    match=0
+    unset vlan phydevice
+
+    if str_starts "$options" "try,"; then
+      options="${i#*try,*}"
+      first=1
+    fi
+
+    # The pattern Looks like a VLAN like eth0.10
+    if strglobin "$pattern" "*.[0-9]*"; then
+      phydevice=${pattern%.*}
+      vlan="vlan=$1:$phydevice"
+      echo "$vlan" >>$conf_path
+      ifcfg_to_ip "$pattern" "$options"
+      continue
+    fi
+
+    # We cannot iterate over devices by now, therefore only '*' or an specific
+    # interface name is supported
+    #if [ "$pattern" = "*" ]; then
+    ifcfg_to_ip "$pattern" "$options"
+    continue
+    #fi
+
+    # nm-initrd-generator is executed too early and there are no
+    # devices at all, therefore this code does not make sense by now
+    for path in /sys/class/net/*; do
+      iface=${path##*/}
+      mac=$(cat "$path/address")
+      echo "   $path"
+      case $iface in
+      lo)
+        echo "Skipping lo interface"
+        continue
+        ;;
+      $pattern)
+        ifcfg_to_ip "$iface" "$options"
+        if [[ $first == 1 ]]; then
+          echo "try given, breaking"
+          match=1
+        fi
+        #if [ -n "$ip" ]; then
+        #  echo "ip=${ip}" >>"/etc/cmdline.d/agama_network.conf"
+        #fi
+        ;;
+      esac
+      case $mac in
+      $pattern)
+        ifcfg_to_ip "$iface" "$options" "$mac"
+        if [[ $first == 1 ]]; then
+          echo "try given, breaking"
+          match=1
+        fi
+        ;;
+      esac
+
+      if [[ "$match" -eq 1 ]] && [[ $first == 1 ]]; then
+        break
+      fi
+    done
+    echo
+
+    set --
+    unset options pattern
+  done <<<"$(getargs ifcfg=)"
+
+  unset CMDLINE
+  return 0
+}
+
+translate_ifcfg

--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network-compat.sh
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network-compat.sh
@@ -16,23 +16,18 @@ ifcfg_to_ip() {
     v=${v#*,}
   done
 
-  if [[ $# -eq 0 ]]; then
-    echo "IFCFG 0 options given, must be wrong"
-    return 1
-  fi
-
   ### See https://en.opensuse.org/SDB:Linuxrc#Network_Config
   # ifcfg=<interface_spec>=[try,]dhcp*,[rfc2132,]OPTION1=value1,OPTION2=value2...
   if str_starts "$1" "dhcp"; then
     autoconf="$1"
     if [ "$autoconf" = "dhcp4" ]; then
-      echo "AUTOCONF"
       autoconf="dhcp"
     fi
     case $autoconf in
     "dhcp" | "dhcp6")
       if [ "$interface" = "*" ]; then
-        echo "ip=${1}" >>"/etc/cmdline.d/40-agama-network.conf"
+        echo "ip=${1}" >>$conf_path
+
       else
         echo "ip=${interface}:${1}" >>$conf_path
       fi

--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/module-setup.sh
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/module-setup.sh
@@ -17,5 +17,6 @@ installkernel() {
 # called by dracut
 install() {
   inst_hook cmdline 99 "$moddir/agama-cmdline-conf.sh"
+  inst_hook cmdline 99 "$moddir/agama-network-compat.sh"
   inst_hook pre-pivot 99 "$moddir/save-agama-conf.sh"
 }

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Fri Jan 31 12:49:24 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Added support for giving a file url with extra kernel cmdline
+  arguments (agama.info) which was known as the info file in 
+  linuxrc.
+- Added basic support for translating the ifcfg kernel cmdline arg
+  to its ip equivalent (gh#agama-project/agama#1896).
+- Moved the kernel cmdline conf under /run/agama/cmdline.d
+
+-------------------------------------------------------------------
 Wed Jan 15 16:53:28 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Drop patterns-yast-yast2_basis requirement


### PR DESCRIPTION
## Problem

As there is no linuxrc in Agama we want to explore the possibility of translating linuxrc network-related boot arguments into the dracut equivalent (which is the supported and recommended method for the new installation media).

- https://jira.suse.com/browse/AGM-38
- https://trello.com/c/iCICenNT

## Solution

A basic translation of the **ifcfg** boot argument has being implemented as a prof of concept but as the nm-initrd-generator parses de cmdline as a cmdline hook it is too early for doing some kind of checks about the devices present in the system and trying to match against the device name and the mac address therefore any kind of pattern except the **'*'** wildcard.

**Supported examples**

- ifcfg=*=dhcp
  ip=dhcp

- ifcfg=eth0=dhcp
  ip=eth0:dhcp

- ifcfg=eth0.10=192.168.0.100/24,192.168.0.1
  vlan=eth0.10:eth0 ip=192.168.0.100::192.168.0.1:24::eth0.10

- ifcfg="eth0=192.168.0.33/24 10.0.0.100/24,192.168.0.1,192.168.0.1 10.0.0.1,suse.de"
  ip=192.168.0.33::192.168.0.1:24::eth0 nameserver=192.168.0.1 nameserver=10.0.0.1 ip=10.0.0.100:::24::eth0

The parser is also added as a cmdline hook, we explored the possibility to call it as a **initqueue/settle** hook, in that case we could try to call the **nm_generate_connections** function directly passing it the **getcmdline** result. At that point we can check the devices present in **/sys/class/net/** doing some filtering based in the name or mac address but for example the try function requires to run the configuration in order to check if the interface was configured or not for continuing trying... for that kind of support we might need to add it to NetworkManager and the nm-initrd-generator.

## Testing

- *Tested manually*

