### PR TITLE
fix: improve handling of init scripts

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Mar 20 09:05:26 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve init scripts execution (gh#agama-project/agama#2161):
+  * Properly run the scripts (gh#agama-project/agama#2144).
+  * Allow setting the scripts path with the SCRIPTS_DIR
+    environment variable.
+  * Do not exit with an error if there are not scripts.
+  * Make agama-scripts.sh idempotent.
+
+-------------------------------------------------------------------
 Fri Mar 14 12:32:42 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow selecting individual packages through a configuration file

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -22,24 +22,26 @@
 
 # This script runs the user-defined Agama init scripts.
 
-WORKDIR="/var/log/agama-installation/scripts/init"
+: "${SCRIPTS_DIR:=/var/log/agama-installation/scripts/init}"
 
 systemctl disable agama-scripts.service
 
-if [ ! -d "$WORKDIR" ]; then
-    exit 1
-fi
-
-for script in  `find $WORKDIR -type f`; do
-    CONTINUE=1
-done
-
-if [ -z "$CONTINUE" ]; then
+if [ ! -d "$SCRIPTS_DIR" ]; then
     exit 0
 fi
 
-for script in  `find $WORKDIR -type f |sort`; do
-    echo -n "Executing Agama auto-installation script: $script"
-    BASENAME=`basename $script`
-    ./"$script" > "$WORKDIR/$BASENAME.log" 2>&1
+SCRIPTS=$(find "$SCRIPTS_DIR" -maxdepth 1 -type f | sort)
+
+if [ -z "$SCRIPTS" ]; then
+    exit 0
+fi
+
+LOG_DIR="$SCRIPTS_DIR/log"
+mkdir -p "$LOG_DIR"
+
+IFS='
+'
+for script in $SCRIPTS; do
+    BASENAME=$(basename "$script")
+    ./"$script" > "$LOG_DIR/$BASENAME.log" 2>&1
 done

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -41,5 +41,5 @@ fi
 for script in  `find $WORKDIR -type f |sort`; do
     echo -n "Executing Agama auto-installation script: $script"
     BASENAME=`basename $script`
-    . $script > $WORKDIR/$BASENAME.log 2>&1
+    ./"$script" > "$WORKDIR/$BASENAME.log" 2>&1
 done


### PR DESCRIPTION
## Problem

Init scripts are executed properly. See #2144.

## Solution

- Run init scripts properly
- Make agama-scripts.sh idempotent
- Allow setting the scripts path with the SCRIPTS_DIR environment variable.
- Do not exit with an error if there are not scripts

## Testing

- _Tested manually_
