### PR TITLE
Make the sles_enhanced_base pattern mandatory for SLES

### DIFF
--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -66,11 +66,11 @@ software:
 
   mandatory_patterns:
     - base_traditional
+    - sles_enhanced_base
   optional_patterns: null # no optional pattern shared
   user_patterns:
     - kvm_host
     - cockpit
-    - sles_enhanced_base
     - sles_minimal_sap
   mandatory_packages:
     - NetworkManager


### PR DESCRIPTION
## Problem

Firewalld should be installed in SLES product but the package is provided by the enhanced base pattern and it is not visible to the user as well it is not mandatory.

- https://trello.com/c/Ksvh989B/4288-sle16-verify-firewall-status

## Solution

Make the sles_enhanced_pattern mandatory for the SLES product.

## Testing

- *Tested manually*

