### PR TITLE
feat(rust): better handling of registration errors

### DIFF
--- a/rust/agama-lib/src/product/http_client.rs
+++ b/rust/agama-lib/src/product/http_client.rs
@@ -82,8 +82,9 @@ impl ProductHTTPClient {
 
         let message = match error {
             ServiceError::BackendError(_, details) => {
-                let details: RegistrationError = serde_json::from_str(&details).unwrap();
-                format!("{} (error code: {})", details.message, details.id)
+                serde_json::from_str::<RegistrationError>(&details)
+                    .map(|d| format!("{} (error code: {})", d.message, d.id))
+                    .unwrap_or(details)
             }
             _ => format!("Could not register the product: #{error:?}"),
         };

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Mar  6 06:52:05 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Better handling of unexpected registration errors (bsc#1238851).
+
+-------------------------------------------------------------------
 Tue Mar  4 13:34:13 UTC 2025 - Martin Vidner <mvidner@suse.com>
 
 - install and package also storage.schema.json (bsc#1238367)


### PR DESCRIPTION
## Problem

The CLI is crashing when an unexpected registration error happens:

- [bsc#1238851](https://bugzilla.suse.com/show_bug.cgi?id=1238851)

## Solution

Improve error reporting in this case. However, the registration error is still unclear.
