### PR TITLE
Drop basic-desktop pulling IceWM from Leap 16.0

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 24 14:08:29 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Drop basic-desktop pulling IceWM from Leap 16.0
+  installation profiles jsc#PED-1721 code-o-o#leap/features#183
+   
+
+-------------------------------------------------------------------
 Fri Mar 21 16:58:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Display the HA pattern after registering the HA extension

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -47,7 +47,6 @@ software:
     - enhanced_base # only pattern that is shared among all roles on Leap
   optional_patterns: null # no optional pattern shared
   user_patterns:
-    - basic_desktop
     - gnome
     - kde
     - multimedia


### PR DESCRIPTION
We want wayland-only desktop in general
* Relates to jsc#PED-1721 code-o-o#leap/features#183