### PR TITLE
feat(live): ISO size reduction

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb 21 16:34:08 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- ISO size reduction, delete not needed packages (python, Mesa,
+  libyui-qt, Qt libs,...)
+- Use XZ compression for initrd to have a smaller image
+  (esp. important for PPC) (part of gh#agama-project/agama#2026)
+
+-------------------------------------------------------------------
 Fri Feb 21 16:03:42 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed broken "live.password_dialog" boot option


### PR DESCRIPTION
## Live ISO improvements

Reduce the initrd and ISO size.

### Delete not needed packages

- Remove Mesa packages, we do not need OpenGL support
- Remove libyui-qt and Qt libs
- Remove python (installed just because of two simple scripts which we do not use)
  - To avoid removing it accidentally when some new dependency appears there is a dependency checl

## Additional improvements

Some more improvements were copied from the openSUSE Tumbleweed Live ISO:

- Use a better compression for initrd (xz instead of zstd with the best compression level)
- Removed some AMD GPU firmware (likely need only for OpenCL or GPU computing)
- Copied Lenovo X13 dracut configuration, might be usable also on other ARM64 machines

## Results (on x86_64)

- The total ISO size decreased from 692MB to 634MB (-58MB, -8%)
- The initrd size decreased from 87MB to 65MB (-22MB, -25%)

On different archs the numbers might be slightly different.

Note: XZ compression is more effective but requires more RAM and CPU for decompression, let's see how that will work on some PPC64 or ARM64 machines...