### PR TITLE
service: Initialize resizeIfNeeded only for existing partitions

### DIFF
--- a/service/lib/agama/storage/config_conversions/to_model_conversions/partition.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/partition.rb
@@ -58,15 +58,17 @@ module Agama
 
           # @return [Booelan]
           def convert_resize
-            size = config.size
+            return false unless config.found_device
 
+            size = config.size
             !size.nil? && !size.default? && size.min == size.max
           end
 
           # @return [Booelan]
           def convert_resize_if_needed
-            size = config.size
+            return false unless config.found_device
 
+            size = config.size
             !size.nil? && !size.default? && size.min != size.max
           end
         end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 20 14:23:49 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed a bug in the storage model conversion that was causing some
+  partition sizes to be reset (gh#openSUSE/agama#2036).
+
+-------------------------------------------------------------------
 Thu Feb 20 12:56:13 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Introduce the storage model to support the new storage user


### PR DESCRIPTION
## Problem

We noticed that moving the drive definition to another device caused the partitions with custom sizes to get reset to automatic size. After some investigation I found out that all partitions with a custom size were actually been created with the flag `resizeIfNeeded` set to true. That looks like a minor detail since that flag is irrelevant for new (non reused) partitions, but it turns out it ended up triggering errors in some subsequent conversions.

## Solution

Do not set `resize` or `resizeIfNeeded` when they are irrelevant.
