### PR TITLE
web: navigation CSS adjustments

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -242,6 +242,8 @@
 
 .pf-v6-c-nav__link {
   --pf-v6-c-nav__link--AlignItems: center;
+  padding-inline-start: var(--pf-t--global--spacer--sm);
+  padding-inline-end: var(--pf-t--global--spacer--sm);
 
   svg {
     font-size: var(--pf-t--global--font--size--lg);


### PR DESCRIPTION
A workaround for using less padding to avoid the menu overlapping the content. Better solution would be more than welcome.