### PR TITLE
feat(ruby): collect the logs at the end of the installation

### DIFF
--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -258,10 +258,6 @@ module Agama
     # @param method [HALT, POWEROFF, STOP, REBOOT]
     # @return [Boolean]
     def finish_installation(method)
-      logs = collect_logs(path: "/tmp/var/logs/")
-
-      logger.info("Installation logs stored in #{logs}")
-
       unless installation_phase.finish?
         logger.error "The installer has not finished correctly. Please check logs"
         return false

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 12 00:44:33 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Copy Agama logs to the installed system (gh#agama/agama-project#2148).
+- Set /var/log/agama-installation permissions to 0700
+  (gh#agama/agama-project#2140).
+
+-------------------------------------------------------------------
 Wed Mar  5 14:50:04 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Automatically retry package download or repository refresh

--- a/service/test/agama/manager_test.rb
+++ b/service/test/agama/manager_test.rb
@@ -228,15 +228,9 @@ describe Agama::Manager do
     let(:method) { "reboot" }
 
     before do
-      allow(subject).to receive(:collect_logs)
       allow(subject).to receive(:iguana?).and_return(iguana)
       allow(subject.installation_phase).to receive(:finish?).and_return(finished)
       allow(logger).to receive(:error)
-    end
-
-    it "collects the logs" do
-      expect(subject).to receive(:collect_logs)
-      subject.finish_installation(method)
     end
 
     context "when it is not in finish the phase" do

--- a/service/test/agama/storage/finisher_test.rb
+++ b/service/test/agama/storage/finisher_test.rb
@@ -141,3 +141,35 @@ describe Agama::Storage::Finisher do
 
   include_examples "progress"
 end
+
+describe Agama::Storage::Finisher::CopyLogsStep do
+  let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:scripts_dir) { File.join(tmp_dir, "run", "agama", "scripts") }
+  let(:tmp_dir) { Dir.mktmpdir }
+
+  subject { Agama::Storage::Finisher::CopyLogsStep.new(logger) }
+
+  before do
+    allow(Yast::Installation).to receive(:destdir).and_return(File.join(tmp_dir, "mnt"))
+    allow(Yast::Execute).to receive(:locally)
+    stub_const("Agama::Storage::Finisher::CopyLogsStep::SCRIPTS_DIR",
+      File.join(tmp_dir, "run", "agama", "scripts"))
+  end
+
+  after do
+    FileUtils.remove_entry(tmp_dir)
+  end
+
+  context "when scripts artifacts exist" do
+    before do
+      FileUtils.mkdir_p(scripts_dir)
+      FileUtils.touch(File.join(scripts_dir, "test.sh"))
+    end
+
+    it "copies the artifacts to the installed system" do
+      subject.run
+      expect(File).to exist(File.join(tmp_dir, "mnt", "var", "log", "agama-installation",
+        "scripts"))
+    end
+  end
+end

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -369,6 +369,7 @@ describe Agama::Storage::Manager do
       allow(File).to receive(:directory?).with("/iguana").and_return iguana
       allow(copy_files_class).to receive(:new).and_return(copy_files)
       allow(Yast::Execute).to receive(:on_target!)
+      allow(Yast::Execute).to receive(:local)
     end
     let(:copy_files_class) { Agama::Storage::Finisher::CopyFilesStep }
     let(:copy_files) { instance_double(copy_files_class, run?: true, run: true, label: "Copy") }
@@ -386,8 +387,10 @@ describe Agama::Storage::Manager do
       expect(scripts_client).to receive(:run).with("post")
       expect(Yast::Execute).to receive(:on_target!)
         .with("systemctl", "enable", "agama-scripts", allowed_exitstatus: [0, 1])
-      expect(Yast::WFM).to receive(:CallFunction).with("copy_logs_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("umount_finish", ["Write"])
+      expect(Yast::Execute).to receive(:locally).with(
+        "agama", "logs", "store", "--destination", /\/var\/log\/agama-installation\/logs/
+      )
       storage.finish
     end
 


### PR DESCRIPTION
## Problem

Agama does not copy the logs to the installed system, so they are lost. Additionally, the /var/log/agama-installation permissions are way too open.

## Solution

* Save the logs into the installed system.
* Set the proper permissions (700) to the /var/log/agama-installation folder (#2140).

## Testing

- Added a new unit test
- Tested manually