### PR TITLE
Fixed killing the checkmedia service too early

### DIFF
--- a/live/root/etc/systemd/system/checkmedia.service
+++ b/live/root/etc/systemd/system/checkmedia.service
@@ -3,6 +3,7 @@ Description=Installation medium integrity check
 
 # before X11 because it switches the terminal to VT7
 Before=x11-autologin.service
+Before=agama.service
 
 # copied from YaST2-Second-Stage.service
 Before=getty@tty1.service
@@ -38,7 +39,7 @@ ExecStartPost=dmesg --console-on
 # enable back the systemd status messages on the console
 ExecStartPost=kill -SIGRTMIN+20 1
 
-StandardInput=tty
+StandardOutput=tty
 RemainAfterExit=true
 TimeoutStartSec=infinity
 

--- a/live/root/etc/systemd/system/live-password.service
+++ b/live/root/etc/systemd/system/live-password.service
@@ -6,6 +6,7 @@ Before=sshd.service
 Before=agama-web-server.service
 # before X11 because it switches the terminal to VT7
 Before=x11-autologin.service
+After=checkmedia.service
 
 # copied from YaST2-Second-Stage.service
 Before=getty@tty1.service

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 17 12:12:02 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed broken media check service (bsc#1239155)
+
+-------------------------------------------------------------------
 Wed Mar 12 17:17:08 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - (gh#agama-project/agama#2142)


### PR DESCRIPTION
## Problem

- The checkmedia service is terminated by systemd quickly after start, the check did not run fully

![checkmedia-failed](https://github.com/user-attachments/assets/3a322460-9902-4798-87e5-b5474bc580a8)



## Solution

- After some experimenting with the systemd services I came to this solution. Do not ask me for details. :smile:  

## Testing

- Tested with manually modified service file before booting
- Tested also with a locally built Live ISO

![checkmedia-fixed](https://github.com/user-attachments/assets/db5790a5-bd05-42e4-8c6d-23a6bd19b400)
