### PR TITLE
Fixed reboot delay caused by the root shell service

### DIFF
--- a/live/root/etc/systemd/system/live-root-shell.service
+++ b/live/root/etc/systemd/system/live-root-shell.service
@@ -1,15 +1,18 @@
 [Unit]
-Description=Start root shell in a free terminal (usually tty2)
+Description=Root shell at tty8
 # after setting the host name to correctly display it in the shell prompt
 After=agama-hostname.service
 
 [Service]
-ExecStart=openvt --verbose --wait bash
-# start it again after crashing or accidentally closing the shell via "exit" or Ctrl+D,
-# unfortunately it might use a different tty after restart :-/
+TTYPath=/dev/tty8
+StandardInput=tty
+ExecStart=/usr/bin/bash
+# start it again after crashing or accidentally closing the shell via "exit" or Ctrl+D
 Restart=always
 Type=exec
 Environment=TERM=linux
+# Bash ignores SIGTERM, send SIGHUP to ensure that it terminates cleanly
+KillSignal=SIGHUP
 
 [Install]
 WantedBy=default.target

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 19 07:37:51 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed reboot delay caused by the root shell service
+  (gh#agama-project/agama#2018)
+- Run the shell at tty8 (there was a collision with the login
+  prompt at tty2)
+
+-------------------------------------------------------------------
 Tue Feb 18 13:14:30 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename kiwi profiles to avoid using dashes, using underscores


### PR DESCRIPTION
## Problem

- There is a 1.5 minute timeout when rebooting the machine
 - https://github.com/agama-project/agama/issues/2018


## Solution

- Properly terminate the running shell to avoid systemd timeout
- Run the shell at tty8 (there was a collision with the login prompt at tty2)
- Use systemd features instead of the openvt tool

## Testing

- Tested manually, the system reboots immediately

