### PR TITLE
fix(rust): do not try to connect when it is not needed

### DIFF
--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -183,10 +183,10 @@ async fn build_manager<'a>() -> anyhow::Result<ManagerClient<'a>> {
 
 /// True if use of the remote API is allowed (yes by default when the API is secure, the user is
 /// asked if the API is insecure - e.g. when it uses self-signed certificate)
-async fn allowed_insecure_api(use_insecure: bool, api_url: String) -> Result<bool, ServiceError> {
+async fn allowed_insecure_api(use_insecure: bool, api_url: &str) -> Result<bool, ServiceError> {
     // fake client used for remote site detection
     let mut ping_client = BaseHTTPClient::default();
-    ping_client.base_url = api_url;
+    ping_client.base_url = api_url.to_string();
 
     // decide whether access to remote site has to be insecure (self-signed certificate or not)
     match ping_client.get::<HashMap<String, String>>("/ping").await {
@@ -223,10 +223,9 @@ async fn build_http_client(
     authenticated: bool,
 ) -> Result<BaseHTTPClient, ServiceError> {
     let mut client = BaseHTTPClient::default();
-
     client.base_url = api_url.to_string();
 
-    if allowed_insecure_api(insecure, api_url.to_string()).await? {
+    if allowed_insecure_api(insecure, &client.base_url).await? {
         client = client.insecure();
     }
 

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -217,29 +217,39 @@ pub fn download_file(url: &str, path: &PathBuf) -> Result<(), ServiceError> {
     Ok(())
 }
 
-pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
-    // somehow check whether we need to ask user for self-signed certificate acceptance
-    let api_url = cli.opts.api.trim_end_matches('/').to_string();
-
+async fn build_http_client(
+    api_url: &str,
+    insecure: bool,
+    authenticated: bool,
+) -> Result<BaseHTTPClient, ServiceError> {
     let mut client = BaseHTTPClient::default();
 
-    client.base_url = api_url.clone();
+    client.base_url = api_url.to_string();
 
-    if allowed_insecure_api(cli.opts.insecure, api_url.clone()).await? {
+    if allowed_insecure_api(insecure, api_url.to_string()).await? {
         client = client.insecure();
     }
 
     // we need to distinguish commands on those which assume that authentication JWT is already
     // available and those which not (or don't need it)
-    client = if let Commands::Auth(_) = cli.command {
-        client.unauthenticated()?
-    } else {
+    if authenticated {
         // this deals with authentication need inside
-        client.authenticated()?
-    };
+        client.authenticated()
+    } else {
+        client.unauthenticated()
+    }
+}
+
+pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
+    // somehow check whether we need to ask user for self-signed certificate acceptance
+
+    let api_url = cli.opts.api.trim_end_matches('/').to_string();
 
     match cli.command {
-        Commands::Config(subcommand) => run_config_cmd(client, subcommand).await?,
+        Commands::Config(subcommand) => {
+            let client = build_http_client(&api_url, cli.opts.insecure, true).await?;
+            run_config_cmd(client, subcommand).await?
+        }
         Commands::Probe => {
             let manager = build_manager().await?;
             wait_for_services(&manager).await?;
@@ -255,10 +265,17 @@ pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
             let method = method.unwrap_or_default();
             finish(&manager, method).await?;
         }
-        Commands::Questions(subcommand) => run_questions_cmd(client, subcommand).await?,
-        Commands::Logs(subcommand) => run_logs_cmd(client, subcommand).await?,
+        Commands::Questions(subcommand) => {
+            let client = build_http_client(&api_url, cli.opts.insecure, true).await?;
+            run_questions_cmd(client, subcommand).await?
+        }
+        Commands::Logs(subcommand) => {
+            let client = build_http_client(&api_url, cli.opts.insecure, true).await?;
+            run_logs_cmd(client, subcommand).await?
+        }
         Commands::Download { url, destination } => download_file(&url, &destination)?,
         Commands::Auth(subcommand) => {
+            let client = build_http_client(&api_url, cli.opts.insecure, false).await?;
             run_auth_cmd(client, subcommand).await?;
         }
     };

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sat Mar 22 22:58:09 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not try to connect to the HTTP server when it is not needed
+  (gh#agama-project/agama#2192).
+
+-------------------------------------------------------------------
 Fri Mar 21 16:37:32 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Add extensions from the registration server (automatic


### PR DESCRIPTION
## Problem

Agama CLI tries to connect to the HTTP server even when it is unnecessary. For instance, when running the `agama download`, the client will try to connect to the HTTP server.

## Solution

With this change, the Agama CLI will connect to the server only when needed.

## Testing

- Tested manually

## Future work

I decided to make a simple fix because we plan to redesign the commands.