### PR TITLE
Tumbleweed: add URL for aarch64 / non-oss

### DIFF
--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -73,7 +73,8 @@ software:
       archs: ppc
     - url: https://download.opensuse.org/tumbleweed/repo/non-oss/
       archs: x86_64
-    # aarch64 does not have non-oss ports. Keep eye if it change
+    - url: https://download.opensuse.org/ports/aarch64/tumbleweed/repo/non-oss/
+      archs: aarch64
     - url: https://download.opensuse.org/ports/zsystems/tumbleweed/repo/non-oss/
       archs: s390
     - url: https://download.opensuse.org/ports/ppc/tumbleweed/repo/non-oss/


### PR DESCRIPTION

## Problem

The exitsing product definition for TW claims there is no non-oss repo for aarch64
This information is wtong: the repo exists

## Solution

Remove the wrong comment, add the URL for the non-oss repo for aarch64

