### PR TITLE
feat: initial SCC proxy support

### DIFF
--- a/rust/agama-lib/src/product.rs
+++ b/rust/agama-lib/src/product.rs
@@ -26,7 +26,6 @@ pub mod proxies;
 mod settings;
 mod store;
 
-pub use crate::software::model::RegistrationRequirement;
 pub use client::{Product, ProductClient};
 pub use http_client::ProductHTTPClient;
 pub use settings::ProductSettings;

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -23,7 +23,6 @@ use std::str::FromStr;
 
 use crate::dbus::{get_optional_property, get_property};
 use crate::error::ServiceError;
-use crate::software::model::RegistrationRequirement;
 use crate::software::proxies::SoftwareProductProxy;
 use serde::Serialize;
 use zbus::Connection;

--- a/rust/agama-lib/src/product/proxies.rs
+++ b/rust/agama-lib/src/product/proxies.rs
@@ -63,8 +63,4 @@ pub trait Registration {
     /// RegCode property
     #[zbus(property)]
     fn reg_code(&self) -> zbus::Result<String>;
-
-    /// Requirement property
-    #[zbus(property)]
-    fn requirement(&self) -> zbus::Result<u32>;
 }

--- a/rust/agama-lib/src/product/store.rs
+++ b/rust/agama-lib/src/product/store.rs
@@ -121,8 +121,7 @@ mod test {
                 .body(
                     r#"{
                     "key": "",
-                    "email": "",
-                    "requirement": "NotRequired"
+                    "email": ""
                 }"#,
                 );
         });

--- a/rust/agama-lib/src/software/model/registration.rs
+++ b/rust/agama-lib/src/software/model/registration.rs
@@ -39,28 +39,6 @@ pub struct RegistrationInfo {
     pub email: String,
 }
 
-#[derive(
-    Clone,
-    Default,
-    Debug,
-    Serialize,
-    Deserialize,
-    strum::Display,
-    strum::EnumString,
-    utoipa::ToSchema,
-)]
-#[strum(serialize_all = "camelCase")]
-#[serde(rename_all = "camelCase")]
-pub enum RegistrationRequirement {
-    /// Product does not require registration
-    #[default]
-    No = 0,
-    /// Product has optional registration
-    Optional = 1,
-    /// It is mandatory to register the product
-    Mandatory = 2,
-}
-
 #[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct RegistrationError {
     /// ID of error. See dbus API for possible values

