### PR TITLE
fix(live): Run shellcheck in CI to find errors in the scripts

### DIFF
--- a/.github/workflows/ci-live.yml
+++ b/.github/workflows/ci-live.yml
@@ -52,8 +52,10 @@ jobs:
       run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
     - name: Install Ruby development files
-      run: zypper --non-interactive install
-        make
+      run: zypper --non-interactive install ShellCheck make
+
+    - name: Run shellcheck
+      run: make shellcheck
 
     - name: Run the tests
       run: make check

--- a/live/Makefile
+++ b/live/Makefile
@@ -70,9 +70,9 @@ check:
 # in full mode with warnings but ignore the failures (some are false positives).
 # TODO: Fix/disable the warnings and run it in more strict mode.
 shellcheck:
-	find root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
+	find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
 	  | xargs -I% bash -c "echo 'Checking errors in %...' && shellcheck --severity=error %"
-	find root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
+	find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
 	  | xargs -I% bash -c "echo 'Checking warnings in %...' && shellcheck %" || true
 
 .PHONY: build all clean shellcheck

--- a/live/Makefile
+++ b/live/Makefile
@@ -66,4 +66,13 @@ build: $(DESTDIR)
 check:
 	for i in ./test/*_test.*; do $${i} || exit 1; done
 
-.PHONY: build all clean
+# Shellcheck reports lots of warnings, run it in the error-only mode first. If that succeeds run it
+# in full mode with warnings but ignore the failures (some are false positives).
+# TODO: Fix/disable the warnings and run it in more strict mode.
+shellcheck:
+	find root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
+	  | xargs -I% bash -c "echo 'Checking errors in %...' && shellcheck --severity=error %"
+	find root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
+	  | xargs -I% bash -c "echo 'Checking warnings in %...' && shellcheck %" || true
+
+.PHONY: build all clean shellcheck

--- a/live/Makefile
+++ b/live/Makefile
@@ -70,9 +70,9 @@ check:
 # in full mode with warnings but ignore the failures (some are false positives).
 # TODO: Fix/disable the warnings and run it in more strict mode.
 shellcheck:
-	find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
+	@find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
 	  | xargs -I% bash -c "echo 'Checking errors in %...' && shellcheck --severity=error %"
-	find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
+	@find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
 	  | xargs -I% bash -c "echo 'Checking warnings in %...' && shellcheck %" || true
 
 .PHONY: build all clean shellcheck

--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -27,7 +27,7 @@ if [ -d "$dst/boot/grub2/themes/SLE" ]; then
   theme="SLE"
 else
   theme="openSUSE"
-end
+fi
 
 #
 # Create grub.cfg

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -93,10 +93,14 @@ echo 'add_dracutmodules+=" agama-logging "' > /etc/dracut.conf.d/10-agama-loggin
 # FIXME: remove when the module is included in the default driver list in
 # in /usr/lib/dracut/modules.d/90kernel-modules/module-setup.sh, see
 # https://github.com/openSUSE/dracut/blob/7559201e7480a65b0da050263d96a1cd8f15f50d/modules.d/90kernel-modules/module-setup.sh#L42-L46
-if [ -f /lib/modules/*/kernel/drivers/usb/host/xhci-pci-renesas.ko* ]; then
-  echo "Adding xhci-pci-renesas driver to initrd..."
-  echo 'add_drivers+=" xhci-pci-renesas "' > /etc/dracut.conf.d/10-extra-drivers.conf
-fi
+for file in /lib/modules/*/kernel/drivers/usb/host/xhci-pci-renesas.ko*
+do
+  if [ -f "$file" ]; then
+    echo "Adding xhci-pci-renesas driver to initrd..."
+    echo 'add_drivers+=" xhci-pci-renesas "' > /etc/dracut.conf.d/10-extra-drivers.conf
+    break
+  fi
+done
 
 if [ "${arch}" = "s390x" ]; then
   # workaround for custom bootloader setting
@@ -174,7 +178,7 @@ if [ -n "$python" ]; then
   # avoid removing python accidentally because of some new unknown dependency
   python_deps=$(echo "$python_deps" | grep -v -e "Failed dependencies" -e "needed by .* libpython" -e "needed by .* bcache-tools" -e "needed by .* xfsprogs" || true)
 
-  if [ -z "$python_deps"]; then
+  if [ -z "$python_deps" ]; then
     echo "Removing Python..."
     # remove libpython as well
     rpm -e --nodeps "$python" $(rpm -qa | grep "^libpython3")


### PR DESCRIPTION
## Problem

- There might be typos  (like in #2029) or mistakes in the Live scripts.

## Solution

- Run `shellcheck` in the CI and fail if any error is reported
- Because shellcheck reports lots of warning and some of them are false positives let's run it in two stages:
  - The first run checks only for errors, if an error is found then the CI fails
  - If no error is found it runs it in full mode with warnings enabled. But in this case the CI always passes.
- Later we should fix the warnings and silence the false positives and make the check to fail also with warnings.

## Testing

- Tested manually and in GitHub Actions
- The first run [found an error](https://github.com/agama-project/agama/actions/runs/13516640787/job/37766570369#step:6:26) and failed
- After fixing the errors (there is actually one more), then it [reports several warnings](https://github.com/agama-project/agama/actions/runs/13516732009/job/37766805780#step:6:31) but the CI succeeds
