### PR TITLE
Fix efi boot

### DIFF
--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -100,7 +100,7 @@ menuentry "Check Installation Medium" --class os --unrestricted {
 }
 menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
   if search --no-floppy --file /efi/boot/fallback.efi --set ; then
-    for os in opensuse sles leap; do
+    for os in opensuse sles leap suse; do
       if [ -f /efi/\$os/grub.efi ] ; then
         chainloader /efi/\$os/grub.efi
         boot

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr  8 15:52:18 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix boot from Hard Disk for EFI x86_64 (bsc#1240646)
+
+-------------------------------------------------------------------
 Thu Apr  3 08:28:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Workaround for a not working file picker in local installation


### PR DESCRIPTION
## Problem

Failed to boot from hard disk for EFI boot.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1240646


## Solution

Add `suse` as EFI boot entry which is used by SLES16.