### PR TITLE
Add alpha-label-less leap16.svg 

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 16:10:51 UTC 2025 - Vaishnavi Nawghare <nawgharevaishnavi@gmail.com>
+
+- Add alpha-label-less leap16.svg
+ (gh#agama-project/agama#2091).
+
+-------------------------------------------------------------------
 Thu Feb 27 10:21:45 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Do not fail to build the storage devices when the RAID members

--- a/web/src/assets/products/Leap16.svg
+++ b/web/src/assets/products/Leap16.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    viewBox="0 0 256 256"
    id="svg895"
-   sodipodi:docname="Leap16Alpha.svg"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+   sodipodi:docname="Leap16.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata901">
     <rdf:RDF>
@@ -35,16 +35,19 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1011"
+     inkscape:window-height="991"
      id="namedview897"
      showgrid="false"
      inkscape:zoom="2.8710938"
-     inkscape:cx="128"
+     inkscape:cx="127.82585"
      inkscape:cy="128"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg895" />
+     inkscape:current-layer="svg895"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <path
      d="m127.65 8.0209a7.5008 7.5008 0 0 0-4.951 2.168l-82.5 82.5a7.5008 7.5008 0 0 0 0 10.605l82.5 82.5a7.5008 7.5008 0 0 0 10.605 0l82.5-82.5a7.5008 7.5008 0 0 0 0-10.605l-82.5-82.5a7.5008 7.5008 0 0 0-5.6544-2.168zm0.3516 18.076 71.895 71.895-71.895 71.895-71.895-71.895zm-90 116.89v7.5a7.5 7.5 0 0 0 2.1974 5.3027l82.5 82.5a7.5008 7.5008 0 0 0 10.605 0l82.5-82.5a7.5 7.5 0 0 0 2.1972-5.3027 7.5 7.5 0 0 0 0-0.35156v-7.1484h-7.5a7.5 7.5 0 0 0-5.3026 2.1973l-77.197 77.197-77.197-77.197a7.5 7.5 0 0 0-5.3028-2.168v-0.0293z"
      color="#000000"
@@ -57,23 +60,4 @@
      stop-color="#000000"
      style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;font-variation-settings:normal;inline-size:0;isolation:auto;mix-blend-mode:normal;shape-margin:0;shape-padding:0;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"
      id="path893" />
-  <rect
-     style="fill:#4d4d4d;stroke:#fbc75d;stroke-width:0.305932;stroke-dasharray:0.305932, 0.305932"
-     id="rect903"
-     width="119.69408"
-     height="44.694069"
-     x="128.0016"
-     y="169.8869"
-     ry="9.3673325" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none"
-     x="140.82344"
-     y="203.17685"
-     id="text907"><tspan
-       sodipodi:role="line"
-       id="tspan905"
-       x="140.82344"
-       y="203.17685"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro';fill:#ffffff;fill-opacity:1">Alpha</tspan></text>
 </svg>


### PR DESCRIPTION
## Problem

The alpha label on the Leap logo in the product installation section appears visually inconsistent and is not fully visible

## Solution

Replaced the older logo with logo without alpha label.
Fixes [#2091](https://github.com/agama-project/agama/issues/2091) 