### PR TITLE
fix(web): stop parsing error messages from SCC

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sun Mar 23 02:13:56 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Stop parsing errors from SCC at frontend side and simply render
+  them as returned by the backend (gh#agama-project/agama#2193).
+
+-------------------------------------------------------------------
 Thu Mar 20 20:58:44 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Stop displaying the hostname alert once the system is registered

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -93,9 +93,7 @@ const RegistrationFormSection = () => {
 
   // FIXME: use the right type for AxiosResponse
   const onRegisterError = ({ response }) => {
-    const originalMessage = response.data.message;
-    const from = originalMessage.indexOf(":") + 1;
-    setError(originalMessage.slice(from).trim());
+    setError(response.data.message);
   };
 
   const submit = async (e: React.SyntheticEvent) => {


### PR DESCRIPTION
Parsing error messages from SCC is fragile, as it relies on splitting the message by a specific character. Instead, render the original error message from SCC directly.


> [!NOTE]
>
> These error messages are not translated yet (see #2194). When translation becomes possible, it might be needed to update [the HTTP call at the backend side](https://github.com/agama-project/agama/blob/7fcae515af27328b5704e6bb850dec071fb3d9aa/rust/agama-lib/src/product/http_client.rs#L94-L99) to render the `localized_error` instead, as the SCC error response looks like
> 
> ```json
> {
>   "type":"error",
>   "error":"Please provide Registration Code.",
>   "localized_error":"Proporcione el código de registro."
> }
> ```

