### PR TITLE
feat: expose passwords and drop autologin

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama.Users1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Users1.bus.xml
@@ -62,6 +62,6 @@
       <arg name="result" direction="out" type="u"/>
     </method>
     <property type="(sbs)" name="RootUser" access="read"/>
-    <property type="(sssbba{sv})" name="FirstUser" access="read"/>
+    <property type="(sssba{sv})" name="FirstUser" access="read"/>
   </interface>
 </node>

--- a/doc/dbus/bus/org.opensuse.Agama.Users1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Users1.bus.xml
@@ -1,10 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/org/opensuse/Agama/Users1">
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg name="xml_data" direction="out" type="s"/>
-    </method>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" direction="in" type="s"/>
@@ -26,10 +22,22 @@
       <arg name="invalidated_properties" type="as"/>
     </signal>
   </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.Agama1.Issues">
+    <property type="a(sssuu)" name="All" access="read"/>
+  </interface>
+  <interface name="org.opensuse.Agama1.ServiceStatus">
+    <property type="aa{sv}" name="All" access="read"/>
+    <property type="u" name="Current" access="read"/>
+  </interface>
   <interface name="org.opensuse.Agama.Users1">
     <method name="SetRootPassword">
       <arg name="Value" direction="in" type="s"/>
-      <arg name="Encrypted" direction="in" type="b"/>
+      <arg name="Hashed" direction="in" type="b"/>
       <arg name="result" direction="out" type="u"/>
     </method>
     <method name="RemoveRootPassword">
@@ -43,7 +51,7 @@
       <arg name="FullName" direction="in" type="s"/>
       <arg name="UserName" direction="in" type="s"/>
       <arg name="Password" direction="in" type="s"/>
-      <arg name="AutoLogin" direction="in" type="b"/>
+      <arg name="HashedPassword" direction="in" type="b"/>
       <arg name="data" direction="in" type="a{sv}"/>
       <arg name="result" direction="out" type="(bas)"/>
     </method>
@@ -53,11 +61,7 @@
     <method name="Write">
       <arg name="result" direction="out" type="u"/>
     </method>
-    <property type="b" name="RootPasswordSet" access="read"/>
-    <property type="s" name="RootSSHKey" access="read"/>
-    <property type="(sssba{sv})" name="FirstUser" access="read"/>
-  </interface>
-  <interface name="org.opensuse.Agama1.Issues">
-    <property type="a(ssuu)" name="All" access="read"/>
+    <property type="(sbs)" name="RootUser" access="read"/>
+    <property type="(sssbba{sv})" name="FirstUser" access="read"/>
   </interface>
 </node>

--- a/doc/dbus/org.opensuse.Agama.Users1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Users1.doc.xml
@@ -29,6 +29,6 @@
       <arg name="result" direction="out" type="u"/>
     </method>
     <property type="(sbs)" name="RootUser" access="read"/>
-    <property type="(sssbba{sv})" name="FirstUser" access="read"/>
+    <property type="(sssba{sv})" name="FirstUser" access="read"/>
   </interface>
 </node>

--- a/doc/dbus/org.opensuse.Agama.Users1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Users1.doc.xml
@@ -2,49 +2,23 @@
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/org/opensuse/Agama/Users1">
   <interface name="org.opensuse.Agama.Users1">
-    <!--
-        SetRootPassword:
-
-        If @Encrypted is set to true, it means that already encrypted password is sent
-
-        Example:
-        <programlisting>SetRootPassword("test", false)</programlisting>
-    -->
     <method name="SetRootPassword">
       <arg name="Value" direction="in" type="s"/>
-      <arg name="Encrypted" direction="in" type="b"/>
+      <arg name="Hashed" direction="in" type="b"/>
       <arg name="result" direction="out" type="u"/>
     </method>
-
     <method name="RemoveRootPassword">
       <arg name="result" direction="out" type="u"/>
     </method>
-
-    <!--
-        SetRootSSHKey:
-
-        Set root ssh public keys. Use empty string to unset it.
-
-        Example:
-        <programlisting>SetRootSSHKey("idrsa long key")</programlisting>
-    -->
     <method name="SetRootSSHKey">
       <arg name="Value" direction="in" type="s"/>
       <arg name="result" direction="out" type="u"/>
     </method>
