### PR TITLE
Fixed syntax error in 99agama-cmdline dracut module

### DIFF
--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-cmdline-conf.sh
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-cmdline-conf.sh
@@ -27,7 +27,7 @@ get_agama_args() {
       fi
       echo $_i >>"${TARGET}"
       if [ -n "$_env" ]; then
-        _i=$(echo "$_i" | tr '[:lower:].-' '[:upper:]__'
+        _i=$(echo "$_i" | tr '[:lower:].-' '[:upper:]__')
         echo $_i >>"${ENV_TARGET}"
       fi
     fi


### PR DESCRIPTION
## Problem

- The Live ISO does not boot

![agama-boot-syntax-error](https://github.com/user-attachments/assets/d95b7bb0-2a91-48db-bfa3-4fa66732a63d)


## Solution

- Fix the syntax error

## Testing

- Tested manually, the ISO boots fine