### PR TITLE
Disable the local media in the installed system (bsc#1236813)

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -201,10 +201,16 @@ module Agama
 
       # Writes the repositories information to the installed system
       def finish
+        # remove the dir:///run/initramfs/live/install repository and similar
+        remove_local_repos
         Yast::Pkg.SourceSaveAll
         Yast::Pkg.TargetFinish
         # copy the libzypp caches to the target
-        copy_zypp_to_target
+        if Agama::Software::Repository.all.empty?
+          logger.info("No repository defined, not copying the libzypp caches")
+        else
+          copy_zypp_to_target
+        end
         registration.finish
       end
 
@@ -699,6 +705,11 @@ module Agama
           # to write the repository setup to the disk
           Yast::Pkg.SourceSaveAll
         end
+      end
+
+      # remove all local repositories
+      def remove_local_repos
+        Agama::Software::Repository.all.select(&:local?).each(&:delete!)
       end
     end
   end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  5 14:32:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Disable the local media in the installed system, esp. the
+  offline repository with URL dir:///run/initramfs/live/install
+  (bsc#1236813)
+
+-------------------------------------------------------------------
 Wed Jan 29 16:28:32 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow reading repository in /install directory on iso

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -446,7 +446,9 @@ describe Agama::Software::Manager do
               repo_id: repo_id, repo_alias: "alias", name: "name",
               url: "dir:///run/initramfs/live/install", enabled: true, autorefresh: false
             )
-          ]
+          ],
+          # for the second and further calls return empty list, the repo has been removed
+          []
         )
       end
 

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -384,6 +384,15 @@ describe Agama::Software::Manager do
     end
 
     it "copies the libzypp cache and credentials to the target system" do
+      allow(Agama::Software::Repository).to receive(:all).and_return(
+        [
+          Agama::Software::Repository.new(
+            repo_id: 42, repo_alias: "alias", name: "name",
+            url: "http://example.com", enabled: true, autorefresh: false
+          )
+        ]
+      )
+
       allow(Dir).to receive(:exist?).and_call_original
       allow(Dir).to receive(:entries).and_call_original
 


### PR DESCRIPTION
## Problem

- When installing SLE16 from the offline medium the initial installation repository is present in the installed system
- However it cannot be reached with URL `dir:///run/initramfs/live/install`, that directory does not exist in installed system
- See https://bugzilla.suse.com/show_bug.cgi?id=1236813

## Solution

- Simply remove the repository, 

## Testing

- Added a new unit test
- Tested manually, when using the offline medium there is no repository defined in the installed system

## Notes

- Some unrelated Rspec test fails, but that happened even before these changes :worried: 
