### PR TITLE
Allow to delete mandatory filesystems

### DIFF
--- a/service/lib/agama/storage/config.rb
+++ b/service/lib/agama/storage/config.rb
@@ -72,14 +72,23 @@ module Agama
         boot_drive&.found_device&.name
       end
 
-      # return [Array<Configs::Partition>]
+      # @return [Array<Configs::Partition>]
       def partitions
         drives.flat_map(&:partitions)
       end
 
-      # return [Array<Configs::LogicalVolume>]
+      # @return [Array<Configs::LogicalVolume>]
       def logical_volumes
         volume_groups.flat_map(&:logical_volumes)
+      end
+
+      # @return [Array<Configs::Filesystem>]
+      def filesystems
+        (
+          drives.map(&:filesystem) +
+          partitions.map(&:filesystem) +
+          logical_volumes.map(&:filesystem)
+        ).compact
       end
     end
   end

--- a/service/lib/agama/storage/config_checker.rb
+++ b/service/lib/agama/storage/config_checker.rb
@@ -21,6 +21,7 @@
 
 require "agama/config"
 require "agama/storage/config_checkers/boot"
+require "agama/storage/config_checkers/filesystems"
 require "agama/storage/config_checkers/drive"
 require "agama/storage/config_checkers/volume_group"
 require "agama/storage/config_checkers/volume_groups"
@@ -41,6 +42,7 @@ module Agama
       # @return [Array<Issue>]
       def issues
         [
+          filesystems_issues,
           boot_issues,
           drives_issues,
           volume_groups_issues
@@ -60,6 +62,13 @@ module Agama
       # @return [Array<Issue>]
       def boot_issues
         ConfigCheckers::Boot.new(storage_config, product_config).issues
+      end
+
+      # Issues related to the list of filesystems (mount paths)
+      #
+      # @return [Array<Issue>]
+      def filesystems_issues
+        ConfigCheckers::Filesystems.new(storage_config, product_config).issues
       end
 
       # Issues from drives.

--- a/service/lib/agama/storage/config_checkers/base.rb
+++ b/service/lib/agama/storage/config_checkers/base.rb
@@ -51,13 +51,16 @@ module Agama
         # Creates an error issue.
         #
         # @param message [String]
+        # @param kind [Symbol, nil] if nil or ommited, default value defined by Agama::Issue
         # @return [Issue]
-        def error(message)
-          Agama::Issue.new(
-            message,
+        def error(message, kind: nil)
+          issue_args = {
             source:   Agama::Issue::Source::CONFIG,
             severity: Agama::Issue::Severity::ERROR
-          )
+          }
+          issue_args[:kind] = kind if kind
+
+          Agama::Issue.new(message, **issue_args)
         end
       end
     end

--- a/service/lib/agama/storage/config_checkers/boot.rb
+++ b/service/lib/agama/storage/config_checkers/boot.rb
@@ -60,7 +60,8 @@ module Agama
           # solver logic changes.
           error(
             _("The boot device cannot be automatically selected because there is no root (/) " \
-              "file system")
+              "file system"),
+            kind: :no_root
           )
         end
 
@@ -69,7 +70,10 @@ module Agama
           return unless configure? && device_alias && !valid_alias?
 
           # TRANSLATORS: %s is replaced by a device alias (e.g., "boot").
-          error(format(_("There is no boot device with alias '%s'"), device_alias))
+          error(
+            format(_("There is no boot device with alias '%s'"), device_alias),
+            kind: :no_such_alias
+          )
         end
 
         # @return [Boolean]

--- a/service/lib/agama/storage/config_checkers/encryption.rb
+++ b/service/lib/agama/storage/config_checkers/encryption.rb
@@ -64,6 +64,11 @@ module Agama
           config.encryption
         end
 
+        # @see Base
+        def error(message)
+          super(message, kind: :encryption)
+        end
+
         # @return [Issue, nil]
         def missing_password_issue
           return unless encryption.missing_password?

