### PR TITLE
fix(storage): adapt tests to BLS requirements

### DIFF
--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  7 16:16:14 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Adapt tests to use the BLS size requirements
+  (gh#agama-project/agama#1979).
+
+-------------------------------------------------------------------
 Wed Feb  5 14:32:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Disable the local media in the installed system, esp. the

--- a/service/test/agama/storage/autoyast_proposal_test.rb
+++ b/service/test/agama/storage/autoyast_proposal_test.rb
@@ -42,7 +42,7 @@ describe Agama::Storage::Proposal do
   let(:scenario) { "windows-linux-pc.yml" }
 
   let(:arch) do
-    instance_double(Y2Storage::Arch, efiboot?: true, ram_size: 4.GiB.to_i)
+    instance_double(Y2Storage::Arch, x86?: true, efiboot?: true, ram_size: 4.GiB.to_i)
   end
 
   let(:config_path) do
@@ -121,7 +121,7 @@ describe Agama::Storage::Proposal do
           expect(efi).to have_attributes(
             filesystem_type:       Y2Storage::Filesystems::Type::VFAT,
             filesystem_mountpoint: "/boot/efi",
-            size:                  512.MiB
+            size:                  1.GiB
           )
 
           expect(root).to have_attributes(
@@ -292,7 +292,7 @@ describe Agama::Storage::Proposal do
           filesystem_type:       Y2Storage::Filesystems::Type::VFAT,
           filesystem_mountpoint: "/boot/efi",
           id:                    Y2Storage::PartitionId::ESP,
-          size:                  512.MiB
+          size:                  1.GiB
         )
       end
 


### PR DESCRIPTION
BLS is now used by default and it requires 1 GiB instead of 512 MiB, see https://github.com/yast/yast-storage-ng/pull/1396.
