### PR TITLE
feat(ruby): disable signature checking for dir:// repositories

### DIFF
--- a/service/lib/agama/software/callbacks/signature.rb
+++ b/service/lib/agama/software/callbacks/signature.rb
@@ -56,6 +56,11 @@ module Agama
         # @param repo_id [Integer] Repository ID. It might be -1 if there is not an associated repo.
         def accept_unsigned_file(filename, repo_id)
           repo = Yast::Pkg.SourceGeneralData(repo_id)
+
+          # Temporarily disable signature checking for local repositories.
+          # https://github.com/agama-project/agama/issues/2092
+          return true if repo && repo["url"].start_with?("dir://")
+
           message = if repo
             format(
               _("The file %{filename} from %{repo_url} is not digitally signed. The origin " \

--- a/service/lib/agama/software/callbacks/signature.rb
+++ b/service/lib/agama/software/callbacks/signature.rb
@@ -59,7 +59,7 @@ module Agama
 
           # Temporarily disable signature checking for local repositories.
           # https://github.com/agama-project/agama/issues/2092
-          return true if repo && repo["url"].start_with?("dir://")
+          return true if repo && repo["url"].start_with?("dir:")
 
           message = if repo
             format(

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 28 13:03:11 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Temporarily disable signature checking for dir:// repositories
+  (gh#agama-project/agama#2092).
+
+-------------------------------------------------------------------
 Wed Feb 26 06:51:36 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 12

--- a/service/test/agama/software/callbacks/signature_test.rb
+++ b/service/test/agama/software/callbacks/signature_test.rb
@@ -70,6 +70,18 @@ describe Agama::Software::Callbacks::Signature do
 
         expect(subject.accept_unsigned_file("repomd.xml", 1))
       end
+
+      context "and the repository is included in the media" do
+        before do
+          allow(Yast::Pkg).to receive(:SourceGeneralData).with(1)
+            .and_return("name" => "OSS", "url" => "dir:///run/initramfs/live/install")
+        end
+
+        it "returns true without asking" do
+          expect(questions_client).to_not receive(:ask)
+          expect(subject.accept_unsigned_file("repomd.xml", 1)).to eq(true)
+        end
+      end
     end
 
     context "when the repo information is not available" do

--- a/service/test/agama/software/callbacks/signature_test.rb
+++ b/service/test/agama/software/callbacks/signature_test.rb
@@ -74,7 +74,7 @@ describe Agama::Software::Callbacks::Signature do
       context "and the repository is included in the media" do
         before do
           allow(Yast::Pkg).to receive(:SourceGeneralData).with(1)
-            .and_return("name" => "OSS", "url" => "dir:///run/initramfs/live/install")
+            .and_return("name" => "OSS", "url" => "dir:/run/initramfs/live/install")
         end
 
         it "returns true without asking" do


### PR DESCRIPTION
Temporarily disable signature checking for dir:// because with the new product composer it is not possible to sign the repositories yet. It will be fixed in the future and we should remove this code then.

See #2092 for further information.

## Testing

* Add a unit test.
* Manually tested.
