### PR TITLE
Remind to update documentation in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,12 @@
 
 *If the fix affects the UI attach some screenshots here.*
 
+## Documentation
+
+*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
+*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
+*other times they need advertisement and explanation.*
+
+*Look for relevant sections and adjust:*
+- <https://agama-project.github.io/> ([source](https://github.com/agama-project/agama-project.github.io/))
+- Run: `git ls-files '*.md'`


### PR DESCRIPTION
## Problem

We implement cool stuff. People do not learn about it. Or they do and they don't know how to use it.

## Solution

Document it. Make sure it gets documented by putting a reminder in the PR template.

## Testing

No code affected. The test is: will people adapt docs? Will reviewers remind them?

## Screenshots

No

## Documentation

The (meta-)documentation **is** the change.
