### PR TITLE
use for all services which makes sense in headless mode target multi-user

### DIFF
--- a/autoinstallation/systemd/agama-auto.service
+++ b/autoinstallation/systemd/agama-auto.service
@@ -13,4 +13,4 @@ Type=simple
 User=root
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-avahi-issue.service
+++ b/live/root/etc/systemd/system/agama-avahi-issue.service
@@ -8,4 +8,4 @@ ExecStart=agama-issue-generator --watch-avahi
 Type=simple
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-certificate-issue.path
+++ b/live/root/etc/systemd/system/agama-certificate-issue.path
@@ -7,4 +7,4 @@ Unit=agama-certificate-issue.service
 PathChanged=/etc/agama.d/ssl/cert.pem
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-certificate-issue.service
+++ b/live/root/etc/systemd/system/agama-certificate-issue.service
@@ -6,4 +6,4 @@ Type=oneshot
 ExecStart=agama-issue-generator --ssl
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-certificate-wait.service
+++ b/live/root/etc/systemd/system/agama-certificate-wait.service
@@ -24,4 +24,4 @@ Type=oneshot
 ExecStart=agama-issue-generator --wait-for-ssl 15
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-cmdline-process.service
+++ b/live/root/etc/systemd/system/agama-cmdline-process.service
@@ -2,7 +2,6 @@
 Description=Agama kernel cmdline processing
 
 # have to be after network to be able to download info files
-# TODO: what to do in air gap scenario where we still need process cmdline?
 After=network-online.target
 
 # before starting the Agama servers so they read configuration parsed
@@ -16,4 +15,4 @@ ExecStart=agama-kernel-cmdline.sh
 StandardOutput=journal
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-dud.service
+++ b/live/root/etc/systemd/system/agama-dud.service
@@ -27,4 +27,4 @@ StandardInput=tty
 TimeoutStartSec=infinity
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-hostname.service
+++ b/live/root/etc/systemd/system/agama-hostname.service
@@ -14,4 +14,4 @@ Type=oneshot
 User=root
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-self-update.service
+++ b/live/root/etc/systemd/system/agama-self-update.service
@@ -26,4 +26,4 @@ StandardInput=tty
 TimeoutStartSec=infinity
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-ssh-issue.service
+++ b/live/root/etc/systemd/system/agama-ssh-issue.service
@@ -8,4 +8,4 @@ Type=oneshot
 ExecStart=agama-issue-generator --ssh
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-url-issue.service
+++ b/live/root/etc/systemd/system/agama-url-issue.service
@@ -8,4 +8,4 @@ ExecStart=agama-issue-generator --watch-network
 Type=simple
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/agama-welcome-issue.service
+++ b/live/root/etc/systemd/system/agama-welcome-issue.service
@@ -7,4 +7,4 @@ Type=oneshot
 ExecStart=agama-issue-generator --welcome
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/checkmedia.service
+++ b/live/root/etc/systemd/system/checkmedia.service
@@ -44,4 +44,4 @@ RemainAfterExit=true
 TimeoutStartSec=infinity
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/live-free-space.service
+++ b/live/root/etc/systemd/system/live-free-space.service
@@ -6,4 +6,4 @@ ExecStart=rm -f /var/lib/live_free_space
 Type=oneshot
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/live-password.service
+++ b/live/root/etc/systemd/system/live-password.service
@@ -46,4 +46,4 @@ RemainAfterExit=true
 TimeoutStartSec=infinity
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/live/root/etc/systemd/system/live-root-shell.service
+++ b/live/root/etc/systemd/system/live-root-shell.service
@@ -15,4 +15,4 @@ Environment=TERM=linux
 KillSignal=SIGHUP
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/rust/share/agama-scripts.service
+++ b/rust/share/agama-scripts.service
@@ -15,4 +15,4 @@ RemainAfterExit=yes
 TimeoutStartSec=infinity
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/rust/share/agama-web-server.service
+++ b/rust/share/agama-web-server.service
@@ -15,4 +15,4 @@ User=root
 TimeoutStopSec=5
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/service/share/agama-dbus-monitor.service
+++ b/service/share/agama-dbus-monitor.service
@@ -10,4 +10,4 @@ Restart=always
 User=root
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/service/share/agama-proxy-setup.service
+++ b/service/share/agama-proxy-setup.service
@@ -8,5 +8,5 @@ Type=oneshot
 ExecStart=/usr/bin/agama-proxy-setup
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target
 

--- a/service/share/agama.service
+++ b/service/share/agama.service
@@ -11,4 +11,4 @@ User=root
 TimeoutStopSec=5
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

Almost all agama systemd services uses default.target. This has two drawbacks:

1. it is discouraged by systemd itself - https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#default.target ( `For typical unit files please set "WantedBy=" to a regular target (like multi-user.target or graphical.target), instead of default.target, since such a service will also be run on special boots like on system update, emergency boot…`
2. it means that user wants to run installer in headless mode and use standard `systemd.unit=multi-user.target` it does not start agama and other services as live iso has as default graphical.


## Solution

change services to use multi-user everywhere where it does not need graphical target ( so all of them as only x11 autologin is for graphical )


## Testing

- *Tested manually* - both with default and with headless setup

