### PR TITLE
Fixed GitHub pages build and deployment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install DocBook tooling
         run: |
           sudo apt-get update
-          sudo apt-get --assume-yes --no-install-recommends install xmlto docbook-xsl xmlstarlet
+          sudo apt-get --assume-yes --no-install-recommends install xmlto docbook-xsl xmlstarlet libglib2.0-dev
 
       - name: Build HTML via DocBook
         run: make -C doc
@@ -55,14 +55,14 @@ jobs:
         run: cd web && npm run typedoc && mv typedoc.out/ ../doc/dist/web-ui
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # upload the built docs
           path: 'doc/dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

- The GitHub pages deployment fails for about a month: https://github.com/agama-project/agama/deployments

## Details

There are several problems:

- The old artifact actions are deprecated and not supported anymore : https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
- The `gdbus-codegen` is not available, probably because of newer Ubuntu version or the they changed the default image content

## Testing

- Tested manually in my fork, it builds and deploys fine to https://lslezak.github.io/agama/ 
