### PR TITLE
License language switcher fixes

### DIFF
--- a/web/src/components/core/Popup.test.tsx
+++ b/web/src/components/core/Popup.test.tsx
@@ -41,7 +41,7 @@ const TestingPopup = (props: PopupProps) => {
 
   return (
     <Popup
-      title="Testing Popup component"
+      title="Testing Popup Title"
       isOpen={isOpen}
       isLoading={isLoading}
       loadingText={loadingText}
@@ -61,7 +61,6 @@ describe("Popup", () => {
   describe("when it is not open", () => {
     beforeEach(() => {
       isOpen = false;
-      isLoading = false;
     });
 
     it("renders nothing", async () => {
@@ -72,56 +71,84 @@ describe("Popup", () => {
     });
   });
 
-  describe("when it is open and not loading", () => {
+  describe("when it is open", () => {
     beforeEach(() => {
       isOpen = true;
-      isLoading = false;
     });
 
-    it("renders the popup content inside a PF/Modal", async () => {
-      installerRender(<TestingPopup>Testing</TestingPopup>);
+    it("renders given title and titleAddon inside PF/ModalHeader", async () => {
+      installerRender(
+        <TestingPopup title="Awesome Popup" titleAddon={<button>With action at title</button>}>
+          Testing
+        </TestingPopup>,
+      );
 
       const dialog = await screen.findByRole("dialog");
-      expect(dialog.classList.contains("pf-v6-c-modal-box")).toBe(true);
-
-      within(dialog).getByText("The Popup Content");
+      const header = within(dialog).getByRole("banner");
+      within(header).getByRole("heading", { name: "Awesome Popup" });
+      within(header).getByRole("button", { name: "With action at title" });
     });
 
-    it("does not display a progress message", async () => {
-      installerRender(<TestingPopup>Testing</TestingPopup>);
+    it("does not render header when none, title nor titleAddon, are giving", async () => {
+      installerRender(
+        <TestingPopup title={undefined} titleAddon={undefined}>
+          Testing
+        </TestingPopup>,
+      );
 
       const dialog = await screen.findByRole("dialog");
-
-      expect(within(dialog).queryByText(loadingText)).toBeNull();
+      expect(screen.queryByRole("banner")).toBeNull();
     });
 
-    it("renders the popup actions inside a PF/Modal footer", async () => {
-      installerRender(<TestingPopup>Testing</TestingPopup>);
+    describe("and not loading", () => {
+      beforeEach(() => {
+        isLoading = false;
+      });
 
-      const dialog = await screen.findByRole("dialog");
-      // NOTE: Sadly, PF Modal/ModalFooter does not have a footer or navigation role.
-      // So, using https://developer.mozilla.org/es/docs/Web/API/Document/querySelector
-      // for getting the footer. See https://github.com/testing-library/react-testing-library/issues/417 too.
-      const footer = dialog.querySelector("footer");
+      it("renders the popup content inside a PF/Modal", async () => {
+        installerRender(<TestingPopup>Testing</TestingPopup>);
 
-      within(footer).getByText("Confirm");
-      within(footer).getByText("Cancel");
+        const dialog = await screen.findByRole("dialog");
+        expect(dialog.classList.contains("pf-v6-c-modal-box")).toBe(true);
+
+        within(dialog).getByText("The Popup Content");
+      });
+
+      it("does not display a progress message", async () => {
+        installerRender(<TestingPopup>Testing</TestingPopup>);
+
+        const dialog = await screen.findByRole("dialog");
+
+        expect(within(dialog).queryByText(loadingText)).toBeNull();
+      });
+
+      it("renders the popup actions inside a PF/Modal footer", async () => {
+        installerRender(<TestingPopup>Testing</TestingPopup>);
+
+        const dialog = await screen.findByRole("dialog");
+        // NOTE: Sadly, PF Modal/ModalFooter does not have a footer or navigation role.
+        // So, using https://developer.mozilla.org/es/docs/Web/API/Document/querySelector
+        // for getting the footer. See https://github.com/testing-library/react-testing-library/issues/417 too.
+        const footer = dialog.querySelector("footer");
+
+        within(footer).getByText("Confirm");
+        within(footer).getByText("Cancel");
+      });
     });
-  });
 
-  describe("when it is open and loading", () => {
-    beforeEach(() => {
-      isOpen = true;
-      isLoading = true;
-    });
+    describe("and loading", () => {
+      beforeEach(() => {
+        isLoading = true;
+      });
 
-    it("displays progress message instead of the content", async () => {
-      installerRender(<TestingPopup>Testing</TestingPopup>);
+      it("displays progress message instead of the content", async () => {
+        installerRender(<TestingPopup>Testing</TestingPopup>);
 
-      const dialog = await screen.findByRole("dialog");
+        const dialog = await screen.findByRole("dialog");
 
-      expect(within(dialog).queryByText("The Popup Content")).toBeNull();
-      within(dialog).getByText(loadingText);
+        expect(within(dialog).queryByText("The Popup Content")).toBeNull();
+        within(dialog).getByText(loadingText);
+      });
     });
   });
 });

--- a/web/src/components/core/Popup.tsx
+++ b/web/src/components/core/Popup.tsx
@@ -38,8 +38,10 @@ import { partition } from "~/utils";
 type ButtonWithoutVariantProps = Omit<ButtonProps, "variant">;
 type PredefinedAction = React.PropsWithChildren<ButtonWithoutVariantProps>;
 export type PopupProps = {
-  /** The dialog header */
+  /** The dialog title */
   title?: ModalHeaderProps["title"];
+  /** Extra content to be placed in the header after the title */
+  titleAddon?: React.ReactNode;
   /** The block/height size for the dialog. Default is "auto". */
   blockSize?: "auto" | "small" | "medium" | "large";
   /** The inline/width size for the dialog. Default is "medium". */
@@ -204,6 +206,7 @@ const AncillaryAction = ({ children, ...actionsProps }: PredefinedAction) => (
  */
 const Popup = ({
   title,
+  titleAddon,
   titleIconVariant,
   description,
   isOpen = false,
@@ -240,6 +243,7 @@ const Popup = ({
           title={title}
           description={description}
           titleIconVariant={titleIconVariant}
+          help={titleAddon}
         />
       )}
       <ModalBody id={contentId}>{isLoading ? <Loading text={loadingText} /> : content}</ModalBody>

--- a/web/src/components/product/LicenseDialog.test.tsx
+++ b/web/src/components/product/LicenseDialog.test.tsx
@@ -66,6 +66,14 @@ describe("LicenseDialog", () => {
     });
   });
 
+  it("renders change language button in the header but not as part of the h1 heading", async () => {
+    installerRender(<LicenseDialog product={product} onClose={onCloseFn} />);
+    const header = await screen.findByRole("banner");
+    const heading = await within(header).findByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(sle.name);
+    within(header).getByRole("button", { name: "License language" });
+  });
+
   it("requests license in the language selected by user", async () => {
     const { user } = installerRender(<LicenseDialog product={product} onClose={onCloseFn} />, {
       withL10n: true,

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -74,6 +74,7 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
           onOpenChange={(isOpen) => setLanguageSelectorOpen(!isOpen)}
           toggle={localesToggler}
           isScrollable
+          popperProps={{ position: "right" }}
         >
           <SelectList>
             {Object.entries(supportedLanguages).map(([id, name]) => (

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -22,11 +22,11 @@
 
 import React, { useEffect, useState } from "react";
 import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   MenuToggle,
   ModalProps,
-  Select,
-  SelectList,
-  SelectOption,
   Stack,
 } from "@patternfly/react-core";
 import { Popup } from "~/components/core";
@@ -66,7 +66,7 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
       isOpen
       title={product.name}
       titleAddon={
-        <Select
+        <Dropdown
           isOpen={languageSelectorOpen}
           selected={language}
           onSelect={onLocaleSelection}
@@ -75,14 +75,14 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
           isScrollable
           popperProps={{ position: "right" }}
         >
-          <SelectList>
+          <DropdownList>
             {Object.entries(supportedLanguages).map(([id, name]) => (
-              <SelectOption key={id} value={id}>
+              <DropdownItem key={id} value={id}>
                 {name}
-              </SelectOption>
+              </DropdownItem>
             ))}
-          </SelectList>
-        </Select>
+          </DropdownList>
+        </Dropdown>
       }
       width="auto"
     >

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -23,15 +23,7 @@
 import React, { useEffect, useState } from "react";
 import { Popup } from "~/components/core";
 import { _ } from "~/i18n";
-import {
-  MenuToggle,
-  ModalProps,
-  Select,
-  SelectOption,
-  Split,
-  SplitItem,
-  Stack,
-} from "@patternfly/react-core";
+import { MenuToggle, ModalProps, Select, SelectOption, Stack } from "@patternfly/react-core";
 import { Product } from "~/types/software";
 import { fetchLicense } from "~/api/software";
 import { useInstallerL10n } from "~/context/installerL10n";
@@ -66,27 +58,21 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
     <Popup
       inlineSize="auto"
       isOpen
-      title={
-        <>
-          <Split hasGutter>
-            <SplitItem isFilled>
-              <h1>{product.name}</h1>
-            </SplitItem>
-            <Select
-              isOpen={languageSelectorOpen}
-              selected={language}
-              onSelect={onLocaleSelection}
-              onOpenChange={(isOpen) => setLanguageSelectorOpen(!isOpen)}
-              toggle={localesToggler}
-            >
-              {Object.entries(supportedLanguages).map(([id, name]) => (
-                <SelectOption key={id} value={id}>
-                  {name}
-                </SelectOption>
-              ))}
-            </Select>
-          </Split>
-        </>
+      title={product.name}
+      titleAddon={
+        <Select
+          isOpen={languageSelectorOpen}
+          selected={language}
+          onSelect={onLocaleSelection}
+          onOpenChange={(isOpen) => setLanguageSelectorOpen(!isOpen)}
+          toggle={localesToggler}
+        >
+          {Object.entries(supportedLanguages).map(([id, name]) => (
+            <SelectOption key={id} value={id}>
+              {name}
+            </SelectOption>
+          ))}
+        </Select>
       }
     >
       <Stack hasGutter>

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -23,7 +23,14 @@
 import React, { useEffect, useState } from "react";
 import { Popup } from "~/components/core";
 import { _ } from "~/i18n";
-import { MenuToggle, ModalProps, Select, SelectOption, Stack } from "@patternfly/react-core";
+import {
+  MenuToggle,
+  ModalProps,
+  Select,
+  SelectList,
+  SelectOption,
+  Stack,
+} from "@patternfly/react-core";
 import { Product } from "~/types/software";
 import { fetchLicense } from "~/api/software";
 import { useInstallerL10n } from "~/context/installerL10n";
@@ -66,12 +73,15 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
           onSelect={onLocaleSelection}
           onOpenChange={(isOpen) => setLanguageSelectorOpen(!isOpen)}
           toggle={localesToggler}
+          isScrollable
         >
-          {Object.entries(supportedLanguages).map(([id, name]) => (
-            <SelectOption key={id} value={id}>
-              {name}
-            </SelectOption>
-          ))}
+          <SelectList>
+            {Object.entries(supportedLanguages).map(([id, name]) => (
+              <SelectOption key={id} value={id}>
+                {name}
+              </SelectOption>
+            ))}
+          </SelectList>
         </Select>
       }
     >

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -21,8 +21,6 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { Popup } from "~/components/core";
-import { _ } from "~/i18n";
 import {
   MenuToggle,
   ModalProps,
@@ -31,10 +29,12 @@ import {
   SelectOption,
   Stack,
 } from "@patternfly/react-core";
+import { Popup } from "~/components/core";
 import { Product } from "~/types/software";
 import { fetchLicense } from "~/api/software";
 import { useInstallerL10n } from "~/context/installerL10n";
 import supportedLanguages from "~/languages.json";
+import { _ } from "~/i18n";
 
 function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; product: Product }) {
   const { language: uiLanguage } = useInstallerL10n();
@@ -63,7 +63,6 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
 
   return (
     <Popup
-      inlineSize="auto"
       isOpen
       title={product.name}
       titleAddon={
@@ -85,6 +84,7 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
           </SelectList>
         </Select>
       }
+      width="auto"
     >
       <Stack hasGutter>
         <pre>{license}</pre>


### PR DESCRIPTION
## Problem

The language selector in the product license dialog overflows on certain viewport sizes, making it impossible to select some options. See https://github.com/agama-project/agama/issues/2105

## Solution

Use the #isScrollable prop.

## Additional Changes

* Refactor the layout by removing the language switcher from within an `<h1>` heading, and preventing nested `<h1>` elements.
* Swap the underlying component used to render the language switcher.
* Enable the dialog to use auto-width.

## Tests

* Added new unit tests to cover the changes.
* Manually tested the dialog on different viewport sizes to ensure the issue is resolved.

## Screenshots

![Screenshot From 2025-03-06 08-03-45](https://github.com/user-attachments/assets/5a5f74a7-bf83-43ee-a066-917c832da626)