--- a/service/lib/agama/storage/config_checkers/filesystem.rb
+++ b/service/lib/agama/storage/config_checkers/filesystem.rb
@@ -62,12 +62,17 @@ module Agama
           config.filesystem
         end
 
+        # @see Base
+        def error(message)
+          super(message, kind: :filesystem)
+        end
+
         # @return [Issue, nil]
         def missing_filesystem_issue
           return if filesystem.reuse?
           return if filesystem.type&.fs_type
 
-          # TRANSLATORS: %s is the replaced by a mount path (e.g., "/home").
+          # TRANSLATORS: %s is replaced by a mount path (e.g., "/home").
           error(format(_("Missing file system type for '%s'"), filesystem.path))
         end
 

--- a/service/lib/agama/storage/config_checkers/filesystems.rb
+++ b/service/lib/agama/storage/config_checkers/filesystems.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/config_checkers/base"
+require "agama/storage/proposal_settings_reader"
+require "yast/i18n"
+
+module Agama
+  module Storage
+    module ConfigCheckers
+      # Class for checking the boot config.
+      class Filesystems < Base
+        include Yast::I18n
+
+        # Boot config issues.
+        #
+        # @return [Array<Issue>]
+        def issues
+          [missing_paths_issue].compact
+        end
+
+      private
+
+        # @return [Issue, nil]
+        def missing_paths_issue
+          missing_paths = required_paths.reject { |p| configured_path?(p) }
+          return if missing_paths.empty?
+
+          error(
+            format(
+              # TRANSLATORS: %s is a path like "/" or a list of paths separated by commas
+              n_(
+                "A separate file system for %s is required.",
+                "Separate file systems are required for the following paths: %s",
+                missing_paths.size
+              ),
+              missing_paths.join(", ")
+            ),
+            kind: :required_filesystems
+          )
+        end
+
+        # @return [Boolean]
+        def configured_path?(path)
+          filesystems.any? { |fs| fs.path?(path) }
+        end
+
+        # @return [Array<Configs::Filesystem>]
+        def filesystems
+          @filesystems ||= storage_config.filesystems
+        end
+
+        # return [Array<String>]
+        def required_paths
+          volumes.select { |v| v.outline.required }.map(&:mount_path)
+        end
+
+        # @return [Array<Agama::Storage::Volume>]
+        def volumes
+          @volumes ||= VolumeTemplatesBuilder.new_from_config(product_config).all
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/config_checkers/filesystems.rb
+++ b/service/lib/agama/storage/config_checkers/filesystems.rb
@@ -26,11 +26,11 @@ require "yast/i18n"
 module Agama
   module Storage
     module ConfigCheckers
-      # Class for checking the boot config.
+      # Class for checking the overal configuration of filesystems.
       class Filesystems < Base
         include Yast::I18n
 
-        # Boot config issues.
+        # Issues related to the configured set of filesystems.
         #
         # @return [Array<Issue>]
         def issues
@@ -41,7 +41,7 @@ module Agama
 
         # @return [Issue, nil]
         def missing_paths_issue
