### PR TITLE
Use $basearch for newly split repodata of Leap 16.0

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar  7 11:27:35 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Use $basearch for newly split repodata of Leap 16.0
+  code-o-o#leap/features#193
+
+-------------------------------------------------------------------
 Thu Mar  6 13:24:10 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Sync Leap 16.0 pattern selection with SLES 16.0

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -33,7 +33,7 @@ translations:
     zh_Hans: Leap 16.0 是基于 SUSE Linux Enterprise Server 构建的社区发行版的最新版本。
 software:
   installation_repositories:
-    - url: https://download.opensuse.org/distribution/leap/16.0/repo/oss
+    - url: https://download.opensuse.org/distribution/leap/16.0/repo/oss/$basearch
   installation_labels:
     - label: Leap-DVD-x86_64
       archs: x86_64


### PR DESCRIPTION
- Leap 16.0 newly uses a split repodata per $arch
  code-o-o#leap/features#193
