### PR TITLE
fix(web): properly reload available devices after reprobing

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  1 08:53:43 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Fix reloading data after reprobing devices
+  (gh#agama-project/agama#2235).
+
+-------------------------------------------------------------------
 Thu Mar 27 12:40:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 13

--- a/web/src/api/storage/devices.ts
+++ b/web/src/api/storage/devices.ts
@@ -37,6 +37,9 @@ import {
 import { StorageDevice } from "~/types/storage";
 
 /**
+ * @fixme Use a transformation instead of building the devices as part of the fetch function, see
+ * https://tkdodo.eu/blog/react-query-data-transformations.
+ *
  * Returns the list of devices in the given scope
  *
  * @param scope - "system": devices in the current state of the system; "result":


### PR DESCRIPTION
## Problem

The storage page shows an empty state (no devices found) after activating/deactivating devices.

Steps to reproduce: 

* Go to iSCSI page and activate devices.
* Go back to storage.
* The storage page shows "No devices found" instead of the configured devices and result.

## Solution

Source of the problem: the query for getting the available devices requires the result of the query for getting all the devices, but it is not refreshed when there are changes in the list of devices.

For solving it, the `useAvailableDevices` hook uses *useMemo* which refreshes the list of available devices if any of the source data changes (either *devices* or the list of *usable Devices*).

See https://tkdodo.eu/blog/react-query-data-transformations#2-in-the-render-function: "Especially if you have additional logic in your custom hook to combine with your data transformation, this is a good option."

## Testing

* Tested manually
