### PR TITLE
Do only one automatic download retry

### DIFF
--- a/service/lib/agama/software/callbacks/media.rb
+++ b/service/lib/agama/software/callbacks/media.rb
@@ -89,7 +89,7 @@ module Agama
           # "IO" = IO error (scratched DVD or HW failure)
           # "IO_SOFT" = network timeout
           # in other cases automatic retry usually does not make much sense
-          if ["IO", "IO_SOFT"].include?(error_code) && attempt < Repository::RETRY_COUNT
+          if ["IO", "IO_SOFT"].include?(error_code) && attempt <= Repository::RETRY_COUNT
             self.attempt += 1
             logger.info("Retry in #{Repository::RETRY_DELAY} seconds, attempt #{attempt}...")
             sleep(Repository::RETRY_DELAY)

--- a/service/lib/agama/software/repository.rb
+++ b/service/lib/agama/software/repository.rb
@@ -34,7 +34,7 @@ module Agama
       # delay before retrying (in seconds)
       RETRY_DELAY = 5
       # number of automatic retries
-      RETRY_COUNT = 3
+      RETRY_COUNT = 1
 
       # Probes a repository
       #
@@ -47,7 +47,7 @@ module Agama
           # on a timeout error the result is nil, retry automatically in that case,
           # note: callbacks are disabled during repo probing call
           type = Yast::Pkg.RepositoryProbe(url.to_s, product_dir)
-          break if !type.nil? || attempt == RETRY_COUNT
+          break if !type.nil? || attempt > RETRY_COUNT
 
           sleep(RETRY_DELAY)
           attempt += 1
@@ -65,7 +65,7 @@ module Agama
 
         loop do
           @loaded = !!super
-          break if @loaded || attempt == RETRY_COUNT
+          break if @loaded || attempt > RETRY_COUNT
 
           sleep(RETRY_DELAY)
           attempt += 1


### PR DESCRIPTION
## Problem

- Related to https://github.com/agama-project/agama/pull/2117
- As discussed on the review, there should be just one automatic retry to report a failure quicker to the user

## Solution

- Change the number
- Additionally the logic has been changed so the retry count really means the retry count. Before it was actually the total amount of attempts, not just the retries.

