### PR TITLE
add error context: Failed to run agama-autoyast

### DIFF
--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -51,7 +51,8 @@ impl AutoyastProfileImporter {
         let tmp_dir = TempDir::with_prefix(TMP_DIR_PREFIX)?;
         Command::new("agama-autoyast")
             .args([url.as_str(), &tmp_dir.path().to_string_lossy()])
-            .status()?;
+            .status()
+            .context("Failed to run agama-autoyast")?;
 
         let autoinst_json = tmp_dir.path().join(AUTOINST_JSON);
         let content = fs::read_to_string(autoinst_json)?;


### PR DESCRIPTION
## Problem

it says "No such file or directory" when I pass an existing profile. It turns out it cannot find a helper _program_

Encountered when trying to run something from a git checkout, it probably works fine on our ISO

## Solution

Add context to the error

## Testing

- Tested manually

## Screenshots

No
