### PR TITLE
skip exporting empty bootloader

### DIFF
--- a/rust/agama-lib/src/bootloader/model.rs
+++ b/rust/agama-lib/src/bootloader/model.rs
@@ -31,3 +31,13 @@ pub struct BootloaderSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
 }
+
+impl BootloaderSettings {
+    pub fn to_option(self) -> Option<Self> {
+        if self.stop_on_boot_menu.is_none() && self.timeout.is_none() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}

--- a/rust/agama-lib/src/bootloader/store.rs
+++ b/rust/agama-lib/src/bootloader/store.rs
@@ -38,8 +38,9 @@ impl BootloaderStore {
         })
     }
 
-    pub async fn load(&self) -> Result<BootloaderSettings, ServiceError> {
-        self.bootloader_client.get_config().await
+    pub async fn load(&self) -> Result<Option<BootloaderSettings>, ServiceError> {
+        Ok(self.bootloader_client.get_config().await?.to_option())
+
     }
 
     pub async fn store(&self, settings: &BootloaderSettings) -> Result<(), ServiceError> {

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -76,7 +76,7 @@ impl Store {
     /// Loads the installation settings from the HTTP interface.
     pub async fn load(&self) -> Result<InstallSettings, ServiceError> {
         let mut settings = InstallSettings {
-            bootloader: Some(self.bootloader.load().await?),
+            bootloader: self.bootloader.load().await?,
             files: Some(self.files.load().await?),
             hostname: Some(self.hostname.load().await?),
             network: Some(self.network.load().await?),


### PR DESCRIPTION
## Problem

There are bunch of empty keys in `agama config show` that has empty children.


## Solution

I try approach with having method to convert to option.