### PR TITLE
Fix forget wireless network action.

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  1 15:52:23 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed sorting of wireless networks based on signal strength and 
+  the forget wireless network action (gh#agama-project/agama#2236).
+
+-------------------------------------------------------------------
 Thu Mar 27 12:40:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 13

--- a/web/src/components/network/WifiNetworksListPage.tsx
+++ b/web/src/components/network/WifiNetworksListPage.tsx
@@ -107,8 +107,11 @@ const WifiDrawerPanelBody = ({
 }) => {
   const { mutate: removeConnection } = useRemoveConnectionMutation();
   const selectedWifi = useSelectedWifi();
+  const { mutate: changeSelection } = useSelectedWifiChange();
 
   const forgetNetwork = async () => {
+    changeSelection({ ssid: null, needsAuth: null });
+    await disconnect(network.settings.id);
     removeConnection(network.settings.id);
   };
 

--- a/web/src/queries/network.ts
+++ b/web/src/queries/network.ts
@@ -96,7 +96,7 @@ const connectionsQuery = () => ({
 });
 
 /**
- * Returns a query for retrieving the list of known access points sortered by
+ * Returns a query for retrieving the list of known access points sorted by
  * the signal strength.
  */
 const accessPointsQuery = () => ({

--- a/web/src/queries/network.ts
+++ b/web/src/queries/network.ts
@@ -96,7 +96,8 @@ const connectionsQuery = () => ({
 });
 
 /**
- * Returns a query for retrieving the list of known access points
+ * Returns a query for retrieving the list of known access points sortered by
+ * the signal strength.
  */
 const accessPointsQuery = () => ({
   queryKey: ["network", "accessPoints"],

--- a/web/src/queries/network.ts
+++ b/web/src/queries/network.ts
@@ -278,6 +278,7 @@ const useWifiNetworks = () => {
   });
 
   return accessPoints
+    .sort((a: AccessPoint, b: AccessPoint) => b.strength - a.strength)
     .filter((ap: AccessPoint) => {
       // Do not include "duplicates"
       if (knownSsids.includes(ap.ssid)) return false;
@@ -287,7 +288,6 @@ const useWifiNetworks = () => {
       knownSsids.push(ap.ssid);
       return true;
     })
-    .sort((a: AccessPoint, b: AccessPoint) => b.strength - a.strength)
     .map((ap: AccessPoint): WifiNetwork => {
       const settings = connections.find((c: Connection) => c.wireless?.ssid === ap.ssid);
       const device = devices.find((d: Device) => d.connection === ap.ssid);

--- a/web/src/queries/network.ts
+++ b/web/src/queries/network.ts
@@ -102,7 +102,7 @@ const accessPointsQuery = () => ({
   queryKey: ["network", "accessPoints"],
   queryFn: async (): Promise<AccessPoint[]> => {
     const accessPoints = await fetchAccessPoints();
-    return accessPoints.map(AccessPoint.fromApi).sort((a, b) => (a.strength < b.strength ? -1 : 1));
+    return accessPoints.map(AccessPoint.fromApi).sort((a, b) => b.strength - a.strength);
   },
   // FIXME: Infinity vs 1second
   staleTime: 1000,
@@ -278,7 +278,6 @@ const useWifiNetworks = () => {
   });
 
   return accessPoints
-    .sort((a: AccessPoint, b: AccessPoint) => b.strength - a.strength)
     .filter((ap: AccessPoint) => {
       // Do not include "duplicates"
       if (knownSsids.includes(ap.ssid)) return false;


### PR DESCRIPTION
## Problem

When try to forget a wireless network it raises an error because it remains selected when it does not exist anymore.

## Solution

It is deselected and disconnected from the selected network to be forgotten.

## Testing

- *Tested manually*
