### PR TITLE
web: Synchronous probing when registering or choosing product

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 25 12:36:50 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Synchronous system probing when choosing or registering the
+  product (gh#agama-project/agama#2072).
+
+-------------------------------------------------------------------
 Mon Feb 24 15:57:12 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Display network edition errors instead of navigating back

--- a/web/src/api/manager.ts
+++ b/web/src/api/manager.ts
@@ -28,6 +28,11 @@ import { get, post } from "~/api/http";
 const startProbing = () => post("/api/manager/probe");
 
 /**
+ * Triggers a synchronous probing process.
+ */
+const probe = () => post("/api/manager/probe_sync");
+
+/**
  * Starts the installation process.
  *
  * The progress of the installation process can be tracked through installer signals.
@@ -44,4 +49,4 @@ const finishInstallation = () => post("/api/manager/finish");
  */
 const fetchLogs = () => get("/api/manager/logs/store");
 
-export { startProbing, startInstallation, finishInstallation, fetchLogs };
+export { startProbing, probe, startInstallation, finishInstallation, fetchLogs };

--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -54,7 +54,7 @@ import {
   updateConfig,
 } from "~/api/software";
 import { QueryHookOptions } from "~/types/queries";
-import { startProbing } from "~/api/manager";
+import { probe as systemProbe } from "~/api/manager";
 
 /**
  * Query to retrieve software configuration
@@ -133,13 +133,13 @@ const useConfigMutation = () => {
 
   const query = {
     mutationFn: updateConfig,
-    onSuccess: (_, config: SoftwareConfig) => {
+    onSuccess: async (_, config: SoftwareConfig) => {
       queryClient.invalidateQueries({ queryKey: ["software/config"] });
+      queryClient.invalidateQueries({ queryKey: ["software/product"] });
       queryClient.invalidateQueries({ queryKey: ["software/proposal"] });
       if (config.product) {
-        queryClient.invalidateQueries({ queryKey: ["software/product"] });
+        await systemProbe();
         queryClient.invalidateQueries({ queryKey: ["storage"] });
-        startProbing();
       }
     },
   };
@@ -157,10 +157,10 @@ const useRegisterMutation = () => {
 
   const query = {
     mutationFn: register,
-    onSuccess: () => {
+    onSuccess: async () => {
+      await systemProbe();
       queryClient.invalidateQueries({ queryKey: ["software/registration"] });
-      queryClient.invalidateQueries({ queryKey: ["storage", "productParams"] });
-      startProbing();
+      queryClient.invalidateQueries({ queryKey: ["storage"] });
     },
   };
   return useMutation(query);


### PR DESCRIPTION
## Problem

There is a race condition that leads to the interface reporting that there are no available devices after changing the product or registering it.

Moreover, even if that race condition is not hit, the interface is displaying the previous storage configuration. That's wrong because changing the product or registering actually resets the storage configuration at the backend (the registration case is debatable, but that's what happens now).

## Solution

Do a synchronous probing and invalidate all the storage queries when probing has finished. With that, the UI contains an up-to-date representation of the backend reality.

## Testing

Tested manually