### PR TITLE
fix(web): correct typos found with cspell

### DIFF
--- a/web/src/queries/users.ts
+++ b/web/src/queries/users.ts
@@ -150,7 +150,7 @@ const useRootUserChanges = () => {
 
     return client.onEvent((event) => {
       if (event.type === "RootChanged") {
-        const { password, sshPublickKey } = event;
+        const { password, sshPublicKey } = event;
         queryClient.setQueryData(["users", "root"], (oldRoot: RootUser) => {
           const newRoot = { ...oldRoot };
           if (password !== undefined) {
@@ -158,8 +158,8 @@ const useRootUserChanges = () => {
             newRoot.hashedPassword = false;
           }
 
-          if (sshPublickKey) {
-            newRoot.sshPublicKey = sshPublickKey;
+          if (sshPublicKey) {
+            newRoot.sshPublicKey = sshPublicKey;
           }
 
           return newRoot;


### PR DESCRIPTION
Fixes typos that were affecting the optimistic update for root authentication methods. While likely unnoticed, it's still important to address them.