### PR TITLE
fix(service): Improved pattern filtering, display all patterns from extensions

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -96,6 +96,8 @@ jobs:
 
     # send the code coverage for the Ruby part to the coveralls.io
     - name: Coveralls GitHub Action
+      # ignore errors in this step
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         base-path: ./service
@@ -106,6 +108,8 @@ jobs:
     # Rust parts (it needs a separate step, the "carryforward" flag can be used
     # only with the "parallel-finished: true" option)
     - name: Coveralls Finished
+      # ignore errors in this step
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true

--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 27 12:35:32 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Patterns from extensions are always displayed, the HA extension
+  pattern can be removed from the display list
+  (related to jsc#AGM-100)
+
+-------------------------------------------------------------------
 Tue Mar 25 11:42:36 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Add gnome pattern to the SLES 16.0 product (gh#agama-project/agama#2204)

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -85,8 +85,6 @@ software:
     - mail_server
     - printing
     - gnome
-    # displayed only after registering the HA extension
-    - ha_sles
   mandatory_packages:
     - NetworkManager
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -725,13 +725,15 @@ module Agama
         Agama::Software::Repository.all.select(&:local?).each(&:delete!)
       end
 
-      # Return all repositories belonging to the base product
+      # Return all enabled repositories belonging to the base product.
       #
       # @return [Array<Integer>] List of repository IDs, returns empty list if
       # no repository is defined yet
       def base_repositories
+        # process only the enabled repositories
+        only_enabled_repos = true
         # the base product repo is the first added repository (the lowest number)
-        base_src_id = Yast::Pkg.SourceGetCurrent(true).min
+        base_src_id = Yast::Pkg.SourceGetCurrent(only_enabled_repos).min
         # a repository might not be defined yet
         return [] unless base_src_id
 
@@ -743,7 +745,7 @@ module Agama
           [base_src_id]
         else
           logger.info "The base product is from a service"
-          Yast::Pkg.SourceGetCurrent(true).select do |r|
+          Yast::Pkg.SourceGetCurrent(only_enabled_repos).select do |r|
             Yast::Pkg.SourceGeneralData(r)["service"] == service
           end
         end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 27 12:35:32 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Always display the patterns from extensions (related to
+  jsc#AGM-100)
+
+-------------------------------------------------------------------
 Thu Mar 27 12:40:02 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 13

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -258,6 +258,8 @@ describe Agama::Software::Manager do
 
   describe "#patterns" do
     it "returns only the specified patterns" do
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([0])
+      allow(Yast::Pkg).to receive(:SourceGeneralData).and_return({ "service" => "" })
       expect(Y2Packager::Resolvable).to receive(:find).and_return(
         [
           double(


### PR DESCRIPTION
## Problem

- The extensions might define additional patterns, but currently only the explicitly listed patterns are displayed in the software selection.
- The problem is that we do not know the extension patterns in advance and in the future we will support custom repositories which might contain 3rd party patterns.

## Solution

- Do the pattern filtering only for the patterns from the base product repository (there are lots of patterns), always display the patterns from other repositories (usually there are just few of them).

## GitHub Action

- Allow the Coveralls step fail in the service CI.
- For some reason it is [currently failing](https://github.com/agama-project/agama/actions/runs/14107140902/job/39516508205#step:10:161), do not fail whole check if just coverage cannot be sent.

## Testing

- Updated unit test
- Tested manually

## Screenshots

The HA-SLES pattern from the HA extension is still displayed in the software selection even after removing it from the display list.

![agama-ha-pattern2](https://github.com/user-attachments/assets/827f8347-3cbc-4838-85c4-08fb8d0b5ff7)

