### PR TITLE
fix(live): Workaround for a not working file picker in a local installation

### DIFF
--- a/live/root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/root/root/.mozilla/firefox/profile/user.js.template
@@ -16,6 +16,10 @@ user_pref("browser.startup.couldRestoreSession.count", 0);
 // disable homepage override on updates
 user_pref("browser.startup.homepage_override.mstone", "ignore");
 
+// workaround for non working file picker, disable XDG portal, use the FF native popup
+// TODO: make the XDG portal working again, it has more features (mounting USB flash)
+user_pref("widget.use-xdg-desktop-portal.file-picker", 0);
+
 // start always in the custom homepage
 user_pref("browser.startup.page", 1);
 // custom homepage: the value is expected to be replaced with the login URL by the startup script

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr  3 08:28:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Workaround for a not working file picker in local installation
+  (gh#agama-project/agama#2243)
+
+-------------------------------------------------------------------
 Wed Apr  2 05:47:01 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use "agama download" to fetch the info file (gh#agama-project/agama#2176).


### PR DESCRIPTION
## Problem

- The file picker does not appear after clicking "Upload" in a local installation, clicking the button does nothing
- https://github.com/agama-project/agama/issues/2243

![agama-ssh-import](https://github.com/user-attachments/assets/3fbec072-18fe-4bf1-919e-6e5101fff7bc)

## Solution

- Workaround: disable using the XDG portal, use the native FF file picker
- Later: fix the XDG portal, it provides more features like mounting USB flash disks

## Testing

- Tested manually

## Screenshots

The file picker appears now:

![agama-ssh-import-workaround](https://github.com/user-attachments/assets/1b5ff944-8e00-48d4-88e6-d1bc4e48afa4)

