### PR TITLE
Make the "lang" URL query optional

### DIFF
--- a/rust/agama-server/src/web/http.rs
+++ b/rust/agama-server/src/web/http.rs
@@ -100,8 +100,8 @@ pub async fn login(
 pub struct LoginFromQueryParams {
     /// Token to use for authentication.
     token: String,
-    /// Requested locale
-    lang: String,
+    /// Optional requested locale
+    lang: Option<String>,
 }
 
 #[utoipa::path(get, path = "/login", responses(
@@ -126,8 +126,10 @@ pub async fn login_from_query(
     let mut target = String::from("/");
 
     // keep the "lang" URL query if it was present in the original request
-    if !&params.lang.is_empty() {
-        target.push_str(format!("?lang={}", params.lang).as_str());
+    if let Some(lang) = params.lang {
+        if !lang.is_empty() {
+            target.push_str(format!("?lang={}", lang).as_str());
+        }
     }
 
     let location = HeaderValue::from_str(target.as_str());

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 10 13:28:34 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixup: Make the "lang" URL query optional, do not fail when it
+  is missing. This fixes crash on non-UEFI systems.
+
+-------------------------------------------------------------------
 Fri Feb  7 11:03:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Forward the "lang" URL query parameter when redirecting in the


### PR DESCRIPTION
## Problem

- Agama fails starting locally on non-UEFI systems

![agama-missing-lang](https://github.com/user-attachments/assets/f9ae44bb-e15c-469f-b1e4-14189989c324)

## Details

- The `lang` URL parameter is used only in UEFI systems, on other systems it is not defined/used.
- It is related to #1924

## Solution

- Make the `lang` URL query parameter optional

## Testing

- Tested manually in bot UEFI and non-UEFI (standard BIOS) systems

