### PR TITLE
fix(web): properly handle empty lists of unsupported AutoYaST elements

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 24 10:17:30 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Properly handle empty lists of unsupported AutoYaST elements
+  (gh#agama-project/agama#2196).
+
+-------------------------------------------------------------------
 Thu Mar 20 20:58:44 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Stop displaying the hostname alert once the system is registered

--- a/web/src/components/questions/UnsupportedAutoYaST.test.tsx
+++ b/web/src/components/questions/UnsupportedAutoYaST.test.tsx
@@ -63,7 +63,7 @@ describe("UnsupportedAutoYaST", () => {
 
   describe("when there are no unsupported (but planned) elements", () => {
     beforeEach(() => {
-      mockQuestion = { ...question, data: {} };
+      mockQuestion = { ...question, data: { planned: "" } };
     });
 
     it('does not render the "Not implemented yet" list', () => {
@@ -75,7 +75,7 @@ describe("UnsupportedAutoYaST", () => {
 
   describe("when there are no unsupported (but planned) elements", () => {
     beforeEach(() => {
-      mockQuestion = { ...question, data: {} };
+      mockQuestion = { ...question, data: { unsupported: "" } };
     });
 
     it('does not render the "Not supported" list', () => {

--- a/web/src/components/questions/UnsupportedAutoYaST.tsx
+++ b/web/src/components/questions/UnsupportedAutoYaST.tsx
@@ -74,8 +74,8 @@ export default function UnsupportedAutoYaST({
     answerCallback(question);
   };
 
-  const planned = question.data.planned?.split(",") || [];
-  const unsupported = question.data.unsupported?.split(",") || [];
+  const planned = question.data.planned ? question.data.planned.split(",") : [];
+  const unsupported = question.data.unsupported ? question.data.unsupported.split(",") : [];
 
   return (
     <Popup isOpen title={_("Unsupported AutoYaST elements")}>


### PR DESCRIPTION
Handle empty lists of unsupported elements. It fixes #2196.

<details>
<summary>Do not display the empty list</summary>

![Captura desde 2025-03-24 10-12-19](https://github.com/user-attachments/assets/4060b15b-7f5f-4b33-be23-2f701fe060da)
</details>