### PR TITLE
Print also the IPv6 installer URLs in the console (bsc#1240197)

### DIFF
--- a/live/root/usr/bin/agama-issue-generator
+++ b/live/root/usr/bin/agama-issue-generator
@@ -172,11 +172,15 @@ function create_qr_codes() {
     if [ -n "$TERM_WIDTH" ] && [ "$TERM_WIDTH" -gt 80 ]; then
       # compute how much QR codes can fit on the screen side-by-side
       QR_NUM=$(( TERM_WIDTH / QR_WIDTH ))
-      # split the list into 2 parts, for the first part display the QR codes
-      QR_ADDRESSES=("${ADDRESSES[@]:0:$QR_NUM}")
-      SZ="${#ADDRESSES[@]}"
-      # for the rest display just the text URL
-      REST_ADDRESSES=("${ADDRESSES[@]:$QR_NUM:$SZ}")
+      # split the list into the IPv4 and IPv6 addresses, display QR codes only for the IPv4 addresses
+      IP4ADDR=()
+      IP6ADDR=()
+      for ADDR in "${ADDRESSES[@]}"; do [[ "$ADDR" =~ : ]] && IP6ADDR+=("$ADDR") || IP4ADDR+=("$ADDR"); done
+      # split the IPv4 list into 2 parts, for the first part display the QR codes,
+      QR_ADDRESSES=("${IP4ADDR[@]:0:$QR_NUM}")
+      SZ="${#IP4ADDR[@]}"
+      # for the rest display just the text URL as the list is too long
+      REST_ADDRESSES=("${IP4ADDR[@]:$QR_NUM:$SZ}")
     else
       QR_ADDRESSES=()
       REST_ADDRESSES=("${ADDRESSES[@]}")
@@ -184,6 +188,9 @@ function create_qr_codes() {
 
     if [ -n "${REST_ADDRESSES[*]}" ]; then
       printf "    https://%s\n" "${REST_ADDRESSES[@]}" >> "$URL_ISSUES"
+    fi
+    if [ -n "${IP6ADDR[*]}" ]; then
+      printf "    https://[%s]\n" "${IP6ADDR[@]}" >> "$URL_ISSUES"
     fi
 
     if [ -z "${QR_ADDRESSES[*]}" ]; then
@@ -234,15 +241,22 @@ build_addresses() {
   for CONNECTION in "${CONNECTIONS[@]}"; do
     TYPE=$(busctl -j get-property org.freedesktop.NetworkManager "$CONNECTION" org.freedesktop.NetworkManager.Connection.Active Type 2> /dev/null | jq --raw-output ".data")
 
-    # ignore loopbacks, we need external adresses
+    # ignore loopbacks, we need external addresses
     if [ "$TYPE" != "loopback" ]; then
       IP4CONFIG=$(busctl -j get-property org.freedesktop.NetworkManager "$CONNECTION" org.freedesktop.NetworkManager.Connection.Active Ip4Config 2> /dev/null | jq --raw-output ".data")
-      ADDRESSES+=($(busctl -j get-property org.freedesktop.NetworkManager "$IP4CONFIG" org.freedesktop.NetworkManager.IP4Config AddressData 2> /dev/null | jq --raw-output ".data[].address.data"))
+      mapfile -t IP4ADDRESSES < <(busctl -j get-property org.freedesktop.NetworkManager "$IP4CONFIG" org.freedesktop.NetworkManager.IP4Config AddressData 2> /dev/null | jq --raw-output ".data[].address.data")
+      ADDRESSES+=("${IP4ADDRESSES[@]}")
+
+      IP6CONFIG=$(busctl -j get-property org.freedesktop.NetworkManager "$CONNECTION" org.freedesktop.NetworkManager.Connection.Active Ip6Config 2> /dev/null | jq --raw-output ".data")
+      # ignore IPv6 link local addresses starting with "fe80:", they are not supported by browsers
+      mapfile -t IP6ADDRESSES < <(busctl -j get-property org.freedesktop.NetworkManager "$IP6CONFIG" org.freedesktop.NetworkManager.IP6Config AddressData 2> /dev/null | jq --raw-output ".data[].address.data" | grep -i -v ^fe80:)
+      ADDRESSES+=("${IP6ADDRESSES[@]}")
     fi
   done
 
   # remove duplicates
   readarray -t ADDRESSES < <(printf "%s\n" "${ADDRESSES[@]}" | sort -u)
+  echo "Found external addresses: ${ADDRESSES[*]}"
 
   # delete the old file
   rm -f "$URL_ISSUES"
@@ -270,7 +284,7 @@ generate_network_url() {
   interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',\
   type=signal" 2> /dev/null | while read -r line; do
     # some IP4 configuration has been changed, rebuild the URLs
-    if echo "$line" | grep -q 'string "org.freedesktop.NetworkManager.IP4Config"'; then
+    if echo "$line" | grep -q -E 'string "org.freedesktop.NetworkManager.IP(4|6)Config"'; then
       echo "Network configuration changed"
       build_addresses
     fi
@@ -280,7 +294,7 @@ generate_network_url() {
 # wait until the SSL fingreprint issue is created with a time limit passed as
 # the second argument (in seconds)
 wait_for_ssl_issue() {
-  for i in $(seq 1 "$1"); do
+  for _ in $(seq 1 "$1"); do
     [ -f "$CERT_ISSUE" ] && exit 0
     sleep 1
   done

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 31 13:06:53 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Print also the IPv6 installer URLs in the console (bsc#1240197)
+
+-------------------------------------------------------------------
 Thu Mar 27 15:56:11 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Version 14pre


### PR DESCRIPTION
## Problem

- The installer prints the "Network is not available, the Agama installer cannot be used remotely" error message on the console when only an IPv6 connection exists.
- https://bugzilla.suse.com/show_bug.cgi?id=1240197

## Solution

- Query also the network IPv6 addresses and display the URLs for them too
- Ignore the IPv6 link local addresses, they are not supported by browsers (mostly because the URL is not standardized :roll_eyes:)
- QR codes are not generated for IPv6 addresses, only for IPv4
  - I'm not sure about the IPv6 support in mobile phones/mobile browsers
  - More over the WiFi would need to support IPv6
  - And you need working IPv6 connection between WiFi and the network where your installer is running
  - Also the IPv6 address is longer and requires a bigger QR code, the logic for displaying IPv4 and IPv6 QR codes side-by-side would be a lot more complicated

## Testing

- Tested manually

## Screenshots

- For testing purposes I temporarily disabled the link local address filtering to display some IPv6 address in my testing VM, in the final code the IPv6 URL below would not be displayed.

![agama-ipv6-issue](https://github.com/user-attachments/assets/87dada67-3852-4e6c-88b1-1ec61c8efbba)


