### PR TITLE
feat(live): Initial inst.dud=URI functionality

### DIFF
--- a/live/root/etc/systemd/system/agama-dud.service
+++ b/live/root/etc/systemd/system/agama-dud.service
@@ -11,7 +11,6 @@ After=agama-self-update.service
 # before starting the Agama servers so they use the new packages
 Before=agama-web-server.service
 Before=agama.service
-Before=x11-autologin.service
 # before interactive password services
 Before=live-password-dialog.service
 Before=live-password-systemd.service
@@ -19,9 +18,7 @@ Before=live-password-systemd.service
 [Service]
 Type=oneshot
 Environment=TERM=linux
-ExecStartPre=dmesg --console-off
 ExecStart=agama-dud
-ExecStartPost=dmesg --console-on
 TTYReset=yes
 TTYVHangup=yes
 StandardInput=tty

--- a/live/root/etc/systemd/system/agama-dud.service
+++ b/live/root/etc/systemd/system/agama-dud.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Agama DUD
+
+After=network-online.target
+
+# and after we process agama params like info which can contain password
+After=agama-cmdline-process.service
+# the DUD should replace wrong self_update
+After=agama-self-update.service
+
+# before starting the Agama servers so they use the new packages
+Before=agama-web-server.service
+Before=agama.service
+Before=x11-autologin.service
+# before interactive password services
+Before=live-password-dialog.service
+Before=live-password-systemd.service
+
+[Service]
+Type=oneshot
+Environment=TERM=linux
+ExecStartPre=dmesg --console-off
+ExecStart=agama-dud
+ExecStartPost=dmesg --console-on
+TTYReset=yes
+TTYVHangup=yes
+StandardInput=tty
+TimeoutStartSec=infinity
+
+[Install]
+WantedBy=default.target

--- a/live/root/usr/bin/agama-dud
+++ b/live/root/usr/bin/agama-dud
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Experimental DUD funtionality for Agama
+#
+# Usage: inst.dud=URI [inst.dud=URI]
+#
+# This is a very simple version of the DUD functionality
+# - There can be multiple inst.dud=URI entries, but...
+# - All of them are considered to be RPMs
+# - The script does not check if downloading succeeded
+# - Or for any deps of the package
+# - Of whether installation/upgrade succeeded
+# - Does not restart itself if the script is updated
+
+# check if there is any DUD
+if ! grep -q "\b\(inst\|agama\)\.dud=.\+\b" /run/agama/cmdline.d/agama.conf; then
+  echo "No DUD present"
+  exit 0
+fi
+
+# Make sure that it does not refresh
+zypper modifyrepo --disable --all
+
+for URI in `sed -n 's/\(.*[[:space:]]\|^\)\(inst\|agama\)\.dud=\([^[:space:]]\+\).*/\3/p' /run/agama/cmdline.d/agama.conf`; do
+  echo "Downloading DUD from" $URI
+  TMPDUD=`mktemp /tmp/agama-XXXXXXXXXX.rpm`
+  agama download $URI $TMPDUD;
+  rpm --upgrade --force --verbose --hash --noverify --nodeps --excludedocs $TMPDUD
+  zypper --non-interactive install $TMPDUD
+  rm $TMPDUD
+done
+
+zypper modifyrepo --enable --all

--- a/live/root/usr/bin/agama-dud
+++ b/live/root/usr/bin/agama-dud
@@ -18,16 +18,10 @@ if ! grep -q "\b\(inst\|agama\)\.dud=.\+\b" /run/agama/cmdline.d/agama.conf; the
   exit 0
 fi
 
-# Make sure that it does not refresh
-zypper modifyrepo --disable --all
-
 for URI in `sed -n 's/\(.*[[:space:]]\|^\)\(inst\|agama\)\.dud=\([^[:space:]]\+\).*/\3/p' /run/agama/cmdline.d/agama.conf`; do
   echo "Downloading DUD from" $URI
   TMPDUD=`mktemp /tmp/agama-XXXXXXXXXX.rpm`
   agama download $URI $TMPDUD;
   rpm --upgrade --force --verbose --hash --noverify --nodeps --excludedocs $TMPDUD
-  zypper --non-interactive install $TMPDUD
   rm $TMPDUD
 done
-
-zypper modifyrepo --enable --all

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 20 18:26:27 UTC 2025 - Lukas Ocilka <locilka@suse.com>
+
+- Added the initial functionality for inst.dud
+  (jsc#3670 and jsc#AGM-65)
+
+-------------------------------------------------------------------
 Thu Mar 20 15:52:36 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed broken "inst.self_update" boot option


### PR DESCRIPTION
## Problem

*Customers and partners need a way to patch the Live Media with PTF or similar mechanism*

- https://jira.suse.com/browse/PED-3670
- https://jira.suse.com/browse/AGM-65

## Solution

There is a new agama-dud systemd service that runs after the agama-self-update so it overwrites anything that the self-update could have changed automatically. This service calls agama-dud script that goes over all inst.dud=... in /run/agama/cmdline.d/agama.conf, downloads those packages and force-installs/upgrades them with rpm.

The solution is "inspired" by the self-update functionality and other scripts and services from the project ;)

Things to solve later

- Everything is an RPM, no other type of DUD is supported yet
- There are no checks, no validation, etc.
- Logging should be added too

## Testing

Tested only manually by adding links to RPMs into /run/agama/cmdline.d/agama.conf and running the new script

## Example of the output

> Downloading DUD from https://download.opensuse.org/repositories/artwork:/wallpapers/openSUSE_Tumbleweed/noarch/propaganda00-0-2.73.noarch.rpm
> File saved to /tmp/agama-WT3vi0ryww.rpm
> warning: /tmp/agama-WT3vi0ryww.rpm: Header V3 DSA/SHA1 Signature, key ID 5b8ee893: NOKEY
> Preparing...                          ################################# [100%]
> Updating / installing...
>    1:propaganda00-0-2.73              ################################# [100%]
