### PR TITLE
Use a custom dracut module for decreasing the kernel logging

### DIFF
--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -80,21 +80,21 @@ terminal_output gfxterm
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4
+    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot}
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }
 menuentry "Failsafe -- Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4 ide=nodma apm=off noresume edd=off nomodeset 3
+    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} ide=nodma apm=off noresume edd=off nomodeset 3
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }
 menuentry "Check Installation Medium" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/aarch64/loader/linux loglevel=4 mediacheck=1 plymouth.enable=0 \${isoboot}
+    linux (\$root)/boot/aarch64/loader/linux mediacheck=1 plymouth.enable=0 \${isoboot}
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }

--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -97,14 +97,14 @@ fi
 
 menuentry "Install $label" --class os --unrestricted {
   echo 'Loading kernel...'
-  linux /boot/ppc64le/linux loglevel=4
+  linux /boot/ppc64le/linux
   echo 'Loading initrd...'
   initrd /boot/ppc64le/initrd
 }
 
 menuentry "Check Installation Medium" --class os --unrestricted {
   echo 'Loading kernel...'
-  linux /boot/ppc64le/linux loglevel=4 mediacheck=1 plymouth.enable=0
+  linux /boot/ppc64le/linux mediacheck=1 plymouth.enable=0
   echo 'Loading initrd...'
   initrd /boot/ppc64le/initrd
 }

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -80,21 +80,21 @@ terminal_output gfxterm
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4
+    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot}
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }
 menuentry "Failsafe -- Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} loglevel=4 ide=nodma apm=off noresume edd=off nomodeset 3
+    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} ide=nodma apm=off noresume edd=off nomodeset 3
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }
 menuentry "Check Installation Medium" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linux (\$root)/boot/x86_64/loader/linux loglevel=4 mediacheck=1 plymouth.enable=0 \${isoboot}
+    linux (\$root)/boot/x86_64/loader/linux mediacheck=1 plymouth.enable=0 \${isoboot}
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }

--- a/live/root/usr/lib/dracut/modules.d/97agama-logging/agama-logging.sh
+++ b/live/root/usr/lib/dracut/modules.d/97agama-logging/agama-logging.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+# Display only kernel errors and more severe messages on the console. This is
+# equivalent of using "loglevel=4" boot option, but we cannot use it because it
+# would be written also to the bootloader configuration in the installed system.
+dmesg --console-level 4

--- a/live/root/usr/lib/dracut/modules.d/97agama-logging/module-setup.sh
+++ b/live/root/usr/lib/dracut/modules.d/97agama-logging/module-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+  return 0
+}
+
+# called by dracut
+depends() {
+  return 0
+}
+
+installkernel() {
+  return 0
+}
+
+# called by dracut
+install() {
+  inst_hook cmdline 97 "$moddir/agama-logging.sh"
+}

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -90,6 +90,9 @@ echo "root_disk=live:LABEL=$label" >>/etc/cmdline.d/10-liveroot.conf
 echo 'install_items+=" /etc/cmdline.d/10-liveroot.conf "' >/etc/dracut.conf.d/10-liveroot-file.conf
 echo 'add_dracutmodules+=" dracut-menu agama-cmdline "' >>/etc/dracut.conf.d/10-liveroot-file.conf
 
+# decrease the kernel logging on the console, use a dracut module to do it early in the boot process
+echo 'add_dracutmodules+=" agama-logging "' > /etc/dracut.conf.d/10-agama-logging.conf
+
 # add xhci-pci-renesas to initrd if available (workaround for bsc#1237235)
 # FIXME: remove when the module is included in the default driver list in
 # in /usr/lib/dracut/modules.d/90kernel-modules/module-setup.sh, see


### PR DESCRIPTION
## Problem

- The 'loglevel=4` Live ISO boot option is also written also to the installed system

## Solution

- Decrease the kernel logging using a custom dracut module
- At first I wanted to use a systemd service, but that runs quite late in the process

## Testing

- Tested manually, the log level is set correctly even without using the boot option.