### PR TITLE
fix(live): Include the "nvme-cli" package (bsc#1238038)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  3 14:19:40 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Include the "nvme-cli" package, needed to activate the NVMF
+  (NVMe over Fabrics) devices (bsc#1238038)
+
+-------------------------------------------------------------------
 Wed Feb 26 11:50:17 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Add IPMI drivers to the initrd (bsc#1237354)

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -149,6 +149,8 @@
         <package name="agama-cli-bash-completion"/>
         <package name="agama-auto"/>
         <package name="agama-integration-tests"/>
+        <!-- needed for the NVMF (NVMe over Fabrics) autoconnect service -->
+        <package name="nvme-cli"/>
         <package name="rubygem(agama-yast)"/>
         <package name="rubygem(byebug)"/>
         <package name="microos-tools"/>


### PR DESCRIPTION
## Problem

- The NVMF devices are not activated
- https://bugzilla.suse.com/show_bug.cgi?id=1238038

## Solution

- Include the `nvme-cli` package in the Live ISO, it contains a systemd service which automatically connects such devices.
