### PR TITLE
Properly set the systemd service timeout

### DIFF
--- a/live/root/etc/systemd/system/agama-self-update.service
+++ b/live/root/etc/systemd/system/agama-self-update.service
@@ -23,7 +23,7 @@ ExecStartPost=dmesg --console-on
 TTYReset=yes
 TTYVHangup=yes
 StandardInput=tty
-TimeoutSec=0
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=default.target

--- a/live/root/etc/systemd/system/checkmedia.service
+++ b/live/root/etc/systemd/system/checkmedia.service
@@ -40,7 +40,7 @@ ExecStartPost=kill -SIGRTMIN+20 1
 
 StandardInput=tty
 RemainAfterExit=true
-TimeoutSec=0
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=default.target

--- a/live/root/etc/systemd/system/live-password.service
+++ b/live/root/etc/systemd/system/live-password.service
@@ -42,7 +42,7 @@ ExecStartPost=kill -SIGRTMIN+20 1
 
 StandardOutput=tty
 RemainAfterExit=true
-TimeoutSec=0
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=default.target

--- a/rust/share/agama-scripts.service
+++ b/rust/share/agama-scripts.service
@@ -12,7 +12,7 @@ Environment=TERM=linux
 ExecStartPre=-/usr/bin/plymouth --hide-splash
 ExecStart=/usr/libexec/agama-scripts.sh
 RemainAfterExit=yes
-TimeoutSec=0
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION

## Problem

- The `checkmedia` service is killed before it finishes
![image](https://github.com/user-attachments/assets/bcd29aab-5982-4c5f-b62f-ac069a49d325)

## Solution

- Properly disable the start timeout, according to the documentation for disabling timeout the value "infinity" should be used.
- See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#TimeoutStartSec=
- I'd keep the default stop time out to allow killing the services when stopping or restarting (`TimeoutSec` sets both.)

