### PR TITLE
feat(web): delete volume group

### DIFF
--- a/web/src/components/storage/AddExistingDeviceMenu.tsx
+++ b/web/src/components/storage/AddExistingDeviceMenu.tsx
@@ -41,6 +41,28 @@ import { useAvailableDevices } from "~/queries/storage";
 import { useConfigModel, useModel } from "~/queries/storage/config-model";
 import { deviceLabel } from "~/components/storage/utils";
 
+const Header = ({ drivesCount }) => {
+  const desc = sprintf(
+    n_(
+      "Extends the installation beyond the currently selected disk",
+      "Extends the installation beyond the current %d disks",
+      drivesCount,
+    ),
+    drivesCount,
+  );
+
+  return (
+    <MenuHeader
+      title={n_(
+        "Select another disk to define partitions",
+        "Select a disk to define partitions",
+        drivesCount,
+      )}
+      description={drivesCount ? desc : null}
+    />
+  );
+};
+
 export default function AddExistingDeviceMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
@@ -49,22 +71,12 @@ export default function AddExistingDeviceMenu() {
   const modelHook = useModel();
 
   const drivesNames = model.drives.map((d) => d.name);
+  const drivesCount = drivesNames.length;
   const devices = allDevices.filter((d) => !drivesNames.includes(d.name));
 
-  const Header = ({ drives }) => {
-    const desc = sprintf(
-      n_(
-        "Extends the installation beyond the currently selected disk",
-        "Extends the installation beyond the current %d disks",
-        drives.length,
-      ),
-      drives.length,
-    );
+  const isDisabled = !devices.length;
 
-    return <MenuHeader title={_("Select another disk to define partitions")} description={desc} />;
-  };
-
-  if (!devices.length) return null;
+  const enabledToggleText = drivesCount ? _("Use additional disk") : _("Use a disk");
 
   return (
     <Dropdown
@@ -73,19 +85,14 @@ export default function AddExistingDeviceMenu() {
       onSelect={toggle}
       onActionClick={toggle}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle
-          ref={toggleRef}
-          onClick={toggle}
-          aria-label={_("Use additional disk toggle")}
-          isExpanded={isOpen}
-        >
-          {_("Use additional disk")}
+        <MenuToggle ref={toggleRef} onClick={toggle} isExpanded={isOpen} isDisabled={isDisabled}>
+          {isDisabled ? _("All disks configured") : enabledToggleText}
         </MenuToggle>
       )}
     >
       <DropdownList>
         {/* @ts-expect-error See https://github.com/patternfly/patternfly/issues/7327 */}
-        <DropdownGroup label={<Header drives={model.drives} />}>
+        <DropdownGroup label={<Header drivesCount={drivesCount} />}>
           <Divider />
           {devices.map((device) => (
             <DropdownItem

--- a/web/src/components/storage/AddExistingDeviceMenu.tsx
+++ b/web/src/components/storage/AddExistingDeviceMenu.tsx
@@ -20,85 +20,79 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
-import { _, n_ } from "~/i18n";
-import { sprintf } from "sprintf-js";
+import React, { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
-  Dropdown,
-  DropdownList,
-  DropdownItem,
-  DropdownGroup,
-  MenuToggleElement,
   MenuToggle,
-  Divider,
   Split,
   Flex,
   Label,
+  DrilldownMenu,
+  MenuContent,
+  Divider,
+  MenuContainer,
+  Menu,
+  MenuList,
+  MenuItem,
 } from "@patternfly/react-core";
-import { MenuHeader } from "~/components/core";
 import MenuDeviceDescription from "./MenuDeviceDescription";
 import { useAvailableDevices } from "~/queries/storage";
 import { useConfigModel, useModel } from "~/queries/storage/config-model";
 import { deviceLabel } from "~/components/storage/utils";
+import { STORAGE as PATHS } from "~/routes/paths";
+import { sprintf } from "sprintf-js";
+import { _, n_ } from "~/i18n";
+import { StorageDevice } from "~/types/storage";
 
-const Header = ({ drivesCount }) => {
-  const desc = sprintf(
-    n_(
-      "Extends the installation beyond the currently selected disk",
-      "Extends the installation beyond the current %d disks",
-      drivesCount,
-    ),
-    drivesCount,
-  );
-
-  return (
-    <MenuHeader
-      title={n_(
-        "Select another disk to define partitions",
-        "Select a disk to define partitions",
-        drivesCount,
-      )}
-      description={drivesCount ? desc : null}
-    />
-  );
+type DisksDrillDownMenuItemProps = {
+  /** Available devices to be chosen */
+  devices: StorageDevice[];
+  /** The amount of drives already configured */
+  drivesCount: number;
+  /** Callback function to be triggered when a device is selected */
+  onDeviceClick: (deviceName: StorageDevice["name"]) => void;
 };
 
-export default function AddExistingDeviceMenu() {
-  const [isOpen, setIsOpen] = useState(false);
-  const toggle = () => setIsOpen(!isOpen);
-  const allDevices = useAvailableDevices();
-  const model = useConfigModel({ suspense: true });
-  const modelHook = useModel();
-
-  const drivesNames = model.drives.map((d) => d.name);
-  const drivesCount = drivesNames.length;
-  const devices = allDevices.filter((d) => !drivesNames.includes(d.name));
-
+/**
+ * Internal component holding the logic for rendering the disks drilldown menu
+ */
+const DisksDrillDownMenuItem = ({
+  drivesCount,
+  devices,
+  onDeviceClick,
+}: DisksDrillDownMenuItemProps) => {
   const isDisabled = !devices.length;
 
-  const enabledToggleText = drivesCount ? _("Use additional disk") : _("Use a disk");
+  const disabledDescription = _("Already using all availalbe disks.");
+  const enabledDescription = drivesCount
+    ? sprintf(
+        n_(
+          "Extends the installation beyond the currently selected disk",
+          "Extends the installation beyond the current %d disks",
+          drivesCount,
+        ),
+        drivesCount,
+      )
+    : _("Extends the installation using a disk");
 
   return (
-    <Dropdown
-      isOpen={isOpen}
-      onOpenChange={toggle}
-      onSelect={toggle}
-      onActionClick={toggle}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle ref={toggleRef} onClick={toggle} isExpanded={isOpen} isDisabled={isDisabled}>
-          {isDisabled ? _("All disks configured") : enabledToggleText}
-        </MenuToggle>
-      )}
-    >
-      <DropdownList>
-        {/* @ts-expect-error See https://github.com/patternfly/patternfly/issues/7327 */}
-        <DropdownGroup label={<Header drivesCount={drivesCount} />}>
+    <MenuItem
+      itemId="group:disks-menu"
+      direction="down"
+      isDisabled={isDisabled}
+      description={isDisabled ? disabledDescription : enabledDescription}
+      drilldownMenu={
+        <DrilldownMenu id="disks-menu">
+          <MenuItem itemId="group:disks-menu-back" direction="up">
+            {_("Back")}
+          </MenuItem>
           <Divider />
           {devices.map((device) => (
-            <DropdownItem
+            <MenuItem
               key={device.sid}
+              itemId={device.sid}
               description={<MenuDeviceDescription device={device} />}
-              onClick={() => modelHook.addDrive(device.name)}
+              onClick={() => onDeviceClick(device.name)}
             >
               <Split hasGutter>
                 {deviceLabel(device)}
@@ -110,10 +104,138 @@ export default function AddExistingDeviceMenu() {
                   ))}
                 </Flex>
               </Split>
-            </DropdownItem>
+            </MenuItem>
           ))}
-        </DropdownGroup>
-      </DropdownList>
-    </Dropdown>
+        </DrilldownMenu>
+      }
+    >
+      {n_(
+        "Select another disk to define partitions",
+        "Select a disk to define partitions",
+        drivesCount,
+      )}
+    </MenuItem>
+  );
+};
+
+/**
+ * Menu that provides options for users to configure storage drives
+ *
+ * It uses a drilled-down menu approach for disks, making the available options less
+ * overwhelming by presenting them in a more organized manner.
+ *
+ * TODO: Refactor and test the component after extracting a basic DrillDown menu to
+ * share the internal logic with other potential menus that could benefit from a similar
+ * approach.
+ */
+export default function AddExistingDeviceMenu() {
+  const navigate = useNavigate();
+  const model = useConfigModel({ suspense: true });
+  const { addDrive } = useModel();
+  const allDevices = useAvailableDevices();
+  const menuRef = useRef();
+  const toggleRef = useRef();
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuDrilledIn, setMenuDrilledIn] = React.useState<string[]>([]);
+  const [drilldownPath, setDrilldownPath] = React.useState<string[]>([]);
+  const [activeMenu, setActiveMenu] = React.useState<string>("root");
+  const [menuHeights, setMenuHeights] = React.useState({});
+
+  const resetState = () => {
+    setMenuDrilledIn([]);
+    setDrilldownPath([]);
+    setActiveMenu("root");
+  };
+
+  const toggle = () => {
+    setIsOpen(!isOpen);
+    resetState();
+  };
+
+  const addDriveAndClose = (driveName) => {
+    addDrive(driveName);
+    setIsOpen(false);
+    resetState();
+  };
+
+  const drivesNames = model.drives.map((d) => d.name);
+  const drivesCount = drivesNames.length;
+  const devices = allDevices.filter((d) => !drivesNames.includes(d.name));
+
+  const drillIn = (
+    _: React.KeyboardEvent | React.MouseEvent,
+    fromMenuId: string,
+    toMenuId: string,
+    pathId: string,
+  ) => {
+    setMenuDrilledIn([...menuDrilledIn, fromMenuId]);
+    setDrilldownPath([...drilldownPath, pathId]);
+    setActiveMenu(toMenuId);
+  };
+
+  const drillOut = (_: React.KeyboardEvent | React.MouseEvent, toMenuId: string) => {
+    const menuDrilledInSansLast = menuDrilledIn.slice(0, menuDrilledIn.length - 1);
+    const pathSansLast = drilldownPath.slice(0, drilldownPath.length - 1);
+    setMenuDrilledIn(menuDrilledInSansLast);
+    setDrilldownPath(pathSansLast);
+    setActiveMenu(toMenuId);
+  };
+
+  const setHeight = (menuId: string, height: number) => {
+    // FIXME: look for a better way to avoid test crashing because of this
+    // method
+    if (process.env.NODE_ENV === "test") return;
+
+    if (
+      menuHeights[menuId] === undefined ||
+      (menuId !== "root" && menuHeights[menuId] !== height)
+    ) {
+      setMenuHeights({ ...menuHeights, [menuId]: height });
+    }
+  };
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={toggle}
+      toggleRef={toggleRef}
+      toggle={
+        <MenuToggle ref={toggleRef} onClick={toggle} isExpanded={isOpen}>
+          {_("Configure a device")}
+        </MenuToggle>
+      }
+      menuRef={menuRef}
+      menu={
+        <Menu
+          id="root"
+          containsDrilldown
+          onDrillIn={drillIn}
+          onDrillOut={drillOut}
+          onGetMenuHeight={setHeight}
+          activeMenu={activeMenu}
+          drilledInMenus={menuDrilledIn}
+          drilldownItemPath={drilldownPath}
+          ref={menuRef}
+        >
+          <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+            <MenuList>
+              <DisksDrillDownMenuItem
+                drivesCount={drivesCount}
+                devices={devices}
+                onDeviceClick={addDriveAndClose}
+              />
+              <Divider />
+              <MenuItem
+                key="lvm-link"
+                onClick={() => navigate(PATHS.volumeGroup.add)}
+                description={_("Extend the installation using LVM")}
+              >
+                {_("Add LVM volume group")}
+              </MenuItem>
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      }
+    />
   );
 }

