### PR TITLE
Install registred addon product

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -129,6 +129,14 @@ module Agama
         true
       end
 
+      # select additional products to install
+      # @param addon_products [Array<String>] list of product names
+      def addon_products(addon_products)
+        # The PackagesProposal module can handle only packages and patterns,
+        # so products need to be handled differently.
+        proposal.addon_products = addon_products
+      end
+
       def probe
         # Should an error be raised?
         return unless product

--- a/service/lib/agama/software/proposal.rb
+++ b/service/lib/agama/software/proposal.rb
@@ -56,6 +56,9 @@ module Agama
       # @return [String,nil] Base product
       attr_accessor :base_product
 
+      # @return [Array<String>] Addon products
+      attr_accessor :addon_products
+
       # @return [Array<String>] List of languages to install
       attr_reader :languages
 
@@ -67,6 +70,7 @@ module Agama
 
         @logger = logger || Logger.new($stdout)
         @base_product = nil
+        @addon_products = []
       end
 
       # Adds the given list of resolvables to the proposal
@@ -90,6 +94,7 @@ module Agama
         # select the base product after running the Packages.Proposal, the force_reset = true
         # option would reset the selection and a random product would be selected by the solver
         select_base_product
+        select_addon_products
         solve_dependencies
 
         valid?
@@ -176,6 +181,11 @@ module Agama
           logger.info "Selecting the base product '#{base_product.name}'"
           base_product&.select
         end
+      end
+
+      # select the addon products to install
+      def select_addon_products
+        addon_products.each { |a| Yast::Pkg.ResolvableInstall(a, :product) }
       end
 
       # Updates the issues from the attempt to create a proposal.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 25 15:47:13 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Install registred addon product (its *-release package)
+  (related to jsc#AGM-100)
+
+-------------------------------------------------------------------
 Tue Mar 25 12:11:35 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Support for autoyast manual files deployment with exception

--- a/service/test/agama/registration_test.rb
+++ b/service/test/agama/registration_test.rb
@@ -43,6 +43,7 @@ describe Agama::Registration do
     allow(manager).to receive(:product).and_return(product)
     allow(manager).to receive(:add_service)
     allow(manager).to receive(:remove_service)
+    allow(manager).to receive(:addon_products)
 
     allow(SUSE::Connect::YaST).to receive(:announce_system).and_return(["test-user", "12345"])
     allow(SUSE::Connect::YaST).to receive(:deactivate_system)


### PR DESCRIPTION
## Problem

- After registering an extension the extension product is not installed in the target system.

## Solution

- Find all products from the registered addons and select them to install.

## Testing

- Tested manually

## Screenshots

The installed system correctly lists all SCC services, the HA product from the HA extension  is installed and the manually selected HA pattern was also installed:

![agama-installed-ha](https://github.com/user-attachments/assets/8275af0d-e0c9-46fe-98b2-5afeb275f5be)


