### PR TITLE
Install dir

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -481,13 +481,11 @@ module Agama
         # path to cdrom which can contain installation repositories
         dir_path = "/run/initramfs/live/install"
 
-        if File.exist?(dir_path)
-          logger.info "/install found on source cd"
-          repositories.add("dir://" + dir_path)
-          return true
-        end
+        return false unless File.exist?(dir_path)
 
-        false
+        logger.info "/install found on source cd"
+        repositories.add("dir://" + dir_path)
+        true
       end
 
       def add_repos_by_label

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 29 16:28:32 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Allow reading repository in /install directory on iso
+  (jsc#PED-10405)
+
+-------------------------------------------------------------------
 Fri Jan 24 09:33:27 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Introduce a new installation phase "finish"


### PR DESCRIPTION
## Problem

For full offline medium support we need to check also if there is repositories in `/install` on medium.


## Solution

Add support to detect it and use it if found.
Note: live `/` is not the one from iso, so it needs to check mounted initramfs


## Testing

- *Tested manually*