### PR TITLE
Replace agama cmdline args prefix with inst

### DIFF
--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -5,7 +5,7 @@ set -ex
 export YAST_SKIP_XML_VALIDATION=1
 
 if [ -z "$1" ]; then
-  url=$(grep 'agama.auto=' </run/agama/cmdline.d/agama.conf | awk -F 'agama.auto=' '{sub(/ .*$/, "", $2); print $2}')
+  url=$(grep '\(agama\|inst\).auto=' < /run/agama/cmdline.d/agama.conf | awk -F ':?(inst|agama).auto=' '{sub(/ .*$/, "", $2); print $2}')
 else
   url="$1"
 fi

--- a/doc/boot_arguments.md
+++ b/doc/boot_arguments.md
@@ -5,11 +5,11 @@ full configuration file or to change some specific values.
 
 ## Loading a new configuration file
 
-It is possible to load a new configuration file specifying a URL through the `agama.config_url`
+It is possible to load a new configuration file specifying a URL through the `inst.config_url`
 option. Here are some examples:
 
-* `agama.config_url=http://192.168.122.1/my-agama.yaml`
-* `agama.config_url=usb:///agama.yaml`
+* `inst.config_url=http://192.168.122.1/my-agama.yaml`
+* `inst.config_url=usb:///agama.yaml`
 
 See [URL handling in the
 installer](https://github.com/yast/yast-installation/blob/master/doc/url.md) to find more details
@@ -17,10 +17,10 @@ about the supported URLs.
 
 ## Custom Installation URL Configuration
 
-You can override the default `installation_url` set in the product files [here](https://github.com/openSUSE/agama/tree/master/products.d) by passing the `agama.install_url` parameter as a boot option in the bootloader.
-This is particularly useful for any pre-production testing in openQA. 
+You can override the default `installation_url` set in the product files [here](https://github.com/openSUSE/agama/tree/master/products.d) by passing the `inst.install_url` parameter as a boot option in the bootloader.
+This is particularly useful for any pre-production testing in openQA.
 
-**Note:** Setting this variable will impact all products. 
+**Note:** Setting this variable will impact all products.
 
 ### Example Usage
 
@@ -28,7 +28,7 @@ To specify a custom installation URLs, pass following as a parameter to kernel i
 You can specify multiple URLs by separating them with commas.
 
 ```
-agama.install_url=https://myrepo,https://myrepo2
+inst.install_url=https://myrepo,https://myrepo2
 ```
 
 ## Changing configuration values
@@ -38,7 +38,7 @@ configuration values. You must specify the option name in dotted notation. A typ
 be to use your own SSL certificates:
 
 ```
-agama.web.ssl=true agama.web.ssl_cert=http://192.168.122.1/mycert.pem agama.web.ssl_key=http://192.168.122.1/mycert.key
+inst.web.ssl=true inst.web.ssl_cert=http://192.168.122.1/mycert.pem inst.web.ssl_key=http://192.168.122.1/mycert.key
 ```
 
 Changing complex options (e.g., collections) is not supported yet.

--- a/live/root/usr/bin/info-cmdline-conf.sh
+++ b/live/root/usr/bin/info-cmdline-conf.sh
@@ -9,7 +9,7 @@ TARGET="${1:-/run/agama/cmdline.d/agama.conf}"
 INFO_CONTENT="${2:-/run/agama/cmdline.d/info.conf}"
 
 expand_info_arg() {
-  INFO_URL=$(sed -n 's/\(.*[[:space:]]\|^\)agama\.info=\([^[:space:]]\+\).*/\2/p' "$TARGET")
+  INFO_URL=$(sed -n 's/\(.*[[:space:]]\|^\)\(inst\|agama\)\.info=\([^[:space:]]\+\).*/\2/p' "$TARGET")
   if [ -z "${INFO_URL}" ]; then
     return 0
   fi
@@ -18,7 +18,7 @@ expand_info_arg() {
   # if so check with security team
   curl --location --silent "${INFO_URL}" > "${INFO_CONTENT}"
   # remove info param
-  sed -in 's/\([[:space:]]\|^\)agama\.info=[^[:space:]]\+//' "${TARGET}"
+  sed -in 's/\([[:space:]]\|^\)\(inst\|agama\)\.info=[^[:space:]]\+//' "${TARGET}"
   # and add content of info file
   cat "${INFO_CONTENT}" >> "${TARGET}"
 

--- a/live/root/usr/bin/kernel-cmdline-conf.sh
+++ b/live/root/usr/bin/kernel-cmdline-conf.sh
@@ -16,7 +16,7 @@ write_kernel_args() {
     case ${_i} in
     # remove all agama kernel params
     # Add here also all linuxrc supported parameters
-    LIBSTORAGE_* | YAST_* | agama* | Y2* | ZYPP_* | autoyast* )
+    LIBSTORAGE_* | YAST_* | inst* | agama* | Y2* | ZYPP_* | autoyast* )
       _found=1
       ;;
     esac

--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-cmdline-conf.sh
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-cmdline-conf.sh
@@ -15,7 +15,7 @@ get_agama_args() {
       _found=1
       _env=1
       ;;
-    agama*)
+    inst* | agama*)
       _found=1
       ;;
     esac

--- a/service/lib/agama/cmdline_args.rb
+++ b/service/lib/agama/cmdline_args.rb
@@ -74,6 +74,8 @@ module Agama
     # command line options into a standard shape
     def self.standardize(option)
       # agama. is now obsolete original kernel argument prefix
+      return if !option.start_with?("agama.")
+
       option.sub("agama.", CMDLINE_PREFIX)
     end
 

--- a/service/lib/agama/cmdline_args.rb
+++ b/service/lib/agama/cmdline_args.rb
@@ -73,9 +73,8 @@ module Agama
     # Despite Agama is young it already contains some relicts. This method should purge them and put
     # command line options into a standard shape
     def self.standardize(option)
-      obsolete_cmdline_prefix = "agama."
-
-      option.sub(obsolete_cmdline_prefix, CMDLINE_PREFIX)
+      # agama. is now obsolete original kernel argument prefix
+      option.sub("agama.", CMDLINE_PREFIX)
     end
 
     # Convenience method to normalize the given value by now it just convert "true" and "false"

--- a/service/lib/agama/cmdline_args.rb
+++ b/service/lib/agama/cmdline_args.rb
@@ -22,7 +22,8 @@
 module Agama
   # This class is responsible for reading Agama kernel cmdline options
   class CmdlineArgs
-    CMDLINE_PREFIX = "agama."
+    CMDLINE_PATH = "/proc/cmdline"
+    CMDLINE_PREFIX = "inst."
 
     attr_accessor :config_url
     attr_reader :data
@@ -46,6 +47,7 @@ module Agama
 
       options = File.read(path)
       options.split.each do |option|
+        option = standardize(option)
         next unless option.start_with?(CMDLINE_PREFIX)
 
         key, value = option.split("=", 2)
@@ -66,6 +68,14 @@ module Agama
       end
 
       args
+    end
+
+    # Despite Agama is young it already contains some relicts. This method should purge them and put
+    # command line options into a standard shape
+    def self.standardize(option)
+      obsolete_cmdline_prefix = "agama."
+
+      option.sub(obsolete_cmdline_prefix, CMDLINE_PREFIX)
     end
 
     # Convenience method to normalize the given value by now it just convert "true" and "false"

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 17:54:19 UTC 2025 - Michal Filka <mfilka@suse.com>
+
+- Instead of "agama." use more generic "inst." prefix for kernel
+  boot options controling the agama installer
+
+-------------------------------------------------------------------
 Wed Feb 19 14:21:40 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - if root ssh key is used, ensure that sshd is enabled and firewall
@@ -10,7 +16,6 @@ Wed Feb 19 14:21:40 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 Wed Feb 19 13:35:07 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - UX: Improve the libzypp callbacks (gh#agama-project/agama#1985)
-
 
 -------------------------------------------------------------------
 Tue Feb 18 17:19:08 UTC 2025 - Knut Anderssen <kanderssen@suse.com>


### PR DESCRIPTION
## Problem

We want to use generic prefix for kernel command line arguments prefix.

## Solution

replaced agama. with inst.


## Testing

- *Tested manually*
