### PR TITLE
fix(ruby): write the registration URL to the installed system

### DIFF
--- a/service/lib/agama/registration.rb
+++ b/service/lib/agama/registration.rb
@@ -171,7 +171,9 @@ module Agama
       run_on_change_callbacks
     end
 
-    # Copies credentials files to the target system.
+    # Copies configuration and credentials files to the target system.
+    #
+    # The configuration file is copied only if a registration URL was given.
     def finish
       return unless reg_code
 
@@ -182,6 +184,14 @@ module Agama
         files << [
           File.join(TARGET_DIR, credentials_path(credentials_file)),
           File.join(Yast::Installation.destdir, credentials_path(credentials_file))
+        ]
+      end
+
+      if registration_url
+        SUSE::Connect::YaST.write_config("url" => registration_url)
+        files << [
+          SUSE::Connect::Config::DEFAULT_CONFIG_FILE,
+          File.join(Yast::Installation.destdir, SUSE::Connect::Config::DEFAULT_CONFIG_FILE)
         ]
       end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr  9 06:42:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Write the registration URL to the installed system (bsc#1239316).
+
+-------------------------------------------------------------------
 Tue Apr  1 12:44:57 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Make the extension version attribute optional, search the version

--- a/service/test/agama/registration_test.rb
+++ b/service/test/agama/registration_test.rb
@@ -489,6 +489,19 @@ describe Agama::Registration do
 
         subject.finish
       end
+
+      context "and a registration URL was given" do
+        before do
+          allow(subject).to receive(:registration_url).and_return("http://reg-server.lan")
+        end
+
+        it "generates and copies the SUSEConnect configuration" do
+          expect(::FileUtils).to receive(:cp).with("/etc/SUSEConnect", "/mnt/etc/SUSEConnect")
+          expect(SUSE::Connect::YaST).to receive(:write_config).with("url" => "http://reg-server.lan")
+
+          subject.finish
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

After installing the system and registering it using inst.register_url boot parameter, the SUSEConnect config file does not exist. This means that the URL is forgotten and SCC is used instead.

- [bsc#1239316](https://bugzilla.suse.com/show_bug.cgi?id=1239316)

## Solution

Write the `SUSEConnect` configuration if a registration URL was specified.

## Testing

- Added a new unit test
- Tested manually yet
