### PR TITLE
fix(rust): add extension to the "filename" in the disposition header

### DIFF
--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -251,10 +251,15 @@ async fn download_logs() -> impl IntoResponse {
                     header::CONTENT_TYPE,
                     HeaderValue::from_static("application/x-compressed-tar"),
                 );
-                headers.insert(
-                    header::CONTENT_DISPOSITION,
-                    HeaderValue::from_static("attachment; filename=\"agama-logs\""),
-                );
+                if let Some(file_name) = path.file_name() {
+                    let disposition =
+                        format!("attachment; filename=\"{}\"", &file_name.to_string_lossy());
+                    headers.insert(
+                        header::CONTENT_DISPOSITION,
+                        HeaderValue::from_str(&disposition)
+                            .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
+                    );
+                }
                 headers.insert(
                     header::CONTENT_ENCODING,
                     HeaderValue::from_static(logs::DEFAULT_COMPRESSION.1),

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 12 13:09:52 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set the extension in the disposition "filename" so Chrome uses
+  the correct name (gh#agama-project/agama#2141).
+
+-------------------------------------------------------------------
 Mon Mar 10 12:13:19 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Package and install the storage model schema


### PR DESCRIPTION
## Problem

When downloading the logs, Chrom(ium|e) does not add an extension to the file name. In Firefox it seems to work just fine. See #2141.

## Solution

Set the extension in the `filename` so Chromium uses the correct name.

## Testing

- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