-
-    <!--
-        SetFirstUser:
-
-        Sets one non root user after installation.
-        @FullName and @UserName have to follow restrictions
-        for respective /etc/passwd entry. To unset it use empty @UserName.
-    -->
     <method name="SetFirstUser">
       <arg name="FullName" direction="in" type="s"/>
       <arg name="UserName" direction="in" type="s"/>
       <arg name="Password" direction="in" type="s"/>
-      <arg name="AutoLogin" direction="in" type="b"/>
+      <arg name="HashedPassword" direction="in" type="b"/>
       <arg name="data" direction="in" type="a{sv}"/>
       <arg name="result" direction="out" type="(bas)"/>
     </method>
@@ -54,25 +28,7 @@
     <method name="Write">
       <arg name="result" direction="out" type="u"/>
     </method>
-
-    <!--
-        RootPasswordSet:
-        whenever root password will be set by installer
-    -->
-    <property type="b" name="RootPasswordSet" access="read"/>
-
-    <!--
-        RootSSHKey:
-        Root public ssh key that can be used to login to machine.
-        Can be empty which means not set
-    -->
-    <property type="s" name="RootSSHKey" access="read"/>
-
-    <!--
-        FirstUser:
-        struct( string FullName, string UserName, string Password, boolean AutoLogin, map AdditionalData)
-        Info about first user to set. if Username is empty, it means not set and other values can be ignored
-    -->
-    <property type="(sssba{sv})" name="FirstUser" access="read"/>
+    <property type="(sbs)" name="RootUser" access="read"/>
+    <property type="(sssbba{sv})" name="FirstUser" access="read"/>
   </interface>
 </node>

--- a/rust/agama-lib/src/users.rs
+++ b/rust/agama-lib/src/users.rs
@@ -27,7 +27,7 @@ pub mod proxies;
 mod settings;
 mod store;
 
-pub use client::{FirstUser, UsersClient};
+pub use client::{FirstUser, RootUser, UsersClient};
 pub use http_client::UsersHTTPClient;
 pub use settings::{FirstUserSettings, RootUserSettings, UserSettings};
 pub use store::UsersStore;

--- a/rust/agama-lib/src/users/client.rs
+++ b/rust/agama-lib/src/users/client.rs
@@ -37,8 +37,6 @@ pub struct FirstUser {
     pub password: String,
     /// Whether the password is hashed (true) or is plain text (false)
     pub hashed_password: bool,
-    /// Whether auto-login should enabled or not
-    pub autologin: bool,
 }
 
 impl FirstUser {
@@ -49,7 +47,6 @@ impl FirstUser {
             user_name: data.1,
             password: data.2,
             hashed_password: data.3,
-            autologin: data.4,
         })
     }
 }
@@ -107,7 +104,6 @@ impl<'a> UsersClient<'a> {
                 &first_user.user_name,
                 &first_user.password,
                 first_user.hashed_password,
-                first_user.autologin,
                 std::collections::HashMap::new(),
             )
             .await

--- a/rust/agama-lib/src/users/client.rs
+++ b/rust/agama-lib/src/users/client.rs
@@ -20,7 +20,7 @@
 
 //! Implements a client to access Agama's users service.
 
-use super::proxies::{FirstUser as FirstUserFromDBus, Users1Proxy};
+use super::proxies::{FirstUser as FirstUserFromDBus, RootUser as RootUserFromDBus, Users1Proxy};
 use crate::error::ServiceError;
 use serde::{Deserialize, Serialize};
 use zbus::Connection;
@@ -51,6 +51,42 @@ impl FirstUser {
     }
 }
 
+/// Represents the settings for the first user
+#[derive(Serialize, Deserialize, Clone, Debug, Default, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RootUser {
+    /// Root user password
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    /// Whether the password is hashed (true) or is plain text (false or None)
+    pub hashed_password: Option<bool>,
+    /// SSH public key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssh_public_key: Option<String>,
+}
+
+impl RootUser {
+    pub fn from_dbus(dbus_data: RootUserFromDBus) -> zbus::Result<Self> {
+        let password = if dbus_data.0.is_empty() {
+            None
+        } else {
+            Some(dbus_data.0)
+        };
+
+        let ssh_public_key = if dbus_data.2.is_empty() {
+            None
+        } else {
+            Some(dbus_data.2)
+        };
+
+        Ok(Self {
+            password,
+            hashed_password: Some(dbus_data.1),
+            ssh_public_key,
+        })
+    }
+}
+
 /// D-Bus client for the users service
 #[derive(Clone)]
 pub struct UsersClient<'a> {
