### PR TITLE
fix(live): use "agama download" to fetch the info file

### DIFF
--- a/.github/workflows/ci-live.yml
+++ b/.github/workflows/ci-live.yml
@@ -51,8 +51,8 @@ jobs:
       # disable unused repositories to have faster refresh
       run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
-    - name: Install Ruby development files
-      run: zypper --non-interactive install ShellCheck make
+    - name: Install development files
+      run: zypper --non-interactive install ShellCheck make agama-cli
 
     - name: Run shellcheck
       run: make shellcheck

--- a/live/root/usr/bin/info-cmdline-conf.sh
+++ b/live/root/usr/bin/info-cmdline-conf.sh
@@ -14,9 +14,8 @@ expand_info_arg() {
     return 0
   fi
 
-  # TODO: should we use also --location-trusted if info file url contain user and password?
-  # if so check with security team
-  curl --location --silent "${INFO_URL}" > "${INFO_CONTENT}"
+  # download the info file
+  agama download "$INFO_URL" "$INFO_CONTENT"
   # remove info param
   sed -in 's/\([[:space:]]\|^\)\(inst\|agama\)\.info=[^[:space:]]\+//' "${TARGET}"
   # and add content of info file

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr  2 05:47:01 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use "agama download" to fetch the info file (gh#agama-project/agama#2176).
+
+-------------------------------------------------------------------
 Mon Mar 31 13:06:53 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Print also the IPv6 installer URLs in the console (bsc#1240197)


### PR DESCRIPTION
## Problem

YaST-like URLs are not supported for info files because we use CURL to retrieve the file.

Fixes #2176.

## Solution

Use "agama download" to get the info file.

## Testing

- Updated the integration test.

> [!WARNING]
> The tests fail because the `agama download` command tries to connect to the Agama HTTP server even if unnecessary. See https://github.com/agama-project/agama/pull/2192 for a fix.