-          missing_paths = required_paths.reject { |p| configured_path?(p) }
+          missing_paths = mandatory_paths.reject { |p| configured_path?(p) }
           return if missing_paths.empty?
 
           error(
@@ -68,14 +68,9 @@ module Agama
           @filesystems ||= storage_config.filesystems
         end
 
-        # return [Array<String>]
-        def required_paths
-          volumes.select { |v| v.outline.required }.map(&:mount_path)
-        end
-
-        # @return [Array<Agama::Storage::Volume>]
-        def volumes
-          @volumes ||= VolumeTemplatesBuilder.new_from_config(product_config).all
+        # @return [Array<String>]
+        def mandatory_paths
+          product_config.mandatory_paths
         end
       end
     end

--- a/service/lib/agama/storage/config_checkers/logical_volume.rb
+++ b/service/lib/agama/storage/config_checkers/logical_volume.rb
@@ -74,8 +74,11 @@ module Agama
 
           return if pool
 
-          # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
-          error(format(_("There is no LVM thin pool volume with alias '%s'"), config.used_pool))
+          error(
+            # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
+            format(_("There is no LVM thin pool volume with alias '%s'"), config.used_pool),
+            kind: :no_such_alias
+          )
         end
       end
     end

--- a/service/lib/agama/storage/config_checkers/search.rb
+++ b/service/lib/agama/storage/config_checkers/search.rb
@@ -61,6 +61,11 @@ module Agama
           config.search
         end
 
+        # @see Base
+        def error(message)
+          super(message, kind: :search)
+        end
+
         # @return [Issue, nil]
         def not_found_issue
           return if search.device || search.skip_device?

--- a/service/lib/agama/storage/config_checkers/volume_group.rb
+++ b/service/lib/agama/storage/config_checkers/volume_group.rb
@@ -84,8 +84,11 @@ module Agama
           configs = storage_config.drives + storage_config.drives.flat_map(&:partitions)
           return if configs.any? { |c| c.alias == pv_alias }
 
-          # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
-          error(format(_("There is no LVM physical volume with alias '%s'"), pv_alias))
+          error(
+            # TRANSLATORS: %s is the replaced by a device alias (e.g., "pv1").
+            format(_("There is no LVM physical volume with alias '%s'"), pv_alias),
+            kind: :no_such_alias
+          )
         end
 
         # Issues from physical volumes devices (target devices).
@@ -109,7 +112,8 @@ module Agama
               # TRANSLATORS: %s is the replaced by a device alias (e.g., "disk1").
               _("There is no target device for LVM physical volumes with alias '%s'"),
               device_alias
-            )
+            ),
+            kind: :no_such_alias
           )
         end
 

--- a/service/lib/agama/storage/config_checkers/volume_groups.rb
+++ b/service/lib/agama/storage/config_checkers/volume_groups.rb
@@ -54,7 +54,8 @@ module Agama
                 # TRANSLATORS: %s is the replaced by a device alias (e.g., "disk1").
                 _("The device '%s' is used several times as target device for physical volumes"),
                 device
-              )
+              ),
+              kind: :vg_target_devices
             )
           end
         end

--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -368,7 +368,7 @@ module Agama
       # @return [Issue]
       def failed_issue
         Issue.new(
-          _("Cannot accommodate the required file systems for installation"),
+          _("Cannot calculate a valid storage setup with the current configuration"),
           source:   Issue::Source::SYSTEM,
           severity: Issue::Severity::ERROR
         )

--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -103,7 +103,6 @@ module Y2Storage
       issues_list.concat(issues)
 
       if fatal_error?
-        # This means some IfNotFound is set to "error" and we failed to find a match
         @devices = nil
         return @devices
       end

--- a/service/test/agama/storage/autoyast_proposal_test.rb
+++ b/service/test/agama/storage/autoyast_proposal_test.rb
@@ -247,7 +247,7 @@ describe Agama::Storage::Proposal do
           subject.calculate_autoyast(partitioning)
           expect(subject.issues).to include(
             an_object_having_attributes(
-              description: /Cannot accommodate/, severity: Agama::Issue::Severity::ERROR
+              description: /Cannot calculate/, severity: Agama::Issue::Severity::ERROR
             )
           )
         end
@@ -375,7 +375,7 @@ describe Agama::Storage::Proposal do
           subject.calculate_autoyast(partitioning)
           expect(subject.issues).to include(
             an_object_having_attributes(
-              description: /Cannot accommodate/, severity: Agama::Issue::Severity::ERROR
+              description: /Cannot calculate/, severity: Agama::Issue::Severity::ERROR
             )
           )
         end

--- a/service/test/agama/storage/config_checker_test.rb
+++ b/service/test/agama/storage/config_checker_test.rb
@@ -231,10 +231,13 @@ describe Agama::Storage::ConfigChecker do
   let(:product_data) do
     {
       "storage" => {
+        "volumes"          => volumes,
         "volume_templates" => volume_templates
       }
     }
   end
