### PR TITLE
Remove the nvme hostid and hostnqn files from the image (bsc#1238038)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 18 16:32:07 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Remove /etc/nvme/host* files from the image (bsc#1238038)
+
+-------------------------------------------------------------------
 Mon Mar 17 12:12:02 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed broken media check service (bsc#1239155)

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -120,6 +120,9 @@ if [ "${arch}" = "s390x" ]; then
   touch /config.bootoptions
 fi
 
+# Remove nvme hostid and hostnqn (bsc#1238038)
+rm -f /etc/nvme/host*
+
 # replace the @@LIVE_MEDIUM_LABEL@@ with the real Live partition label name from KIWI
 sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/live-password
 sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/checkmedia-service


### PR DESCRIPTION
## Problem

The nvme-cli package has a call to nvme gen-hostnqn in the %post script which makes the agama live image to include the /etc/nvme/hostid and /etc/nvme/hostnqn files which is wrong.

- https://bugzilla.suse.com/show_bug.cgi?id=1238038#c70

## Solution

The nvme-cli should not generate these files in the build environment but to prevent this issue to happen we also remove them explicitly.


