### PR TITLE
fix(ruby): fix localization and scripts conversion

### DIFF
--- a/autoinstallation/README.md
+++ b/autoinstallation/README.md
@@ -32,8 +32,8 @@ repository to get an impression of how a profile looks like.
 
 ```json
 {
-  "l10n": {
-    "languages": ["en_US.UTF-8"]
+  "localization": {
+    "language": "en_US.UTF-8"
   },
   "product": {
     "id": "Tumbleweed"

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -22,7 +22,7 @@
 require "yast"
 require "autoinstall/script_runner"
 require "autoinstall/script"
-require "agama/autoyast/l10n_reader"
+require "agama/autoyast/localization_reader"
 require "agama/autoyast/product_reader"
 require "agama/autoyast/root_reader"
 require "agama/autoyast/scripts_reader"
@@ -51,7 +51,9 @@ module Agama
     class Converter
       # Sections which have a corresponding reader. The reader is expected to be
       # named in Pascal case and adding "Reader" as suffix (e.g., "L10nReader").
-      SECTIONS = ["l10n", "product", "root", "scripts", "software", "storage", "user"].freeze
+      SECTIONS = [
+        "localization", "product", "root", "scripts", "software", "storage", "user"
+      ].freeze
 
       # Builds the Agama profile
       #

--- a/service/lib/agama/autoyast/l10n_reader.rb
+++ b/service/lib/agama/autoyast/l10n_reader.rb
@@ -36,12 +36,12 @@ module Agama
       #
       # If there is no l10n information, it returns an empty hash.
       #
-      # @return [Hash] Agama "l10n" section
+      # @return [Hash] Agama "localization" section
       def read
         l10n = keyboard
           .merge(languages)
           .merge(timezone)
-        l10n.empty? ? {} : { "l10n" => l10n }
+        l10n.empty? ? {} : { "localization" => l10n }
       end
 
     private

--- a/service/lib/agama/autoyast/localization_reader.rb
+++ b/service/lib/agama/autoyast/localization_reader.rb
@@ -25,8 +25,8 @@ require "yast"
 module Agama
   # :nodoc:
   module AutoYaST
-    # Builds an Agama "l10n" section from an AutoYaST profile.
-    class L10nReader
+    # Builds an Agama "localization" section from an AutoYaST profile.
+    class LocalizationReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
@@ -38,10 +38,10 @@ module Agama
       #
       # @return [Hash] Agama "localization" section
       def read
-        l10n = keyboard
+        localization = keyboard
           .merge(languages)
           .merge(timezone)
-        l10n.empty? ? {} : { "localization" => l10n }
+        localization.empty? ? {} : { "localization" => localization }
       end
 
     private

--- a/service/lib/agama/autoyast/scripts_reader.rb
+++ b/service/lib/agama/autoyast/scripts_reader.rb
@@ -44,6 +44,7 @@ module Agama
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
+        @anonymous_counter=0
       end
 
       # Returns a hash that corresponds to Agama "scripts" section.
@@ -100,10 +101,10 @@ module Agama
       # @param section [Hash] AutoYaST script section
       def read_script(section)
         script = {
-          "name" => section["file_name"]
+          "name" => section["filename"] || "annonymous#{@anonymous_counter+=1}"
         }
 
-        if section["location"]
+        if section["location"] && !section["location"].empty?
           script["url"] = section["location"]
         elsif section["source"]
           script["body"] = section["source"]

--- a/service/lib/agama/autoyast/scripts_reader.rb
+++ b/service/lib/agama/autoyast/scripts_reader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+Yast.import "URL"
 
 # :nodoc:
 module Agama
@@ -44,7 +45,7 @@ module Agama
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
-        @anonymous_counter=0
+        @index = 0
       end
 
       # Returns a hash that corresponds to Agama "scripts" section.
@@ -101,7 +102,7 @@ module Agama
       # @param section [Hash] AutoYaST script section
       def read_script(section)
         script = {
-          "name" => section["filename"] || "annonymous#{@anonymous_counter+=1}"
+          "name" => filename_for(section)
         }
 
         if section["location"] && !section["location"].empty?
@@ -121,6 +122,28 @@ module Agama
       def read_post_script(section)
         read_script(section)
           .merge("chroot" => section.fetch("chrooted", false))
+      end
+
+      # Extracts the name of the script
+      #
+      # If the "filename" attribute is defined, it is used. Otherwise, it tries
+      # to infer the name from the "location" attribute. If the "location" is
+      # not defined, it uses a generic name plus the index of the script.
+      #
+      # @param section [Hash] AutoYaST script definition
+      # @return [String]
+      def filename_for(section)
+        return section["filename"] if section["filename"]
+
+        location = section["location"].to_s
+        if !location.empty?
+          url = Yast::URL.Parse(location)
+          path = File.basename(url["path"].to_s)
+          return path unless path.empty? || path == "/"
+        end
+
+        @index += 1
+        "script-#{@index}"
       end
     end
   end

--- a/service/lib/agama/commands/agama_autoyast.rb
+++ b/service/lib/agama/commands/agama_autoyast.rb
@@ -20,6 +20,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "json"
 require "agama/autoyast/converter"
 require "agama/autoyast/profile_fetcher"
 require "agama/autoyast/profile_reporter"
@@ -86,7 +87,10 @@ module Agama
         converter = Agama::AutoYaST::Converter.new
         agama_config = converter.to_agama(profile)
         FileUtils.mkdir_p(directory)
-        File.write(File.join(directory, "autoinst.json"), agama_config.to_json)
+        File.write(
+          File.join(directory, "autoinst.json"),
+          JSON.pretty_generate(agama_config)
+        )
       rescue StandardError
         raise CouldNotWriteAgamaConfig
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Feb 13 21:37:32 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix several AutoYaST conversion problems (gh#agama-project/agama#1995):
+  - Fix handling of scripts file names and location
+    (gh#agama-project/agama#1903).
+  - Fix the name of the localization section (gh#agama-project/agama#1960).
+  - Use a more readable JSON format (gh#agama-project/agama#1907).
+
+-------------------------------------------------------------------
 Wed Feb 12 08:16:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Report unsupported AutoYaST elements

--- a/service/test/agama/autoyast/converter_test.rb
+++ b/service/test/agama/autoyast/converter_test.rb
@@ -79,7 +79,7 @@ describe Agama::AutoYaST::Converter do
 
     it "exports l10n settings" do
       result = subject.to_agama(profile)
-      expect(result["l10n"]).to include(
+      expect(result["localization"]).to include(
         "languages" => ["en_US.UTF-8"],
         "timezone"  => "Atlantic/Canary",
         "keyboard"  => "us"

--- a/service/test/agama/autoyast/localization_reader_test.rb
+++ b/service/test/agama/autoyast/localization_reader_test.rb
@@ -21,11 +21,11 @@
 
 require_relative "../../test_helper"
 require "yast"
-require "agama/autoyast/l10n_reader"
+require "agama/autoyast/localization_reader"
 
 Yast.import "Profile"
 
-describe Agama::AutoYaST::L10nReader do
+describe Agama::AutoYaST::LocalizationReader do
   let(:profile) do
     {}
   end
@@ -35,7 +35,7 @@ describe Agama::AutoYaST::L10nReader do
   end
 
   describe "#read" do
-    context "when there is no l10n-related sections" do
+    context "when there is no localization-related sections" do
       let(:profile) { {} }
 
       it "returns an empty hash" do
@@ -49,8 +49,8 @@ describe Agama::AutoYaST::L10nReader do
       end
 
       it "includes a 'keyboard' key with its value" do
-        l10n = subject.read["l10n"]
-        expect(l10n["keyboard"]).to eq("us")
+        localization = subject.read["localization"]
+        expect(localization["keyboard"]).to eq("us")
       end
     end
 
@@ -65,8 +65,8 @@ describe Agama::AutoYaST::L10nReader do
       end
 
       it "includes a 'languages' key with all the languages" do
-        l10n = subject.read["l10n"]
-        expect(l10n["languages"]).to eq(["en_US.UTF-8", "es_ES.UTF-8", "cs_CZ.UTF-8"])
+        localization = subject.read["localization"]
+        expect(localization["languages"]).to eq(["en_US.UTF-8", "es_ES.UTF-8", "cs_CZ.UTF-8"])
       end
 
       context "when the encoding is not included" do
@@ -80,8 +80,8 @@ describe Agama::AutoYaST::L10nReader do
         end
 
         it "uses the UTF-8 encoding" do
-          l10n = subject.read["l10n"]
-          expect(l10n["languages"]).to eq(["en_US.UTF-8", "es_ES.UTF-8"])
+          localization = subject.read["localization"]
+          expect(localization["languages"]).to eq(["en_US.UTF-8", "es_ES.UTF-8"])
         end
       end
     end
@@ -92,8 +92,8 @@ describe Agama::AutoYaST::L10nReader do
       end
 
       it "includes a 'keyboard' key with its value" do
-        l10n = subject.read["l10n"]
-        expect(l10n["timezone"]).to eq("Europe/Berlin")
+        localization = subject.read["localization"]
+        expect(localization["timezone"]).to eq("Europe/Berlin")
       end
     end
   end

--- a/service/test/agama/autoyast/scripts_reader_test.rb
+++ b/service/test/agama/autoyast/scripts_reader_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -32,27 +32,60 @@ RSpec.shared_examples "a script reader" do |ay_section, section|
 
   context "when the script definition includes the sources" do
     let(:script) do
-      { "file_name" => "script.sh",
-        "location"  => "https://example.com/script.sh" }
+      { "filename" => "script.sh",
+        "location" => "https://example.com/script.sh" }
     end
 
     it "sets the \"url\" to the \"location\"" do
       scripts = subject.read["scripts"][section]
       expect(scripts.first).to include("url" => "https://example.com/script.sh")
     end
+
+    context "and the script filename is not specified" do
+      let(:script) do
+        { "location" => "https://example.com/script.sh" }
+      end
+
+      it "uses the path as the filename" do
+        scripts = subject.read["scripts"][section]
+        expect(scripts.first).to include("name" => "script.sh")
+      end
+
+      context "but there is no path in the URL" do
+        let(:script) do
+          { "location" => "https://example.com/" }
+        end
+
+        it "uses the script type as the filename" do
+          scripts = subject.read["scripts"][section]
+          expect(scripts.first).to include("name" => "script-1")
+        end
+      end
+    end
   end
 
   context "when the script definition specifies a location" do
     let(:script) do
       {
-        "file_name" => "script.sh",
-        "source"    => "#!/bin/bash\necho 'Hello World!'"
+        "filename" => "script.sh",
+        "source"   => "#!/bin/bash\necho 'Hello World!'"
       }
     end
 
     it "sets the \"body\" to the \"sources\"" do
       scripts = subject.read["scripts"][section]
       expect(scripts.first).to include("body" => "#!/bin/bash\necho 'Hello World!'")
+    end
+
+    context "and the script filename is not specified" do
+      let(:script) do
+        { "source" => "#!/bin/bash\necho 'Hello World!'" }
+      end
+
+      it "uses the script type as the filename" do
+        scripts = subject.read["scripts"][section]
+        expect(scripts.first).to include("name" => "script-1")
+      end
     end
   end
 end
@@ -77,9 +110,9 @@ describe Agama::AutoYaST::ScriptsReader do
       it_behaves_like "a script reader", "chroot-scripts", "post"
 
       let(:chroot_script) do
-        { "file_name" => "test.sh",
-          "chrooted"  => true,
-          "source"    => "#!/bin/bash\necho 'Hello World!'" }
+        { "filename" => "test.sh",
+          "chrooted" => true,
+          "source"   => "#!/bin/bash\necho 'Hello World!'" }
       end
 
       let(:profile) do
@@ -92,8 +125,8 @@ describe Agama::AutoYaST::ScriptsReader do
 
       context "when the \"chrooted\" option is not set" do
         let(:chroot_script) do
-          { "file_name" => "test.sh",
-            "source"    => "#!/bin/bash\necho 'Hello World!'" }
+          { "filename" => "test.sh",
+            "source"   => "#!/bin/bash\necho 'Hello World!'" }
         end
 
         it "sets the \"chroot\" option to false" do


### PR DESCRIPTION
## Problem

The conversion of the localization and scripts sections has several problems:

- #1903
- #1907
- #1960

This PR include some changes from #1951 and #1946.

## Solution

- Fix the handling of the scripts file name and location.
- Fix the name of the localization setting ("localization" instead of "l10n").

Additionally, use "pretty" JSON when exporting the converted profile.

## Testing

- _Added a new unit test_
