### PR TITLE
First version of an improved Proposal error alert

### DIFF
--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { Alert } from "@patternfly/react-core";
+import { Alert, Content } from "@patternfly/react-core";
 import { _, n_, formatList } from "~/i18n";
 import { useIssues } from "~/queries/issues";
 import { useConfigModel } from "~/queries/storage";
@@ -34,11 +34,11 @@ function Description({ partitions }) {
 
   if (!newPartitions.length) {
     return (
-      <p>
+      <Content>
         {_(
           "It is not possible to install the system with the current configuration. Adjust the settings below.",
         )}
-      </p>
+      </Content>
     );
   }
 
@@ -57,15 +57,16 @@ function Description({ partitions }) {
 
   return (
     <>
-      <p>{msg1}</p>
-      <p>{_("Adjust the settings below to make the new system fit into the available space.")}</p>
+      <Content>{msg1}</Content>
+      <Content>
+        {_("Adjust the settings below to make the new system fit into the available space.")}
+      </Content>
     </>
   );
 }
 
 /**
  * Information about a failed storage proposal
- * @component
  *
  */
 export default function ProposalFailedInfo() {

--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -27,6 +27,7 @@ import { useIssues } from "~/queries/issues";
 import { useConfigModel } from "~/queries/storage";
 import { IssueSeverity } from "~/types/issues";
 import * as partitionUtils from "~/components/storage/utils/partition";
+import { sprintf } from "sprintf-js";
 
 function Description({ partitions }) {
   const newPartitions = partitions.filter((p) => !p.name);

--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Alert } from "@patternfly/react-core";
+import { _, n_, formatList } from "~/i18n";
+import { useIssues } from "~/queries/issues";
+import { useConfigModel } from "~/queries/storage";
+import { IssueSeverity } from "~/types/issues";
+import * as partitionUtils from "~/components/storage/utils/partition";
+
+function Description({ partitions }) {
+  const newPartitions = partitions.filter((p) => !p.name);
+
+  if (!newPartitions.length) {
+    return (
+      <p>
+        {_(
+          "It is not possible to install the system with the current configuration. Adjust the settings below.",
+        )}
+      </p>
+    );
+  }
+
+  const mountPaths = newPartitions.map((p) => partitionUtils.pathWithSize(p));
+  const msg1 = sprintf(
+    // TRANSLATORS: %s is a list of formatted mount points with a partition size like
+    // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)'
+    // (or a single mount point in the singular case).
+    n_(
+      "It is not possible to allocate the requested partition for %s.",
+      "It is not possible to allocate the requested partitions for %s.",
+      mountPaths.length,
+    ),
+    formatList(mountPaths),
+  );
+
+  return (
+    <>
+      <p>{msg1}</p>
+      <p>{_("Adjust the settings below to make the new system fit into the available space.")}</p>
+    </>
+  );
+}
+
+/**
+ * Information about a failed storage proposal
+ * @component
+ *
+ */
+export default function ProposalFailedInfo() {
+  const errors = useIssues("storage").filter((s) => s.severity === IssueSeverity.Error);
+  const model = useConfigModel({ suspense: true });
+
+  if (!errors.length) return;
+
+  const modelPartitions = model.drives.flatMap((d) => d.partitions || []);
+
+  return (
+    <Alert variant="warning" title={_("Failed to calculate a storage layout")}>
+      <Description partitions={modelPartitions} />
+    </Alert>
+  );
+}

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -21,12 +21,13 @@
  */
 
 import React from "react";
-import { Alert, Content, Grid, GridItem, SplitItem } from "@patternfly/react-core";
+import { Content, Grid, GridItem, SplitItem } from "@patternfly/react-core";
 import { Page } from "~/components/core/";
 import { Loading } from "~/components/layout";
 import EncryptionField from "~/components/storage/EncryptionField";
 import ProposalResultSection from "./ProposalResultSection";
 import ProposalTransactionalInfo from "./ProposalTransactionalInfo";
+import ProposalFailedInfo from "./ProposalFailedInfo";
 import ConfigEditor from "./ConfigEditor";
 import ConfigEditorMenu from "./ConfigEditorMenu";
 import AddExistingDeviceMenu from "./AddExistingDeviceMenu";
@@ -75,13 +76,7 @@ export default function ProposalPage() {
       <Page.Content>
         <Grid hasGutter>
           <ProposalTransactionalInfo />
-          {!validProposal && (
-            <Alert variant="warning" title={_("Storage proposal not possible")}>
-              {errors.map((e, i) => (
-                <div key={i}>{e.message}</div>
-              ))}
-            </Alert>
-          )}
+          <ProposalFailedInfo />
 
           <GridItem sm={12} xl={8}>
             <Page.Section

--- a/web/src/components/storage/utils/drive.tsx
+++ b/web/src/components/storage/utils/drive.tsx
@@ -25,7 +25,6 @@
 import { _, n_, formatList } from "~/i18n";
 import { configModel } from "~/api/storage/types";
 import { SpacePolicy, SPACE_POLICIES, baseName, formattedPath } from "~/components/storage/utils";
-import * as partitionUtils from "~/components/storage/utils/partition";
 import { sprintf } from "sprintf-js";
 
 /**
@@ -127,11 +126,10 @@ const contentDescription = (drive: configModel.Drive): string => {
   }
 
   if (reusedPartitions.length === 0) {
-    const mountPaths = newPartitions.map((p) => partitionUtils.pathWithSize(p));
+    const mountPaths = newPartitions.map((p) => formattedPath(p.mountPath));
     return sprintf(
-      // TRANSLATORS: %s is a list of formatted mount points with a partition size like
-      // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)'
-      // (or a single mount point in the singular case).
+      // TRANSLATORS: %s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
+      // single mount point in the singular case).
       n_(
         "A new partition will be created for %s",
         "New partitions will be created for %s",


### PR DESCRIPTION
## Problem

The current error displayed when the proposal failed is not good enough, we just moved the content from the old "result" box (that is not displayed anymore if the proposal is not possible) to an alert at the top of the screen. But we never adapted the texts.

## Solution

We want a better error that gives the user some hint of what's going on. This is a first version.

![failed_proposal_step1](https://github.com/user-attachments/assets/7b3ce79d-d9b1-4519-8d0d-a901a885a8ab)

## Future

The is room for improvements, like adding texts explaining the impact of disabling Btrfs snapshots and so on. But we need to move fast, so we agreed to not invest too much for now.

https://github.com/ancorgs/agama/pull/2 is a draft pull request on top of this one that shows all the information that could be displayed. But it needs more work regarding code organization, look&feel and wording.