### PR TITLE
live/src/agama-installer.kiwi: Adapt to latest patterns (SR#364982).

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 25 13:28:15 UTC 2025 - Giacomo Leidi <giacomo.leidi@suse.com>
+
+- live/src/agama-installer.kiwi: Adapt to latest patterns (SR#364982)
+
+-------------------------------------------------------------------
 Mon Mar 24 10:57:22 UTC 2025 - Lukas Ocilka <locilka@suse.com>
 
 - Fixed DUD issues (gh#agama-project/agama#2199):

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -195,7 +195,7 @@
     <packages type="image" profiles="SUSE_SLE_16,SUSE_SLE_16_PXE">
         <package name="agama-products-sle"/>
         <package name="grub2-branding-SLE" arch="aarch64,x86_64"/>
-        <package name="patterns-sles-base"/>
+        <package name="patterns-base-base"/>
         <package name="suse-build-key"/>
         <package name="MozillaFirefox-branding-SLE"/>
         <package name="kernel-default-extra"/>


### PR DESCRIPTION
## Problem

https://build.suse.de/requests/364982 dropped the `patterns-sles-base` , it is now provided by `patterns-base-base`.

## Solution

Rename `patterns-sles-base` to `patterns-base-base`.


