### PR TITLE
append only valid key=value lines for agama.conf

### DIFF
--- a/live/root/usr/bin/info-cmdline-conf.sh
+++ b/live/root/usr/bin/info-cmdline-conf.sh
@@ -20,7 +20,7 @@ expand_info_arg() {
   # remove info param
   sed -in 's/\([[:space:]]\|^\)\(inst\|agama\)\.info=[^[:space:]]\+//' "${TARGET}"
   # and add content of info file
-  cat "${INFO_CONTENT}" >> "${TARGET}"
+  grep -- '=' "${INFO_CONTENT}" >> "${TARGET}"
 
   return 0
 }


### PR DESCRIPTION
inst.info=URL allows to retrieve agama settings from a remote location. Usually the expected settings are in key=value format.

This change allows to reuse the inst.info=URL feature for the cobbler "nopxe" API, just like it is done in linuxrc. The system needs to notify cobbler that it booted "far enough", so that cobbler can change the boot loader default from "boot from network" to "boot from local disk". The client has to send a HTTP GET request to the specified URL. cobbler sends the four bytes 'True' in return, which can system has to ignore. Since the content is not and can not be a valid Agama key=value pair, consider only lines that contain '=' in the input file.

Fixes #2185