### PR TITLE
Fix Product name for SLES for SAP

### DIFF
--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -1,5 +1,5 @@
 id: SLES_SAP
-name: SUSE Linux Enterprise Server for SAP Applications 16.0 Beta
+name: SUSE Linux Enterprise Server for SAP applications 16.0 Beta
 archs: x86_64,aarch64,ppc
 registration: true
 version: "16-0"
@@ -10,7 +10,7 @@ license: "license.beta"
 # translations!!
 # ------------------------------------------------------------------------------
 description: "The leading OS for a secure and reliable SAP platform.
-Endorsed for SAP deployments, SUSE Linux Enterprise Server for SAP Applications
+Endorsed for SAP deployments, SUSE Linux Enterprise Server for SAP applications
 futureproofs the SAP project, offers uninterrupted business, and minimizes
 operational risks and costs."
 icon: SUSE.svg


### PR DESCRIPTION
It should be SLES for SAP applications with lowercase "a".


## Problem

Fix capitalization


## Solution

Fix capitalization


## Testing

Not tested by me.

## Screenshots



