### PR TITLE
Change the default lsm to SELinux for both Leap and Tumblweed jsc#PED-12021

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 13 11:19:19 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Change the default lsm to SELinux in enforcing for both Leap and Tumblweed
+  keep AppArmor around as an option jsc#PED-12021
+  https://news.opensuse.org/2025/02/13/tw-plans-to-adopt-selinux-as-default/ 
+
+-------------------------------------------------------------------
 Fri Jan 24 06:45:45 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Change the registration property in a product's definition to a

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -59,7 +59,7 @@ software:
   base_product: openSUSE
 
 security:
-  lsm: apparmor
+  lsm: selinux
   available_lsms:
     apparmor:
       patterns:

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -116,7 +116,7 @@ software:
   base_product: openSUSE
 
 security:
-  lsm: apparmor
+  lsm: selinux
   available_lsms:
     apparmor:
       patterns:
@@ -124,7 +124,7 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: permissive
+      policy: enforcing
     none:
       patterns: null
 


### PR DESCRIPTION
- Change the default lsm to SELinux enforcing for both Leap and Tumblweed
  keep AppArmor around as an option jsc#PED-12021

Related article  https://news.opensuse.org/2025/02/13/tw-plans-to-adopt-selinux-as-default/ 