### PR TITLE
Add the aaa_base-extras package

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 21 07:31:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add aaa_base-extras which includes setup-systemd-proxy-env.path
+  (gh#agama-project/agama#2184).
+
+-------------------------------------------------------------------
 Thu Mar 20 15:52:36 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed broken "inst.self_update" boot option

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -167,6 +167,7 @@
         <package name="yast2-schema"/>
         <package name="qrencode"/>
         <package name="qemu-guest-agent" />
+        <package name="aaa_base-extras"/>
         <archive name="root.tar.xz"/>
     </packages>
     <!-- additional packages for the Leap distributions -->


### PR DESCRIPTION
## Problem

The Agama ISO is not building anymore because it is missing `setup-systemd-proxy-env.path`. This path was part of `microos-tools`, but it as been [moved to aaa_base](https://github.com/openSUSE/microos-tools/blob/fa1a910b31274675516b29443923738d3738bba2/NEWS#L2).

## Solution

Add `aaa_base-extras`, which contains the path.

## Testing

- *Tested manually*
