### PR TITLE
do not export empty defaults for user

### DIFF
--- a/rust/agama-lib/src/dbus.rs
+++ b/rust/agama-lib/src/dbus.rs
@@ -101,6 +101,15 @@ pub fn extract_id_from_path(path: &OwnedObjectPath) -> Result<u32, zvariant::Err
         })
 }
 
+// small helper to convert dbus empty string to None
+pub fn optional_string(value: String) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -84,11 +84,8 @@ pub struct RootUserSettings {
     pub ssh_public_key: Option<String>,
 }
 
-
 impl RootUserSettings {
     pub fn skip_export(&self) -> bool {
-        self.password.is_none()
-            && self.hashed_password.is_none()
-            && self.ssh_public_key.is_none()
+        self.password.is_none() && self.hashed_password.is_none() && self.ssh_public_key.is_none()
     }
 }

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -38,12 +38,16 @@ pub struct UserSettings {
 #[serde(rename_all = "camelCase")]
 pub struct FirstUserSettings {
     /// First user's full name
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub full_name: Option<String>,
     /// First user's username
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_name: Option<String>,
     /// First user's password (in clear text)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
     /// Whether the password is hashed or is plain text
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hashed_password: Option<bool>,
 }
 

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -40,12 +40,22 @@ impl UsersStore {
         })
     }
 
+    // small helper to convert dbus empty string to None
+    fn optional_string(value: String) -> Option<String> {
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
     pub async fn load(&self) -> Result<UserSettings, ServiceError> {
         let first_user = self.users_client.first_user().await?;
         let first_user = FirstUserSettings {
-            user_name: Some(first_user.user_name),
-            full_name: Some(first_user.full_name),
-            password: Some(first_user.password),
+            user_name: Self::optional_string(first_user.user_name),
+            full_name: Self::optional_string(first_user.full_name),
+            password: Self::optional_string(first_user.password),
+            // sadly for boolean we do not have on dbus way to set it to not_set
             hashed_password: Some(first_user.hashed_password),
         };
         let root_user = self.users_client.root_user().await?;

--- a/rust/agama-lib/src/users/store.rs
+++ b/rust/agama-lib/src/users/store.rs
@@ -58,16 +58,26 @@ impl UsersStore {
             // sadly for boolean we do not have on dbus way to set it to not_set
             hashed_password: Some(first_user.hashed_password),
         };
+        let first_user = if first_user.skip_export() {
+            None
+            } else {
+                Some(first_user)
+            };
         let root_user = self.users_client.root_user().await?;
         let root_user = RootUserSettings {
             password: root_user.password,
             hashed_password: root_user.hashed_password,
             ssh_public_key: root_user.ssh_public_key,
         };
+        let root_user = if root_user.skip_export() {
+            None
+            } else {
+                Some(root_user)
+            };
 
         Ok(UserSettings {
-            first_user: Some(first_user),
-            root: Some(root_user),
+            first_user: first_user,
+            root: root_user,
         })
     }
 


### PR DESCRIPTION
## Problem

When user do not configure first user and try to export profile or do `agama config edit` and do not touch user section it failed to load with invalid user that cannot be empty.


## Solution

Skip exporting user if it is not defined.


## Testing

- *Tested manually*

