### PR TITLE
fix(web): adjust product title

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -191,6 +191,10 @@
 .pf-v6-c-masthead {
   --pf-v6-c-masthead__logo--Width: fit-content;
   --pf-v6-c-masthead--PaddingBlock: var(--pf-t--global--spacer--sm);
+
+  h1 {
+    font-size: clamp(1.1rem, 0rem + 1.6vw, 1.75rem);
+  }
 }
 
 .pf-v6-c-page__main-section {


### PR DESCRIPTION
It uses the [CSS `clamp()`](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp) function to set the font size, allowing it to adjust fluidly based on the viewport size. This is a workaround that requires further testing and refinement. It should also be applied to the other headings.

## Screenshots

|Width | Before | After |
|-|-|-|
|1024  | ![Screen Shot 2025-02-25 at 13 41 40](https://github.com/user-attachments/assets/3d248e34-bd5b-4d79-8f5b-b6314c35d14c) | ![Screen Shot 2025-02-25 at 13 41 46](https://github.com/user-attachments/assets/8817bbdf-fc29-430a-92c0-be0b2180a56f) |
|1280 | ![Screen Shot 2025-02-25 at 13 40 48](https://github.com/user-attachments/assets/d174c6b0-3a59-48ce-9c7e-938c50d97323) | ![Screen Shot 2025-02-25 at 13 40 56](https://github.com/user-attachments/assets/47340515-0b48-4f46-9894-4a33100f7488) |
|1600|![Screen Shot 2025-02-25 at 13 41 30](https://github.com/user-attachments/assets/6c0efa56-04d4-440c-aebe-a65c1799fd6a) | ![Screen Shot 2025-02-25 at 13 41 24](https://github.com/user-attachments/assets/59b5dcb2-8c70-4690-a3a6-66e7e9f50fbf) |

