### PR TITLE
Several Live ISO improvements

### DIFF
--- a/live/Makefile
+++ b/live/Makefile
@@ -57,10 +57,10 @@ $(DESTDIR)/%.tar.xz: % $$(shell find % -type f,l)
 	echo "$@ $${MSG}"
 
 # build the ISO locally
+# allow passing optional parameters to osc like "-p <dir>" or "-k <dir>" via OSC_OPTS
 build: $(DESTDIR)
 	if [ ! -e  $(DESTDIR)/.osc ]; then make clean; osc -A $(OBS_API) co -o $(DESTDIR) $(OBS_PROJECT) $(OBS_PACKAGE); fi
 	$(MAKE) all
-	# allow passing optional parameters to osc like "-p <dir>" or "-k <dir>"
 	(cd $(DESTDIR) && osc -A $(OBS_API) build -M $(FLAVOR) $(OSC_OPTS) $(OBS_TARGET) $(ARCH) $(KIWI_FILE))
 
 .PHONY: build all clean

--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -80,21 +80,21 @@ terminal_output gfxterm
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot}
+    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }
 menuentry "Failsafe -- Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} ide=nodma apm=off noresume edd=off nomodeset 3
+    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4 ide=nodma apm=off noresume edd=off nomodeset 3
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }
 menuentry "Check Installation Medium" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/aarch64/loader/linux mediacheck=1 plymouth.enable=0 \${isoboot}
+    linux (\$root)/boot/aarch64/loader/linux loglevel=4 mediacheck=1 plymouth.enable=0 \${isoboot}
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }

--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -97,14 +97,14 @@ fi
 
 menuentry "Install $label" --class os --unrestricted {
   echo 'Loading kernel...'
-  linux /boot/ppc64le/linux
+  linux /boot/ppc64le/linux loglevel=4
   echo 'Loading initrd...'
   initrd /boot/ppc64le/initrd
 }
 
 menuentry "Check Installation Medium" --class os --unrestricted {
   echo 'Loading kernel...'
-  linux /boot/ppc64le/linux mediacheck=1 plymouth.enable=0
+  linux /boot/ppc64le/linux loglevel=4 mediacheck=1 plymouth.enable=0
   echo 'Loading initrd...'
   initrd /boot/ppc64le/initrd
 }
@@ -128,8 +128,8 @@ XXX
 #
 cat >$dst/ppc/bootinfo.txt <<XXX
 <chrp-boot>
-<description>$kiwi_iname</description>
-<os-name>openSuSE Tumbleweed</os-name>
+<description>Install $label</description>
+<os-name>$label</os-name>
 <boot-script>boot &device;:1,\boot\grub2\grub.elf</boot-script>
 </chrp-boot>
 XXX

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -80,21 +80,21 @@ terminal_output gfxterm
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot}
+    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }
 menuentry "Failsafe -- Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} ide=nodma apm=off noresume edd=off nomodeset 3
+    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4 ide=nodma apm=off noresume edd=off nomodeset 3
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }
 menuentry "Check Installation Medium" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/x86_64/loader/linux mediacheck=1 plymouth.enable=0 \${isoboot}
+    linux (\$root)/boot/x86_64/loader/linux loglevel=4 mediacheck=1 plymouth.enable=0 \${isoboot}
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }

--- a/live/root/etc/systemd/system/agama-hostname.service
+++ b/live/root/etc/systemd/system/agama-hostname.service
@@ -5,7 +5,7 @@ After=systemd-hostnamed.target
 # but before starting the mDNS server
 Before=avahi-daemon.service
 # run only if the hostname has the default value, if it has been changed
-# by the hernel command line or systemd then keep it
+# by the kernel command line or systemd then keep it
 ConditionHost=localhost
 
 [Service]

--- a/live/root/etc/systemd/system/live-root-shell.service
+++ b/live/root/etc/systemd/system/live-root-shell.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Start root shell in a free terminal (usually tty2)
+# after setting the host name to correctly display it in the shell prompt
+After=agama-hostname.service
+
+[Service]
+ExecStart=openvt --verbose --wait bash
+# start it again after crashing or accidentally closing the shell via "exit" or Ctrl+D,
+# unfortunately it might use a different tty after restart :-/
+Restart=always
+Type=exec
+Environment=TERM=linux
+
+[Install]
+WantedBy=default.target

--- a/live/root/etc/systemd/system/x11-autologin.service
+++ b/live/root/etc/systemd/system/x11-autologin.service
@@ -18,6 +18,9 @@ UtmpMode=user
 StandardOutput=journal
 ExecStartPre=/usr/bin/chvt 7
 ExecStart=/usr/bin/startx -- vt7 -keeptty -verbose 3 -logfile /dev/null
+# Directly kill the xinit process, the startx script unfortunately ignores
+# SIGTERM and does pass that to the started xinit.
+ExecStop=pkill xinit
 Restart=no
 
 [Install]

--- a/live/root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/root/root/.mozilla/firefox/profile/user.js.template
@@ -8,6 +8,11 @@ user_pref("signon.generation.enabled", false);
 // disable the initial configuration workflow
 user_pref("browser.aboutwelcome.enabled", false);
 
+// do not ask to restore the session after restarting the browser
+// via "systemctl restart x11-autologin"
+user_pref("browser.sessionstore.resume_from_crash", false);
+user_pref("browser.startup.couldRestoreSession.count", 0);
+
 // disable homepage override on updates
 user_pref("browser.startup.homepage_override.mstone", "ignore");
 

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Feb 12 08:04:11 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Start root shell in a free terminal (usually tty2)
+- Fixed restarting the x11-autologin service
+- Do not ask to restore the browser session after restarting it
+- Print only kernel errors or more severe messages on the console,
+  avoid spamming the terminal with useless texts
+
+-------------------------------------------------------------------
 Fri Feb  7 16:31:50 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - live: fix_bootconfig.s390x: restore initrd.off naming for the initrd offset

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -5,7 +5,7 @@ Wed Feb 12 08:04:11 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 - Fixed restarting the x11-autologin service
 - Do not ask to restore the browser session after restarting it
 - Print only kernel errors or more severe messages on the console,
-  avoid spamming the terminal with useless texts
+  avoid spamming the terminal with useless texts (bsc#1237056)
 
 -------------------------------------------------------------------
 Fri Feb  7 16:31:50 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -55,6 +55,7 @@ systemctl enable live-password-dialog.service
 systemctl enable live-password-iso.service
 systemctl enable live-password-random.service
 systemctl enable live-password-systemd.service
+systemctl enable live-root-shell.service
 systemctl enable checkmedia.service
 systemctl enable setup-systemd-proxy-env.path
 systemctl enable x11-autologin.service


### PR DESCRIPTION
## Improvements

- Start root shell in a free terminal (usually tty2)
- Fixed restarting the x11-autologin service
- Do not ask to restore the browser session after restarting it
- Print only kernel errors or more severe messages on the console, avoid spamming the terminal with useless texts

## Testing

- Tested manually in a locally built ISO