--- a/web/src/components/storage/ConfigEditor.test.tsx
+++ b/web/src/components/storage/ConfigEditor.test.tsx
@@ -55,14 +55,28 @@ jest.mock("~/queries/storage/config-model", () => ({
 jest.mock("./DriveEditor", () => () => <div>drive editor</div>);
 jest.mock("./VolumeGroupEditor", () => () => <div>volume group editor</div>);
 
+const hasDrives: apiModel.Config = {
+  drives: [{ name: "/dev/vda" }],
+};
+
+const hasVolumeGroups: apiModel.Config = {
+  volumeGroups: [{ vgName: "/dev/system" }],
+};
+
+const hasBoth: apiModel.Config = {
+  drives: [{ name: "/dev/vda" }],
+  volumeGroups: [{ vgName: "/dev/system" }],
+};
+
+const hasNothing: apiModel.Config = {};
+
 beforeEach(() => {
   mockUseDevices.mockReturnValue([disk]);
 });
 
-describe("if no drive is used for installation", () => {
+describe("when no drive is used for installation", () => {
   beforeEach(() => {
-    const modelData: apiModel.Config = {};
-    mockUseConfigModel.mockReturnValue(modelData);
+    mockUseConfigModel.mockReturnValue(hasVolumeGroups);
   });
 
   it("does not render the drive editor", () => {
@@ -71,12 +85,9 @@ describe("if no drive is used for installation", () => {
   });
 });
 
-describe("if a drive is used for installation", () => {
+describe("when a drive is used for installation", () => {
   beforeEach(() => {
-    const modelData: apiModel.Config = {
-      drives: [{ name: "/dev/vda" }],
-    };
-    mockUseConfigModel.mockReturnValue(modelData);
+    mockUseConfigModel.mockReturnValue(hasDrives);
   });
 
   it("renders the drive editor", () => {
@@ -85,10 +96,9 @@ describe("if a drive is used for installation", () => {
   });
 });
 
-describe("if no volume group is used for installation", () => {
+describe("when no volume group is used for installation", () => {
   beforeEach(() => {
-    const modelData: apiModel.Config = {};
-    mockUseConfigModel.mockReturnValue(modelData);
+    mockUseConfigModel.mockReturnValue(hasDrives);
   });
 
   it("does not render the volume group editor", () => {
@@ -97,16 +107,42 @@ describe("if no volume group is used for installation", () => {
   });
 });
 
-describe("if a volume group is used for installation", () => {
+describe("when a volume group is used for installation", () => {
   beforeEach(() => {
-    const modelData: apiModel.Config = {
-      volumeGroups: [{ vgName: "/dev/system" }],
-    };
-    mockUseConfigModel.mockReturnValue(modelData);
+    mockUseConfigModel.mockReturnValue(hasVolumeGroups);
   });
 
-  it("renders the drive editor", () => {
+  it("renders the volume group editor", () => {
     plainRender(<ConfigEditor />);
     expect(screen.queryByText("volume group editor")).toBeInTheDocument();
+  });
+});
+
+describe("when both a drive and volume group are used for installation", () => {
+  beforeEach(() => {
+    mockUseConfigModel.mockReturnValue(hasBoth);
+  });
+
+  it("renders a volume group editor followed by drive editor", () => {
+    plainRender(<ConfigEditor />);
+    const volumeGroupEditor = screen.getByText("volume group editor");
+    const driveEditor = screen.getByText("drive editor");
+
+    expect(volumeGroupEditor.compareDocumentPosition(driveEditor)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+});
+
+describe("when neither a drive nor volume group are used for installation", () => {
+  beforeEach(() => {
+    mockUseConfigModel.mockReturnValue(hasNothing);
+  });
+
+  it("renders a no configuration alert with a button for resetting to default", () => {
+    plainRender(<ConfigEditor />);
+    screen.getByText("Custom alert:");
+    screen.getByText("No devices configured yet");
+    screen.getByRole("button", { name: "resets to default" });
   });
 });

--- a/web/src/components/storage/ConfigEditor.test.tsx
+++ b/web/src/components/storage/ConfigEditor.test.tsx
@@ -143,6 +143,6 @@ describe("when neither a drive nor volume group are used for installation", () =
     plainRender(<ConfigEditor />);
     screen.getByText("Custom alert:");
     screen.getByText("No devices configured yet");
-    screen.getByRole("button", { name: "resets to default" });
+    screen.getByRole("button", { name: "reset to defaults" });
   });
 });

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -21,15 +21,23 @@
  */
 
 import React from "react";
+import { _ } from "~/i18n";
 import { useDevices } from "~/queries/storage";
 import { useConfigModel } from "~/queries/storage/config-model";
 import DriveEditor from "~/components/storage/DriveEditor";
 import VolumeGroupEditor from "~/components/storage/VolumeGroupEditor";
-import { List, ListItem } from "@patternfly/react-core";
+import { List, ListItem, EmptyState } from "@patternfly/react-core";
 
 export default function ConfigEditor() {
   const model = useConfigModel({ suspense: true });
   const devices = useDevices("system", { suspense: true });
+
+  const drives = model.drives || [];
+  const volumeGroups = model.volumeGroups || [];
+
+  if (!drives.length && !volumeGroups.length) {
+    return <EmptyState titleText={_("Select a device for installing the system")} status="info" />;
+  }
 
   return (
     <List isPlain>

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -22,11 +22,36 @@
 
 import React from "react";
 import { _ } from "~/i18n";
-import { useDevices } from "~/queries/storage";
+import { useDevices, useResetConfigMutation } from "~/queries/storage";
 import { useConfigModel } from "~/queries/storage/config-model";
 import DriveEditor from "~/components/storage/DriveEditor";
 import VolumeGroupEditor from "~/components/storage/VolumeGroupEditor";
-import { Alert, List, ListItem } from "@patternfly/react-core";
+import { Alert, Button, List, ListItem } from "@patternfly/react-core";
+
+const NoDevicesConfiguredAlert = () => {
+  const { mutate: reset } = useResetConfigMutation();
+  const title = _("No devices configured yet");
+  // TRANSLATORS: %s will be replaced by a "resets to default" button
+  const body = _(
+    "Use actions below to set up your devices or click %s to start from scratch with the default configuration.",
+  );
+  const [bodyStart, bodyEnd] = body.split("%s");
+
+  return (
+    <Alert title={title} variant="custom" isInline>
+      {bodyStart}{" "}
+      <Button variant="link" onClick={() => reset()} isInline>
+        <b>
+          {
+            // TRANSLATORS: label for a link
+            _("resets to default")
+          }
+        </b>
+      </Button>{" "}
+      {bodyEnd}
+    </Alert>
+  );
+};
 
 export default function ConfigEditor() {
   const model = useConfigModel({ suspense: true });
@@ -35,11 +60,7 @@ export default function ConfigEditor() {
   const volumeGroups = model.volumeGroups || [];
 
   if (!drives.length && !volumeGroups.length) {
-    return (
-      <Alert title={_("No configuration set")} variant="custom" isInline>
-        {_("Use the actions below to get started.")}
-      </Alert>
-    );
+    return <NoDevicesConfiguredAlert />;
   }
 
   return (

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -44,7 +44,7 @@ const NoDevicesConfiguredAlert = () => {
         <b>
           {
             // TRANSLATORS: label for a button
-            _("reset to default")
+            _("reset to defaults")
           }
         </b>
       </Button>{" "}

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -26,17 +26,20 @@ import { useDevices } from "~/queries/storage";
 import { useConfigModel } from "~/queries/storage/config-model";
 import DriveEditor from "~/components/storage/DriveEditor";
 import VolumeGroupEditor from "~/components/storage/VolumeGroupEditor";
-import { List, ListItem, EmptyState } from "@patternfly/react-core";
+import { Alert, List, ListItem } from "@patternfly/react-core";
 
 export default function ConfigEditor() {
   const model = useConfigModel({ suspense: true });
   const devices = useDevices("system", { suspense: true });
-
   const drives = model.drives || [];
   const volumeGroups = model.volumeGroups || [];
 
   if (!drives.length && !volumeGroups.length) {
-    return <EmptyState titleText={_("Select a device for installing the system")} status="info" />;
+    return (
+      <Alert title={_("No configuration set")} variant="custom" isInline>
+        {_("Use the actions below to get started.")}
+      </Alert>
+    );
   }
 
   return (

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -31,7 +31,7 @@ import { Alert, Button, List, ListItem } from "@patternfly/react-core";
 const NoDevicesConfiguredAlert = () => {
   const { mutate: reset } = useResetConfigMutation();
   const title = _("No devices configured yet");
-  // TRANSLATORS: %s will be replaced by a "resets to default" button
+  // TRANSLATORS: %s will be replaced by a "reset to default" button
   const body = _(
     "Use actions below to set up your devices or click %s to start from scratch with the default configuration.",
   );
@@ -43,8 +43,8 @@ const NoDevicesConfiguredAlert = () => {
       <Button variant="link" onClick={() => reset()} isInline>
         <b>
           {
-            // TRANSLATORS: label for a link
-            _("resets to default")
+            // TRANSLATORS: label for a button
+            _("reset to default")
           }
         </b>
       </Button>{" "}

--- a/web/src/components/storage/ConfigEditorMenu.tsx
+++ b/web/src/components/storage/ConfigEditorMenu.tsx
@@ -63,14 +63,6 @@ export default function ConfigEditorMenu() {
     >
       <DropdownList>
         <DropdownItem
-          key="lvm-link"
-          onClick={() => navigate(PATHS.volumeGroup.add)}
-          description={_("Extend the installation using LVM")}
-        >
-          {_("Add LVM volume group")}
-        </DropdownItem>
-        <Divider />
-        <DropdownItem
           key="boot-link"
           onClick={() => navigate(PATHS.editBootDevice)}
           description={_("Select the disk to configure partitions for booting")}

--- a/web/src/components/storage/ConfigureDeviceMenu.test.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.test.tsx
@@ -23,7 +23,7 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { mockNavigateFn, plainRender } from "~/test-utils";
-import AddExistingDeviceMenu from "~/components/storage/AddExistingDeviceMenu";
+import ConfigureDeviceMenu from "./ConfigureDeviceMenu";
 import { StorageDevice } from "~/types/storage";
 import { apiModel } from "~/api/storage/types";
 
@@ -80,13 +80,13 @@ jest.mock("~/queries/storage/config-model", () => ({
   useConfigModel: () => mockUseConfigModelFn(),
 }));
 
-describe("AddExistingDeviceMenu", () => {
+describe("ConfigureDeviceMenu", () => {
   beforeEach(() => {
     mockUseConfigModelFn.mockReturnValue({ drives: [] });
   });
 
   it("renders an initially closed menu ", async () => {
-    const { user } = plainRender(<AddExistingDeviceMenu />);
+    const { user } = plainRender(<ConfigureDeviceMenu />);
     const toggler = screen.getByRole("button", { name: "Configure a device", expanded: false });
     expect(screen.queryAllByRole("menu").length).toBe(0);
     await user.click(toggler);
@@ -95,7 +95,7 @@ describe("AddExistingDeviceMenu", () => {
   });
 
   it("allows users to add a new LVM volume group", async () => {
-    const { user } = plainRender(<AddExistingDeviceMenu />);
+    const { user } = plainRender(<ConfigureDeviceMenu />);
     const toggler = screen.getByRole("button", { name: "Configure a device", expanded: false });
     await user.click(toggler);
     const lvmMenuItem = screen.getByRole("menuitem", { name: /LVM/ });
@@ -106,7 +106,7 @@ describe("AddExistingDeviceMenu", () => {
   describe("when there are unused disks", () => {
     describe("and no disks have been configured yet", () => {
       it("allows users to add a new drive", async () => {
-        const { user } = plainRender(<AddExistingDeviceMenu />);
+        const { user } = plainRender(<ConfigureDeviceMenu />);
         const toggler = screen.getByRole("button", { name: /Configure a device/ });
         await user.click(toggler);
         const disksMenuItem = screen.getByRole("menuitem", { name: /disk to define/ });
@@ -123,7 +123,7 @@ describe("AddExistingDeviceMenu", () => {
       });
 
       it("allows users to add a new drive to an unused disk", async () => {
-        const { user } = plainRender(<AddExistingDeviceMenu />);
+        const { user } = plainRender(<ConfigureDeviceMenu />);
         const toggler = screen.getByRole("button", { name: /Configure a device/ });
         await user.click(toggler);
         const disksMenuItem = screen.getByRole("menuitem", { name: /disk to define/ });
@@ -142,7 +142,7 @@ describe("AddExistingDeviceMenu", () => {
     });
 
     it("renders the disks menu as disabled with an informative label", async () => {
-      const { user } = plainRender(<AddExistingDeviceMenu />);
+      const { user } = plainRender(<ConfigureDeviceMenu />);
       const toggler = screen.getByRole("button", { name: /Configure a device/ });
       await user.click(toggler);
       const disksMenuItem = screen.getByRole("menuitem", { name: /disk to define/ });

--- a/web/src/components/storage/ConfigureDeviceMenu.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.tsx
@@ -128,7 +128,7 @@ const DisksDrillDownMenuItem = ({
  * share the internal logic with other potential menus that could benefit from a similar
  * approach.
  */
-export default function AddExistingDeviceMenu() {
+export default function ConfigureDeviceMenu() {
   const navigate = useNavigate();
   const model = useConfigModel({ suspense: true });
   const { addDrive } = useModel();

--- a/web/src/components/storage/ProposalPage.test.tsx
+++ b/web/src/components/storage/ProposalPage.test.tsx
@@ -106,7 +106,7 @@ jest.mock("./ProposalFailedInfo", () => () => <div>failed info</div>);
 jest.mock("./UnsupportedModelInfo", () => () => <div>unsupported info</div>);
 jest.mock("./ProposalResultSection", () => () => <div>result</div>);
 jest.mock("./ConfigEditor", () => () => <div>installation devices</div>);
-jest.mock("./AddExistingDeviceMenu", () => () => <div>add device menu</div>);
+jest.mock("./ConfigureDeviceMenu", () => () => <div>add device menu</div>);
 jest.mock("./ConfigEditorMenu", () => () => <div>config editor menu</div>);
 jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
   <div>registration alert</div>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -36,14 +36,15 @@ import {
 } from "@patternfly/react-core";
 import { Page, Link } from "~/components/core/";
 import { Icon, Loading } from "~/components/layout";
-import ProposalResultSection from "./ProposalResultSection";
-import ProposalTransactionalInfo from "./ProposalTransactionalInfo";
-import ProposalFailedInfo from "./ProposalFailedInfo";
-import FixableConfigInfo from "./FixableConfigInfo";
-import UnsupportedModelInfo from "./UnsupportedModelInfo";
 import ConfigEditor from "./ConfigEditor";
 import ConfigEditorMenu from "./ConfigEditorMenu";
-import AddExistingDeviceMenu from "./AddExistingDeviceMenu";
+import ConfigureDeviceMenu from "./ConfigureDeviceMenu";
+import EncryptionSection from "./EncryptionSection";
+import FixableConfigInfo from "./FixableConfigInfo";
+import ProposalFailedInfo from "./ProposalFailedInfo";
+import ProposalResultSection from "./ProposalResultSection";
+import ProposalTransactionalInfo from "./ProposalTransactionalInfo";
+import UnsupportedModelInfo from "./UnsupportedModelInfo";
 import {
   useAvailableDevices,
   useResetConfigMutation,
@@ -57,7 +58,6 @@ import { useDASDSupported } from "~/queries/storage/dasd";
 import { useSystemErrors, useConfigErrors } from "~/queries/issues";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
-import EncryptionSection from "./EncryptionSection";
 
 function InvalidConfigEmptyState(): React.ReactNode {
   const errors = useConfigErrors("storage");
@@ -198,7 +198,7 @@ function ProposalSections(): React.ReactNode {
               actions={
                 <>
                   <SplitItem>
-                    <AddExistingDeviceMenu />
+                    <ConfigureDeviceMenu />
                   </SplitItem>
                   <SplitItem>
                     <ConfigEditorMenu />

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -198,10 +198,10 @@ function ProposalSections(): React.ReactNode {
               actions={
                 <>
                   <SplitItem>
-                    <ConfigEditorMenu />
+                    <AddExistingDeviceMenu />
                   </SplitItem>
                   <SplitItem>
-                    <AddExistingDeviceMenu />
+                    <ConfigEditorMenu />
                   </SplitItem>
                 </>
               }

--- a/web/src/components/storage/VolumeGroupEditor.tsx
+++ b/web/src/components/storage/VolumeGroupEditor.tsx
@@ -23,12 +23,12 @@
 import React from "react";
 import { useNavigate, generatePath } from "react-router-dom";
 import { _ } from "~/i18n";
-import { sprintf } from "sprintf-js";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { apiModel } from "~/api/storage/types";
 import { model } from "~/types/storage";
 import { contentDescription } from "~/components/storage/utils/volume-group";
 import { useVolumeGroup } from "~/hooks/storage/model";
+import useDeleteVolumeGroup from "~/hooks/storage/delete-volume-group";
 import DeviceMenu from "~/components/storage/DeviceMenu";
 import DeviceHeader from "~/components/storage/DeviceHeader";
 import MountPathMenuItem from "~/components/storage/MountPathMenuItem";
@@ -44,13 +44,19 @@ import {
 
 import spacingStyles from "@patternfly/react-styles/css/utilities/Spacing/spacing";
 
-const RemoveVgOption = ({ vg }: { vg: model.VolumeGroup }) => {
-  const device = vg.getTargetDevices()[0];
-  const desc = sprintf(_("The logical volumes will become partitions at %s"), device?.name);
+const DeleteVgOption = ({ vg }: { vg: model.VolumeGroup }) => {
+  const deleteVolumeGroup = useDeleteVolumeGroup();
 
   return (
-    <MenuItem isDanger description={desc}>
-      {_("Do not create")}
+    <MenuItem
+      key="delete-volume-group"
+      itemId="delete-volume-group"
+      isDanger
+      description={_("Delete the volume group and its logical volumes")}
+      role="menuitem"
+      onClick={() => deleteVolumeGroup(vg.vgName)}
+    >
+      <span>{_("Delete volume group")}</span>
     </MenuItem>
   );
 };
@@ -76,7 +82,7 @@ const VgMenu = ({ vg }: { vg: model.VolumeGroup }) => {
     <DeviceMenu title={<b aria-hidden>{vg.vgName}</b>}>
       <MenuList>
         <EditVgOption vg={vg} />
-        <RemoveVgOption vg={vg} />
+        <DeleteVgOption vg={vg} />
       </MenuList>
     </DeviceMenu>
   );

--- a/web/src/hooks/storage/delete-volume-group.ts
+++ b/web/src/hooks/storage/delete-volume-group.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import useApiModel from "~/hooks/storage/api-model";
+import useUpdateApiModel from "~/hooks/storage/update-api-model";
+import { QueryHookOptions } from "~/types/queries";
+import { deleteVolumeGroup } from "~/hooks/storage/helpers/volume-group";
+
+export type DeleteVolumeGroupFn = (vgName: string) => void;
+
+export default function useDeleteVolumeGroup(options?: QueryHookOptions): DeleteVolumeGroupFn {
+  const apiModel = useApiModel(options);
+  const updateApiModel = useUpdateApiModel();
+  return (vgName: string) => updateApiModel(deleteVolumeGroup(apiModel, vgName));
+}

--- a/web/src/hooks/storage/edit-volume-group.ts
+++ b/web/src/hooks/storage/edit-volume-group.ts
@@ -27,7 +27,7 @@ import { QueryHookOptions } from "~/types/queries";
 
 export type EditVolumeGroupFn = (
   odlVgName: string,
-  VgName: string,
+  vgName: string,
   targetDevices: string[],
 ) => void;
 

--- a/web/src/hooks/storage/helpers/volume-group.ts
+++ b/web/src/hooks/storage/helpers/volume-group.ts
@@ -82,4 +82,20 @@ function editVolumeGroup(
   return apiModel;
 }
 
-export { addVolumeGroup, editVolumeGroup };
+function deleteVolumeGroup(apiModel: apiModel.Config, vgName: string): apiModel.Config {
+  apiModel = copyApiModel(apiModel);
+
+  const index = (apiModel.volumeGroups || []).findIndex((v) => v.vgName === vgName);
+  if (index === -1) return apiModel;
+
+  const targetDevices = apiModel.volumeGroups[index].targetDevices || [];
+
+  apiModel.volumeGroups.splice(index, 1);
+  targetDevices.forEach((d) => {
+    apiModel = deleteIfUnused(apiModel, d);
+  });
+
+  return apiModel;
+}
+
+export { addVolumeGroup, editVolumeGroup, deleteVolumeGroup };


### PR DESCRIPTION
* Allow deleting a volume group.
* The target devices of the deleted volume group are deleted too as side effect if they are not used.
* The config editor shows an alert if the config has not devices.