+
+  let(:volumes) { ["/"] }
 
   let(:volume_templates) do
     [
@@ -790,6 +793,8 @@ describe Agama::Storage::ConfigChecker do
     end
 
     context "if some volumes are required" do
+      let(:volumes) { ["/", "swap"] }
+
       let(:volume_templates) do
         [
           {

--- a/service/test/agama/storage/proposal_test.rb
+++ b/service/test/agama/storage/proposal_test.rb
@@ -917,7 +917,7 @@ describe Agama::Storage::Proposal do
         subject.calculate_agama(config)
 
         expect(subject.issues).to include(
-          an_object_having_attributes(description: /Cannot accommodate/)
+          an_object_having_attributes(description: /Cannot calculate/)
         )
       end
     end

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -116,7 +116,7 @@ describe Y2Storage::AgamaProposal do
               "subvolumes"        => ["home", "opt", "root", "srv"]
             },
             "outline"    => {
-              "required"               => true,
+              "required"               => false,
               "snapshots_configurable" => true,
               "filesystems"            => ["btrfs", "xfs", "ext3", "ext4"],
               "auto_size"              => {

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 19 19:04:09 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Allow temporary removal of the root file system
+ (gh#agama-project/agama#2160).
+
+-------------------------------------------------------------------
 Tue Mar 18 10:59:20 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Fix registration form issue when email is not provided

--- a/web/src/components/storage/DriveEditor.test.tsx
+++ b/web/src/components/storage/DriveEditor.test.tsx
@@ -207,7 +207,7 @@ describe("PartitionMenuItem", () => {
     const partitionsButton = screen.getByRole("button", { name: "Partitions" });
     await user.click(partitionsButton);
     const partitionsMenu = screen.getByRole("menu");
-    const deleteRootButton = within(partitionsMenu).queryByRole("menuitem", {
+    const deleteRootButton = within(partitionsMenu).getByRole("menuitem", {
       name: "Delete /",
     });
     await user.click(deleteRootButton);

--- a/web/src/components/storage/DriveEditor.test.tsx
+++ b/web/src/components/storage/DriveEditor.test.tsx
@@ -164,6 +164,8 @@ const mockDeleteDrive = jest.fn();
 const mockGetPartition = jest.fn();
 const mockDeletePartition = jest.fn();
 
+let additionalDrives = true;
+
 jest.mock("~/queries/storage", () => ({
   ...jest.requireActual("~/queries/storage"),
   useAvailableDevices: () => [sda],
@@ -174,10 +176,14 @@ jest.mock("~/queries/storage", () => ({
 jest.mock("~/queries/storage/config-model", () => ({
   ...jest.requireActual("~/queries/storage/config-model"),
   useConfigModel: () => ({ drives: [drive1, drive2] }),
-  useDrive: () => ({
+  useDrive: (name) => ({
+    isExplicitBoot: name === "/dev/sda",
     delete: mockDeleteDrive,
     getPartition: mockGetPartition,
     deletePartition: mockDeletePartition,
+  }),
+  useModel: () => ({
+    hasAdditionalDrives: additionalDrives,
   }),
 }));
 
@@ -223,28 +229,64 @@ describe("PartitionMenuItem", () => {
 });
 
 describe("RemoveDriveOption", () => {
-  it("allows users to delete a drive which does not contain root", async () => {
-    const { user } = plainRender(<DriveEditor drive={drive2} driveDevice={sdb} />);
-
-    const driveButton = screen.getByRole("button", { name: "Drive" });
-    await user.click(driveButton);
-    const drivesMenu = screen.getByRole("menu");
-    const deleteDriveButton = within(drivesMenu).getByRole("menuitem", {
-      name: /Do not use/,
+  describe("if there are additional drives", () => {
+    beforeEach(() => {
+      additionalDrives = true;
     });
-    await user.click(deleteDriveButton);
-    expect(mockDeleteDrive).toHaveBeenCalled();
+
+    it("allows users to delete regular drives", async () => {
+      const { user } = plainRender(<DriveEditor drive={drive2} driveDevice={sdb} />);
+
+      const driveButton = screen.getByRole("button", { name: "Drive" });
+      await user.click(driveButton);
+      const drivesMenu = screen.getByRole("menu");
+      const deleteDriveButton = within(drivesMenu).getByRole("menuitem", {
+        name: /Do not use/,
+      });
+      await user.click(deleteDriveButton);
+      expect(mockDeleteDrive).toHaveBeenCalled();
+    });
+
+    it("does not allow users to delete drives explicitly used to boot", async () => {
+      const { user } = plainRender(<DriveEditor drive={drive1} driveDevice={sda} />);
+
+      const driveButton = screen.getByRole("button", { name: "Drive" });
+      await user.click(driveButton);
+      const drivesMenu = screen.getByRole("menu");
+      const deleteDriveButton = within(drivesMenu).queryByRole("menuitem", {
+        name: /Do not use/,
+      });
+      expect(deleteDriveButton).not.toBeInTheDocument();
+    });
   });
 
-  it("does not allow users to delete a drive which contains root", async () => {
-    const { user } = plainRender(<DriveEditor drive={drive1} driveDevice={sda} />);
-
-    const driveButton = screen.getByRole("button", { name: "Drive" });
-    await user.click(driveButton);
-    const drivesMenu = screen.getByRole("menu");
-    const deleteDriveButton = within(drivesMenu).queryByRole("menuitem", {
-      name: /Do not use/,
+  describe("if there are no additional drives", () => {
+    beforeEach(() => {
+      additionalDrives = false;
     });
-    expect(deleteDriveButton).not.toBeInTheDocument();
+
+    it("does not allow users to delete regular drives", async () => {
+      const { user } = plainRender(<DriveEditor drive={drive2} driveDevice={sdb} />);
+
+      const driveButton = screen.getByRole("button", { name: "Drive" });
+      await user.click(driveButton);
+      const drivesMenu = screen.getByRole("menu");
+      const deleteDriveButton = within(drivesMenu).queryByRole("menuitem", {
+        name: /Do not use/,
+      });
+      expect(deleteDriveButton).not.toBeInTheDocument();
+    });
+
+    it("does not allow users to delete drives explicitly used to boot", async () => {
+      const { user } = plainRender(<DriveEditor drive={drive1} driveDevice={sda} />);
+
+      const driveButton = screen.getByRole("button", { name: "Drive" });
+      await user.click(driveButton);
+      const drivesMenu = screen.getByRole("menu");
+      const deleteDriveButton = within(drivesMenu).queryByRole("menuitem", {
+        name: /Do not use/,
+      });
+      expect(deleteDriveButton).not.toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/storage/DriveEditor.test.tsx
+++ b/web/src/components/storage/DriveEditor.test.tsx
@@ -195,7 +195,7 @@ describe("PartitionMenuItem", () => {
     expect(mockDeletePartition).toHaveBeenCalled();
   });
 
-  it("does not allow users to delete a required partition", async () => {
+  it("allows users to delete a required partition", async () => {
     const { user } = plainRender(<DriveEditor drive={drive1} driveDevice={sda} />);
 
     const partitionsButton = screen.getByRole("button", { name: "Partitions" });
@@ -204,7 +204,8 @@ describe("PartitionMenuItem", () => {
     const deleteRootButton = within(partitionsMenu).queryByRole("menuitem", {
       name: "Delete /",
     });
-    expect(deleteRootButton).not.toBeInTheDocument();
+    await user.click(deleteRootButton);
+    expect(mockDeletePartition).toHaveBeenCalled();
   });
 
   it("allows users to edit a partition", async () => {

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -29,7 +29,7 @@ import { useAvailableDevices } from "~/queries/storage";
 import { configModel } from "~/api/storage/types";
 import { StorageDevice } from "~/types/storage";
 import { STORAGE as PATHS } from "~/routes/paths";
-import { useDrive } from "~/queries/storage/config-model";
+import { useDrive, useModel } from "~/queries/storage/config-model";
 import * as driveUtils from "~/components/storage/utils/drive";
 import * as partitionUtils from "~/components/storage/utils/partition";
 import { contentDescription } from "~/components/storage/utils/device";
@@ -380,14 +380,15 @@ const SearchSelector = ({ drive, selected, onChange }) => {
 
 const RemoveDriveOption = ({ drive }) => {
   const driveModel = useDrive(drive.name);
+  const { hasAdditionalDrives } = useModel();
 
   if (!driveModel) return;
 
   const { isExplicitBoot, delete: deleteDrive } = driveModel;
 
+  if (!hasAdditionalDrives) return;
   if (isExplicitBoot) return;
   if (driveUtils.hasPv(drive)) return;
-  if (driveUtils.hasRoot(drive)) return;
 
   return (
     <>

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -25,7 +25,7 @@ import { useNavigate, generatePath } from "react-router-dom";
 import { _, formatList } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import { baseName, deviceLabel, formattedPath, SPACE_POLICIES } from "~/components/storage/utils";
-import { useAvailableDevices, useVolume } from "~/queries/storage";
+import { useAvailableDevices } from "~/queries/storage";
 import { configModel } from "~/api/storage/types";
 import { StorageDevice } from "~/types/storage";
 import { STORAGE as PATHS } from "~/routes/paths";
@@ -572,8 +572,6 @@ const PartitionMenuItem = ({ driveName, mountPath }) => {
   const navigate = useNavigate();
   const drive = useDrive(driveName);
   const partition = drive.getPartition(mountPath);
-  const volume = useVolume(mountPath);
-  const isRequired = volume.outline?.required || false;
   const description = partition ? partitionUtils.typeWithSize(partition) : null;
 
   return (
@@ -597,15 +595,13 @@ const PartitionMenuItem = ({ driveName, mountPath }) => {
               )
             }
           />
-          {!isRequired && (
-            <MenuItemAction
-              style={{ alignSelf: "center" }}
-              icon={<Icon name="delete" aria-label={"Delete"} />}
-              actionId={`delete-${mountPath}`}
-              aria-label={`Delete ${mountPath}`}
-              onClick={() => drive.deletePartition(mountPath)}
-            />
-          )}
+          <MenuItemAction
+            style={{ alignSelf: "center" }}
+            icon={<Icon name="delete" aria-label={"Delete"} />}
+            actionId={`delete-${mountPath}`}
+            aria-label={`Delete ${mountPath}`}
+            onClick={() => drive.deletePartition(mountPath)}
+          />
         </>
       }
     >

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -386,7 +386,12 @@ const RemoveDriveOption = ({ drive }) => {
 
   const { isExplicitBoot, delete: deleteDrive } = driveModel;
 
+  // When no additional drives has been added, the "Do not use" button can be confusing so it is
+  // omitted for all drives.
   if (!hasAdditionalDrives) return;
+
+  // FIXME: in these two cases the button should likely be present, but disabled and with an
+  // explanation of why those particular drive definitions cannot be removed.
   if (isExplicitBoot) return;
   if (driveUtils.hasPv(drive)) return;
 

--- a/web/src/components/storage/FixableConfigInfo.tsx
+++ b/web/src/components/storage/FixableConfigInfo.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Alert, List, ListItem } from "@patternfly/react-core";
+import { n_ } from "~/i18n";
+import { useConfigErrors } from "~/queries/issues";
+
+const Description = ({ errors }) => {
+  return (
+    <List isPlain>
+      {errors.map((e, i) => (
+        <ListItem key={i}>{e.description}</ListItem>
+      ))}
+    </List>
+  );
+};
+
+/**
+ * Information about a wrong but fixable storage configuration
+ *
+ */
+export default function FixableConfigInfo() {
+  const configErrors = useConfigErrors("storage");
+
+  if (!configErrors.length) return;
+
+  const title = n_(
+    "The configuration must be adapted to address the following issue:",
+    "The configuration must be adapted to address the following issues:",
+    configErrors.length,
+  );
+
+  return (
+    <Alert variant="warning" title={title}>
+      <Description errors={configErrors} />
+    </Alert>
+  );
+}

--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -23,7 +23,7 @@
 import React from "react";
 import { Alert, Content } from "@patternfly/react-core";
 import { _, n_, formatList } from "~/i18n";
-import { useIssues } from "~/queries/issues";
+import { useIssues, useConfigErrors } from "~/queries/issues";
 import { useConfigModel } from "~/queries/storage/config-model";
 import { IssueSeverity } from "~/types/issues";
 import * as partitionUtils from "~/components/storage/utils/partition";
@@ -70,9 +70,11 @@ function Description({ partitions }) {
  *
  */
 export default function ProposalFailedInfo() {
+  const configErrors = useConfigErrors("storage");
   const errors = useIssues("storage").filter((s) => s.severity === IssueSeverity.Error);
   const model = useConfigModel({ suspense: true });
 
+  if (configErrors.length) return;
   if (!errors.length) return;
 
   const modelPartitions = model.drives.flatMap((d) => d.partitions || []);

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -39,6 +39,7 @@ import { Icon, Loading } from "~/components/layout";
 import ProposalResultSection from "./ProposalResultSection";
 import ProposalTransactionalInfo from "./ProposalTransactionalInfo";
 import ProposalFailedInfo from "./ProposalFailedInfo";
+import FixableConfigInfo from "./FixableConfigInfo";
 import UnsupportedModelInfo from "./UnsupportedModelInfo";
 import ConfigEditor from "./ConfigEditor";
 import ConfigEditorMenu from "./ConfigEditorMenu";
@@ -184,6 +185,7 @@ function ProposalSections(): React.ReactNode {
     <Grid hasGutter>
       <ProposalTransactionalInfo />
       <ProposalFailedInfo />
+      <FixableConfigInfo />
       <UnsupportedModelInfo />
       {model && (
         <>
@@ -235,13 +237,9 @@ export default function ProposalPage(): React.ReactNode {
     if (isDeprecated) reprobe().catch(console.log);
   }, [isDeprecated, reprobe]);
 
-  /**
-   * @fixme For now, a config model is only considered as editable if there is no config error. The
-   *  UI for handling a model is not prepared yet to properly work with a model generated from a
-   *  config with errors. Components like ConfigEditor should be adapted in order to properly manage
-   *  those scenarios.
-   */
-  const isModelEditable = model && !configErrors.length;
+  const fixable = ["no_root", "required_filesystems"];
+  const unfixableErrors = configErrors.filter((e) => !fixable.includes(e.kind));
+  const isModelEditable = model && !unfixableErrors.length;
   const hasDevices = !!availableDevices.length;
   const hasResult = !systemErrors.length;
   const showSections = hasDevices && (isModelEditable || hasResult);


### PR DESCRIPTION
This is a re-incarnation of #2129, that was automatically closed by Github.

## Problem

Agama does not allow to delete the "/" partition nor the drive containing it.

But that was only implemented to hide some limitations of the current UI. In fact, deleting "/" or any other mandatory partition should be allowed. Of course, a proposal without mandatory mount paths is not valid and cannot be computed. But that doesn’t mean the user cannot delete them temporarily in order to create it elsewhere.

## Solution

- Detect and properly report when mandatory partitions are missing.
- Adapt the UI to not panic (ie. resort to an empty state) when there are configuration errors that can actually be fixed by using the UI.
- Allow to delete all partitions (including "/").
- Adapt the "do not use" button of the drives to the new situation

## Screenshots

Now the trash-can icon is there for root as well...

![avion1](https://github.com/user-attachments/assets/92cacbcf-2420-4de2-9328-5f3530fbe0d6)

But nothing dramatic happens if the user clicks on it.

![avion2](https://github.com/user-attachments/assets/5b4d8981-4a3f-4c27-a8d4-b7a86fdc9667)

## Testing

- Tested manually
- Unit tests adapted