### PR TITLE
Implemented conversion of files section from AutoYaST xml format to Agama JSON

### DIFF
--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -52,7 +52,7 @@ module Agama
       # Sections which have a corresponding reader. The reader is expected to be
       # named in Pascal case and adding "Reader" as suffix (e.g., "L10nReader").
       SECTIONS = [
-        "localization", "product", "root", "scripts", "software", "storage", "user"
+        "files", "localization", "product", "root", "scripts", "software", "storage", "user"
       ].freeze
 
       # Builds the Agama profile

--- a/service/lib/agama/autoyast/files_reader.rb
+++ b/service/lib/agama/autoyast/files_reader.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Builds the Agama "files" section from an AutoYaST profile.
+    class FilesReader
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # Returns a hash corresponding to Agama "files" section.
+      #
+      # If there is no files-related information, it returns an empty hash.
+      #
+      # @return [Hash] Agama "files" section
+      def read
+        return {} if profile["files"].nil?
+
+        # files section contains list of file nodes.
+        # supported file sub-elements:
+        # - file_location (a file source)
+        # - file_path (this one seems to be the only mandatory,
+        #             a file destination or directory to be created if ends with '/')
+        # - file_owner
+        # - file_permissions
+        #
+        # unsupported for now:
+        # - file_content
+        # - file_script
+        return {}
+      end
+
+    private
+
+      attr_reader :profile
+
+    end
+  end
+end

--- a/service/lib/agama/autoyast/files_reader.rb
+++ b/service/lib/agama/autoyast/files_reader.rb
@@ -55,10 +55,10 @@ module Agama
 
         files_json = files.reduce([]) do |res, f|
           file = file_source(f)
+          file = file.merge(file_owner(f))
 
           file["destination"] = f["file_path"] if f["file_path"]
           file["permissions"] = f["file_permissions"] if f["file_permissions"]
-          file["owner"] = f["file_owner"] if f["file_owner"]
 
           res.push(file)
         end
@@ -80,6 +80,15 @@ module Agama
         else
           {}
         end
+      end
+
+      def file_owner(file)
+        return {} if file.nil? || file.empty? || !file["file_owner"]
+
+        {
+          "user": file["file_owner"].split(/\./).first,
+          "group": file["file_owner"].split(/\./).last,
+        }
       end
     end
   end

--- a/service/lib/agama/autoyast/files_reader.rb
+++ b/service/lib/agama/autoyast/files_reader.rb
@@ -41,16 +41,29 @@ module Agama
 
         # files section contains list of file nodes.
         # supported file sub-elements:
-        # - file_location (a file source)
+        # - file_location (a file source) (-> source)
         # - file_path (this one seems to be the only mandatory,
         #             a file destination or directory to be created if ends with '/')
-        # - file_owner
-        # - file_permissions
+        #             (-> destination)
+        # - file_owner (-> owner)
+        # - file_permissions (permissions)
         #
         # unsupported for now:
         # - file_content
         # - file_script
-        return {}
+        files = profile.fetch_as_array("files")
+
+        files_json = files.reduce([]) do |res, file|
+          # Currently we support only url to file source
+          file["source"] = file.delete("file_location")
+          file["destination"] = file.delete("file_path")
+          file["permissions"] = file.delete("file_permissions")
+          file["owner"] = file.delete("file_owner")
+
+          res.push(file)
+        end
+
+        { "files" => files_json }
       end
 
     private

--- a/service/lib/agama/autoyast/files_reader.rb
+++ b/service/lib/agama/autoyast/files_reader.rb
@@ -69,7 +69,6 @@ module Agama
     private
 
       attr_reader :profile
-
     end
   end
 end

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -7,7 +7,7 @@
   { "key": "dhcp-server", "support": "no" },
   { "key": "dns-server", "support": "no" },
   { "key": "fcoe-client", "support": "no" },
-  { "key": "files", "support": "planned" },
+  { "key": "files", "support": "yes" },
   { "key": "firstboot", "support": "no" },
   { "key": "ftp-server", "support": "no" },
   { "key": "general", "support": "no" },


### PR DESCRIPTION
## Problem

We want to (partially) support files section when converting old AY profile into Agama's new json based

## Solution

implemented files reader for Agama's AutoYaST converter.
For now only static file sources are supported no dynamic files allowed (files embedded into the profile)


## Testing

- *Tested manually*




