### PR TITLE
Drop yast2-schema and autoyast2-installation requirements (SR#367433, SR#367417)

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -75,7 +75,6 @@ jobs:
     - name: Install required packages
       run: zypper --non-interactive install
         suseconnect-ruby-bindings
-        autoyast2-installation
         yast2
         yast2-bootloader
         yast2-country

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 25 17:55:06 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- agama-installer.kiwi: drop yast2-schema (SR#367433,
+  gh#agama-project/agama#2208)
+
+-------------------------------------------------------------------
 Tue Mar 25 13:28:15 UTC 2025 - Giacomo Leidi <giacomo.leidi@suse.com>
 
 - live/src/agama-installer.kiwi: Adapt to latest patterns (SR#364982)

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -164,7 +164,6 @@
         <package name="spice-vdagent"/>
         <package name="libtss2-tcti-device0"/>
         <package name="jq"/>
-        <package name="yast2-schema"/>
         <package name="qrencode"/>
         <package name="qemu-guest-agent" />
         <package name="aaa_base-extras"/>

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -13,7 +13,6 @@
     Requires:       dbus-1-daemon
     Requires:       suseconnect-ruby-bindings
     # YaST dependencies
-    Requires:       autoyast2-installation
     # ArchFilter
     Requires:       yast2 >= 4.5.20
     Requires:       yast2-bootloader

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -56,6 +56,5 @@
     Requires:       snapper
     Requires:       udftools
     Requires:       xfsprogs
-    Requires:       yast2-schema
     # lsblk
     Requires:       util-linux-systemd

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 25 18:08:11 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Drop autoyast2-installation requirement (SR#367417, gh#agama-project/agama#2208)
+
+-------------------------------------------------------------------
 Tue Mar 25 18:03:57 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Drop yast2-schema requirement (SR#367433, gh#agama-project/agama#2208)

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Mar 25 18:03:57 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Drop yast2-schema requirement (SR#367433, gh#agama-project/agama#2208)
+
+-------------------------------------------------------------------
 Tue Mar 25 12:11:35 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Support for autoyast manual files deployment with exception

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -55,7 +55,6 @@ $SUDO $ZYPPER install \
   dbus-1-common \
   dbus-1-daemon \
   suseconnect-ruby-bindings \
-  autoyast2-installation \
   yast2 \
   yast2-bootloader \
   yast2-country \

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -64,7 +64,6 @@ $SUDO $ZYPPER install \
   yast2-iscsi-client \
   yast2-network \
   yast2-proxy \
-  yast2-schema \
   yast2-storage-ng \
   yast2-users \
   bcache-tools \


### PR DESCRIPTION
yast2-schema and autoyast2 were dropped from SLFO:Main, so we shouldn't install them anymore.
