### PR TITLE
feat(autoinstallation): Make the addon version optional

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -111,6 +111,8 @@ jobs:
     # send the code coverage for the Rust part to the coveralls.io
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@v2
+      # ignore errors in this step
+      continue-on-error: true
       with:
         base-path: ./rust
         format: cobertura
@@ -122,6 +124,8 @@ jobs:
     # only with the "parallel-finished: true" option)
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2
+      # ignore errors in this step
+      continue-on-error: true
       with:
         parallel-finished: true
         carryforward: "service,web"

--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -135,7 +135,11 @@ impl<'a> ProductClient<'a> {
             .into_iter()
             .map(|(id, version, code)| AddonParams {
                 id,
-                version,
+                version: if version.is_empty() {
+                    None
+                } else {
+                    Some(version)
+                },
                 registration_code: if code.is_empty() { None } else { Some(code) },
             })
             .collect();
@@ -158,7 +162,7 @@ impl<'a> ProductClient<'a> {
             .registration_proxy
             .register_addon(
                 &addon.id,
-                &addon.version,
+                &addon.version.clone().unwrap_or_default(),
                 &addon.registration_code.clone().unwrap_or_default(),
             )
             .await?)

--- a/rust/agama-lib/src/product/settings.rs
+++ b/rust/agama-lib/src/product/settings.rs
@@ -27,7 +27,12 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct AddonSettings {
     pub id: String,
-    pub version: String,
+    /// Optional version of the addon, if not specified the version is found
+    /// from the available addons
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Free extensions do not require a registration code
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub registration_code: Option<String>,
 }
 

--- a/rust/agama-lib/src/software/model/registration.rs
+++ b/rust/agama-lib/src/software/model/registration.rs
@@ -35,8 +35,8 @@ pub struct RegistrationParams {
 pub struct AddonParams {
     // Addon identifier
     pub id: String,
-    // Addon version, the same addon might be available in multiple versions
-    pub version: String,
+    // Addon version, if not specified the version is found from the available addons
+    pub version: Option<String>,
     // Optional registration code, not required for free extensions
     pub registration_code: Option<String>,
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  1 12:44:57 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Make the extension version attribute optional, search the version
+  automatically if it is missing (related to jsc#AGM-100)
+
+-------------------------------------------------------------------
 Fri Mar 28 21:45:05 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow to specify bootloader timeout in profile (jsc#PED-10810)

--- a/service/lib/agama/autoyast/product_reader.rb
+++ b/service/lib/agama/autoyast/product_reader.rb
@@ -83,9 +83,16 @@ module Agama
       # convert addons according to the new schema
       def convert_addons(addons)
         addons.map do |a|
-          addon = { "id" => a["name"], "version" => a["version"] }
+          addon = { "id" => a["name"] }
+
+          version = a["version"].to_s
+          # omit the version if it was 11.x, 12.x or 15.x, the version is now optional
+          version = "" if version.match(/^1[125]\.\d$/)
+          addon["version"] = version unless version.empty?
+
           code = a["reg_code"].to_s
           addon["registrationCode"] = code unless code.empty?
+
           addon
         end
       end

--- a/service/lib/agama/errors.rb
+++ b/service/lib/agama/errors.rb
@@ -24,5 +24,22 @@ module Agama
   module Errors
     # Invalid value given by the user
     class InvalidValue < StandardError; end
+
+    # Registration specific errors
+    module Registration
+      # The requested extension was not found
+      class ExtensionNotFound < StandardError
+        def initialize(name)
+          super("#{name.inspect} is not available")
+        end
+      end
+
+      # The requested extension exists in multiple versions
+      class MultipleExtensionsFound < StandardError
+        def initialize(name, versions)
+          super("#{name.inspect} is available in multiple versions: #{versions.join(", ")}")
+        end
+      end
+    end
   end
 end

--- a/service/lib/agama/registered_addon.rb
+++ b/service/lib/agama/registered_addon.rb
@@ -32,14 +32,20 @@ module Agama
     # @return [String]
     attr_reader :version
 
+    # The addon version was explicitly specified by the user or it was autodetected.
+    #
+    # @return [Boolean] true if explicitly specified by user, false when autodetected
+    attr_reader :required_version
+
     # Code used for registering the addon.
     #
     # @return [String] empty string if the registration code is not required
     attr_reader :reg_code
 
-    def initialize(name, version, reg_code = "")
+    def initialize(name, version, required_version, reg_code = "")
       @name = name
       @version = version
+      @required_version = required_version
       @reg_code = reg_code
     end
   end

--- a/service/lib/agama/registration.rb
+++ b/service/lib/agama/registration.rb
@@ -27,6 +27,7 @@ require "y2packager/new_repository_setup"
 require "y2packager/resolvable"
 
 require "agama/cmdline_args"
+require "agama/errors"
 require "agama/registered_addon"
 
 Yast.import "Arch"
@@ -90,13 +91,8 @@ module Agama
       # TODO: check if we can do it in memory for libzypp
       SUSE::Connect::YaST.create_credentials_file(@login, @password, GLOBAL_CREDENTIALS_PATH)
 
-      target_product = OpenStruct.new(
-        arch:       Yast::Arch.rpm_arch,
-        identifier: product.id,
-        version:    product.version || "1.0"
-      )
       activate_params = {}
-      service = SUSE::Connect::YaST.activate_product(target_product, activate_params, email)
+      service = SUSE::Connect::YaST.activate_product(base_target_product, activate_params, email)
       process_service(service)
 
       @reg_code = code
@@ -105,25 +101,33 @@ module Agama
     end
 
     def register_addon(name, version, code)
-      if @registered_addons.any? { |a| a.name == name && a.version == version }
-        @logger.info "Addon #{name}-#{version} already registered, skipping registration"
+      register_version = if version.empty?
+        # version is not specified, find it automatically
+        find_addon_version(name)
+      else
+        # use the explicitly required version
+        version
+      end
+
+      if @registered_addons.any? { |a| a.name == name && a.version == register_version }
+        @logger.info "Addon #{name}-#{register_version} already registered, skipping registration"
         return
       end
 
-      @logger.info "Registering addon #{name}-#{version}"
+      @logger.info "Registering addon #{name}-#{register_version}"
       # do not log the code, but at least log if it is empty
       @logger.info "Using empty registration code" if code.empty?
 
       target_product = OpenStruct.new(
         arch:       Yast::Arch.rpm_arch,
         identifier: name,
-        version:    version
+        version:    register_version
       )
       activate_params = { token: code }
       service = SUSE::Connect::YaST.activate_product(target_product, activate_params, @email)
       process_service(service)
 
-      @registered_addons << RegisteredAddon.new(name, version, code)
+      @registered_addons << RegisteredAddon.new(name, register_version, !version.empty?, code)
       # select the products to install
       @software.addon_products(find_addon_products)
 
@@ -150,6 +154,7 @@ module Agama
       # reset
       @software.addon_products([])
       @services = []
+      @available_addons = nil
 
       reg_params = connect_params(token: reg_code, email: email)
       SUSE::Connect::YaST.deactivate_system(reg_params)
@@ -313,6 +318,48 @@ module Agama
       data = Yast::Pkg.SourceGeneralData(repo)
       data["SrcId"] = repo
       data
+    end
+
+    # Get the available addons for the specified base product.
+    #
+    # @note The result is bound to the registration code used for the base product, the result
+    # might be different for different codes. E.g. the Alpha/Beta extensions might or might not
+    # be included in the list.
+    def available_addons
+      return @available_addons if @available_addons
+
+      @available_addons = SUSE::Connect::YaST.show_product(base_target_product,
+        connect_params).extensions
+      @logger.info "Available addons: #{available_addons.inspect}"
+      @available_addons
+    end
+
+    # Find the version for the specified addon, if none if multiple addons with the same name
+    # are found an exception is thrown.
+    #
+    # @return [String] the addon version, e.g. "16.0"
+    def find_addon_version(name)
+      raise Errors::Registration::ExtensionNotFound, name unless available_addons
+
+      requested_addons = available_addons.select { |a| a.identifier == name }
+      case requested_addons.size
+      when 0
+        raise Errors::Registration::ExtensionNotFound, name
+      when 1
+        requested_addons.first.version
+      else
+        raise Errors::Registration::MultipleExtensionsFound.new(name,
+          requested_addons.map(&:version))
+      end
+    end
+
+    # Construct the base product data for sending to the server
+    def base_target_product
+      OpenStruct.new(
+        arch:       Yast::Arch.rpm_arch,
+        identifier: product.id,
+        version:    product.version || "1.0"
+      )
     end
   end
 end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  1 12:44:57 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Make the extension version attribute optional, search the version
+  automatically if it is missing (related to jsc#AGM-100)
+
+-------------------------------------------------------------------
 Fri Mar 28 21:45:56 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow to specify bootloader timeout in profile (jsc#PED-10810)


### PR DESCRIPTION
## Problem

- The addon version is required in the autoinstallation profile, i.e. you have to pass
  ```json
  {
    "id": "sle-ha",
    "version": "16.0",
    "registrationCode": "<CODE>"
  }
  ```
- For most addons from SCC the version is bound to the SP release, e.g. in SP1 the version will be "16.1", in SP2 "16.2", etc...
- That means you have to update the profile for each SP release and you cannot use the same profile for multiple SP releases. That's quite annoying.

## Solution

- Make the version attribute optional, allow it to be missing.
- If the version is missing query the available addons and find the version to register automatically from the list.
- If multiple versions are found report an error, in that case the version needs to be specified explicitly in the profile.
- So now you can just write:
  ```json
  {
    "id": "sle-ha",
    "registrationCode": "<CODE>"
  }
  ```
  For free extensions you will only need the `id` value.

## Notes

- The installer remembers whether a specific version was requested or it was found automatically.
- It uses this information when exporting the current configuration. When the version was specified at import it will be specified in the export, if it was missing at import it will be missing in export as well.
- That means at export you should get the same imported data.

## Testing

- Added a new unit test
- Tested manually


