### PR TITLE
live: fix_bootconfig.s390x: use initrd.ofs for the initrd offset filename

### DIFF
--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -5,6 +5,8 @@
 # https://github.com/openSUSE/agama/issues/1609
 # KIWI config
 
+set -e
+
 dst="$1"
 
 if [ ! -d "$dst" ] ; then

--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -37,6 +37,8 @@
 #     └── bootinfo.txt
 #
 
+set -e
+
 dst="$1"
 
 if [ ! -d "$dst" ] ; then

--- a/live/config-cdroot/fix_bootconfig.s390x
+++ b/live/config-cdroot/fix_bootconfig.s390x
@@ -40,6 +40,8 @@
 # └── susehmc.ins
 #
 
+set -e
+
 dst="$1"
 
 if [ ! -d "$dst" ] ; then

--- a/live/config-cdroot/fix_bootconfig.s390x
+++ b/live/config-cdroot/fix_bootconfig.s390x
@@ -29,7 +29,7 @@
 # │   └── s390x
 # │       ├── cd.ikr
 # │       ├── initrd
-# │       ├── initrd.off
+# │       ├── initrd.ofs
 # │       ├── initrd.siz
 # │       ├── linux
 # │       ├── parmfile
@@ -97,8 +97,8 @@ initrd_siz_ofs=0x00010414
 initrd_ofs=0x01000000
 parmfile_ofs=0x00010480
 
-# Create initrd.off (note: 32 bit, stored in big endian).
-printf "%08x" $((initrd_ofs)) | xxd -r -p - $boot_dir/initrd.off
+# Create initrd.ofs (note: 32 bit, stored in big endian).
+printf "%08x" $((initrd_ofs)) | xxd -r -p - $boot_dir/initrd.ofs
 
 # Create initrd.siz (note: 32 bit, stored in big endian).
 read initrd_size x < <(du -b $boot_dir/initrd)
@@ -108,7 +108,7 @@ printf "%08x" $((initrd_size)) | xxd -r -p - $boot_dir/initrd.siz
 cat >$boot_dir/suse.ins <<XXX
 * SUSE Linux for IBM z Systems Installation System
 linux 0x00000000
-initrd.off $initrd_ofs_ofs
+initrd.ofs $initrd_ofs_ofs
 initrd.siz $initrd_siz_ofs
 initrd $initrd_ofs
 parmfile $parmfile_ofs
@@ -118,7 +118,7 @@ XXX
 cat >$dst/suse.ins <<XXX
 * SUSE Linux for IBM z Systems Installation System
 boot/s390x/linux 0x00000000
-boot/s390x/initrd.off $initrd_ofs_ofs
+boot/s390x/initrd.ofs $initrd_ofs_ofs
 boot/s390x/initrd.siz $initrd_siz_ofs
 boot/s390x/initrd $initrd_ofs
 boot/s390x/parmfile $parmfile_ofs
@@ -128,7 +128,7 @@ XXX
 cat >$dst/susehmc.ins <<XXX
 * SUSE Linux for IBM z Systems Installation System via HMC
 boot/s390x/linux 0x00000000
-boot/s390x/initrd.off $initrd_ofs_ofs
+boot/s390x/initrd.ofs $initrd_ofs_ofs
 boot/s390x/initrd.siz $initrd_siz_ofs
 boot/s390x/initrd $initrd_ofs
 boot/s390x/parmfile.hmc $parmfile_ofs
@@ -158,7 +158,7 @@ XXX
 
 # Create cd.ikr with all the file blobs mentioned in suse.ins.
 dd status=none if=$boot_dir/linux of=$boot_dir/cd.ikr
-dd status=none conv=notrunc obs=1 seek=$((initrd_ofs_ofs)) if=$boot_dir/initrd.off of=$boot_dir/cd.ikr
+dd status=none conv=notrunc obs=1 seek=$((initrd_ofs_ofs)) if=$boot_dir/initrd.ofs of=$boot_dir/cd.ikr
 dd status=none conv=notrunc obs=1 seek=$((initrd_siz_ofs)) if=$boot_dir/initrd.siz of=$boot_dir/cd.ikr
 dd status=none conv=notrunc obs=4096 seek=$((initrd_ofs/4096)) if=$boot_dir/initrd of=$boot_dir/cd.ikr
 # clear kernel cmdline area; it's actually 4 kiB, but 1 block should be more than enough

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -5,6 +5,8 @@
 # https://github.com/openSUSE/agama/issues/1609
 # KIWI config
 
+set -e
+
 dst="$1"
 
 if [ ! -d "$dst" ] ; then

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb  3 23:01:37 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- fix_bootimage: exit on failures (gh#agama-project/agama#1969)
+
+-------------------------------------------------------------------
 Mon Jan 20 10:37:43 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add SUSE licenses (jsc#PED-11987).

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb  3 23:08:34 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- live: fix_bootconfig.s390x: use initrd.ofs for the initrd
+  offset filename (gh#agama-project/agama#1969)
+
+-------------------------------------------------------------------
 Mon Feb  3 23:01:37 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - fix_bootimage: exit on failures (gh#agama-project/agama#1969)


### PR DESCRIPTION
## Problem

mksusecd expects the offset to be written in initrd.ofs.

## Solution

Change the filename from `initrd.off` to `initrd.ofs` to match what mksuse expects.

This fixes building of "combined" Full offline images on s390x.

This pull request also adds a commit that ensures that the arch-specific `fix_bootconfig` scripts exit at the first failure.
`xxd` is not available in the build environment (in SLFO:Main at least), so `initrd.off` (now `.ofs`) and `initrd.siz` were never being created in the first place. Exiting as soon as the first failure will hopefully help us catch this kind of bugs earlier :smile: 

**NOTE:** due to this, s390x builds might fail if xxd is not present. This OBS prjconf snippet should ensure that it is getting installed on image builds:

```
Substitute: kiwi-image:iso    kiwi-systemdeps-iso-media qemu-tools xxd
```

## Testing

- *Tested manually*

