### PR TITLE
fix: run init scripts and save post script logs

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 25 22:36:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the missing shebang line to the agama-scripts.sh shell script
+  (gh#agama-project/agama#2077).
+- Save logs after running post installation scripts
+  (gh#agama-project/agama#2078).
+
+-------------------------------------------------------------------
 Mon Feb 24 14:42:28 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Keep the encoding when storing the locale (gh#agama-project/agama#2062).

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+#
 # Copyright (c) [2024] SUSE LLC
 #
 # All Rights Reserved.

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -80,8 +80,8 @@ module Agama
           BootloaderStep.new(logger),
           IguanaStep.new(logger),
           SnapshotsStep.new(logger),
-          CopyLogsStep.new(logger),
           PostScripts.new(logger),
+          CopyLogsStep.new(logger),
           UnmountStep.new(logger)
         ]
       end


### PR DESCRIPTION
## Problem

- https://github.com/agama-project/agama/issues/2077
- https://github.com/agama-project/agama/issues/2078

## Solution

- Save the logs after running the post scripts.
- Add the shebang line to the `agama-scripts.sh` shell script.

## What is missing

- Adding `agama-scripts` to the SUSE preset.
