### PR TITLE
Live ISO optimizations: faster build and smaller ISO

### DIFF
--- a/live/root/tmp/driver_cleanup.rb
+++ b/live/root/tmp/driver_cleanup.rb
@@ -127,25 +127,9 @@ loop do
   to_delete.reject!{|a| referenced.any?{|d| d.path == a.path}}
 end
 
-# total size counter
-driver_size = 0
+delete_drivers = to_delete.map(&:path)
+puts "Found #{delete_drivers.size} drivers to delete"
+File.delete(*delete_drivers) if do_delete
 
-# process the list of the drivers to delete
-to_delete.each do |d|
-  driver_size += File.size(d.path)
-
-  if (do_delete)
-    puts "Deleting #{d.path}"
-    File.delete(d.path)
-  else
-    puts "Driver to delete #{d.path}"
-  end
-end
-
-puts "Found #{to_delete.size} drivers to delete (#{driver_size/1024/1024} MiB)"
-
-# at the end update the kernel driver metadata (modules.dep and others)
-if (do_delete)
-  puts "Updating driver metadata..."
-  system("/sbin/depmod -a -F #{dir.shellescape}/System.map")
-end
+# Note: The module dependencies are updated by the config.sh script
+# after decompressing the drivers.

--- a/live/root/tmp/fw_cleanup.rb
+++ b/live/root/tmp/fw_cleanup.rb
@@ -72,6 +72,7 @@ Find.find(dir) do |path|
   end
 end
 
+puts "Removing unused firmware..."
 # counter for total unused firmware size
 unused_size = 0
 
@@ -84,7 +85,6 @@ Find.find(fw_dir) do |fw_path|
   if !fw.include?(fw_name)
     unused_size += File.size(fw_path)
     if (do_delete)
-      puts "Deleting firmware file #{fw_path}"
       File.delete(fw_path)
     else
       puts "Found unused firmware #{fw_path}"
@@ -95,9 +95,9 @@ end
 # do some cleanup at the end
 if (do_delete)
   puts "Removing dangling symlinks..."
-  system("find #{fw_dir.shellescape} -xtype l -print -delete")
+  system("find #{fw_dir.shellescape} -xtype l -delete")
   puts "Removing empty directories..."
-  system("find #{fw_dir.shellescape} -type d -empty -print -delete")
+  system("find #{fw_dir.shellescape} -type d -empty -delete")
 end
 
 puts "Unused firmware size: #{unused_size} (#{unused_size >> 20} MiB)"

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -8,7 +8,7 @@ Wed Feb 12 12:02:39 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
   (they are compressed by the squashfs as well). Compressing
   all drivers together in the image is more effective than
   compressing several thousands individual files.
-  This makes the image about 33MB smaller (on x86_64).
+  This makes the image about 33MB smaller (on x86_64). (boo#1192457)
 - Hardlink the duplicate licenses, makes the ISO ~1MB smaller
 
 -------------------------------------------------------------------

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Wed Feb 12 12:02:39 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not print details about removed kernel drivers and firmware
+  files during build, this speeds up the build significantly
+  (~1 minute faster build) and avoids huge build log.
+- Uncompress the kernel drivers, no need to compress them twice
+  (they are compressed by the squashfs as well). Compressing
+  all drivers together in the image is more effective than
+  compressing several thousands individual files.
+  This makes the image about 33MB smaller (on x86_64).
+- Hardlink the duplicate licenses, makes the ISO ~1MB smaller
+
+-------------------------------------------------------------------
 Wed Feb 12 10:17:47 UTC 2025 - Giacomo Leidi <giacomo.leidi@suse.com>
 
 - Add ISO publisher (gh#agama-project/agama#1967)

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -179,8 +179,18 @@ du -h -s /lib/modules /lib/firmware
 
 ################################################################################
 # The rest of the file was copied from the openSUSE Tumbleweed Live ISO
-# https://build.opensuse.org/package/view_file/openSUSE:Factory:Live/livecd-tumbleweed-kde/config.sh?expand=1
+# https://build.opensuse.org/projects/openSUSE:Factory:Live/packages/livecd-tumbleweed-kde/files/config.sh?expand=1
 #
+
+# Decompress kernel modules, better for squashfs (boo#1192457)
+find /lib/modules/*/kernel -name '*.ko.xz' -exec xz -d {} +
+find /lib/modules/*/kernel -name '*.ko.zst' -exec zstd --rm -d {} +
+for moddir in /lib/modules/*; do
+  depmod "$(basename "$moddir")"
+done
+
+# Reuse what the macro does
+rpm --eval "%fdupes /usr/share/licenses" | sh
 
 # disable the services included by dependencies
 for s in purge-kernels; do


### PR DESCRIPTION
All these changes make the build one minute faster (on my local workstation) and the resulting ISO is 34MB smaller (on x86_64, might be different elsewhere).

## Improvements

- Do not print details about removed kernel drivers and firmware files during build, this speeds up the build significantly
 (~1 minute faster build) and avoids huge build log.
- Uncompress the kernel drivers, no need to compress them twice (they are compressed by the squashfs as well). Compressing all drivers together in the image is more effective than compressing several thousands individual files. This makes the image about 33MB smaller (on x86_64).
- Hardlink the duplicate licenses, makes the ISO ~1MB smaller

