### PR TITLE
fix(web): improve handling errors on network form

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 24 15:57:12 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Display network edition errors instead of navigating back
+  (gh#agama-project/agama#2064).
+
+-------------------------------------------------------------------
 Mon Feb 24 14:17:34 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Ignore non-critical issues to avoid preventing the installation

--- a/web/src/components/network/IpSettingsForm.tsx
+++ b/web/src/components/network/IpSettingsForm.tsx
@@ -23,6 +23,7 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
+  Alert,
   Content,
   Form,
   FormGroup,
@@ -62,9 +63,10 @@ export default function IpSettingsForm() {
   );
   const [method, setMethod] = useState<ConnectionMethod>(connection.method4);
   const [gateway, setGateway] = useState<string>(connection.gateway4);
-  const [errors, setErrors] = useState<object>({});
+  const [fieldErrors, setFieldErrors] = useState<object>({});
+  const [requestError, setRequestError] = useState<string | undefined>();
 
-  const isSetAsInvalid = (field: string) => Object.keys(errors).includes(field);
+  const isSetAsInvalid = (field: string) => Object.keys(fieldErrors).includes(field);
   const isGatewayDisabled = addresses.length === 0;
 
   const validatedAttrValue = (field: string) => {
@@ -75,9 +77,9 @@ export default function IpSettingsForm() {
 
   const cleanError = (field: string) => {
     if (isSetAsInvalid(field)) {
-      const nextErrors = { ...errors };
+      const nextErrors = { ...fieldErrors };
       delete nextErrors[field];
-      setErrors(nextErrors);
+      setFieldErrors(nextErrors);
     }
   };
 
@@ -96,7 +98,7 @@ export default function IpSettingsForm() {
   };
 
   const validate = (sanitizedAddresses: IPAddress[]) => {
-    setErrors({});
+    setFieldErrors({});
 
     const nextErrors: { method?: string } = {};
     if (!usingDHCP(method) && sanitizedAddresses.length === 0) {
@@ -104,7 +106,7 @@ export default function IpSettingsForm() {
       nextErrors.method = _("At least one address must be provided for selected mode");
     }
 
-    setErrors(nextErrors);
+    setFieldErrors(nextErrors);
 
     return Object.keys(nextErrors).length === 0;
   };
@@ -125,17 +127,22 @@ export default function IpSettingsForm() {
       gateway4: gateway,
       nameservers: sanitizedNameservers.map((s) => s.address),
     });
+
     updateConnection(updatedConnection)
       .then(() => navigate(-1))
-      .catch((error) => setError(error));
+      .catch((error) => {
+        setRequestError(error.message);
+      });
   };
+
+  console.log("errors", fieldErrors);
 
   const renderError = (field: string) => {
     if (!isSetAsInvalid(field)) return null;
 
     return (
       <HelperText>
-        <HelperTextItem variant="error">{errors[field]}</HelperTextItem>
+        <HelperTextItem variant="error">{fieldErrors[field]}</HelperTextItem>
       </HelperText>
     );
   };
@@ -149,7 +156,12 @@ export default function IpSettingsForm() {
       </Page.Header>
 
       <Page.Content>
-        {renderError("object")}
+        {requestError && (
+          <Alert variant="warning" isInline title={_("Something went wrong")}>
+            <Content component="p">{requestError}</Content>
+          </Alert>
+        )}
+
         <Form id="editConnectionForm" onSubmit={onSubmitForm}>
           <Grid hasGutter>
             <GridItem sm={12} xl={6} rowSpan={2}>

--- a/web/src/components/network/IpSettingsForm.tsx
+++ b/web/src/components/network/IpSettingsForm.tsx
@@ -126,8 +126,8 @@ export default function IpSettingsForm() {
       nameservers: sanitizedNameservers.map((s) => s.address),
     });
     updateConnection(updatedConnection)
-      .catch((error) => setErrors(error))
-      .then(() => navigate(-1));
+      .then(() => navigate(-1))
+      .catch((error) => setError(error));
   };
 
   const renderError = (field: string) => {

--- a/web/src/components/network/IpSettingsForm.tsx
+++ b/web/src/components/network/IpSettingsForm.tsx
@@ -135,8 +135,6 @@ export default function IpSettingsForm() {
       });
   };
 
-  console.log("errors", fieldErrors);
-
   const renderError = (field: string) => {
     if (!isSetAsInvalid(field)) return null;
 


### PR DESCRIPTION
## Problem

The network form wasn't showing errors when the request failed, due to the incorrect order of the `.then()` and `.catch()` promise methods.

## Solution

Fixed the order of these methods and render request error message at the top of the form to inform users when something goes wrong during the request.


## Screenshots

| Before | After |
|-|-|
| No error, just navigate to the page without changes. | ![localhost_8080_ (24)](https://github.com/user-attachments/assets/1563187c-73ff-437e-84c8-de251f08b8c6) |


## Notes

This is, of course, far for being perfect. It's a workaround to avoid users both, navigating back without changes and still in the form without noticing something was wrong. 

Detected while fixing #2058 
