### PR TITLE
fix(live): disable screen saver

### DIFF
--- a/live/root/.xinitrc
+++ b/live/root/.xinitrc
@@ -1,1 +1,7 @@
+# disable Display Power Management Signaling
+xset -dpms
+
+# disable screen saver
+xset s off
+
 icewm-session -c /etc/icewm/preferences.yast2

--- a/live/root/etc/icewm/preferences.yast2
+++ b/live/root/etc/icewm/preferences.yast2
@@ -17,6 +17,9 @@ BorderSizeY=3
 DlgBorderSizeX=3
 DlgBorderSizeY=3
 
+# No lock display/screensaver
+LockCommand=""
+
 # Disable most shortcuts
 # :r !grep -o '\<Key[^=]*' /etc/icewm/preferences | grep -v Switch | sed 's/$/=""/'
 KeyWinRaise=""

--- a/live/root/root/.xinitrc
+++ b/live/root/root/.xinitrc
@@ -1,1 +1,7 @@
+# disable Display Power Management Signaling
+xset -dpms
+
+# disable screen saver
+xset s off
+
 icewm-session -c /etc/icewm/preferences.yast2

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -154,6 +154,7 @@
         <package name="microos-tools"/>
         <package name="icewm-lite"/>
         <package name="xinit"/>
+        <package name="xset"/>
         <package name="xorg-x11-server"/>
         <package name="xorg-x11-fonts-core"/>
         <package name="xf86-input-libinput" />


### PR DESCRIPTION
## Problem

Using the live iso, the screen becomes black after ten 10 minutes and there is no way to make it work again, see https://github.com/agama-project/agama/issues/2047. 


## Solution

Configure icewm and X11 to disable dpms (Display Power Management Signaling) and screen saver.