@@ -69,6 +105,10 @@ impl<'a> UsersClient<'a> {
         FirstUser::from_dbus(self.users_proxy.first_user().await)
     }
 
+    pub async fn root_user(&self) -> zbus::Result<RootUser> {
+        RootUser::from_dbus(self.users_proxy.root_user().await?)
+    }
+
     /// SetRootPassword method
     pub async fn set_root_password(&self, value: &str, hashed: bool) -> Result<u32, ServiceError> {
         Ok(self.users_proxy.set_root_password(value, hashed).await?)
@@ -76,16 +116,6 @@ impl<'a> UsersClient<'a> {
 
     pub async fn remove_root_password(&self) -> Result<u32, ServiceError> {
         Ok(self.users_proxy.remove_root_password().await?)
-    }
-
-    /// Whether the root password is set or not
-    pub async fn is_root_password(&self) -> Result<bool, ServiceError> {
-        Ok(self.users_proxy.root_password_set().await?)
-    }
-
-    /// Returns the SSH key for the root user
-    pub async fn root_ssh_key(&self) -> zbus::Result<String> {
-        self.users_proxy.root_sshkey().await
     }
 
     /// SetRootSSHKey method

--- a/rust/agama-lib/src/users/http_client.rs
+++ b/rust/agama-lib/src/users/http_client.rs
@@ -54,7 +54,7 @@ impl UsersHTTPClient {
     /// Returns 0 if successful (always, for current backend)
     pub async fn set_root_password(&self, value: &str, hashed: bool) -> Result<u32, ServiceError> {
         let rps = RootPatchSettings {
-            sshkey: None,
+            ssh_public_key: None,
             password: Some(value.to_owned()),
             hashed_password: Some(hashed),
         };
@@ -66,7 +66,7 @@ impl UsersHTTPClient {
     /// Returns 0 if successful (always, for current backend)
     pub async fn set_root_sshkey(&self, value: &str) -> Result<u32, ServiceError> {
         let rps = RootPatchSettings {
-            sshkey: Some(value.to_owned()),
+            ssh_public_key: Some(value.to_owned()),
             password: None,
             hashed_password: None,
         };

--- a/rust/agama-lib/src/users/http_client.rs
+++ b/rust/agama-lib/src/users/http_client.rs
@@ -18,8 +18,8 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use super::client::FirstUser;
-use crate::users::model::{RootConfig, RootPatchSettings};
+use super::client::{FirstUser, RootUser};
+use crate::users::model::RootPatchSettings;
 use crate::{base_http_client::BaseHTTPClient, error::ServiceError};
 
 pub struct UsersHTTPClient {
@@ -46,14 +46,8 @@ impl UsersHTTPClient {
         result
     }
 
-    async fn root_config(&self) -> Result<RootConfig, ServiceError> {
+    pub async fn root_user(&self) -> Result<RootUser, ServiceError> {
         self.client.get("/users/root").await
-    }
-
-    /// Whether the root password is set or not
-    pub async fn is_root_password(&self) -> Result<bool, ServiceError> {
-        let root_config = self.root_config().await?;
-        Ok(root_config.password)
     }
 
     /// SetRootPassword method.
@@ -66,12 +60,6 @@ impl UsersHTTPClient {
         };
         let ret = self.client.patch("/users/root", &rps).await?;
         Ok(ret)
-    }
-
-    /// Returns the SSH key for the root user
-    pub async fn root_ssh_key(&self) -> Result<String, ServiceError> {
-        let root_config = self.root_config().await?;
-        Ok(root_config.sshkey)
     }
 
     /// SetRootSSHKey method.

--- a/rust/agama-lib/src/users/model.rs
+++ b/rust/agama-lib/src/users/model.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct RootPatchSettings {
     /// empty string here means remove ssh key for root
-    pub sshkey: Option<String>,
+    pub ssh_public_key: Option<String>,
     /// empty string here means remove password for root
     pub password: Option<String>,
     /// specify if patched password is provided in plain text (default) or hashed

--- a/rust/agama-lib/src/users/model.rs
+++ b/rust/agama-lib/src/users/model.rs
@@ -21,14 +21,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
-pub struct RootConfig {
-    /// returns if password for root is set or not
-    pub password: bool,
-    /// empty string mean no sshkey is specified
-    pub sshkey: String,
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RootPatchSettings {
     /// empty string here means remove ssh key for root

--- a/rust/agama-lib/src/users/proxies.rs
+++ b/rust/agama-lib/src/users/proxies.rs
@@ -48,7 +48,6 @@ use zbus::proxy;
 /// * user name
 /// * password
 /// * hashed_password (true = hashed, false = plain text)
-/// * auto-login (enabled or not)
 /// * some optional and additional data
 // NOTE: Manually added to this file.
 pub type FirstUser = (
@@ -79,7 +78,6 @@ pub trait Users1 {
         user_name: &str,
         password: &str,
         hashed_password: bool,
-        auto_login: bool,
         data: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
     ) -> zbus::Result<(bool, Vec<String>)>;
 

--- a/rust/agama-lib/src/users/proxies.rs
+++ b/rust/agama-lib/src/users/proxies.rs
@@ -31,8 +31,8 @@
 //! This type implements the [D-Bus standard interfaces], (`org.freedesktop.DBus.*`) for which the
 //! following zbus API can be used:
 //!
-//! * [`zbus::fdo::IntrospectableProxy`]
 //! * [`zbus::fdo::PropertiesProxy`]
+//! * [`zbus::fdo::IntrospectableProxy`]
 //!
 //! Consequently `zbus-xmlgen` did not generate code for the above interfaces.
 //!
@@ -57,6 +57,15 @@ pub type FirstUser = (
     bool,
     std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
 );
+
+/// Root user as it comes from D-Bus.
+///
+/// It is composed of:
+///
+/// * password (an empty string if it is not set)
+/// * hashed_password (true = hashed, false = plain text)
+/// * SSH public key
+pub type RootUser = (String, bool, String);
 
 #[proxy(
     default_service = "org.opensuse.Agama.Manager1",
@@ -95,11 +104,7 @@ pub trait Users1 {
     #[zbus(property)]
     fn first_user(&self) -> zbus::Result<FirstUser>;
 
-    /// RootPasswordSet property
+    /// RootUser property
     #[zbus(property)]
-    fn root_password_set(&self) -> zbus::Result<bool>;
-
-    /// RootSSHKey property
-    #[zbus(property, name = "RootSSHKey")]
-    fn root_sshkey(&self) -> zbus::Result<String>;
+    fn root_user(&self) -> zbus::Result<RootUser>;
 }

--- a/rust/agama-lib/src/users/proxies.rs
+++ b/rust/agama-lib/src/users/proxies.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -55,7 +55,6 @@ pub type FirstUser = (
     String,
     String,
     String,
-    bool,
     bool,
     std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
 );

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -45,8 +45,6 @@ pub struct FirstUserSettings {
     pub password: Option<String>,
     /// Whether the password is hashed or is plain text
     pub hashed_password: Option<bool>,
-    /// Whether auto-login should enabled or not
-    pub autologin: Option<bool>,
 }
 
 /// Root user settings

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -191,14 +191,14 @@ mod test {
             when.method(PATCH)
                 .path("/api/users/root")
                 .header("content-type", "application/json")
-                .body(r#"{"sshkey":null,"password":"1234","hashedPassword":false}"#);
+                .body(r#"{"sshPublicKey":null,"password":"1234","hashedPassword":false}"#);
             then.status(200).body("0");
         });
         let root_mock2 = server.mock(|when, then| {
             when.method(PATCH)
                 .path("/api/users/root")
                 .header("content-type", "application/json")
-                .body(r#"{"sshkey":"keykeykey","password":null,"hashedPassword":null}"#);
+                .body(r#"{"sshPublicKey":"keykeykey","password":null,"hashedPassword":null}"#);
             then.status(200).body("0");
         });
         let url = server.url("/api");

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -48,11 +48,13 @@ impl UsersStore {
             password: Some(first_user.password),
             hashed_password: Some(first_user.hashed_password),
         };
-        let mut root_user = RootUserSettings::default();
-        let ssh_public_key = self.users_client.root_ssh_key().await?;
-        if !ssh_public_key.is_empty() {
-            root_user.ssh_public_key = Some(ssh_public_key)
-        }
+        let root_user = RootUserSettings::default();
+        let root_user = RootUserSettings {
+            password: root_user.password,
+            hashed_password: root_user.hashed_password,
+            ssh_public_key: root_user.ssh_public_key,
+        };
+
         Ok(UserSettings {
             first_user: Some(first_user),
             root: Some(root_user),

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -48,7 +48,7 @@ impl UsersStore {
             password: Some(first_user.password),
             hashed_password: Some(first_user.hashed_password),
         };
-        let root_user = RootUserSettings::default();
+        let root_user = self.users_client.root_user().await?;
         let root_user = RootUserSettings {
             password: root_user.password,
             hashed_password: root_user.hashed_password,
@@ -138,8 +138,9 @@ mod test {
                 .header("content-type", "application/json")
                 .body(
                     r#"{
-                    "sshkey": "keykeykey",
-                    "password": true
+                    "sshPublicKey": "keykeykey",
+                    "password": "nots3cr3t",
+                    "hashedPassword": false
                 }"#,
                 );
         });
@@ -156,8 +157,8 @@ mod test {
         };
         let root_user = RootUserSettings {
             // FIXME this is weird: no matter what HTTP reports, we end up with None
-            password: None,
-            hashed_password: None,
+            password: Some("nots3cr3t".to_owned()),
+            hashed_password: Some(false),
             ssh_public_key: Some("keykeykey".to_owned()),
         };
         let expected = UserSettings {

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -44,7 +44,6 @@ impl UsersStore {
         let first_user = self.users_client.first_user().await?;
         let first_user = FirstUserSettings {
             user_name: Some(first_user.user_name),
-            autologin: Some(first_user.autologin),
             full_name: Some(first_user.full_name),
             password: Some(first_user.password),
             hashed_password: Some(first_user.hashed_password),
@@ -76,7 +75,6 @@ impl UsersStore {
         let first_user = FirstUser {
             user_name: settings.user_name.clone().unwrap_or_default(),
             full_name: settings.full_name.clone().unwrap_or_default(),
-            autologin: settings.autologin.unwrap_or_default(),
             password: settings.password.clone().unwrap_or_default(),
             hashed_password: settings.hashed_password.unwrap_or_default(),
         };
@@ -128,8 +126,7 @@ mod test {
                     "fullName": "Tux",
                     "userName": "tux",
                     "password": "fish",
-                    "hashedPassword": false,
-                    "autologin": true
+                    "hashedPassword": false
                 }"#,
                 );
         });
@@ -154,7 +151,6 @@ mod test {
             user_name: Some("tux".to_owned()),
             password: Some("fish".to_owned()),
             hashed_password: Some(false),
-            autologin: Some(true),
         };
         let root_user = RootUserSettings {
             // FIXME this is weird: no matter what HTTP reports, we end up with None
@@ -184,7 +180,7 @@ mod test {
             when.method(PUT)
                 .path("/api/users/first")
                 .header("content-type", "application/json")
-                .body(r#"{"fullName":"Tux","userName":"tux","password":"fish","hashedPassword":false,"autologin":true}"#);
+                .body(r#"{"fullName":"Tux","userName":"tux","password":"fish","hashedPassword":false}"#);
             then.status(200);
         });
         // note that we use 2 requests for root
@@ -211,7 +207,6 @@ mod test {
             user_name: Some("tux".to_owned()),
             password: Some("fish".to_owned()),
             hashed_password: Some(false),
-            autologin: Some(true),
         };
         let root_user = RootUserSettings {
             password: Some("1234".to_owned()),

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -198,7 +198,7 @@ async fn patch_root(
     Json(config): Json<RootPatchSettings>,
 ) -> Result<impl IntoResponse, Error> {
     let mut retcode1 = 0;
-    if let Some(key) = config.sshkey {
+    if let Some(key) = config.ssh_public_key {
         retcode1 = state.users.set_root_sshkey(&key).await?;
     }
 

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -33,11 +33,7 @@ use crate::{
 };
 use agama_lib::{
     error::ServiceError,
-    users::{
-        model::{RootConfig, RootPatchSettings},
-        proxies::Users1Proxy,
-        FirstUser, UsersClient,
-    },
+    users::{model::RootPatchSettings, proxies::Users1Proxy, FirstUser, RootUser, UsersClient},
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
 use tokio_stream::{Stream, StreamExt};
@@ -54,23 +50,15 @@ struct UsersState<'a> {
 /// * `connection`: D-Bus connection to listen for events.
 pub async fn users_streams(dbus: zbus::Connection) -> Result<EventStreams, Error> {
     const FIRST_USER_ID: &str = "first_user";
-    const ROOT_PASSWORD_ID: &str = "root_password";
-    const ROOT_SSHKEY_ID: &str = "root_sshkey";
-    // here we have three streams, but only two events. Reason is
-    // that we have three streams from dbus about property change
-    // and unify two root user properties into single event to http API
+    const ROOT_USER_ID: &str = "root_user";
     let result: EventStreams = vec![
         (
             FIRST_USER_ID,
             Box::pin(first_user_changed_stream(dbus.clone()).await?),
         ),
         (
-            ROOT_PASSWORD_ID,
-            Box::pin(root_password_changed_stream(dbus.clone()).await?),
-        ),
-        (
-            ROOT_SSHKEY_ID,
-            Box::pin(root_ssh_key_changed_stream(dbus.clone()).await?),
+            ROOT_USER_ID,
+            Box::pin(root_user_changed_stream(dbus.clone()).await?),
         ),
     ];
 
@@ -100,39 +88,18 @@ async fn first_user_changed_stream(
     Ok(stream)
 }
 
-async fn root_password_changed_stream(
+async fn root_user_changed_stream(
     dbus: zbus::Connection,
 ) -> Result<impl Stream<Item = Event> + Send, Error> {
     let proxy = Users1Proxy::new(&dbus).await?;
     let stream = proxy
-        .receive_root_password_set_changed()
+        .receive_root_user_changed()
         .await
         .then(|change| async move {
-            if let Ok(is_set) = change.get().await {
-                return Some(Event::RootChanged {
-                    password: Some(is_set),
-                    sshkey: None,
-                });
-            }
-            None
-        })
-        .filter_map(|e| e);
-    Ok(stream)
-}
-
-async fn root_ssh_key_changed_stream(
-    dbus: zbus::Connection,
-) -> Result<impl Stream<Item = Event> + Send, Error> {
-    let proxy = Users1Proxy::new(&dbus).await?;
-    let stream = proxy
-        .receive_root_sshkey_changed()
-        .await
-        .then(|change| async move {
-            if let Ok(key) = change.get().await {
-                return Some(Event::RootChanged {
-                    password: None,
-                    sshkey: Some(key),
-                });
+            if let Ok(user) = change.get().await {
+                if let Ok(root) = RootUser::from_dbus(user) {
+                    return Some(Event::RootUserChanged(root));
+                }
             }
             None
         })
@@ -257,13 +224,10 @@ async fn patch_root(
     path = "/root",
     context_path = "/api/users",
     responses(
-        (status = 200, description = "Configuration for the root user", body = RootConfig),
+        (status = 200, description = "Configuration for the root user", body = RootUser),
         (status = 400, description = "The D-Bus service could not perform the action"),
     )
 )]
-async fn get_root_config(State(state): State<UsersState<'_>>) -> Result<Json<RootConfig>, Error> {
-    let password = state.users.is_root_password().await?;
-    let sshkey = state.users.root_ssh_key().await?;
-    let config = RootConfig { password, sshkey };
-    Ok(Json(config))
+async fn get_root_config(State(state): State<UsersState<'_>>) -> Result<Json<RootUser>, Error> {
+    Ok(Json(state.users.root_user().await?))
 }

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -91,7 +91,6 @@ async fn first_user_changed_stream(
                     user_name: user.1,
                     password: user.2,
                     hashed_password: user.3,
-                    autologin: user.4,
                 };
                 return Some(Event::FirstUserChanged(user_struct));
             }

--- a/rust/agama-server/src/web/docs/users.rs
+++ b/rust/agama-server/src/web/docs/users.rs
@@ -45,7 +45,7 @@ impl ApiDocBuilder for UsersApiDocBuilder {
     fn components(&self) -> utoipa::openapi::Components {
         ComponentsBuilder::new()
             .schema_from::<agama_lib::users::FirstUser>()
-            .schema_from::<agama_lib::users::model::RootConfig>()
+            .schema_from::<agama_lib::users::RootUser>()
             .schema_from::<agama_lib::users::model::RootPatchSettings>()
             .schema_from::<crate::web::common::Issue>()
             .schema(

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -33,7 +33,7 @@ use agama_lib::{
         },
         ISCSINode,
     },
-    users::FirstUser,
+    users::{FirstUser, RootUser},
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -64,10 +64,7 @@ pub enum Event {
     },
     RegistrationChanged,
     FirstUserChanged(FirstUser),
-    RootChanged {
-        password: Option<bool>,
-        sshkey: Option<String>,
-    },
+    RootUserChanged(RootUser),
     NetworkChange {
         #[serde(flatten)]
         change: NetworkChange,

--- a/service/lib/agama/dbus/users.rb
+++ b/service/lib/agama/dbus/users.rb
@@ -59,7 +59,7 @@ module Agama
       private_constant :USERS_INTERFACE
 
       FUSER_SIG = "in FullName:s, in UserName:s, in Password:s, in HashedPassword:b, " \
-                  "in AutoLogin:b, in data:a{sv}"
+                  "in data:a{sv}"
       private_constant :FUSER_SIG
 
       dbus_interface USERS_INTERFACE do
@@ -99,10 +99,10 @@ module Agama
           # It returns an Struct with the first field with the result of the operation as a boolean
           # and the second parameter as an array of issues found in case of failure
           FUSER_SIG + ", out result:(bas)" do
-            |full_name, user_name, password, hashed_password, auto_login, data|
+            |full_name, user_name, password, hashed_password, data|
           logger.info "Setting first user #{full_name}"
           user_issues = backend.assign_first_user(full_name, user_name, password,
-            hashed_password, auto_login, data)
+            hashed_password, data)
 
           if user_issues.empty?
             dbus_properties_changed(USERS_INTERFACE, { "FirstUser" => first_user }, [])
@@ -143,7 +143,6 @@ module Agama
           user.name,
           user.password_content || "",
           user.password&.value&.encrypted? || false,
-          backend.autologin?(user),
           {}
         ]
       end

--- a/service/lib/agama/users.rb
+++ b/service/lib/agama/users.rb
@@ -72,13 +72,7 @@ module Agama
       update_issues
     end
 
-    # Whether the given user is configured for autologin
     #
-    # @param [Y2Users::User] user
-    # @return [Boolean]
-    def autologin?(user)
-      config.login.autologin_user == user
-    end
 
     # First created user
     #
@@ -118,8 +112,6 @@ module Agama
       return fatal_issues.map(&:message) unless fatal_issues.empty?
 
       config.attach(user)
-      config.login ||= Y2Users::LoginConfig.new
-      config.login.autologin_user = auto_login ? user : nil
       update_issues
       []
     end

--- a/service/test/agama/dbus/users_test.rb
+++ b/service/test/agama/dbus/users_test.rb
@@ -70,7 +70,7 @@ describe Agama::DBus::Users do
       let(:user) { nil }
 
       it "returns default data" do
-        expect(subject.first_user).to eq(["", "", "", false, false, {}])
+        expect(subject.first_user).to eq(["", "", "", false, {}])
       end
     end
 
@@ -85,7 +85,7 @@ describe Agama::DBus::Users do
       end
 
       it "returns the first user data" do
-        expect(subject.first_user).to eq(["Test user", "test", password.value.to_s, true, true, {}])
+        expect(subject.first_user).to eq(["Test user", "test", password.value.to_s, true, {}])
       end
     end
   end

--- a/service/test/agama/dbus/users_test.rb
+++ b/service/test/agama/dbus/users_test.rb
@@ -84,10 +84,6 @@ describe Agama::DBus::Users do
           password_content: password.value.to_s)
       end
 
-      before do
-        allow(backend).to receive(:autologin?).with(user).and_return(true)
-      end
-
       it "returns the first user data" do
         expect(subject.first_user).to eq(["Test user", "test", password.value.to_s, true, true, {}])
       end

--- a/service/test/agama/users_test.rb
+++ b/service/test/agama/users_test.rb
@@ -37,6 +37,13 @@ describe Agama::Users do
   describe "#assign_root_password" do
     let(:root_user) { instance_double(Y2Users::User) }
 
+    describe "#root_user" do
+      it "returns the root user" do
+        root = subject.root_user
+        expect(root.name).to eq("root")
+      end
+    end
+
     context "when the password is hashed" do
       it "sets the password as hashed" do
         subject.assign_root_password("hashed", true)
@@ -57,24 +64,10 @@ describe Agama::Users do
   describe "#remove_root_password" do
     it "removes the password" do
       subject.assign_root_password("12345", false)
-      expect { subject.remove_root_password }.to change { subject.root_password? }
-        .from(true).to(false)
-    end
-  end
-
-  describe "#root_password?" do
-    it "returns true if the root password is set" do
-      subject.assign_root_password("12345", false)
-      expect(subject.root_password?).to eq(true)
-    end
-
-    it "returns false if the root password is not set" do
-      expect(subject.root_password?).to eq(false)
-    end
-
-    it "returns true if the root password is set to nil" do
-      subject.assign_root_password("", false)
-      expect(subject.root_password?).to eq(false)
+      root = subject.root_user
+      expect(root.password).to be_kind_of(Y2Users::Password)
+      subject.remove_root_password
+      expect(root.password).to be_nil
     end
   end
 

--- a/service/test/agama/users_test.rb
+++ b/service/test/agama/users_test.rb
@@ -74,7 +74,7 @@ describe Agama::Users do
   describe "#assign_first_user" do
     context "when the options given do not present any issue" do
       it "adds the user to the user's configuration" do
-        subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
+        subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
         user = users_config.users.by_name("jane")
         expect(user.full_name).to eq("Jane Doe")
         expect(user.password).to eq(Y2Users::Password.create_plain("12345"))
@@ -82,11 +82,11 @@ describe Agama::Users do
 
       context "when a first user exists" do
         before do
-          subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
+          subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
         end
 
         it "replaces the user with the new one" do
-          subject.assign_first_user("John Doe", "john", "12345", false, false, {})
+          subject.assign_first_user("John Doe", "john", "12345", false, {})
 
           user = users_config.users.by_name("jane")
           expect(user).to be_nil
@@ -97,23 +97,23 @@ describe Agama::Users do
       end
 
       it "returns an empty array of issues" do
-        issues = subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
+        issues = subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
         expect(issues).to be_empty
       end
     end
 
     context "when the given arguments presents some critical error" do
       it "does not add the user to the config" do
-        subject.assign_first_user("Jonh Doe", "john", "", false, false, {})
+        subject.assign_first_user("Jonh Doe", "john", "", false, {})
         user = users_config.users.by_name("john")
         expect(user).to be_nil
-        subject.assign_first_user("Ldap user", "ldap", "12345", false, false, {})
+        subject.assign_first_user("Ldap user", "ldap", "12345", false, {})
         user = users_config.users.by_name("ldap")
         expect(user).to be_nil
       end
 
       it "returns an array with all the issues" do
-        issues = subject.assign_first_user("Root user", "root", "12345", false, false, {})
+        issues = subject.assign_first_user("Root user", "root", "12345", false, {})
         expect(issues.size).to eql(1)
       end
     end
@@ -121,7 +121,7 @@ describe Agama::Users do
 
   describe "#remove_first_user" do
     before do
-      subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
+      subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
     end
 
     it "removes the already defined first user" do
@@ -149,7 +149,7 @@ describe Agama::Users do
     end
 
     it "writes system and installer defined users" do
-      subject.assign_first_user("Jane Doe", "jane", "12345", false, false, {})
+      subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
 
       expect(Y2Users::Linux::Writer).to receive(:new) do |target_config, _old_config|
         user_names = target_config.users.map(&:name)
@@ -189,7 +189,7 @@ describe Agama::Users do
 
       context "when a first user is defined" do
         before do
-          subject.assign_first_user("Jane Doe", "jdoe", "123456", false, false, {})
+          subject.assign_first_user("Jane Doe", "jdoe", "123456", false, {})
         end
 
         it "returns an empty list" do


### PR DESCRIPTION
## Problem

The users API does not expose the passwords. Initially, we implemented like that for security
reasons, but giving that the password is send over an authenticated HTTPS connection, we do not
think it is relevant. After all, you are sending/receiving the password using the same channel.

Moreover, the D-Bus API is kind of inconsistent. The "first user" is exposed as a single "object",
while the root data are separate D-Bus properties.

## Solution

- Make user/root passwords visible.
- Drop the autologin property, as it is not wanted anymore.

About the D-Bus API, this PR puts all the root information together using a `RootUser` property.
Ideally, we should have a `SetRootUser` method too, but it will have to wait a bit.

## Testing

- Added a new unit test
- Tested manually
