### PR TITLE
fix(web): make username suggestions work again

### DIFF
--- a/web/src/components/users/FirstUserForm.test.tsx
+++ b/web/src/components/users/FirstUserForm.test.tsx
@@ -20,8 +20,8 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
-import { screen } from "@testing-library/react";
+import React, { act } from "react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import FirstUserForm from "./FirstUserForm";
 
@@ -49,6 +49,25 @@ jest.mock("~/queries/users", () => ({
 }));
 
 describe("FirstUserForm", () => {
+  it("allows using suggested username", async () => {
+    const { user } = installerRender(<FirstUserForm />);
+    const fullNameInput = screen.getByRole("textbox", { name: "Full name" });
+    const userNameInput = screen.getByRole("textbox", { name: "Username" });
+    await user.type(fullNameInput, "Gecko Giggles");
+    // Suggestions rely on blur/focus,
+    // See https://testing-library.com/docs/guide-events#focusblur
+    act(() => {
+      fullNameInput.blur();
+    });
+    act(() => {
+      userNameInput.focus();
+    });
+    const suggestions = screen.getByRole("menu");
+    const secondSuggestion = within(suggestions).getByRole("menuitem", { name: /ggiggles$/ });
+    await user.click(secondSuggestion);
+    expect(userNameInput).toHaveValue("ggiggles");
+  });
+
   describe("when user is not defined", () => {
     beforeEach(() => {
       mockUserName = "";

--- a/web/src/components/users/FirstUserForm.tsx
+++ b/web/src/components/users/FirstUserForm.tsx
@@ -148,9 +148,7 @@ export default function FirstUserForm() {
   };
 
   const onSuggestionSelected = (suggestion: string) => {
-    if (!usernameInputRef.current) return;
-    usernameInputRef.current.value = suggestion;
-    usernameInputRef.current.focus();
+    setUserName(suggestion);
     setInsideDropDown(false);
     setShowSuggestions(false);
   };


### PR DESCRIPTION
These suggestions stop working at #1999 (specifically in commit afb1a54c4eda) which started using a form internal state for keeping input values instead of relying on the native Form API.

Sadly, there wasn't a test for the username suggestions and it was broken silently.