### PR TITLE
feat(web): edit file system label

### DIFF
--- a/rust/agama-lib/share/storage.model.schema.json
+++ b/rust/agama-lib/share/storage.model.schema.json
@@ -100,7 +100,8 @@
         "reuse": { "type": "boolean" },
         "default": { "type": "boolean" },
         "type": { "$ref": "#/$defs/filesystemType" },
-        "snapshots": { "type": "boolean" }
+        "snapshots": { "type": "boolean" },
+        "label": { "type": "string" }
       }
     },
     "filesystemType": {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 06:52:52 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Extend storage model schema to support file system label (needed
+  for jsc#AGM-122 and bsc#1237165).
+
+-------------------------------------------------------------------
 Wed Feb 26 06:51:37 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 12

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/filesystem.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -43,7 +43,8 @@ module Agama
             {
               reuse: model_json.dig(:filesystem, :reuse),
               path:  model_json[:mountPath],
-              type:  convert_type
+              type:  convert_type,
+              label: model_json.dig(:filesystem, :label)
             }
           end
 

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -41,7 +41,8 @@ module Agama
               reuse:     config.reuse?,
               default:   convert_default,
               type:      convert_type,
-              snapshots: convert_snapshots
+              snapshots: convert_snapshots,
+              label:     config.label
             }
           end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 06:52:45 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Add file system label to the config model (needed for jsc#AGM-122
+  and bsc#1237165).
+
+-------------------------------------------------------------------
 Wed Feb 26 06:51:36 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 12

--- a/service/test/agama/storage/config_conversions/to_model_test.rb
+++ b/service/test/agama/storage/config_conversions/to_model_test.rb
@@ -103,7 +103,8 @@ shared_examples "with filesystem" do |result_scope|
       {
         reuse:   true,
         default: false,
-        type:    "xfs"
+        type:    "xfs",
+        label:   "test"
       }
     )
   end

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 11:21:45 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Allow setting the file system label (related to jsc#AGM-122
+  and bsc#1237165).
+
+-------------------------------------------------------------------
 Thu Feb 27 10:21:45 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Do not fail to build the storage devices when the RAID members

--- a/web/src/api/storage/types/config-model.ts
+++ b/web/src/api/storage/types/config-model.ts
@@ -64,6 +64,7 @@ export interface Filesystem {
   default: boolean;
   type?: FilesystemType;
   snapshots?: boolean;
+  label?: string;
 }
 export interface Partition {
   name?: string;

--- a/web/src/components/storage/PartitionPage.test.tsx
+++ b/web/src/components/storage/PartitionPage.test.tsx
@@ -158,13 +158,16 @@ describe("PartitionPage", () => {
     const size = screen.getByRole("button", { name: "Size" });
     // File system and size fields disabled until valid mount point selected
     expect(filesystem).toBeDisabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
     expect(size).toBeDisabled();
+
     await user.click(mountPoint);
     const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
     const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
     await user.click(homeMountPoint);
     // Valid mount point selected, enable file system and size fields
     expect(filesystem).toBeEnabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
     expect(size).toBeEnabled();
     // Display mount point options
     await user.click(mountPointMode);
@@ -206,6 +209,7 @@ describe("PartitionPage", () => {
     await user.click(homeMountPoint);
     expect(mountPoint).toHaveValue("/home");
     expect(filesystem).toBeEnabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
     expect(size).toBeEnabled();
     const clearMountPointButton = screen.getByRole("button", {
       name: "Clear selected mount point",
@@ -214,6 +218,7 @@ describe("PartitionPage", () => {
     expect(mountPoint).toHaveValue("");
     // File system and size fields disabled until valid mount point selected
     expect(filesystem).toBeDisabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
     expect(size).toBeDisabled();
   });
 
@@ -227,7 +232,11 @@ describe("PartitionPage", () => {
           min: gib(5),
           max: gib(15),
         },
-        filesystem: { default: false, type: "xfs" },
+        filesystem: {
+          default: false,
+          type: "xfs",
+          label: "HOME",
+        },
       });
     });
 
@@ -239,6 +248,8 @@ describe("PartitionPage", () => {
       within(targetButton).getByText(/As a new partition/);
       const filesystemButton = screen.getByRole("button", { name: "File system" });
       within(filesystemButton).getByText("XFS");
+      const label = screen.getByRole("textbox", { name: "File system label" });
+      expect(label).toHaveValue("HOME");
       const sizeOptionButton = screen.getByRole("button", { name: "Size" });
       within(sizeOptionButton).getByText("Custom");
       const minSizeInput = screen.getByRole("textbox", { name: "Minimum size value" });


### PR DESCRIPTION
Allow setting the file system label for the new partitions.

Note: the label field only appears if the file system is going to be created (i.e., an existing file system is not reused).

* https://bugzilla.suse.com/show_bug.cgi?id=1237165
* https://jira.suse.com/browse/AGM-122

![Screenshot From 2025-02-26 06-38-22](https://github.com/user-attachments/assets/5aac876a-fa31-4df9-ad73-4b5bb2b31264)
