### PR TITLE
Temporarily hide the abort installation option

### DIFF
--- a/service/lib/agama/software/callbacks/progress.rb
+++ b/service/lib/agama/software/callbacks/progress.rb
@@ -92,7 +92,9 @@ module Agama
           question = Agama::Question.new(
             qclass:         "software.package_error.install_error",
             text:           description,
-            options:        [retry_label.to_sym, continue_label.to_sym, abort_label.to_sym],
+            # FIXME: temporarily removed the "Abort" option until the final failed
+            # state is handled properly
+            options:        [retry_label.to_sym, continue_label.to_sym],
             default_option: retry_label.to_sym,
             data:           { "package" => current_package }
           )
@@ -101,8 +103,9 @@ module Agama
             case question_client.answer
             when retry_label.to_sym
               "R"
-            when abort_label.to_sym
-              "C"
+            # FIXME: temporarily disabled
+            # when abort_label.to_sym
+            #   "C"
             when continue_label.to_sym
               "I"
             else

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 24 12:03:58 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Temporarily hide the abort installation option in the package
+  installation failure question until the failed state is properly
+  handled. (related to gh#agama-project/agama#2049)
+
+-------------------------------------------------------------------
 Mon Feb 24 07:41:17 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adjust default encryption settings to better support TPM-based


### PR DESCRIPTION
## Problem

- Aborting the installation currently does not work properly, it displays the congratulation dialog regardless whether it succeeded or not.
- See #2049


## Workaround

- Temporarily hide the option.
