### PR TITLE
Button to add a drive to the storage proposal

### DIFF
--- a/web/src/components/core/MenuHeader.tsx
+++ b/web/src/components/core/MenuHeader.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) [2023-2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Flex, Content } from "@patternfly/react-core";
+import spacingStyles from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+export type MenuHeaderProps = { title: string; description: React.ReactNode };
+
+/**
+ * Renders the content to be used at a menu entry describing subsequent options.
+ * @component
+ *
+ * @param title - Short sentence describing the functionality.
+ * @param descriptions - Extra details rendered with a smaller font.
+ */
+export default function MenuHeader({ title, description }: MenuHeaderProps) {
+  return (
+    <Flex
+      direction={{ default: "column" }}
+      gap={{ default: "gapXs" }}
+      className={[spacingStyles.pxMd, spacingStyles.pyXs].join(" ")}
+    >
+      <Content component="h4">{title}</Content>
+      {description && <small>{description}</small>}
+    </Flex>
+  );
+}

--- a/web/src/components/core/index.ts
+++ b/web/src/components/core/index.ts
@@ -46,3 +46,4 @@ export { default as EmptyState } from "./EmptyState";
 export { default as InstallerOptions } from "./InstallerOptions";
 export { default as IssuesDrawer } from "./IssuesDrawer";
 export { default as Drawer } from "./Drawer";
+export { default as MenuHeader } from "./MenuHeader";

--- a/web/src/components/storage/AddExistingDeviceMenu.test.tsx
+++ b/web/src/components/storage/AddExistingDeviceMenu.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, within } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+import AddExistingDeviceMenu from "~/components/storage/AddExistingDeviceMenu";
+import { StorageDevice } from "~/types/storage";
+import * as ConfigModel from "~/api/storage/types/config-model";
+
+const vda: StorageDevice = {
+  sid: 59,
+  type: "disk",
+  isDrive: true,
+  description: "",
+  vendor: "Micron",
+  model: "Micron 1100 SATA",
+  driver: ["ahci", "mmcblk"],
+  bus: "IDE",
+  name: "/dev/vda",
+  size: 1e12,
+  systems: ["Windows 11", "openSUSE Leap 15.2"],
+};
+
+const vdb: StorageDevice = {
+  sid: 60,
+  type: "disk",
+  isDrive: true,
+  description: "",
+  vendor: "Seagate",
+  model: "Unknown",
+  driver: ["ahci", "mmcblk"],
+  bus: "IDE",
+  name: "/dev/vdb",
+  size: 1e6,
+  systems: [],
+};
+
+const vdaDrive: ConfigModel.Drive = {
+  name: "/dev/vda",
+  spacePolicy: "delete",
+  partitions: [],
+};
+
+const vdbDrive: ConfigModel.Drive = {
+  name: "/dev/vdb",
+  spacePolicy: "delete",
+  partitions: [],
+};
+
+const mockUseConfigModelFn = jest.fn();
+const mockAddDriveFn = jest.fn();
+
+jest.mock("~/queries/storage", () => ({
+  ...jest.requireActual("~/queries/storage"),
+  useConfigModel: () => mockUseConfigModelFn(),
+  useAvailableDevices: () => [vda, vdb],
+  useModel: () => ({ addDrive: mockAddDriveFn }),
+}));
+
+describe("when there are unused disks", () => {
+  beforeEach(() => {
+    mockUseConfigModelFn.mockReturnValue({ drives: [] });
+  });
+
+  it("renders the menu", async () => {
+    plainRender(<AddExistingDeviceMenu />);
+    expect(screen.queryByText(/Use additional disk/)).toBeInTheDocument();
+  });
+
+  it("allows users to add a new drive", async () => {
+    const { user } = plainRender(<AddExistingDeviceMenu />);
+
+    const button = screen.getByRole("button", { name: /Use additional/ });
+    await user.click(button);
+    const devicesMenu = screen.getByRole("menu");
+    const vdaItem = within(devicesMenu).getByRole("menuitem", { name: /vda/ });
+    await user.click(vdaItem);
+    expect(mockAddDriveFn).toHaveBeenCalled();
+  });
+});
+
+describe("when there are no more unused disks", () => {
+  beforeEach(() => {
+    mockUseConfigModelFn.mockReturnValue({ drives: [vdaDrive, vdbDrive] });
+  });
+
+  it("renders nothing", async () => {
+    plainRender(<AddExistingDeviceMenu />);
+    expect(screen.queryByText(/Use additional disk/)).toBeNull();
+  });
+});

--- a/web/src/components/storage/AddExistingDeviceMenu.tsx
+++ b/web/src/components/storage/AddExistingDeviceMenu.tsx
@@ -80,6 +80,7 @@ export default function AddExistingDeviceMenu() {
       )}
     >
       <DropdownList>
