### PR TITLE
fix: properly convert "sources" to "content"

### DIFF
--- a/service/lib/agama/autoyast/scripts_reader.rb
+++ b/service/lib/agama/autoyast/scripts_reader.rb
@@ -120,7 +120,7 @@ module Agama
         if section["location"] && !section["location"].empty?
           script["url"] = section["location"]
         elsif section["source"]
-          script["body"] = section["source"]
+          script["content"] = section["source"]
         end
 
         script

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 28 11:13:48 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Properly map AutoYaST scripts "sources" to "content"
+  (gh#agama-project/agama#2224).
+
+-------------------------------------------------------------------
 Thu Mar 27 12:40:02 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 13

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -262,7 +262,7 @@
             "agama": "scripts.pre[].name"
           },
           { "key": "location", "support": "yes", "agama": "scripts.pre[].url" },
-          { "key": "source", "support": "yes", "agama": "scripts.pre[].body" },
+          { "key": "source", "support": "yes", "agama": "scripts.pre[].content" },
           {
             "key": "interpreter",
             "support": "no",
@@ -292,7 +292,7 @@
           {
             "key": "source",
             "support": "yes",
-            "agama": "scripts.postPartitioning[].body"
+            "agama": "scripts.postPartitioning[].content"
           },
           {
             "key": "interpreter",
@@ -324,7 +324,7 @@
           {
             "key": "source",
             "support": "yes",
-            "agama": "scripts.chroot[].body"
+            "agama": "scripts.chroot[].content"
           },
           {
             "key": "interpreter",
@@ -353,7 +353,7 @@
             "support": "yes",
             "agama": "scripts.init[].url"
           },
-          { "key": "source", "support": "yes", "agama": "scripts.init[].body" },
+          { "key": "source", "support": "yes", "agama": "scripts.init[].content" },
           {
             "key": "interpreter",
             "support": "no",
@@ -381,7 +381,7 @@
             "support": "yes",
             "agama": "scripts.init[].url"
           },
-          { "key": "source", "support": "yes", "agama": "scripts.init[].body" },
+          { "key": "source", "support": "yes", "agama": "scripts.init[].content" },
           { "key": "rerun", "support": "no" }
         ]
       }

--- a/service/test/agama/autoyast/scripts_reader_test.rb
+++ b/service/test/agama/autoyast/scripts_reader_test.rb
@@ -72,9 +72,9 @@ RSpec.shared_examples "a script reader" do |ay_section, section|
       }
     end
 
-    it "sets the \"body\" to the \"sources\"" do
+    it "uses the \"sources\" as \"content\"" do
       scripts = subject.read["scripts"][section]
-      expect(scripts.first).to include("body" => "#!/bin/bash\necho 'Hello World!'")
+      expect(scripts.first).to include("content" => "#!/bin/bash\necho 'Hello World!'")
     end
 
     context "and the script filename is not specified" do
@@ -133,7 +133,9 @@ describe Agama::AutoYaST::ScriptsReader do
           expect(subject.read["scripts"]).to include(
             "post" => [
               {
-                "name" => "test.sh", "chroot" => false, "body" => "#!/bin/bash\necho 'Hello World!'"
+                "name"    => "test.sh",
+                "chroot"  => false,
+                "content" => "#!/bin/bash\necho 'Hello World!'"
               }
             ]
           )


### PR DESCRIPTION
In #2121 we decided to unify files and scripts to use the same `content` property, instead of `body`. However, we did not update the conversion for AutoYaST scripts.
