### PR TITLE
Reduce the PPC initrd size

### DIFF
--- a/live/root/tmp/module.list
+++ b/live/root/tmp/module.list
@@ -3,6 +3,10 @@
 # Lines starting with '-' specify modules to drop.
 # The lines below are actually perl regexps, so be careful.
 #
+# If a module is specified both to be added and dropped, it is dropped.
+#
+# Arch-dependend blocks start with <ARCH> and end with </ARCH> (on separate lines).
+#
 kernel/drivers/base/
 kernel/drivers/block/
 -kernel/drivers/block/paride
@@ -311,3 +315,14 @@ updates/
 -updates/net/sunrpc/
 -updates/fs/lockd/
 -updates/fs/nfs*
+
+<ppc64le>
+# for the source of this module list, see bsc#1213879 comment 35
+-kernel/drivers/net/wireless/
+-kernel/net/ieee80211/
+-kernel/net/mac80211/
+-kernel/net/wireless/
+-kernel/net/wimax/
+-kernel/drivers/gpu/
+-kernel/drivers/video/
+</ppc64le>

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 24 16:19:03 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Reduce the PPC initrd size (gh#agama-project/agama#2026),
+  use the same solution from installation-images
+  (gh#openSUSE/installation-images#754)
+
+-------------------------------------------------------------------
 Mon Feb 24 13:35:04 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Use a TrueType font in xterm

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -208,8 +208,8 @@ du -h -s /lib/modules /lib/firmware
 # remove the multimedia drivers
 # set DEBUG=1 to print the deleted drivers
 /tmp/driver_cleanup.rb --delete
-# remove the script, not needed anymore
-rm /tmp/driver_cleanup.rb
+# remove the script and data, not needed anymore
+rm /tmp/driver_cleanup.rb /tmp/module.list*
 
 # remove the unused firmware (not referenced by kernel drivers)
 /tmp/fw_cleanup.rb --delete


### PR DESCRIPTION
## Problem

- PPC quite often has problems with too large initrd
- See #2026

## Solution

- Use the same solution from installation-images (https://github.com/openSUSE/installation-images/pull/754)

## Testing

- Tested manually on x86_64
  - The initrd size decreased just about 1 MB (tiny difference), but the overall ISO size decreased about 98MB (that's quite a lot)
  - Let's see how the numbers will look on PPC