--- a/rust/agama-server/src/web/docs/software.rs
+++ b/rust/agama-server/src/web/docs/software.rs
@@ -53,7 +53,6 @@ impl ApiDocBuilder for SoftwareApiDocBuilder {
     fn components(&self) -> Components {
         ComponentsBuilder::new()
             .schema_from::<agama_lib::product::Product>()
-            .schema_from::<agama_lib::product::RegistrationRequirement>()
             .schema_from::<agama_lib::software::Pattern>()
             .schema_from::<agama_lib::software::SelectedBy>()
             .schema_from::<agama_lib::software::model::LanguageTag>()

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -23,7 +23,6 @@ use agama_lib::{
     jobs::Job,
     localization::model::LocaleConfig,
     manager::InstallationPhase,
-    product::RegistrationRequirement,
     progress::Progress,
     software::SelectedBy,
     storage::{
@@ -58,9 +57,6 @@ pub enum Event {
     },
     ProductChanged {
         id: String,
-    },
-    RegistrationRequirementChanged {
-        requirement: RegistrationRequirement,
     },
     RegistrationChanged,
     FirstUserChanged(FirstUser),

--- a/service/lib/agama/cmdline_args.rb
+++ b/service/lib/agama/cmdline_args.rb
@@ -35,6 +35,10 @@ module Agama
       @data = data
     end
 
+    def self.read
+      read_from("/proc/cmdline")
+    end
+
     # Reads the kernel command line options
     def self.read_from(path)
       options = File.read(path)

--- a/service/lib/agama/dbus/software/product.rb
+++ b/service/lib/agama/dbus/software/product.rb
@@ -114,7 +114,6 @@ module Agama
 
             if code == 0
               dbus_properties_changed(PRODUCT_INTERFACE, { "SelectedProduct" => id }, [])
-              dbus_properties_changed(REGISTRATION_INTERFACE, { "Requirement" => requirement }, [])
               # FIXME: Product issues might change after selecting a product. Nevertheless,
               #   #on_issues_change callbacks should be used for emitting issues signals, ensuring
               #   they are emitted every time the backend changes its issues. Currently,
@@ -134,23 +133,6 @@ module Agama
 
         def email
           backend.registration.email || ""
-        end
-
-        # Registration requirement.
-        #
-        # @return [Integer] Possible values:
-        #   0: not required
-        #   1: optional
-        #   2: mandatory
-        def requirement
-          case backend.registration.requirement
-          when Agama::Registration::Requirement::MANDATORY
-            2
-          when Agama::Registration::Requirement::OPTIONAL
-            1
-          else
-            0
-          end
         end
 
         # Tries to register with the given registration code.
@@ -226,8 +208,6 @@ module Agama
           dbus_reader(:reg_code, "s")
 
           dbus_reader(:email, "s")
-
-          dbus_reader(:requirement, "u")
 
           dbus_method(:Register, "in reg_code:s, in options:a{sv}, out result:(us)") do |*args|
             [register(args[0], email: args[1]["Email"])]

--- a/service/lib/agama/registration.rb
+++ b/service/lib/agama/registration.rb
@@ -50,12 +50,6 @@ module Agama
     # @return [String, nil]
     attr_reader :email
 
-    module Requirement
-      NO = :no
-      OPTIONAL = :optional
-      MANDATORY = :mandatory
-    end
-
     # @param software_manager [Agama::Software::Manager]
     # @param logger [Logger]
     def initialize(software_manager, logger)
@@ -155,16 +149,6 @@ module Agama
       files.each do |src_dest|
         FileUtils.cp(*src_dest)
       end
-    end
-
-    # Indicates whether the registration is optional, mandatory or not required.
-    #
-    # @return [Symbol] See {Requirement}.
-    def requirement
-      return Requirement::NO unless product
-      return Requirement::MANDATORY if product.repositories.none?
-
-      Requirement::NO
     end
 
     # Callbacks to be called when registration changes (e.g., a different product is selected).

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Feb 18 11:27:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Implement basic support for RMT/SCC proxies (gh#agama-project/agama#2007).
+
+-------------------------------------------------------------------
 Mon Feb 17 09:17:47 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for post-partitioning scripts (jsc#AGM-108).

--- a/service/test/agama/dbus/software/product_test.rb
+++ b/service/test/agama/dbus/software/product_test.rb
@@ -152,36 +152,6 @@ describe Agama::DBus::Software::Product do
     end
   end
 
-  describe "#requirement" do
-    before do
-      allow(backend.registration).to receive(:requirement).and_return(requirement)
-    end
-
-    context "if the registration is not required" do
-      let(:requirement) { Agama::Registration::Requirement::NO }
-
-      it "returns 0" do
-        expect(subject.requirement).to eq(0)
-      end
-    end
-
-    context "if the registration is optional" do
-      let(:requirement) { Agama::Registration::Requirement::OPTIONAL }
-
-      it "returns 1" do
-        expect(subject.requirement).to eq(1)
-      end
-    end
-
-    context "if the registration is mandatory" do
-      let(:requirement) { Agama::Registration::Requirement::MANDATORY }
-
-      it "returns 2" do
-        expect(subject.requirement).to eq(2)
-      end
-    end
-  end
-
   describe "#register" do
     before do
       allow(backend.registration).to receive(:reg_code).and_return(nil)

--- a/service/test/agama/registration_test.rb
+++ b/service/test/agama/registration_test.rb
@@ -345,38 +345,6 @@ describe Agama::Registration do
     end
   end
 
-  describe "#requirement" do
-    context "if there is not product selected yet" do
-      let(:product) { nil }
-
-      it "returns not required" do
-        expect(subject.requirement).to eq(Agama::Registration::Requirement::NO)
-      end
-    end
-
-    context "if there is a selected product" do
-      let(:product) do
-        Agama::Software::Product.new("test").tap { |p| p.repositories = repositories }
-      end
-
-      context "and the product has repositories" do
-        let(:repositories) { ["https://repo"] }
-
-        it "returns not required" do
-          expect(subject.requirement).to eq(Agama::Registration::Requirement::NO)
-        end
-      end
-
-      context "and the product has no repositories" do
-        let(:repositories) { [] }
-
-        it "returns mandatory" do
-          expect(subject.requirement).to eq(Agama::Registration::Requirement::MANDATORY)
-        end
-      end
-    end
-  end
-
   describe "#finish" do
     context "system is not registered" do
       before do

--- a/web/src/types/registration.ts
+++ b/web/src/types/registration.ts
@@ -21,8 +21,6 @@
  */
 
 type Registration = {
-  /** Registration requirement (i.e., "not-required", "optional", "mandatory") */
-  requirement: "no" | "optional" | "mandatory";
   /** Registration code, if any */
   code?: string;
   /** Registration email, if any */


### PR DESCRIPTION
## Problem

Our QA team needs basic support to register against SCC proxy servers.

## Solution

* Add a new `inst.register_url` to define the URL for registering the system.
* Take the opportunity to clean-up unused registration code.

## Testing

- Added a new unit test
- Tested manually

## Screenshots

<details>
<summary>Error using a different server</summary>

![Captura desde 2025-02-18 10-55-30](https://github.com/user-attachments/assets/2b81b93b-a751-4830-b90e-2b7fbc042fbd)
</details>