### PR TITLE
Include the short Git commit hash in the RPM package version

### DIFF
--- a/autoinstallation/package/_service
+++ b/autoinstallation/package/_service
@@ -3,7 +3,7 @@
     <!-- the URL is modified by the .github/workflows/obs-staging-shared.yml
     action when submitting to OBS -->
     <param name="url">https://github.com/agama-project/agama.git</param>
-    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param>
+    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@.%h</param>
     <param name="versionrewrite-pattern">v(.*)</param>    
     <param name="scm">git</param>
     <!-- the revision might be changed to "release" branch or a git tag by the

--- a/products.d/_service
+++ b/products.d/_service
@@ -3,7 +3,7 @@
     <!-- the URL is modified by the .github/workflows/obs-staging-shared.yml
     action when submitting to OBS -->
     <param name="url">https://github.com/agama-project/agama.git</param>
-    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param>
+    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@.%h</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <param name="scm">git</param>
     <!-- the revision might be changed to "release" branch or a git tag by the

--- a/rust/package/_service
+++ b/rust/package/_service
@@ -3,7 +3,7 @@
     <!-- the URL is modified by the .github/workflows/obs-staging-shared.yml
     action when submitting to OBS -->
     <param name="url">https://github.com/agama-project/agama.git</param>
-    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param>
+    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@.%h</param>
     <param name="versionrewrite-pattern">v(.*)</param>    
     <param name="scm">git</param>
     <!-- the revision might be changed to "release" branch or a git tag by the

--- a/service/agama-yast.gemspec
+++ b/service/agama-yast.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   if File.exist?(File.join(__dir__, "../.git"))
     # the version is <version_tag>.devel<number_of_commits_since_the_tag>
     # or just <version_tag> if there are no additional commits
-    spec.version = `git describe --tags --match "v[0-9]*"`.chomp.sub(/^v/, "").sub(/-([0-9]+)-g\h+\Z/, ".devel\\1")
+    spec.version = `git describe --tags --match "v[0-9]*"`.chomp.sub(/^v/, "").sub(/-([0-9]+)-g(\h+)\Z/, ".devel\\1.\\2")
   else
     # running in yupdate script, use a fake version
     spec.version = "99.yupdate"

--- a/web/package/_service
+++ b/web/package/_service
@@ -1,6 +1,6 @@
 <services>
   <service name="obs_scm" mode="manual">
-    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@</param>
+    <param name="versionformat">@PARENT_TAG@+@TAG_OFFSET@.%h</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <!-- the URL is modified by the .github/workflows/obs-staging-shared.yml
     action when submitting to OBS -->


### PR DESCRIPTION
## Problem

- To find whether an Agama package contains a certain fix is not easy.
- The package version contains the Git version tag + number of commits since that tag, so it is possible to find that respective commit but that is not trivial.
- Moreover if the package comes from a different branch the number of commits can be the same as in `master` but with different content. The version number is not unique.

## Solution

- Include the short Git commit hash in the package version.
- Then finding the appropriate Git commit in the history is trivial.
- This makes the version unique even for different branches or forks.

## Testing

- Tested manually in https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:git_commit_in_version OBS project
- When listing the installed package versions the Git commit is included (highlighted with extra `grep`):
  
  ![image](https://github.com/user-attachments/assets/41e263ff-8055-44be-bca9-675256a42ac4)
- Note: All packages have the save version/Git commit because I updated all of them in a single commit. Later the versions will be more different.
- Zypper (libzypp) treats the versions correctly, the number of commits takes precedence so even if the Git commit uses a lower number the higher commit count is correctly evaluated as a newer version:
  
  ![image](https://github.com/user-attachments/assets/82f3edd3-5314-4890-bdb0-3e370691ef71)

- That means updating the packages in the potential self-update will work correctly.

