### PR TITLE
feat(live): Use a TrueType font in xterm

### DIFF
--- a/live/root/root/.Xdefaults
+++ b/live/root/root/.Xdefaults
@@ -1,2 +1,7 @@
 ! Use the default font also for the xterm menus (Ctrl + click)
 XTerm*font: fixed
+
+! enable TrueType rendering, it looks better and supports UTF-8
+XTerm*renderFont: true
+XTerm*faceName: fixed
+XTerm*faceSize: 10

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb 24 13:35:04 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Use a TrueType font in xterm
+
+-------------------------------------------------------------------
 Fri Feb 21 16:34:08 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - ISO size reduction, delete not needed packages (python, Mesa,


### PR DESCRIPTION
## Problem

- The default bitmap font is too small and hardly readable
- The font size cannot be changed in the Ctrl + right click menu
- The UTF-8 characters are not displayed properly

## Solution

- Switch to a TrueType font
- It is better readable, changing the font size works and it can display UTF-8 properly

## Testing

- Tested manually

## Screenshots

- Top left: the current default font, notice a broken bullet symbol at the top left corner
- Top right: the new default
- Bottom: the new default, manually changed to the "Large" font size using the menu


![agama-xterm-ttf](https://github.com/user-attachments/assets/59516cfa-a08c-4957-be48-dcf2f7b26df4)

