### PR TITLE
fix(live): Install kernel-default-extra package

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 08:08:25 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Install additional kernel drivers from the kernel-default-extra
+  package (gh#agama-project/agama#2059)
+
+-------------------------------------------------------------------
 Wed Feb 26 06:51:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 12

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -178,6 +178,7 @@
         <package name="staging-build-key"/>
         <package name="openSUSE-build-key"/>
         <package name="MozillaFirefox-branding-openSUSE"/>
+        <package name="kernel-default-extra"/>
     </packages>
     <!-- additional packages for the openSUSE distributions -->
     <packages type="image" profiles="openSUSE,openSUSE_PXE">
@@ -196,6 +197,7 @@
         <package name="patterns-sles-base"/>
         <package name="suse-build-key"/>
         <package name="MozillaFirefox-branding-SLE"/>
+        <package name="kernel-default-extra"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
## Problem

- The installer misses some drivers like Wifi ath11k
- See #2059

## Solution

- Install additional `kernel-default-extra` package which includes the needed drivers
- Needed only in SLFO/Leap16, Tumbleweed ships all drivers in a single `kernel-default` package

## Testing

- Tested manually, the ath11k drivers are present
