### PR TITLE
fix(live): processing of "inst.self_update" boot option

### DIFF
--- a/live/root/usr/bin/agama-self-update
+++ b/live/root/usr/bin/agama-self-update
@@ -6,7 +6,7 @@
 # Agama Devel OBS project.
 
 # check if self-update is required
-if ! grep -q "[[:space:]^]agama.self_update=1\([[:space:]]\|$\)" /run/agama/cmdline.d/agama.conf; then
+if ! grep -q "\b\(inst\|agama\)\.self_update=1\b" /run/agama/cmdline.d/agama.conf; then
   exit 0
 fi
 

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 20 15:52:36 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed broken "inst.self_update" boot option
+  (gh#agama-project/agama#2175)
+
+-------------------------------------------------------------------
 Tue Mar 18 16:32:07 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Remove /etc/nvme/host* files from the image (bsc#1238038)


### PR DESCRIPTION
## Problem

The agama-self-update checks only agama.self_update and no inst.self_update which was adopted rececently as reported by https://github.com/agama-project/agama/issues/2175. 

Apart of it, the regular expresion for matching if it is between spaces or at the beginning of a line is also wrong and a similar fix was already done by @lslezak for live.password_dialog option (https://github.com/agama-project/agama/pull/2045).

## Solution

- Fixed regexp matching in the agama-self-update script, using word boundary matching (\b) and also checking inst and agama prefix.

## Test

- Tested regular expression manually.
