### PR TITLE
Decrease the libzypp timeout, retry automatically

### DIFF
--- a/live/root/usr/bin/agama-issue-generator
+++ b/live/root/usr/bin/agama-issue-generator
@@ -24,8 +24,9 @@ CERT_ISSUE=/run/issue.d/50-agama-ssl-certificate.issue
 # a helper function which generates the Agama welcome message displayed at the
 # console
 generate_welcome() {
-  # get the latest version of any Agama package
-  AGAMA_VERSION=$(rpm -qa | grep agama | xargs rpm -q --queryformat \
+  # get the latest version of any Agama package (except the integration tests, it lives in a
+  # separate git repository and has different number of commits than the rest)
+  AGAMA_VERSION=$(rpm -qa | grep agama | grep -v agama-integration-tests | xargs rpm -q --queryformat \
     "%{VERSION}\n" | sed -e "s/\\.devel/+/" -e 's/+0$//' | sort -V | tail -n 1)
 
   ISSUE=/run/issue.d/10-agama-welcome.issue

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  5 14:54:48 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Decrease the libzypp timeout from the default 60 seconds to
+  20 seconds (Agama now does automatic retry)
+- Display proper Agama version in the console
+
+-------------------------------------------------------------------
 Wed Feb 26 11:50:17 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Add IPMI drivers to the initrd (bsc#1237354)

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -32,6 +32,9 @@ if stat -t /usr/lib/rpm/gnupg/keys/*.asc 2>/dev/null 1>/dev/null; then
   rpm --import /usr/lib/rpm/gnupg/keys/*.asc
 fi
 
+# decrease the libzypp timeout to 20 seconds (the default is 60 seconds)
+sed -i -e "s/^\s*#\s*download.connect_timeout\s*=\s*.*$/download.connect_timeout = 20/" /etc/zypp/zypp.conf
+
 # activate services
 systemctl enable sshd.service
 systemctl enable NetworkManager.service

--- a/service/lib/agama/software/callbacks/media.rb
+++ b/service/lib/agama/software/callbacks/media.rb
@@ -23,6 +23,7 @@ require "logger"
 require "yast"
 require "agama/question"
 require "agama/software/callbacks/base"
+require "agama/software/repository"
 
 Yast.import "Pkg"
 Yast.import "URL"
@@ -32,6 +33,12 @@ module Agama
     module Callbacks
       # Callbacks related to media handling
       class Media < Base
+        def initialize(questions_client, logger)
+          super
+          # retry counter
+          self.attempt = 0
+        end
+
         # Register the callbacks
         def setup
           Yast::Pkg.CallbackMediaChange(
@@ -41,13 +48,25 @@ module Agama
               "boolean, list <string>, integer)"
             )
           )
+          Yast::Pkg.CallbackStartProvide(
+            Yast::FunRef.new(method(:start_provide), "void (string, integer, boolean)")
+          )
+        end
+
+        # @param name [String] name of the package to download
+        # @param size [Integer] download size
+        # @param _remote [Boolean] true if the package is downloaded from a remote repository,
+        #   false for local packages
+        def start_provide(name, size, _remote)
+          self.attempt = 1
+          logger.info("Downloading #{name}, size: #{size}")
         end
 
         # Media change callback
         #
         # @return [String]
         # @see https://github.com/yast/yast-yast2/blob/19180445ab935a25edd4ae0243aa7a3bcd09c9de/library/packages/src/modules/PackageCallbacks.rb#L620
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def media_change(error_code, error, url, product, current, current_label, wanted,
           wanted_label, double_sided, devices, current_device)
           logger.debug(
@@ -67,6 +86,18 @@ module Agama
               current_device)
           )
 
+          # "IO" = IO error (scratched DVD or HW failure)
+          # "IO_SOFT" = network timeout
+          # in other cases automatic retry usually does not make much sense
+          if ["IO", "IO_SOFT"].include?(error_code) && attempt < Repository::RETRY_COUNT
+            self.attempt += 1
+            logger.info("Retry in #{Repository::RETRY_DELAY} seconds, attempt #{attempt}...")
+            sleep(Repository::RETRY_DELAY)
+
+            # retry
+            return ""
+          end
+
           question = Agama::Question.new(
             qclass:         "software.package_error.medium_error",
             text:           error,
@@ -75,10 +106,19 @@ module Agama
             data:           { "url" => url }
           )
           questions_client.ask(question) do |question_client|
-            (question_client.answer == retry_label.to_sym) ? "" : "S"
+            if question_client.answer == retry_label.to_sym
+              self.attempt += 1
+              ""
+            else
+              "S"
+            end
           end
         end
-        # rubocop:enable Metrics/ParameterLists
+      # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
+
+      private
+
+        attr_accessor :attempt
       end
     end
   end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  5 14:50:04 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Automatically retry package download or repository refresh
+  before reporting an error
+
+-------------------------------------------------------------------
 Wed Mar  5 08:09:28 UTC 2025 - Michal Filka <mfilka@suse.com>
 
 - introduced boot_strategy into storage section of product

--- a/service/test/agama/software/callbacks/media_test.rb
+++ b/service/test/agama/software/callbacks/media_test.rb
@@ -35,6 +35,9 @@ describe Agama::Software::Callbacks::Media do
     before do
       allow(questions_client).to receive(:ask).and_yield(question_client)
       allow(question_client).to receive(:answer).and_return(answer)
+
+      # mock sleep() to speed up test
+      allow(subject).to receive(:sleep)
     end
 
     let(:question_client) { instance_double(Agama::DBus::Clients::Question) }
@@ -58,6 +61,19 @@ describe Agama::Software::Callbacks::Media do
           "NOT_FOUND", "Package not found", "", "", 0, "", 0, "", true, [], 0
         )
         expect(ret).to eq("S")
+      end
+    end
+
+    context "when a timeout error occurs" do
+      # actually not used, just required by the global "before"
+      let(:answer) { nil }
+
+      it "returns '' without asking" do
+        expect(questions_client).to_not receive(:ask)
+        ret = subject.media_change(
+          "IO_SOFT", "Timeout", "", "", 0, "", 0, "", true, [], 0
+        )
+        expect(ret).to eq("")
       end
     end
   end


### PR DESCRIPTION
## Problem

- Too long timeout for network operations
- No automatic retry

## Solution

- Decrease the libzypp timeout from the default 60 seconds to 20 seconds
- Automatically retry package download or repository refresh before reporting an error

## Additional fix

- Display proper Agama version in the console
- The original problem:
![image](https://github.com/user-attachments/assets/e0f4e92d-3638-472e-9f46-e4cec3e2f56f)

## Testing

- Added new unit tests
- Tested manually, the repository refresh or package download is tried 3 times before reporting and error
