### PR TITLE
feat(auto): try to load profiles from predefined locations

### DIFF
--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -20,7 +20,7 @@ import_profile() {
     echo "Using the profile located at $url"
     agama profile import "$url" && return 0
   else
-    urls=("label://OEMDRV/autoinst.xml" "label://OEMDRV/autoinst.jsonnet" "label://OEMDRV/autoinst.json" "file:///autoinst.xml" "file:///autoinst.jsonnet" "file:///autoinst.json")
+    urls=("label://OEMDRV/autoinst.jsonnet" "label://OEMDRV/autoinst.json" "label://OEMDRV/autoinst.xml" "file:///autoinst.jsonnet" "file:///autoinst.json" "file:///autoinst.xml")
     for url in "${urls[@]}"; do
       YAST_SKIP_PROFILE_FETCH_ERROR=1 agama profile import "$url" && return 0
     done

--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -54,5 +54,5 @@ if [ 1 -eq $? ]; then
   exit 0
 fi
 
-install
+agama install
 finish

--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -1,28 +1,38 @@
-#!/usr/bin/sh
-set -ex
+#!/usr/bin/bash
+set -x
 
-# Temporarily skip the AutoYaST XML validation
-export YAST_SKIP_XML_VALIDATION=1
+# Find the URL given by the user.
+find_user_url() {
+  local url=$1
+  if [ -z "$1" ]; then
+    url=$(grep '\(agama\|inst\).auto=' </run/agama/cmdline.d/agama.conf | awk -F ':?(inst|agama).auto=' '{sub(/ .*$/, "", $2); print $2}')
+    echo $url
+  else
+    echo $1
+  fi
+}
 
-if [ -z "$1" ]; then
-  url=$(grep '\(agama\|inst\).auto=' < /run/agama/cmdline.d/agama.conf | awk -F ':?(inst|agama).auto=' '{sub(/ .*$/, "", $2); print $2}')
-else
-  url="$1"
-fi
+# Try to import a profile from a list of URLs
+import_profile() {
+  local url=$1
 
-if [ -z "$url" ]; then
-  echo "no autoinstallation profile"
-  exit 0
-fi
+  if [ -n "$url" ]; then
+    echo "Using the profile located at $url"
+    agama profile import "$url" && return 0
+  else
+    urls=("label://OEMDRV/autoinst.xml" "label://OEMDRV/autoinst.jsonnet" "label://OEMDRV/autoinst.json" "file:///autoinst.xml" "file:///autoinst.jsonnet" "file:///autoinst.json")
+    for url in "${urls[@]}"; do
+      YAST_SKIP_PROFILE_FETCH_ERROR=1 agama profile import "$url" && return 0
+    done
+  fi
 
-method=$(grep '\(agama\|inst\).finish=' </run/agama/cmdline.d/agama.conf | awk -F ':?(inst|agama).finish=' '{sub(/ .*$/, "", $2); print $2}')
+  return 1
+}
 
-echo "Using the profile at $url"
+# Finish the process depending on the method selected by the user.
+finish() {
+  method=$(grep '\(agama\|inst\).finish=' </run/agama/cmdline.d/agama.conf | awk -F ':?(inst|agama).finish=' '{sub(/ .*$/, "", $2); print $2}')
 
-case "$url" in
-*)
-  /usr/bin/agama profile import "$url"
-  /usr/bin/agama install
   case "$method" in
   "stop" | "halt" | "poweroff")
     /usr/bin/agama finish "$method"
@@ -31,5 +41,17 @@ case "$url" in
     /usr/bin/agama finish
     ;;
   esac
-  ;;
-esac
+}
+
+# Temporarily skip the AutoYaST XML validation
+export YAST_SKIP_XML_VALIDATION=1
+
+url=$(find_user_url "$1")
+import_profile $url
+
+if [ 1 -eq $? ]; then
+  exit 0
+fi
+
+/usr/bin/agama install
+finish

--- a/autoinstallation/bin/agama-auto
+++ b/autoinstallation/bin/agama-auto
@@ -35,10 +35,10 @@ finish() {
 
   case "$method" in
   "stop" | "halt" | "poweroff")
-    /usr/bin/agama finish "$method"
+    agama finish "$method"
     ;;
   *)
-    /usr/bin/agama finish
+    agama finish
     ;;
   esac
 }
@@ -50,8 +50,9 @@ url=$(find_user_url "$1")
 import_profile $url
 
 if [ 1 -eq $? ]; then
+# Exit if a profile was not found.
   exit 0
 fi
 
-/usr/bin/agama install
+install
 finish

--- a/autoinstallation/package/agama-auto.changes
+++ b/autoinstallation/package/agama-auto.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 21 16:10:56 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Start the autoinstallation if a profile is found in a predefined
+  location (gh#agama-project/agama#2180).
+
+-------------------------------------------------------------------
 Thu Feb 13 12:10:11 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - gh#agama-project/agama#1970


### PR DESCRIPTION
## Problem

Linuxrc & AutoYaST used to load profiles from predefined locations automatically. Some customers and partners depend on such behavior, so Agama should behave in the same way.

## Solution

If no URL was given, Agama tries to load the profile from the following locations:

- An `autoinst.jsonnet`, `autoinst.json` and `autoinst.xml` files located on a file system labeled as `OEMDRV`.
- An `autoinst.jsonnet`, `autoinst.json` and `autoinst.xml` files in the root file system.

## Testing

- *Tested manually*

## To do

- [x] Do not report an error if any of the fallback profiles do not work (see https://github.com/yast/yast-autoinstallation/pull/882).
- [x] Read profiles from the predefined locations.