### PR TITLE
fix(web): prevent hostname alert after system registration

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 20 20:58:44 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Stop displaying the hostname alert once the system is registered
+  (gh#agama-project/agama#2183).
+
+-------------------------------------------------------------------
 Wed Mar 19 19:04:09 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Allow temporary removal of the root file system

--- a/web/src/components/product/ProductRegistrationPage.test.tsx
+++ b/web/src/components/product/ProductRegistrationPage.test.tsx
@@ -200,6 +200,14 @@ describe("ProductRegistrationPage", () => {
       registrationInfoMock = { key: "INTERNAL-USE-ONLY-1234-5678", email: "example@company.test" };
     });
 
+    it("does not render a custom alert about hostname", () => {
+      installerRender(<ProductRegistrationPage />);
+
+      expect(screen.queryByText("Custom alert:")).toBeNull();
+      expect(screen.queryByText(/hostname/)).toBeNull();
+      expect(screen.queryByRole("link", { name: "hostname" })).toBeNull();
+    });
+
     it("renders registration information with code partially hidden", async () => {
       const { user } = installerRender(<ProductRegistrationPage />);
       const visibilityCodeToggler = screen.getByRole("button", { name: "Show" });

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -178,7 +178,8 @@ const HostnameAlert = () => {
 
 export default function ProductRegistrationPage() {
   const { selectedProduct: product } = useProduct();
-  const registration = useRegistration();
+  const { key } = useRegistration();
+  const isUnregistered = isEmpty(key);
 
   // TODO: render something meaningful instead? "Product not registrable"?
   if (!product.registration) return;
@@ -190,8 +191,8 @@ export default function ProductRegistrationPage() {
       </Page.Header>
 
       <Page.Content>
-        <HostnameAlert />
-        {isEmpty(registration.key) ? <RegistrationFormSection /> : <RegisteredProductSection />}
+        {isUnregistered && <HostnameAlert />}
+        {isUnregistered ? <RegistrationFormSection /> : <RegisteredProductSection />}
       </Page.Content>
     </Page>
   );


### PR DESCRIPTION
The alert about the hostname for system registration is not necessary once the system has been successfully registered.
