### PR TITLE
Fixed possible double timeout (bsc#1236820)

### DIFF
--- a/service/lib/agama/software/repositories_manager.rb
+++ b/service/lib/agama/software/repositories_manager.rb
@@ -71,7 +71,11 @@ module Agama
         repositories.each do |repo|
           if repo.probe
             repo.enable!
-            repo.refresh
+            # In some rare scenarios although the repository probe succeeded the refresh might fail
+            # with network timeout. In that case disable the repository to avoid implicitly
+            # refreshing it again in the Pkg.SourceLoad call which could time out again, effectively
+            # doubling the total timeout.
+            repo.disable! unless repo.refresh
           else
             repo.disable!
           end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 11 15:11:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed possible double timeout when refreshing the installation
+  repository (bsc#1236820)
+
+-------------------------------------------------------------------
 Fri Feb  7 16:29:28 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Report problems when trying to download a package, install it

--- a/service/test/agama/software/repositories_manager_test.rb
+++ b/service/test/agama/software/repositories_manager_test.rb
@@ -23,9 +23,10 @@ require_relative "../../test_helper"
 require "agama/software/repositories_manager"
 
 describe Agama::Software::RepositoriesManager do
+  # probe and refresh succeed
   let(:repo) do
     instance_double(
-      Agama::Software::Repository, enable!: nil, probe: true, enabled?: true, refresh: false
+      Agama::Software::Repository, enable!: nil, probe: true, enabled?: true, refresh: true
     )
   end
 
@@ -45,25 +46,40 @@ describe Agama::Software::RepositoriesManager do
   end
 
   describe "#load" do
+    # probe and refresh fail
     let(:repo1) do
       instance_double(
-        Agama::Software::Repository, disable!: nil, probe: false, refresh: false
+        Agama::Software::Repository, enable!: nil, disable!: nil, probe: false, refresh: false
+      )
+    end
+
+    # corner case, probe succeeds but refresh fails
+    let(:repo2) do
+      instance_double(
+        Agama::Software::Repository, enable!: nil, disable!: nil, probe: true, refresh: false
       )
     end
 
     before do
       subject.repositories << repo
       subject.repositories << repo1
+      subject.repositories << repo2
       allow(Yast::Pkg).to receive(:SourceLoad)
     end
 
     it "enables the repositories that can be read" do
       expect(repo).to receive(:enable!)
+      expect(repo).to_not receive(:disable!)
       subject.load
     end
 
-    it "disables the repositories that cannot be read" do
+    it "disables the repositories that cannot be probed" do
       expect(repo1).to receive(:disable!)
+      subject.load
+    end
+
+    it "disables the repositories that cannot be refreshed" do
+      expect(repo2).to receive(:disable!)
       subject.load
     end
 


### PR DESCRIPTION
## Problem

- Too long repository refresh timeout, Agama seems to be stuck
- See https://bugzilla.suse.com/show_bug.cgi?id=1236820#c6
- In this particular case probing the repository succeeded, but the refresh started one second later timed out :scream: 

## Solution

- Disable the repository if the refresh failed
- That avoids automatically refreshing all not yet refreshed repositories in the `Pkg.SourceLoad` call in the next step

