### PR TITLE
Handle properly the inst.finish option

### DIFF
--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -15,7 +15,7 @@ if [ -z "$url" ]; then
   exit 0
 fi
 
-method=$(grep 'agama.finish=' </run/agama/cmdline.d/agama.conf | awk -F 'agama.finish=' '{sub(/ .*$/, "", $2); print $2}')
+method=$(grep '\(agama\|inst\).finish=' </run/agama/cmdline.d/agama.conf | awk -F ':?(inst|agama).finish=' '{sub(/ .*$/, "", $2); print $2}')
 
 echo "Using the profile at $url"
 

--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -25,7 +25,7 @@ case "$url" in
   /usr/bin/agama install
   case "$method" in
   "stop" | "halt" | "poweroff")
-    /usr/bin/agama finish $method
+    /usr/bin/agama finish "$method"
     ;;
   *)
     /usr/bin/agama finish


### PR DESCRIPTION
## Problem

We have replaced the **agama** prefix for the installer kernel **cmdline** argument by the inst one but the finish option was not adapted accordingly to check both.

## Solution

Adapt the script to support both, **agama.finish** and **inst.finish**
