### PR TITLE
fix(live): Fixed build in SLE16

### DIFF
--- a/live/README.md
+++ b/live/README.md
@@ -104,7 +104,7 @@ make build OBS_PROJECT=home:<USER>:branches:systemsmanagement:Agama:Devel
 To build a SLE image using the internal OBS instance run
 
 ```shell
-make build OBS_API=https://api.suse.de OBS_PROJECT=<project> OBS_PACKAGE=agama-installer-SLE FLAVOR=SLE
+make build OBS_API=https://api.suse.de OBS_PROJECT=Devel:YaST:Agama:Head OBS_PACKAGE=agama-installer FLAVOR=SUSE_SLE_16
 ```
 
 #### Using locally built RPM packages

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 24 17:07:07 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed build in SLE16, some packages to remove are not
+  preinstalled in SLE16, do not fail in that case
+
+-------------------------------------------------------------------
 Mon Feb 24 16:19:03 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Reduce the PPC initrd size (gh#agama-project/agama#2026),

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -188,9 +188,12 @@ fi
 # remove OpenGL support
 rpm -qa | grep ^Mesa | xargs rpm -e --nodeps
 
-# uninstall libyui-qt and libqt (pulled in by the YaST dependencies)
-rpm -q --whatprovides libyui-qt libyui-qt-pkg | xargs rpm -e --nodeps
-rpm -qa | grep ^libQt | xargs rpm -e --nodeps
+# uninstall libyui-qt and libqt (pulled in by the YaST dependencies),
+# not present in SLES, do not fail if not installed
+if rpm -q --whatprovides libyui-qt libyui-qt-pkg > /dev/null; then
+  rpm -q --whatprovides libyui-qt libyui-qt-pkg | xargs rpm -e --nodeps
+fi
+rpm -qa | grep ^libQt | xargs --no-run-if-empty rpm -e --nodeps
 
 ## removing drivers and firmware makes the Live ISO about 370MiB smaller
 #


### PR DESCRIPTION
## Problem

- The Live ISO does not build in SLE16

## Solution

- Some packages to remove are not preinstalled in SLE16, do not fail in that case.

## Testing

- Tested manually, the ISO build fine locally

## Notes

- Updated the command for building the SLE image locally in the documentation.
