### PR TITLE
refactor(web): change the alerts look and feel

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -296,9 +296,26 @@
   --pf-v6-c-alert--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --pf-v6-c-alert--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --pf-v6-c-alert--PaddingInlineEnd: var(--pf-t--global--spacer--md);
+  border-width: 0;
+  border-radius: 0;
+  border-inline-start-width: var(--pf-t--global--border--width--box--status--default);
 
   &:has(.pf-v6-c-alert__description) {
     row-gap: var(--pf-t--global--spacer--xs);
+  }
+
+  $pf-alert-modifiers: "custom", "info", "success", "warning", "danger";
+
+  @each $modifier in $pf-alert-modifiers {
+    &.pf-m-#{$modifier} {
+      background: linear-gradient(
+        to right in srgb,
+        color-mix(in srgb, var(--pf-v6-c-alert--m-#{$modifier}--BorderColor), transparent 94%),
+        color-mix(in srgb, var(--pf-v6-c-alert--m-#{$modifier}--BorderColor), transparent 96%),
+        color-mix(in srgb, var(--pf-v6-c-alert--m-#{$modifier}--BorderColor), transparent 98%),
+        transparent
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Refactor the alert design to stop rendering them as "boxes", which were cluttering the interface. Instead, they now use a left border and a gradient background to maintain visual hints about the scope of their content without the boxy appearance.

| Before | After  |
|-|-|
| ![localhost_8080_ (29)](https://github.com/user-attachments/assets/d9e717ae-ac7d-4e3a-b02d-89a82173d253) | ![localhost_8080_ (28)](https://github.com/user-attachments/assets/c52a50ba-dc47-47db-b573-7263eb2aca5c) | 
