### PR TITLE
service: Adjust management of default encryption settings

### DIFF
--- a/service/lib/agama/storage/config_solvers/encryption.rb
+++ b/service/lib/agama/storage/config_solvers/encryption.rb
@@ -53,10 +53,7 @@ module Agama
 
           encryption = config.encryption
           encryption.method ||= default_encryption.method
-
-          # Recovering values from the default encryption only makes sense if the encryption method
-          # is the same.
-          solve_encryption_values(encryption) if encryption.method == default_encryption.method
+          solve_encryption_values(encryption)
         end
 
         def solve_physical_volumes_encryptions
@@ -69,14 +66,17 @@ module Agama
 
           encryption = config.physical_volumes_encryption
           encryption.method ||= default_encryption.method
-
-          # Recovering values from the default encryption only makes sense if the encryption method
-          # is the same.
-          solve_encryption_values(encryption) if encryption.method == default_encryption.method
+          solve_encryption_values(encryption)
         end
 
         # @param config [Configs::Encryption]
         def solve_encryption_values(config)
+          # FIXME: We need better mechanisms to define these values (eg. the process for TpmFde
+          # enforces pbkdf2, but that is not reflected in the case of planned devices).
+          # As a first (not perfect) control mechanism, the values are ignored if the default
+          # encryption type does not match
+          return if config.method.encryption_type != default_encryption.method.encryption_type
+
           config.password ||= default_encryption.password
           config.pbkd_function ||= default_encryption.pbkd_function
           config.label ||= default_encryption.label

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 24 07:41:17 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adjust default encryption settings to better support TPM-based
+  unlocking (gh#agama-project/agama#2053).
+
+-------------------------------------------------------------------
 Fri Feb 21 13:59:30 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Initial support for global encryption in the storage model


### PR DESCRIPTION
## Problem

When using TPM-based encryption, Agama is proposing a separate /boot partition.

The root of the problem is that the default PBKDF (pbkdf2) was not being initialized for the planned root partition. That is a problem because BootRequirementsChecker relies on `Planned::Device#encryption_pbkdf` to decide whether a separate "/boot" is needed.

## Solution

Relax the criteria to ignore the default value of `encryption_pbkdf`. In fact, the whole area would deserve an important overhaul. But discriminating based on the encryption type instead of the encryption method is good enough for now.

## Testing

Manually tested that this fixes the TPM case.