+        {/* @ts-ignore:next-line See https://github.com/patternfly/patternfly/issues/7327 */}
         <DropdownGroup label={<Header drives={model.drives} />}>
           <Divider />
           {devices.map((device) => (

--- a/web/src/components/storage/AddExistingDeviceMenu.tsx
+++ b/web/src/components/storage/AddExistingDeviceMenu.tsx
@@ -80,7 +80,7 @@ export default function AddExistingDeviceMenu() {
       )}
     >
       <DropdownList>
-        {/* @ts-ignore:next-line See https://github.com/patternfly/patternfly/issues/7327 */}
+        {/* @ts-expect-error See https://github.com/patternfly/patternfly/issues/7327 */}
         <DropdownGroup label={<Header drives={model.drives} />}>
           <Divider />
           {devices.map((device) => (

--- a/web/src/components/storage/AddExistingDeviceMenu.tsx
+++ b/web/src/components/storage/AddExistingDeviceMenu.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import { _, n_ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+import {
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  DropdownGroup,
+  MenuToggleElement,
+  MenuToggle,
+  Divider,
+} from "@patternfly/react-core";
+import { MenuHeader } from "~/components/core";
+import MenuDeviceDescription from "./MenuDeviceDescription";
+import { useAvailableDevices, useConfigModel, useModel } from "~/queries/storage";
+import { deviceLabel } from "~/components/storage/utils";
+
+export default function AddExistingDeviceMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = () => setIsOpen(!isOpen);
+  const allDevices = useAvailableDevices();
+  const model = useConfigModel({ suspense: true });
+  const modelHook = useModel();
+
+  const drivesNames = model.drives.map((d) => d.name);
+  const devices = allDevices.filter((d) => !drivesNames.includes(d.name));
+
+  const Header = ({ drives }) => {
+    const desc = sprintf(
+      n_(
+        "Extends the installation beyond the currently selected disk",
+        "Extends the installation beyond the current %d disks",
+        drives.length,
+      ),
+      drives.length,
+    );
+
+    return <MenuHeader title={_("Select another disk to define partitions")} description={desc} />;
+  };
+
+  if (!devices.length) return null;
+
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onOpenChange={toggle}
+      onSelect={toggle}
+      onActionClick={toggle}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={toggle}
+          aria-label={_("Use additional disk toggle")}
+          isExpanded={isOpen}
+        >
+          {_("Use additional disk")}
+        </MenuToggle>
+      )}
+    >
+      <DropdownList>
+        <DropdownGroup label={<Header drives={model.drives} />}>
+          <Divider />
+          {devices.map((device) => (
+            <DropdownItem
+              key={device.sid}
+              description={<MenuDeviceDescription device={device} />}
+              onClick={() => modelHook.addDrive(device.name)}
+            >
+              {deviceLabel(device)}
+            </DropdownItem>
+          ))}
+        </DropdownGroup>
+      </DropdownList>
+    </Dropdown>
+  );
+}

--- a/web/src/components/storage/ConfigEditorMenu.tsx
+++ b/web/src/components/storage/ConfigEditorMenu.tsx
@@ -56,7 +56,6 @@ export default function ConfigEditorMenu() {
       )}
     >
       <DropdownList>
-        <DropdownItem key="disk">{_("Use additional disk")}</DropdownItem>
         <DropdownItem key="vg">{_("Add LVM volume group")}</DropdownItem>
         <DropdownItem key="raid">{_("Add MD RAID")}</DropdownItem>
         <Divider />

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -33,6 +33,8 @@ import { useDrive, usePartition } from "~/queries/storage/config-model";
 import * as driveUtils from "~/components/storage/utils/drive";
 import { typeDescription, contentDescription } from "~/components/storage/utils/device";
 import { Icon } from "../layout";
+import { MenuHeader } from "~/components/core";
+import MenuDeviceDescription from "./MenuDeviceDescription";
 import {
   Card,
   CardBody,
@@ -42,7 +44,6 @@ import {
   Flex,
   Label,
   Split,
-  Stack,
   Menu,
   MenuContainer,
   MenuContent,
@@ -53,7 +54,6 @@ import {
   MenuToggleProps,
   MenuToggleElement,
   MenuGroup,
-  Content,
 } from "@patternfly/react-core";
 
 import spacingStyles from "@patternfly/react-styles/css/utilities/Spacing/spacing";
@@ -70,17 +70,6 @@ export const InlineMenuToggle = React.forwardRef(
       {...props}
     />
   ),
-);
-
-const MenuHeader = ({ title, description }) => (
-  <Flex
-    direction={{ default: "column" }}
-    gap={{ default: "gapXs" }}
-    className={[spacingStyles.pxMd, spacingStyles.pyXs].join(" ")}
-  >
-    <Content component="h4">{title}</Content>
-    {description && <small>{description}</small>}
-  </Flex>
 );
 
 // FIXME: Presentation is quite poor
@@ -287,25 +276,6 @@ const SearchSelectorMultipleOptions = ({ selected, withNewVg = false, onChange }
   const navigate = useNavigate();
   const devices = useAvailableDevices();
 
-  // FIXME: Presentation is quite poor
-  const DeviceDescription = ({ device }) => {
-    return (
-      <Stack>
-        <Split hasGutter>
-          <span>{typeDescription(device)}</span>
-          <span>{contentDescription(device)}</span>
-        </Split>
-        <Split hasGutter>
-          {device.systems.map((s, i) => (
-            <Label key={i} isCompact>
-              {s}
-            </Label>
-          ))}
-        </Split>
-      </Stack>
-    );
-  };
-
   const NewVgOption = () => {
     if (withNewVg)
       return (
@@ -334,7 +304,7 @@ const SearchSelectorMultipleOptions = ({ selected, withNewVg = false, onChange }
             key={device.sid}
             itemId={device.sid}
             isSelected={isSelected}
-            description={<DeviceDescription device={device} />}
+            description={<MenuDeviceDescription device={device} />}
             onClick={() => onChange(device.name)}
           >
             <Name />

--- a/web/src/components/storage/MenuDeviceDescription.tsx
+++ b/web/src/components/storage/MenuDeviceDescription.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) [2023-2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Stack, Split, Label } from "@patternfly/react-core";
+import { typeDescription, contentDescription } from "~/components/storage/utils/device";
+import { StorageDevice } from "~/types/storage";
+
+/**
+ * Renders the content to be used at a menu entry describing a device.
+ * @component
+ *
+ * @param device - Device to represent
+ */
+export default function MenuDeviceDescription({ device }: { device: StorageDevice }) {
+  return (
+    <Stack>
+      <Split hasGutter>
+        <span>{typeDescription(device)}</span>
+        <span>{contentDescription(device)}</span>
+      </Split>
+      <Split hasGutter>
+        {device.systems.map((s, i) => (
+          <Label key={i} isCompact>
+            {s}
+          </Label>
+        ))}
+      </Split>
+    </Stack>
+  );
+}

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -29,6 +29,7 @@ import ProposalResultSection from "./ProposalResultSection";
 import ProposalTransactionalInfo from "./ProposalTransactionalInfo";
 import ConfigEditor from "./ConfigEditor";
 import ConfigEditorMenu from "./ConfigEditorMenu";
+import AddExistingDeviceMenu from "./AddExistingDeviceMenu";
 import { toValidationError } from "~/utils";
 import { useIssues } from "~/queries/issues";
 import { IssueSeverity } from "~/types/issues";
@@ -91,6 +92,9 @@ export default function ProposalPage() {
               actions={
                 <>
                   <SplitItem isFilled> </SplitItem>
+                  <SplitItem>
+                    <AddExistingDeviceMenu />
+                  </SplitItem>
                   <SplitItem>
                     <ConfigEditorMenu />
                   </SplitItem>

--- a/web/src/queries/storage/config-model.ts
+++ b/web/src/queries/storage/config-model.ts
@@ -168,6 +168,15 @@ function switchDrive(
   return model;
 }
 
+function addDrive(originalModel: configModel.Config, driveName: string): configModel.Config {
+  if (findDrive(originalModel, driveName)) return;
+
+  const model = copyModel(originalModel);
+  model.drives.push({ name: driveName });
+
+  return model;
+}
+
 function setCustomSpacePolicy(
   originalModel: configModel.Config,
   driveName: string,
@@ -320,5 +329,21 @@ export function useDrive(name: string): DriveHook | undefined {
       mutate(setSpacePolicy(model, name, policy, actions));
     },
     delete: () => mutate(removeDrive(model, name)),
+  };
+}
+
+/**
+ * Hook for operating on the collections of the model.
+ */
+export type ModelHook = {
+  addDrive: (driveName: string) => void;
+};
+
+export function useModel(): ModelHook {
+  const model = useConfigModel();
+  const { mutate } = useConfigModelMutation();
+
+  return {
+    addDrive: (driveName) => mutate(addDrive(model, driveName)),
   };
 }


### PR DESCRIPTION
Adds the following button to the new storage UI.

![addDrive](https://github.com/user-attachments/assets/3cbc6bab-a8d4-4907-b27e-372feb6a20c0)

If there are no extra devices to add, the button is not displayed.

### Testing

- Tested manually (see screenshot)
- Added unit test for the new menu component