### PR TITLE
Bump the version to 13pre

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -78,7 +78,7 @@ project for submitting.
   - `git checkout -b beta2`
   - `git push origin beta2`
 - Configure submission, use the systemsmanagement:Agama:Release project as the target
-  - `branch2obs.sh -t systemsmanagement:Agama:Release`
+  - `branch2obs.sh -p systemsmanagement:Agama:Release`
 - Bump the version in master branch for the next release
   - `git checkout master`
   - Update the ISO version in `live/src/agama-installer.kiwi`, use the `pre` suffix to distinguish

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 11 16:29:40 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Bump the version to 13pre
+
+-------------------------------------------------------------------
 Wed Mar  5 14:54:48 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Decrease the libzypp timeout from the default 60 seconds to

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -20,7 +20,7 @@
         <profile name="Leap_16.0_PXE" description="openSUSE Leap OEM image for remote installation" import="true" />
     </profiles>
     <preferences>
-        <version>12.0.0</version>
+        <version>13pre.0.0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>


### PR DESCRIPTION
## Problem

- There could  be a confusion between the official Agama version 12 and the version from our OBS

## Solution

- Bump the version to `13pre` so it is clear this is not the version 12 but still not the future version 13 (so that 12 is the latest final release).
