### PR TITLE
fix(rust): set VC and X11 keymap

### DIFF
--- a/rust/agama-server/src/l10n/model.rs
+++ b/rust/agama-server/src/l10n/model.rs
@@ -244,7 +244,7 @@ impl L10n {
                 "--locale",
                 self.locales.first().unwrap_or(&"en_US.UTF-8".to_string()),
                 "--keymap",
-                &self.keymap.to_string(),
+                &self.keymap.dashed(),
                 "--timezone",
                 &self.timezone,
             ])

--- a/rust/agama-server/src/l10n/model.rs
+++ b/rust/agama-server/src/l10n/model.rs
@@ -209,16 +209,20 @@ impl L10n {
             return Err(LocaleError::UnknownKeymap(keymap_id));
         }
 
-        let keymap = keymap_id.to_string();
         self.ui_keymap = keymap_id;
 
         Command::new("/usr/bin/localectl")
-            .args(["set-keymap", &keymap])
+            .args(["set-keymap", &self.ui_keymap.dashed()])
             .output()
             .map_err(LocaleError::Commit)?;
 
         let output = run_with_timeout(
-            &["setxkbmap", "-display", &display(), &keymap],
+            &[
+                "setxkbmap",
+                "-display",
+                &display(),
+                &self.ui_keymap.to_string(),
+            ],
             SETXKBMAP_TIMEOUT,
         );
         output.map_err(|e| {

--- a/rust/agama-server/src/l10n/model.rs
+++ b/rust/agama-server/src/l10n/model.rs
@@ -213,7 +213,7 @@ impl L10n {
         self.ui_keymap = keymap_id;
 
         Command::new("/usr/bin/localectl")
-            .args(["set-x11-keymap", &keymap])
+            .args(["set-keymap", &keymap])
             .output()
             .map_err(LocaleError::Commit)?;
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 14 17:00:33 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set console and X11 keymaps when changing the installer keymap
+  (bsc#1236174).
+
+-------------------------------------------------------------------
 Mon Feb 10 13:28:34 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixup: Make the "lang" URL query optional, do not fail when it

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -3,6 +3,8 @@ Fri Feb 14 17:00:33 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Set console and X11 keymaps when changing the installer keymap
   (bsc#1236174).
+- Use the "dashed" form of the keymap identifier when calling
+  systemd-firstboot (bsc#1236174).
 
 -------------------------------------------------------------------
 Mon Feb 10 13:28:34 UTC 2025 - Ladislav Slezák <lslezak@suse.com>


### PR DESCRIPTION
Bug [bsc#1236174](https://bugzilla.suse.com/show_bug.cgi?id=1236174)

* When changing the installer font, only the X11 keymap is adjusted.
* When writing the keymap to be used by the target system, Agama does not uses the "dashed" form: "es(ast)" instead of es-ast (original fix was in #1952, merged into the wrong branch).

## Solution

* Use `set-keymap` instead of `set-x11-keymap`.
* Use the dashed form to set the language with `systemd-firstboot`.

## Screenshot

<details>
<summary>output of `localectl` after changing the keymap</summary>

![finish-classic](https://github.com/user-attachments/assets/1503e422-8cce-4e00-a5cb-36059cb8e1ab)
</details>