### PR TITLE
replace touch which is not available in initrd with echo -n

### DIFF
--- a/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-cmdline-conf.sh
+++ b/live/root/usr/lib/dracut/modules.d/99agama-cmdline/agama-cmdline-conf.sh
@@ -7,8 +7,8 @@
 TARGET="${1:-/run/agama/cmdline.d/agama.conf}"
 ENV_TARGET="${1:-/run/agama/environment.conf}"
 mkdir -p "/run/agama/cmdline.d"
-touch "$TARGET"
-touch "$ENV_TARGET"
+echo -n "" >> "$TARGET"
+echo -n "" >> "$ENV_TARGET"
 get_agama_args() {
   local _i _found _env
 


### PR DESCRIPTION
## Problem

`touch` is not available in initrd, so dracut cannot use it.


## Solution

use `echo -n` instead