### PR TITLE
Fix condition for multiple elements in bootloader

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -72,7 +72,7 @@
         { "required": [ "stopOnBootMenu" ]},
         { "required": [ "timeout" ]},
         { "not": {
-          "allOf": [
+          "anyOf": [
             { "required": [ "stopOnBootMenu" ]},
             { "required": [ "timeout" ]}
           ]


### PR DESCRIPTION
A bit of details. If allOf is used, then it is correct also if just single one is used, but intention is to express that one of given parameters is specified or none.