### PR TITLE
feat: add support for post-partitioning scripts

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -21,6 +21,14 @@
             "$ref": "#/$defs/preScript"
           }
         },
+        "postPartitioning": {
+          "title": "Post-partitioning scripts",
+          "description": "User-defined scripts to run after the partitioning finishes",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/postPartitioning"
+          }
+        },
         "post": {
           "title": "Post-installation scripts",
           "description": "User-defined scripts to run after the installation finishes",
@@ -1446,6 +1454,28 @@
     },
     "preScript": {
       "title": "User-defined installation script that runs before the installation starts",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Script name, to be used as file name",
+          "type": "string"
+        },
+        "body": {
+          "title": "Script content",
+          "description": "Script content, starting with the shebang",
+          "type": "string"
+        },
+        "url": {
+          "title": "Script URL",
+          "description": "URL to fetch the script from"
+        }
+      },
+      "required": ["name"],
+      "oneOf": [{ "required": ["body"] }, { "required": ["url"] }]
+    },
+    "postPartitioning": {
+      "title": "User-defined installation script that runs after the partitioning finishes",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/rust/agama-lib/src/scripts/settings.rs
+++ b/rust/agama-lib/src/scripts/settings.rs
@@ -20,7 +20,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{InitScript, PostScript, PreScript};
+use super::{InitScript, PostPartitioningScript, PostScript, PreScript};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -28,6 +28,9 @@ pub struct ScriptsConfig {
     /// User-defined pre-installation scripts
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pre: Option<Vec<PreScript>>,
+    /// User-defined post-partitioning scripts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_partitioning: Option<Vec<PostPartitioningScript>>,
     /// User-defined post-installation scripts
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post: Option<Vec<PostScript>>,

--- a/rust/agama-lib/src/scripts/store.rs
+++ b/rust/agama-lib/src/scripts/store.rs
@@ -44,6 +44,7 @@ impl ScriptsStore {
 
         Ok(ScriptsConfig {
             pre: Self::scripts_by_type(&scripts),
+            post_partitioning: Self::scripts_by_type(&scripts),
             post: Self::scripts_by_type(&scripts),
             init: Self::scripts_by_type(&scripts),
         })
@@ -55,6 +56,12 @@ impl ScriptsStore {
         if let Some(scripts) = &settings.pre {
             for pre in scripts {
                 self.scripts.add_script(pre.clone().into()).await?;
+            }
+        }
+
+        if let Some(scripts) = &settings.post_partitioning {
+            for post in scripts {
+                self.scripts.add_script(post.clone().into()).await?;
             }
         }
 

--- a/rust/agama-server/src/web/docs/scripts.rs
+++ b/rust/agama-server/src/web/docs/scripts.rs
@@ -42,6 +42,7 @@ impl ApiDocBuilder for ScriptsApiDocBuilder {
         ComponentsBuilder::new()
             .schema_from::<agama_lib::scripts::BaseScript>()
             .schema_from::<agama_lib::scripts::InitScript>()
+            .schema_from::<agama_lib::scripts::PostPartitioningScript>()
             .schema_from::<agama_lib::scripts::PostScript>()
             .schema_from::<agama_lib::scripts::PreScript>()
             .schema_from::<agama_lib::scripts::Script>()

--- a/service/lib/agama/autoyast/scripts_reader.rb
+++ b/service/lib/agama/autoyast/scripts_reader.rb
@@ -53,6 +53,7 @@ module Agama
       # @return [Hash] Agama "scripts" section
       def read
         scripts = {}
+          .merge(read_post_partitioning_scripts)
           .merge(read_post_scripts)
           .merge(read_init_scripts)
         return {} if scripts.empty?
@@ -66,6 +67,17 @@ module Agama
 
       def scripts_section
         @scripts_section ||= profile.fetch("scripts", {})
+      end
+
+      # Reads the "postpartitioning-scripts" section and builds an Agama "postPartitioning"
+      # section.
+      def read_post_partitioning_scripts
+        scripts = scripts_section.fetch("postpartitioning-scripts", []).map do |script|
+          read_script(script)
+        end
+        return {} if scripts.empty?
+
+        { "postPartitioning" => scripts }
       end
 
       # Reads the "chroot-scripts" section and builds an Agama "post" section.

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -26,6 +26,7 @@ require "bootloader/finish_client"
 require "y2storage/storage_manager"
 require "agama/with_progress"
 require "agama/helpers"
+require "agama/http"
 require "abstract_method"
 
 Yast.import "Arch"

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb 17 09:17:47 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for post-partitioning scripts (jsc#AGM-108).
+
+-------------------------------------------------------------------
 Thu Feb 13 21:37:32 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix several AutoYaST conversion problems (gh#agama-project/agama#1995):

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -266,6 +266,37 @@
         ]
       },
       {
+        "key": "postpartitioning-scripts[]",
+        "children": [
+          {
+            "key": "filename",
+            "support": "yes",
+            "agama": "scripts.postPartitioning[].name"
+          },
+          {
+            "key": "location",
+            "support": "yes",
+            "agama": "scripts.postPartitioning[].url"
+          },
+          {
+            "key": "source",
+            "support": "yes",
+            "agama": "scripts.postPartitioning[].body"
+          },
+          {
+            "key": "interpreter",
+            "support": "no",
+            "notes": "Use the shebang line in your scripts."
+          },
+          { "key": "feedback", "support": "no" },
+          { "key": "feedback_type", "support": "no" },
+          { "key": "debug", "support": "no" },
+          { "key": "notification", "support": "no" },
+          { "key": "param-list", "support": "no" },
+          { "key": "rerun", "support": "no" }
+        ]
+      },
+      {
         "key": "chroot-scripts[]",
         "agama": "scripts.post[]",
         "children": [

--- a/service/test/agama/autoyast/scripts_reader_test.rb
+++ b/service/test/agama/autoyast/scripts_reader_test.rb
@@ -141,6 +141,10 @@ describe Agama::AutoYaST::ScriptsReader do
       end
     end
 
+    context "when a post-partitioning scripts is defined" do
+      it_behaves_like "a script reader", "postpartitioning-scripts", "postPartitioning"
+    end
+
     context "when an init script is defined" do
       it_behaves_like "a script reader", "init-scripts", "init"
     end

--- a/service/test/agama/manager_test.rb
+++ b/service/test/agama/manager_test.rb
@@ -60,6 +60,11 @@ describe Agama::Manager do
       on_service_status_change: nil, errors?: false
     )
   end
+  let(:scripts) do
+    instance_double(
+      Agama::HTTP::Clients::Scripts, run: nil
+    )
+  end
 
   let(:product) { nil }
 
@@ -70,6 +75,8 @@ describe Agama::Manager do
     allow(Agama::DBus::Clients::Software).to receive(:new).and_return(software)
     allow(Agama::DBus::Clients::Storage).to receive(:new).and_return(storage)
     allow(Agama::Users).to receive(:new).and_return(users)
+    allow(Agama::HTTP::Clients::Scripts).to receive(:new)
+      .and_return(scripts)
   end
 
   describe "#startup_phase" do
@@ -133,6 +140,7 @@ describe Agama::Manager do
       expect(software).to receive(:finish)
       expect(locale).to receive(:finish)
       expect(storage).to receive(:install)
+      expect(scripts).to receive(:run).with("post_partitioning")
       expect(storage).to receive(:finish)
       expect(users).to receive(:write)
       subject.install_phase


### PR DESCRIPTION
## Problem

It is not possible to execute post-partitioning scripts. The typical use case is deploying configuration files before the packages are installed. This can be used, for instance, to modify the behavior of an RPM script.

## Solution

* Add support for running `post-partitioning` scripts.
* Import the `postpartitioning-scripts` section from AutoYaST profiles.

## Testing

- *Added a new unit test*
- *Tested manually*