### PR TITLE
fix(live): fix reference to openSUSE_PXE in _multibuild

### DIFF
--- a/live/src/_multibuild
+++ b/live/src/_multibuild
@@ -1,4 +1,4 @@
 <multibuild>
   <flavor>openSUSE</flavor>
-  <flavor>openSUSE-PXE</flavor>
+  <flavor>openSUSE_PXE</flavor>
 </multibuild>


### PR DESCRIPTION
Fix the `openSUSE_PXE` reference in the `_multibuild` file.
