### PR TITLE
fix(live): add IPMI drivers to the initrd (bsc#1237354)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Feb 26 11:50:17 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Add IPMI drivers to the initrd (bsc#1237354)
+
+-------------------------------------------------------------------
 Wed Feb 26 08:08:25 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Install additional kernel drivers from the kernel-default-extra

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -97,7 +97,17 @@ for file in /lib/modules/*/kernel/drivers/usb/host/xhci-pci-renesas.ko*
 do
   if [ -f "$file" ]; then
     echo "Adding xhci-pci-renesas driver to initrd..."
-    echo 'add_drivers+=" xhci-pci-renesas "' > /etc/dracut.conf.d/10-extra-drivers.conf
+    echo 'add_drivers+=" xhci-pci-renesas "' >> /etc/dracut.conf.d/10-extra-drivers.conf
+    break
+  fi
+done
+
+# add ipmi drivers (bsc#1237354)
+for dir in /lib/modules/*/kernel/drivers/char/ipmi
+do
+  if [ -d "$dir" ]; then
+    echo "Adding ipmi drivers to initrd..."
+    echo 'add_drivers+=" acpi_ipmi ipmi_devintf ipmi_poweroff ipmi_si ipmi_ssif ipmi_watchdog "' >> /etc/dracut.conf.d/10-extra-drivers.conf
     break
   fi
 done


### PR DESCRIPTION
## Problem

- Dell PowerEdge 17G server cannot boot the installer
- https://bugzilla.suse.com/show_bug.cgi?id=1237354

## Solution

- Add missing IPMI drivers to the initrd

## Testing

- Tested manually with locally built ISO, `lsinitrd` confirms that the IPMI drivers are included
