### PR TITLE
doc: update AutoYaST compatibility document

### DIFF
--- a/service/lib/tasks/autoyast.rb
+++ b/service/lib/tasks/autoyast.rb
@@ -39,12 +39,16 @@ module Agama
         lines = ["# AutoYaST compatibility reference"]
 
         top_level = description.elements.select(&:top_level?)
+          .sort_by(&:short_key)
+        unsupported, rest = top_level.partition { |e| e.support == :no }
 
-        top_level.each do |e|
+        rest.each do |e|
           lines.concat(section(e))
         end
 
         lines.join("\n")
+
+        lines.concat(unsupported_elements(unsupported))
       end
 
     private
@@ -84,6 +88,20 @@ module Agama
         end
         lines << ""
         lines
+      end
+
+      def unsupported_elements(elements)
+        lines = []
+        lines << "## Unsupported sections"
+        lines << ""
+        lines << "The following sections are not supported and we do not plan to " \
+                 "support them  in the future."
+        lines << ""
+        elements.each_with_object(lines) do |e, all|
+          line = "* `#{e.short_key}`"
+          line << ": #{e.notes}" if e.notes
+          all << line
+        end
       end
 
       # Generates the notes for a given element.

--- a/service/lib/tasks/autoyast.rb
+++ b/service/lib/tasks/autoyast.rb
@@ -94,7 +94,7 @@ module Agama
         lines = []
         lines << "## Unsupported sections"
         lines << ""
-        lines << "The following sections are not supported and we do not plan to " \
+        lines << "The following sections are not supported and there are no plans to " \
                  "support them  in the future."
         lines << ""
         elements.each_with_object(lines) do |e, all|

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -14,6 +14,7 @@
   { "key": "groups", "support": "no" },
   { "key": "host", "support": "no" },
   { "key": "http-server", "support": "no" },
+  { "key": "kdump", "support": "planned" },
   {
     "key": "keyboard",
     "children": [


### PR DESCRIPTION
- docs(ruby): put unsupported sections at the end
- docs(ruby): add kdump to the AutoYaST compatibility document

Used to generate [the reference](https://agama-project.github.io/docs/user/autoyast/reference).