### PR TITLE
fix(web): allow registering system without providing an email

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 18 10:59:20 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Fix registration form issue when email is not provided
+  (gh#agama-project/agama#2172)
+
+-------------------------------------------------------------------
 Fri Mar 14 11:05:49 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Allow updating hostname from web user interface

--- a/web/src/components/product/ProductRegistrationPage.test.tsx
+++ b/web/src/components/product/ProductRegistrationPage.test.tsx
@@ -146,6 +146,7 @@ describe("ProductRegistrationPage", () => {
       expect(registerMutationMock).toHaveBeenCalledWith(
         {
           key: "INTERNAL-USE-ONLY-1234-5678",
+          email: "",
         },
         expect.anything(),
       );
@@ -158,7 +159,7 @@ describe("ProductRegistrationPage", () => {
       await user.click(submitButton);
 
       screen.getByText("Warning alert:");
-      screen.getByText("All fields are required");
+      screen.getByText("Some fields are missing. Please check and fill them.");
       expect(registerMutationMock).not.toHaveBeenCalled();
 
       await user.type(registrationCodeInput, "INTERNAL-USE-ONLY-1234-5678");
@@ -171,7 +172,7 @@ describe("ProductRegistrationPage", () => {
       await user.click(submitButton);
 
       screen.getByText("Warning alert:");
-      screen.getByText("All fields are required");
+      screen.getByText("Some fields are missing. Please check and fill them.");
       expect(registerMutationMock).not.toHaveBeenCalled();
 
       const emailInput = screen.getByRole("textbox", { name: /Email/ });

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -102,17 +102,15 @@ const RegistrationFormSection = () => {
     e.preventDefault();
     setError(null);
 
-    const data: RegistrationInfo = { key };
-    if (provideEmail) data.email = email;
+    const data: RegistrationInfo = { key, email: provideEmail ? email : "" };
 
     // TODO: Replace with a more sophisticated mechanism to ensure all available
     // fields are filled and validated. Ideally, this should be a reusable solution
     // applicable to all Agama forms.
-    if (Object.values(data).some(isEmpty)) {
-      setError("All fields are required");
+    if (isEmpty(key) || (provideEmail && isEmpty(email))) {
+      setError("Some fields are missing. Please check and fill them.");
       return;
     }
-
     setLoading(true);
 
     // @ts-expect-error


### PR DESCRIPTION
The registration form was updated in PR #2147 to make the email field optional, neither rendering nor validating it unless the user opts to provide an email address.

However, the process was failing silently due to the backend complaining about a malformed JSON.

> Failed to deserialize the JSON body into the target type: missing
> field `email` at line 1 column 16

This PR fixes the issue by sending the email as an empty string when the user chooses not to provide it.