### PR TITLE
Set BLS env for storage-ng according to the product selection

### DIFF
--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -79,6 +79,7 @@ security:
       patterns: null
 
 storage:
+  boot_strategy: BLS
   space_policy: delete
   volumes:
     - "/"

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -130,6 +130,7 @@ security:
       patterns: null
 
 storage:
+  boot_strategy: BLS
   space_policy: delete
   volumes:
     - "/"

--- a/service/lib/agama/config.rb
+++ b/service/lib/agama/config.rb
@@ -217,6 +217,13 @@ module Agama
       data.dig("storage", "lvm") || false
     end
 
+    # Boot strategy for the product
+    #
+    # @return [String, nil]
+    def boot_strategy
+      data.dig("storage", "boot_strategy") || nil
+    end
+
   private
 
     def mandatory_path?(path)

--- a/service/lib/agama/config.rb
+++ b/service/lib/agama/config.rb
@@ -221,7 +221,7 @@ module Agama
     #
     # @return [String, nil]
     def boot_strategy
-      data.dig("storage", "boot_strategy") || nil
+      data.dig("storage", "boot_strategy")
     end
 
   private

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -125,6 +125,8 @@ module Agama
 
         @product = new_product
 
+        ENV["ENV_NO_BLS_BOOT"] = "yes" if use_bls?(id)
+
         update_issues
         true
       end
@@ -152,6 +154,8 @@ module Agama
       def initialize_target
         # create the zypp lock also in the target directory
         ENV["ZYPP_LOCKFILE_ROOT"] = TARGET_DIR
+        # controls if grub-bls should be used. We enable it only for some products.
+        ENV["ENV_NO_BLS_BOOT"] = "no"
         # cleanup the previous content (after service restart or crash)
         FileUtils.rm_rf(TARGET_DIR)
         FileUtils.mkdir_p(TARGET_DIR)
@@ -442,6 +446,14 @@ module Agama
 
       # @return [Logger]
       attr_reader :logger
+
+      # Decides whether grub-bls should be used for given product
+      def use_bls?(id)
+        return true if id =~ /Tumbleweed/
+        return true if id =~ /Slowroll/
+
+        return false
+      end
 
       # Generates a list of products according to the information of the config file.
       #

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -125,8 +125,6 @@ module Agama
 
         @product = new_product
 
-        ENV["ENV_NO_BLS_BOOT"] = "yes" if use_bls?(id)
-
         update_issues
         true
       end
@@ -154,8 +152,6 @@ module Agama
       def initialize_target
         # create the zypp lock also in the target directory
         ENV["ZYPP_LOCKFILE_ROOT"] = TARGET_DIR
-        # controls if grub-bls should be used. We enable it only for some products.
-        ENV["ENV_NO_BLS_BOOT"] = "no"
         # cleanup the previous content (after service restart or crash)
         FileUtils.rm_rf(TARGET_DIR)
         FileUtils.mkdir_p(TARGET_DIR)
@@ -446,14 +442,6 @@ module Agama
 
       # @return [Logger]
       attr_reader :logger
-
-      # Decides whether grub-bls should be used for given product
-      def use_bls?(id)
-        return true if id =~ /Tumbleweed/
-        return true if id =~ /Slowroll/
-
-        return false
-      end
 
       # Generates a list of products according to the information of the config file.
       #

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -119,6 +119,7 @@ module Agama
       def probe(keep_config: false)
         start_progress_with_size(4)
         product_config.pick_product(software.selected_product)
+        ENV["YAST_NO_BLS_BOOT"] = "yes" if !product_config.boot_strategy&.casecmp("BLS")
         check_multipath
         progress.step(_("Activating storage devices")) { activate_devices }
         progress.step(_("Probing storage devices")) { probe_devices }

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "bootloader/proposal_client"
 require "y2storage/storage_manager"
+require "y2storage/storage_env"
 require "y2storage/clients/inst_prepdisk"
 require "agama/storage/actions_generator"
 require "agama/storage/bootloader"
@@ -123,7 +124,7 @@ module Agama
         # Underlying yast-storage-ng has own mechanism for proposing boot strategies.
         # However, we don't always want to use BLS when it proposes so. Currently
         # we want to use BLS only for Tumbleweed / Slowroll
-        ENV["YAST_NO_BLS_BOOT"] = "yes" if !product_config.boot_strategy&.casecmp("BLS")
+        prohibit_bls_boot if !product_config.boot_strategy&.casecmp("BLS")
 
         check_multipath
         progress.step(_("Activating storage devices")) { activate_devices }
@@ -219,6 +220,12 @@ module Agama
 
       # @return [Logger]
       attr_reader :logger
+
+      def prohibit_bls_boot
+        ENV["YAST_NO_BLS_BOOT"] = "1"
+        # avoiding problems with cached values
+        Y2Storage::StorageEnv.instance.reset_cache
+      end
 
       # Issues are updated when the proposal is calculated
       def register_proposal_callbacks

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -119,7 +119,12 @@ module Agama
       def probe(keep_config: false)
         start_progress_with_size(4)
         product_config.pick_product(software.selected_product)
+
+        # Underlying yast-storage-ng has own mechanism for proposing boot strategies.
+        # However, we don't always want to use BLS when it proposes so. Currently
+        # we want to use BLS only for Tumbleweed / Slowroll
         ENV["YAST_NO_BLS_BOOT"] = "yes" if !product_config.boot_strategy&.casecmp("BLS")
+
         check_multipath
         progress.step(_("Activating storage devices")) { activate_devices }
         progress.step(_("Probing storage devices")) { probe_devices }

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  5 08:09:28 UTC 2025 - Michal Filka <mfilka@suse.com>
+
+- introduced boot_strategy into storage section of product
+  definition yaml file. It allows to control what boot strategy
+  will be proposed by storage. Currently works only for BLS. 
+
+-------------------------------------------------------------------
 Wed Feb 26 06:52:45 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add file system label to the config model (needed for jsc#AGM-122

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -221,7 +221,7 @@ describe Agama::Storage::Manager do
     it "sets env YAST_NO_BLS_BOOT to yes if product doesn't requires bls boot explicitly" do
       expect(config).to receive(:pick_product)
       expect(config).to receive(:boot_strategy).and_return(nil)
-      expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "yes")
+      expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "1")
 
       storage.probe
     end

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -218,6 +218,14 @@ describe Agama::Storage::Manager do
 
     let(:callback) { proc {} }
 
+    it "sets env YAST_NO_BLS_BOOT to yes if product doesn't requires bls boot explicitly" do
+      expect(config).to receive(:pick_product)
+      expect(config).to receive(:boot_strategy).and_return(nil)
+      expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "yes")
+
+      storage.probe
+    end
+
     it "probes the storage devices and calculates a proposal" do
       expect(config).to receive(:pick_product).with("ALP")
       expect(iscsi).to receive(:activate)


### PR DESCRIPTION
## Problem

Folowup of https://github.com/yast/yast-storage-ng/pull/1396/files#diff-d0c8ea3d63135679325c6c61b13d11f85edc06bbb141d983037c55846699e125R143

The above proposal intoduced BLS boot proposal. Only limitation was target architecture, but it doesn't fit for conservative products like SLE for now.

## Solution

Added product based condition for seting nev variable controling BLS selection in storage-ng. BLS is proposed only for tumbleweed (including Slowroll)


## Testing

- *Added a new unit test*
- *Tested manually*
