### PR TITLE
fix(web): CLI do not crash if it cannot mount a file system

### DIFF
--- a/rust/agama-lib/src/utils/transfer/file_systems.rs
+++ b/rust/agama-lib/src/utils/transfer/file_systems.rs
@@ -65,11 +65,11 @@ impl FileSystem {
         let mount_point = self.mount_point.clone().unwrap_or(default_mount_point);
 
         if !self.is_mounted() {
-            self.mount(&mount_point).unwrap();
+            self.mount(&mount_point)?;
         }
         let result = func(&mount_point);
         if !self.is_mounted() {
-            self.umount(&mount_point).unwrap();
+            self.umount(&mount_point)?;
         }
 
         result

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  8 22:04:03 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- "agama download" do not crash if it cannot mount a file system
+  (gh#agama-project/agama#2253).
+
+-------------------------------------------------------------------
 Mon Apr  7 14:02:57 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Skip exporting scripts, files, bootloader and softare section


### PR DESCRIPTION
It might happen that, for some reason, "agama download" cannot mount a file system (e.g., `/dev/loop1`). In that case, it should continue with the next device to probe.
