### PR TITLE
fix(ruby): enable the agama-scripts service if installed

### DIFF
--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -260,8 +260,8 @@ module Agama
         # So this method just tries to enable the service.
         def enable_init_scripts
           # systemctl will return 1 if the service does not exist.
-          Yast::Execute.locally!(
-            "systemctl", "--root", "/mnt", "enable", "agama-scripts",
+          Yast::Execute.on_target!(
+            "systemctl", "enable", "agama-scripts",
             allowed_exitstatus: [0, 1]
           )
         end

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -241,9 +241,29 @@ module Agama
         end
 
         def run
+          run_post_scripts
+          enable_init_scripts
+        end
+
+      private
+
+        # Run the post scripts
+        def run_post_scripts
           require "agama/http"
           client = Agama::HTTP::Clients::Scripts.new
           client.run("post")
+        end
+
+        # Enables the agama-scripts service to run init scripts
+        #
+        # The package agama-scripts is only installed when needed.
+        # So this method just tries to enable the service.
+        def enable_init_scripts
+          # systemctl will return 1 if the service does not exist.
+          Yast::Execute.locally!(
+            "systemctl", "--root", "/mnt", "enable", "agama-scripts",
+            allowed_exitstatus: [0, 1]
+          )
         end
       end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Feb 25 23:48:46 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Enable agama-scripts service if installed (gh#agama-project/agama#2077).
+
+-------------------------------------------------------------------
 Mon Feb 24 12:03:58 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Temporarily hide the abort installation option in the package

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -360,6 +360,7 @@ describe Agama::Storage::Manager do
       allow(File).to receive(:directory?).and_call_original
       allow(File).to receive(:directory?).with("/iguana").and_return iguana
       allow(copy_files_class).to receive(:new).and_return(copy_files)
+      allow(Yast::Execute).to receive(:on_target!)
     end
     let(:copy_files_class) { Agama::Storage::Finisher::CopyFilesStep }
     let(:copy_files) { instance_double(copy_files_class, run?: true, run: true, label: "Copy") }
@@ -375,6 +376,8 @@ describe Agama::Storage::Manager do
       expect(Yast::WFM).to receive(:CallFunction).with("storage_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("snapshots_finish", ["Write"])
       expect(scripts_client).to receive(:run).with("post")
+      expect(Yast::Execute).to receive(:on_target!)
+        .with("systemctl", "enable", "agama-scripts", allowed_exitstatus: [0, 1])
       expect(Yast::WFM).to receive(:CallFunction).with("copy_logs_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("umount_finish", ["Write"])
       storage.finish


### PR DESCRIPTION
Ensure the `agama-scripts` service is enabled so that "init" scripts run on the first boot. This one is the second part of #2080.

It enables this service in the same way AutoYaST enables `autoyast-initscripts`.

## Tests

* Manually tested.
* It looks like a better alternative to #2081.