### PR TITLE
Fix agama config show before a product is selected

### DIFF
--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -148,7 +148,7 @@ impl<'a> StorageClient<'a> {
     pub async fn set_config(&self, settings: StorageSettings) -> Result<u32, ServiceError> {
         Ok(self
             .storage_proxy
-            .set_config(serde_json::to_string(&settings).unwrap().as_str())
+            .set_config(serde_json::to_string(&settings)?.as_str())
             .await?)
     }
 
@@ -160,7 +160,7 @@ impl<'a> StorageClient<'a> {
     /// Get the storage config according to the JSON schema
     pub async fn get_config(&self) -> Result<StorageSettings, ServiceError> {
         let serialized_settings = self.storage_proxy.get_config().await?;
-        let settings = serde_json::from_str(serialized_settings.as_str()).unwrap();
+        let settings = serde_json::from_str(serialized_settings.as_str())?;
         Ok(settings)
     }
 

--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -230,7 +230,7 @@ impl<'a> StorageClient<'a> {
         &'b self,
         object: &'b DBusObject,
         name: &str,
-    ) -> Option<&HashMap<String, OwnedValue>> {
+    ) -> Option<&'b HashMap<String, OwnedValue>> {
         let interface: OwnedInterfaceName = InterfaceName::from_str_unchecked(name).into();
         let interfaces = &object.1;
         interfaces.get(&interface)

--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -158,7 +158,7 @@ impl<'a> StorageClient<'a> {
     }
 
     /// Get the storage config according to the JSON schema
-    pub async fn get_config(&self) -> Result<StorageSettings, ServiceError> {
+    pub async fn get_config(&self) -> Result<Option<StorageSettings>, ServiceError> {
         let serialized_settings = self.storage_proxy.get_config().await?;
         let settings = serde_json::from_str(serialized_settings.as_str())?;
         Ok(settings)

--- a/rust/agama-lib/src/storage/http_client.rs
+++ b/rust/agama-lib/src/storage/http_client.rs
@@ -32,7 +32,7 @@ impl StorageHTTPClient {
         Self { client: base }
     }
 
-    pub async fn get_config(&self) -> Result<StorageSettings, ServiceError> {
+    pub async fn get_config(&self) -> Result<Option<StorageSettings>, ServiceError> {
         self.client.get("/storage/config").await
     }
 

--- a/rust/agama-lib/src/storage/store.rs
+++ b/rust/agama-lib/src/storage/store.rs
@@ -37,7 +37,7 @@ impl StorageStore {
         })
     }
 
-    pub async fn load(&self) -> Result<StorageSettings, ServiceError> {
+    pub async fn load(&self) -> Result<Option<StorageSettings>, ServiceError> {
         self.storage_client.get_config().await
     }
 

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -80,9 +80,10 @@ impl Store {
             ..Default::default()
         };
 
-        let storage_settings = self.storage.load().await?;
-        settings.storage = storage_settings.storage;
-        settings.storage_autoyast = storage_settings.storage_autoyast;
+        if let Some(storage_settings) = self.storage.load().await? {
+            settings.storage = storage_settings.storage;
+            settings.storage_autoyast = storage_settings.storage_autoyast;
+        }
 
         // TODO: use try_join here
         Ok(settings)

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -154,7 +154,9 @@ pub async fn storage_service(dbus: zbus::Connection) -> Result<Router, ServiceEr
         (status = 400, description = "The D-Bus service could not perform the action")
     )
 )]
-async fn get_config(State(state): State<StorageState<'_>>) -> Result<Json<StorageSettings>, Error> {
+async fn get_config(
+    State(state): State<StorageState<'_>>,
+) -> Result<Json<Option<StorageSettings>>, Error> {
     // StorageSettings is just a wrapper over serde_json::value::RawValue
     let settings = state.client.get_config().await.map_err(Error::Service)?;
     Ok(Json(settings))


### PR DESCRIPTION
## Problem

- https://github.com/agama-project/agama/issues/2057 
- https://trello.com/c/I7rdVd7D

## Solution

~Return an empty JSON object (Ruby Hash) instead of null/nil~

Adapt the Rust client to deal with the `null` and omit the section.

## Testing

- Tested manually: 
  - `./testing-using-container.sh` and in its shell, `agama config show`
  - Web UI still works normally
- Added a unit test

## Debugging

[`git bisect`](https://git-scm.com/docs/git-bisect) saved me

## Screenshots

No