### PR TITLE
Product configuration: adjust product name and some sizes of storage proposal

### DIFF
--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -120,7 +120,7 @@ storage:
         auto_size:
           base_min: 5 GiB
           base_max: 15 GiB
-          snapshots_increment: 250%
+          snapshots_increment: 150%
           max_fallback_for:
             - "/home"
         snapshots_configurable: true
@@ -137,7 +137,7 @@ storage:
       filesystem: xfs
       size:
         auto: false
-        min: 10 GiB
+        min: 5 GiB
         max: unlimited
       outline:
         required: false
@@ -150,7 +150,7 @@ storage:
     - filesystem: xfs
       size:
         auto: false
-        min: 1 GiB
+        min: 512 MiB
       outline:
         required: false
         filesystems:

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -136,7 +136,7 @@ storage:
         auto_size:
           base_min: 5 GiB
           base_max: 15 GiB
-          snapshots_increment: 250%
+          snapshots_increment: 150%
           max_fallback_for:
             - "/home"
         snapshots_configurable: true
@@ -153,7 +153,7 @@ storage:
       filesystem: xfs
       size:
         auto: false
-        min: 10 GiB
+        min: 5 GiB
         max: unlimited
       outline:
         required: false
@@ -166,7 +166,7 @@ storage:
     - filesystem: xfs
       size:
         auto: false
-        min: 1 GiB
+        min: 512 MiB
       outline:
         required: false
         filesystems:

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -106,7 +106,7 @@ storage:
         auto_size:
           base_min: 5 GiB
           base_max: 15 GiB
-          snapshots_increment: 250%
+          snapshots_increment: 150%
           max_fallback_for:
             - "/home"
         snapshots_configurable: true
@@ -123,7 +123,7 @@ storage:
       filesystem: xfs
       size:
         auto: false
-        min: 10 GiB
+        min: 5 GiB
         max: unlimited
       outline:
         required: false
@@ -136,7 +136,7 @@ storage:
     - filesystem: xfs
       size:
         auto: false
-        min: 1 GiB
+        min: 512 MiB
       outline:
         required: false
         filesystems:

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -1,5 +1,5 @@
 id: SLES_SAP
-name: SUSE Linux Enterprise Server for SAP Applications 16.0 Beta
+name: SUSE Linux Enterprise Server for SAP applications 16.0 Beta
 archs: x86_64,aarch64,ppc
 registration: true
 version: "16-0"
@@ -10,7 +10,7 @@ license: "license.beta"
 # translations!!
 # ------------------------------------------------------------------------------
 description: "The leading OS for a secure and reliable SAP platform.
-Endorsed for SAP deployments, SUSE Linux Enterprise Server for SAP Applications
+Endorsed for SAP deployments, SUSE Linux Enterprise Server for SAP applications
 futureproofs the SAP project, offers uninterrupted business, and minimizes
 operational risks and costs."
 icon: SUSE.svg

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -143,7 +143,7 @@ storage:
       filesystem: xfs
       size:
         auto: false
-        min: 10 GiB
+        min: 5 GiB
         max: unlimited
       outline:
         required: false
@@ -156,7 +156,7 @@ storage:
     - filesystem: xfs
       size:
         auto: false
-        min: 1 GiB
+        min: 512 MiB
       outline:
         required: false
         filesystems:

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -194,7 +194,7 @@ storage:
       filesystem: xfs
       size:
         auto: false
-        min: 10 GiB
+        min: 5 GiB
         max: unlimited
       outline:
         required: false
@@ -207,7 +207,7 @@ storage:
     - filesystem: xfs
       size:
         auto: false
-        min: 1 GiB
+        min: 512 MiB
       outline:
         required: false
         filesystems:


### PR DESCRIPTION
## Problem

The sizes limits to be used by the storage proposal were basically copied over from YaST and from previous products/distributions. But several aspects are different at Agama and at the new distributions, so the values do not match that well.

On the other hand, I got the following feedback about the name we use for one of the products:

> [...] according to the SAP branding guide we are only permitted to use "SUSE Linux Enterprise for SAP applications" with NO capital "A". [...]

## Solution

First the easy part: remove the capital A.

About sizes, the following adjustments were made:

- For SLES, SLES4SAP, Leap, TW and Slowroll:
  - The minimum of /home is aligned with the minimum of /. For YaST the minimum of /home was higher to enforce automatic de-activation of a separate /home. But we don't have such a mechanism at Agama.
  - The minimum of the generic partition is reduced to a more reasonable value, which also have the advantage of introducing the usage of another unit (MiB instead of using GiB for everything).
- Only for SLES, SLES4SAP and Leap
  - The snapshots increment is reduced because:
     - There is very little software available right now, so the resulting default partitioning is huge and mostly empty.
     - These are supposed to be stable systems with not so many updates, so it is expected that snapshots will take less space than with rolling distributions.
- For openSUSE MicroOS
  - No changes. All values look reasonable to me.