### PR TITLE
fix(live): Add the xhci-pci-renesas driver to the initrd if available (dracut workaround)

### DIFF
--- a/live/root/tmp/driver_cleanup.rb
+++ b/live/root/tmp/driver_cleanup.rb
@@ -60,6 +60,7 @@ end
 
 # really delete or just do a smoke test?
 do_delete = ARGV[0] == "--delete"
+debug = ENV["DEBUG"] == "1"
 
 # read the configuration files
 config = File.read(File.join(__dir__, "module.list")).split("\n")
@@ -129,6 +130,7 @@ end
 
 delete_drivers = to_delete.map(&:path)
 puts "Found #{delete_drivers.size} drivers to delete"
+puts delete_drivers if debug
 File.delete(*delete_drivers) if do_delete
 
 # Note: The module dependencies are updated by the config.sh script

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 18 11:10:22 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Add the xhci-pci-renesas driver to the initrd if available
+  (workaround for bsc#1237235)
+
+-------------------------------------------------------------------
 Wed Feb 12 12:02:39 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Do not print details about removed kernel drivers and firmware

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -87,6 +87,15 @@ echo "root_disk=live:LABEL=$label" >>/etc/cmdline.d/10-liveroot.conf
 echo 'install_items+=" /etc/cmdline.d/10-liveroot.conf "' >/etc/dracut.conf.d/10-liveroot-file.conf
 echo 'add_dracutmodules+=" dracut-menu agama-cmdline "' >>/etc/dracut.conf.d/10-liveroot-file.conf
 
+# add xhci-pci-renesas to initrd if available (workaround for bsc#1237235)
+# FIXME: remove when the module is included in the default driver list in
+# in /usr/lib/dracut/modules.d/90kernel-modules/module-setup.sh, see
+# https://github.com/openSUSE/dracut/blob/7559201e7480a65b0da050263d96a1cd8f15f50d/modules.d/90kernel-modules/module-setup.sh#L42-L46
+if [ -f /lib/modules/*/kernel/drivers/usb/host/xhci-pci-renesas.ko* ]; then
+  echo "Adding xhci-pci-renesas driver to initrd..."
+  echo 'add_drivers+=" xhci-pci-renesas "' > /etc/dracut.conf.d/10-extra-drivers.conf
+fi
+
 if [ "${arch}" = "s390x" ]; then
   # workaround for custom bootloader setting
   touch /config.bootoptions
@@ -167,6 +176,7 @@ rpm -e --nodeps alsa alsa-utils alsa-ucm-conf || true
 du -h -s /lib/modules /lib/firmware
 
 # remove the multimedia drivers
+# set DEBUG=1 to print the deleted drivers
 /tmp/driver_cleanup.rb --delete
 # remove the script, not needed anymore
 rm /tmp/driver_cleanup.rb


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1237235
- The `xhci-pci-renesas` driver is missing in the Live ISO initrd and the system does not boot 


## Solution

- As a workaround explicitly add the driver to the dracut configuration
- Ideally this should be fixed in the dracut package to include the driver by default, but that will likely take some time. So apply a quick workaround so they have something to test ASAP.
- I added an optional debug option to the driver cleanup script for easier debugging (the first idea was that the driver is accidentally deleted by the script, but that was not the case)

## Testing

- When building the ISO locally the `xhci-pci-renesas` driver is included by dracut
