### PR TITLE
feat(live): Implement the media check functionality

### DIFF
--- a/live/root/etc/systemd/system/checkmedia.service
+++ b/live/root/etc/systemd/system/checkmedia.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=Installation medium integrity check
+
+# before X11 because it switches the terminal to VT7
+Before=x11-autologin.service
+
+# copied from YaST2-Second-Stage.service
+Before=getty@tty1.service
+Before=getty@tty2.service
+Before=getty@tty3.service
+Before=getty@tty4.service
+Before=getty@tty5.service
+Before=getty@tty6.service
+Before=serial-getty@hvc0.service
+Before=serial-getty@sclp_line0.service
+Before=serial-getty@ttyAMA0.service
+Before=serial-getty@ttyS0.service
+Before=serial-getty@ttyS1.service
+Before=serial-getty@ttyS2.service
+Before=serial-getty@ttysclp0.service
+
+# kernel command line option
+ConditionKernelCommandLine=mediacheck=1
+
+[Service]
+Type=oneshot
+Environment=TERM=linux
+
+# disable the kernel output on the console
+ExecStartPre=dmesg --console-off
+# disable the systemd status messages on the console
+ExecStartPre=kill -SIGRTMIN+21 1
+
+ExecStart=checkmedia-service
+
+# enable back the kernel output on the console
+ExecStartPost=dmesg --console-on
+# enable back the systemd status messages on the console
+ExecStartPost=kill -SIGRTMIN+20 1
+
+StandardInput=tty
+RemainAfterExit=true
+TimeoutSec=0
+
+[Install]
+WantedBy=default.target

--- a/live/root/usr/bin/checkmedia-service
+++ b/live/root/usr/bin/checkmedia-service
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+# Note: the LIVE_MEDIUM_LABEL placeholder is replaced by the real label in config.sh script
+
+# get the partition where the live ISO is mounted, the real name is set by the
+# config.sh script which gets the live partition label name from KIWI
+disk=$(blkid -L "@@LIVE_MEDIUM_LABEL@@")
+
+if [ -z "$disk" ]; then
+  echo -e "\e[31mPartition \"@@LIVE_MEDIUM_LABEL@@\" not found, skipping media check\e[0m"
+  read -n1 -s -p "Press any key to continue... "
+  echo
+  exit 0
+fi
+
+echo "Checking data integrity of device $disk (@@LIVE_MEDIUM_LABEL@@)..."
+
+if checkmedia -v "$disk"; then
+  echo -e "\e[32mMedium check succeeded\e[0m"
+  read -n1 -s -p "Press any key to continue... "
+  echo
+else
+  echo -e "\e[31mERROR: Medium check failed!\e[0m"
+  echo "The installation medium is broken, it should not be used for installation."
+  read -n1 -s -p "Press any key to halt the system... "
+  echo
+  halt
+fi

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Feb  7 08:21:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Implemented media check functionality (bsc#1236103)
+
+-------------------------------------------------------------------
 Fri Feb  7 08:10:46 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Use better ISO Volume ID labels (bsc#1236401)

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -55,6 +55,7 @@ systemctl enable live-password-dialog.service
 systemctl enable live-password-iso.service
 systemctl enable live-password-random.service
 systemctl enable live-password-systemd.service
+systemctl enable checkmedia.service
 systemctl enable setup-systemd-proxy-env.path
 systemctl enable x11-autologin.service
 systemctl enable spice-vdagentd.service
@@ -92,6 +93,7 @@ fi
 
 # replace the @@LIVE_MEDIUM_LABEL@@ with the real Live partition label name from KIWI
 sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/live-password
+sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/checkmedia-service
 
 # Increase the Live ISO image size to have some extra free space for installing
 # additional debugging or development packages.


### PR DESCRIPTION
## Problem

- Selecting the "Mediacheck" boot option does nothing, it just starts Agama as usually

## Solution

- Implement a systemd service which runs the `mediacheck` tool when the `mediacheck=1` boot option is used

## Details

- After finishing the check Agama starts as usually
- When the check fails then the system is halted to prevent from using a broken medium. (Of course, user can always reboot the system manually and use it anyway, but we should clearly indicate that it is a bad idea.)

## Testing

- Tested manually

## Screenshots

![agama-mediacheck](https://github.com/user-attachments/assets/9966d275-6bb5-4006-b4ad-74eef9f95e8a)


