### PR TITLE
bsc#1237803

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 10:21:45 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Do not fail to build the storage devices when the RAID members
+  are not exported (bsc#1237803).
+
+-------------------------------------------------------------------
 Wed Feb 26 06:51:37 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 12

--- a/web/src/api/storage/devices.ts
+++ b/web/src/api/storage/devices.ts
@@ -61,12 +61,12 @@ const fetchDevices = async (scope: "result" | "system") => {
     const buildCollection = (sids: number[], jsonDevices: Device[]): StorageDevice[] => {
       if (sids === null || sids === undefined) return [];
 
-      return sids.map((sid) =>
-        buildDevice(
-          jsonDevices.find((dev) => dev.deviceInfo?.sid === sid),
-          jsonDevices,
-        ),
-      );
+      // Some devices might not be found because they are not exported, for example, the members of
+      // a BIOS RAID, see bsc#1237803.
+      return sids
+        .map((sid) => jsonDevices.find((dev) => dev.deviceInfo?.sid === sid))
+        .filter((jsonDevice) => jsonDevice)
+        .map((jsonDevice) => buildDevice(jsonDevice, jsonDevices));
     };
 
     const addDriveInfo = (device: StorageDevice, info: Drive) => {


### PR DESCRIPTION
## Problem

The web UI fails when there is a BIOS RAID because its members are not exported on D-Bus.

https://bugzilla.suse.com/show_bug.cgi?id=1237803

## Solution

Fix code for building the storage device, ignoring the not found RAID members.

## Testing

* Tested manually
