### PR TITLE
Add bridge support for the HTTP API and CLI

### DIFF
--- a/rust/agama-lib/share/examples/network/bond.json
+++ b/rust/agama-lib/share/examples/network/bond.json
@@ -1,0 +1,14 @@
+{
+  "network": {
+    "connections": [
+      {
+        "id": "bond0",
+        "bond": {
+          "ports": ["eth0", "eth1"],
+          "mode": "active-backup",
+          "options": "primary=eth1"
+        }
+      }
+    ]
+  }
+}

--- a/rust/agama-lib/share/examples/network/bridge.json
+++ b/rust/agama-lib/share/examples/network/bridge.json
@@ -1,0 +1,13 @@
+{
+  "network": {
+    "connections": [
+      {
+        "id": "br0",
+        "bridge": {
+          "ports": ["eth0", "eth1"],
+          "stp": false
+        }
+      }
+    ]
+  }
+}

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -446,22 +446,22 @@
                   "forwardDelay": {
                     "title": "Spanning Tree Protocol forward delay, in seconds",
                     "type": "integer",
-                    "minimum": "0"
+                    "minimum": 0
                   },
                   "priority": {
                     "title": "Spanning Tree Protocol priority. Lower values are 'better'",
                     "type": "integer",
-                    "minimum": "0"
+                    "minimum": 0
                   },
                   "maxAge": {
                     "title": "Spanning Tree Protocol maximum message age, in seconds",
                     "type": "integer",
-                    "minimum": "0"
+                    "minimum": 0
                   },
                   "helloTime": {
                     "title": "Spanning Tree Protocol hello time, in seconds",
                     "type": "integer",
-                    "minimum": "0"
+                    "minimum": 0
                   },
                   "ports": {
                     "type": "array",
@@ -472,7 +472,6 @@
                   }
                 }
               },
-
               "match": {
                 "type": "object",
                 "title": "Match settings",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -434,6 +434,45 @@
                   }
                 }
               },
+              "bridge": {
+                "type": "object",
+                "title": "Bridge configuration",
+                "additionalProperties": false,
+                "properties": {
+                  "stp": {
+                    "title": "whether the Spanning Tree Protocol is enabled or not",
+                    "type": "boolean"
+                  },
+                  "forwardDelay": {
+                    "title": "Spanning Tree Protocol forward delay, in seconds",
+                    "type": "integer",
+                    "minimum": "0"
+                  },
+                  "priority": {
+                    "title": "Spanning Tree Protocol priority. Lower values are 'better'",
+                    "type": "integer",
+                    "minimum": "0"
+                  },
+                  "maxAge": {
+                    "title": "Spanning Tree Protocol maximum message age, in seconds",
+                    "type": "integer",
+                    "minimum": "0"
+                  },
+                  "helloTime": {
+                    "title": "Spanning Tree Protocol hello time, in seconds",
+                    "type": "integer",
+                    "minimum": "0"
+                  },
+                  "ports": {
+                    "type": "array",
+                    "items": {
+                      "title": "A list of the interfaces or connections to be part of the bridge",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+
               "match": {
                 "type": "object",
                 "title": "Match settings",
@@ -669,7 +708,11 @@
         }
       },
       "required": ["name"],
-      "oneOf": [{ "required": ["body"] }, { "required": ["url"] }, { "required": ["content"]}]
+      "oneOf": [
+        { "required": ["body"] },
+        { "required": ["url"] },
+        { "required": ["content"] }
+      ]
     },
     "postPartitioning": {
       "title": "User-defined installation script that runs after the partitioning finishes",
@@ -697,7 +740,11 @@
         }
       },
       "required": ["name"],
-      "oneOf": [{ "required": ["body"] }, { "required": ["url"] }, { "required": ["content"]}]
+      "oneOf": [
+        { "required": ["body"] },
+        { "required": ["url"] },
+        { "required": ["content"] }
+      ]
     },
     "postScript": {
       "title": "User-defined installation script that runs after the installation finishes",
@@ -730,7 +777,11 @@
         }
       },
       "required": ["name"],
-      "oneOf": [{ "required": ["body"] }, { "required": ["url"] }, { "required": ["content"]}]
+      "oneOf": [
+        { "required": ["body"] },
+        { "required": ["url"] },
+        { "required": ["content"] }
+      ]
     },
     "initScript": {
       "title": "User-defined installation script that runs during the first boot of the target system, once the installation is finished",
@@ -758,7 +809,11 @@
         }
       },
       "required": ["name"],
-      "oneOf": [{ "required": ["body"] }, { "required": ["url"] }, { "required": ["content"]}]
+      "oneOf": [
+        { "required": ["body"] },
+        { "required": ["url"] },
+        { "required": ["content"] }
+      ]
     },
     "file": {
       "title": "User-defined file to deploy",
@@ -795,7 +850,7 @@
         }
       },
       "required": ["destination"],
-      "oneOf": [{ "required": ["url"] }, { "required": ["content"]}]
+      "oneOf": [{ "required": ["url"] }, { "required": ["content"] }]
     }
   }
 }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -449,7 +449,7 @@
                     "minimum": 0
                   },
                   "priority": {
-                    "title": "Spanning Tree Protocol priority. Lower values are 'better'",
+                    "title": "Spanning Tree Protocol priority (lower values are 'better')",
                     "type": "integer",
                     "minimum": 0
                   },

--- a/rust/agama-lib/src/hostname/client.rs
+++ b/rust/agama-lib/src/hostname/client.rs
@@ -43,7 +43,6 @@ impl<'a> HostnameClient<'a> {
         let settings = HostnameSettings {
             hostname: Some(hostname),
             static_hostname: Some(static_hostname),
-            ..Default::default()
         };
 
         Ok(settings)

--- a/rust/agama-lib/src/network/store.rs
+++ b/rust/agama-lib/src/network/store.rs
@@ -94,6 +94,16 @@ fn add_ordered_connection(
         }
     }
 
+    if let Some(bridge) = &conn.bridge {
+        for port in &bridge.ports {
+            if let Some(conn) = find_connection(port, conns) {
+                add_ordered_connection(conn, conns, ordered);
+            } else if !ordered.contains(&conn.id) {
+                ordered.push(port.clone());
+            }
+        }
+    }
+
     if !ordered.contains(&conn.id) {
         ordered.push(conn.id.to_owned())
     }
@@ -119,13 +129,22 @@ fn default_connection(id: &str) -> NetworkConnection {
 #[cfg(test)]
 mod tests {
     use super::ordered_connections;
-    use crate::network::settings::{BondSettings, NetworkConnection};
+    use crate::network::settings::{BondSettings, BridgeSettings, NetworkConnection};
 
     #[test]
     fn test_ordered_connections() {
         let bond = NetworkConnection {
             id: "bond0".to_string(),
             bond: Some(BondSettings {
+                ports: vec!["eth0".to_string(), "eth1".to_string(), "eth3".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let bridge = NetworkConnection {
+            id: "br0".to_string(),
+            bridge: Some(BridgeSettings {
                 ports: vec!["eth0".to_string(), "eth1".to_string(), "eth3".to_string()],
                 ..Default::default()
             }),

--- a/rust/agama-lib/src/network/store.rs
+++ b/rust/agama-lib/src/network/store.rs
@@ -176,6 +176,18 @@ mod tests {
                 "bond0".to_string(),
                 "eth2".to_string()
             ]
+        );
+
+        let conns = vec![bridge];
+        let ordered = ordered_connections(&conns);
+        assert_eq!(
+            ordered,
+            vec![
+                "eth0".to_string(),
+                "eth1".to_string(),
+                "eth3".to_string(),
+                "br0".to_string()
+            ]
         )
     }
 }

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -236,6 +236,9 @@ impl NetworkState {
                 for conn in self.connections.iter_mut() {
                     if controlled.contains(&conn.uuid) {
                         conn.controller = Some(controller.uuid);
+                        if conn.interface.is_none() {
+                            conn.interface = Some(conn.clone().id);
+                        }
                     } else if conn.controller == Some(controller.uuid) {
                         conn.controller = None;
                     }

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -237,7 +237,7 @@ impl NetworkState {
                     if controlled.contains(&conn.uuid) {
                         conn.controller = Some(controller.uuid);
                         if conn.interface.is_none() {
-                            conn.interface = Some(conn.clone().id);
+                            conn.interface = Some(conn.id.clone());
                         }
                     } else if conn.controller == Some(controller.uuid) {
                         conn.controller = None;

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -23,7 +23,9 @@
 //! * This module contains the types that represent the network concepts. They are supposed to be
 //!   agnostic from the real network service (e.g., NetworkManager).
 use crate::error::NetworkStateError;
-use crate::settings::{BondSettings, IEEE8021XSettings, NetworkConnection, WirelessSettings};
+use crate::settings::{
+    BondSettings, BridgeSettings, IEEE8021XSettings, NetworkConnection, WirelessSettings,
+};
 use crate::types::{BondMode, ConnectionState, DeviceState, DeviceType, Status, SSID};
 use agama_utils::openapi::schemas;
 use cidr::IpInet;
@@ -625,6 +627,10 @@ impl TryFrom<NetworkConnection> for Connection {
             let config = BondConfig::try_from(bond_config)?;
             connection.config = config.into();
         }
+        if let Some(bridge_config) = conn.bridge {
+            let config = BridgeConfig::try_from(bridge_config)?;
+            connection.config = config.into();
+        }
 
         if let Some(ieee_8021x_config) = conn.ieee_8021x {
             connection.ieee_8021x_config = Some(IEEE8021XConfig::try_from(ieee_8021x_config)?);
@@ -692,6 +698,9 @@ impl TryFrom<Connection> for NetworkConnection {
             ConnectionConfig::Bond(config) => {
                 connection.bond = Some(BondSettings::try_from(config)?);
             }
+            ConnectionConfig::Bridge(config) => {
+                connection.bridge = Some(BridgeSettings::try_from(config)?);
+            }
             _ => {}
         }
 
@@ -718,6 +727,12 @@ pub enum PortConfig {
     #[default]
     None,
     Bridge(BridgePortConfig),
+}
+
+impl From<BridgeConfig> for ConnectionConfig {
+    fn from(value: BridgeConfig) -> Self {
+        Self::Bridge(value)
+    }
 }
 
 impl From<BondConfig> for ConnectionConfig {
@@ -1696,7 +1711,8 @@ impl TryFrom<BondConfig> for BondSettings {
 
 #[derive(Debug, Default, PartialEq, Clone, Serialize, utoipa::ToSchema)]
 pub struct BridgeConfig {
-    pub stp: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stp: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1709,6 +1725,49 @@ pub struct BridgeConfig {
     pub ageing_time: Option<u32>,
 }
 
+impl TryFrom<ConnectionConfig> for BridgeConfig {
+    type Error = NetworkStateError;
+
+    fn try_from(value: ConnectionConfig) -> Result<Self, Self::Error> {
+        match value {
+            ConnectionConfig::Bridge(config) => Ok(config),
+            _ => Err(NetworkStateError::UnexpectedConfiguration),
+        }
+    }
+}
+
+impl TryFrom<BridgeSettings> for BridgeConfig {
+    type Error = NetworkStateError;
+
+    fn try_from(settings: BridgeSettings) -> Result<Self, Self::Error> {
+        let stp = settings.stp;
+        let priority = settings.priority;
+        let forward_delay = settings.forward_delay;
+        let hello_time = settings.forward_delay;
+
+        Ok(BridgeConfig {
+            stp,
+            priority,
+            forward_delay,
+            hello_time,
+            ..Default::default()
+        })
+    }
+}
+
+impl TryFrom<BridgeConfig> for BridgeSettings {
+    type Error = NetworkStateError;
+
+    fn try_from(bridge: BridgeConfig) -> Result<Self, Self::Error> {
+        Ok(BridgeSettings {
+            stp: bridge.stp,
+            priority: bridge.priority,
+            forward_delay: bridge.forward_delay,
+            hello_time: bridge.hello_time,
+            ..Default::default()
+        })
+    }
+}
 #[derive(Debug, Default, PartialEq, Clone, Serialize, utoipa::ToSchema)]
 pub struct BridgePortConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/agama-network/src/nm/client.rs
+++ b/rust/agama-network/src/nm/client.rs
@@ -231,19 +231,9 @@ impl<'a> NetworkManagerClient<'a> {
         }
 
         for conn in connections.iter_mut() {
-            let Some(id) = controlled_by.get(&conn.uuid) else {
-                continue;
+            if controlled_by.contains_key(&conn.uuid) {
+                conn.controller = Some(conn.uuid);
             };
-
-            if let controller = conn.uuid {
-                conn.controller = Some(controller);
-            } else {
-                tracing::warn!(
-                    "Could not found a connection for the interface '{}' (required by connection '{}')",
-                    conn.uuid,
-                    conn.id
-                );
-            }
         }
 
         Ok(connections)

--- a/rust/agama-network/src/nm/client.rs
+++ b/rust/agama-network/src/nm/client.rs
@@ -231,16 +231,16 @@ impl<'a> NetworkManagerClient<'a> {
         }
 
         for conn in connections.iter_mut() {
-            let Some(conn_uuid) = controlled_by.get(&conn.uuid) else {
+            let Some(id) = controlled_by.get(&conn.uuid) else {
                 continue;
             };
 
-            if let Ok(controller) = Uuid::parse_str(&conn_uuid) {
+            if let controller = conn.uuid {
                 conn.controller = Some(controller);
             } else {
                 tracing::warn!(
                     "Could not found a connection for the interface '{}' (required by connection '{}')",
-                    conn_uuid,
+                    conn.uuid,
                     conn.id
                 );
             }

--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -547,7 +547,9 @@ fn bond_config_to_dbus(config: &BondConfig) -> HashMap<&str, zvariant::Value> {
 fn bridge_config_to_dbus(bridge: &BridgeConfig) -> HashMap<&str, zvariant::Value> {
     let mut hash = HashMap::new();
 
-    hash.insert("stp", bridge.stp.into());
+    if let Some(stp) = bridge.stp {
+        hash.insert("stp", stp.into());
+    }
     if let Some(prio) = bridge.priority {
         hash.insert("priority", prio.into());
     }
@@ -573,7 +575,7 @@ fn bridge_config_from_dbus(conn: &OwnedNestedHash) -> Result<Option<BridgeConfig
     };
 
     Ok(Some(BridgeConfig {
-        stp: get_property(bridge, "stp")?,
+        stp: get_optional_property(bridge, "stp")?,
         priority: get_optional_property(bridge, "priority")?,
         forward_delay: get_optional_property(bridge, "forward-delay")?,
         hello_time: get_optional_property(bridge, "hello-time")?,
@@ -1302,7 +1304,10 @@ mod test {
     use crate::{
         model::*,
         nm::{
-            dbus::{BOND_KEY, ETHERNET_KEY, INFINIBAND_KEY, WIRELESS_KEY, WIRELESS_SECURITY_KEY},
+            dbus::{
+                BOND_KEY, BRIDGE_KEY, ETHERNET_KEY, INFINIBAND_KEY, WIRELESS_KEY,
+                WIRELESS_SECURITY_KEY,
+            },
             error::NmError,
         },
     };

--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -80,6 +80,8 @@ pub fn connection_to_dbus<'a>(
             .as_deref()
             .unwrap_or(controller.id.as_str());
         connection_dbus.insert("master", master.into());
+        connection_dbus.remove("autoconnect");
+        connection_dbus.insert("autoconnect", false.into());
     } else {
         connection_dbus.insert("port-type", "".into());
         connection_dbus.insert("master", "".into());
@@ -122,6 +124,7 @@ pub fn connection_to_dbus<'a>(
         }
         ConnectionConfig::Bond(bond) => {
             connection_dbus.insert("type", BOND_KEY.into());
+            connection_dbus.insert("autoconnect-slaves", 1.into());
             if !connection_dbus.contains_key("interface-name") {
                 connection_dbus.insert("interface-name", conn.id.as_str().into());
             }
@@ -136,6 +139,7 @@ pub fn connection_to_dbus<'a>(
         }
         ConnectionConfig::Bridge(bridge) => {
             connection_dbus.insert("type", BRIDGE_KEY.into());
+            connection_dbus.insert("autoconnect-slaves", 1.into());
             result.insert(BRIDGE_KEY, bridge_config_to_dbus(bridge));
         }
         ConnectionConfig::Infiniband(infiniband) => {
@@ -265,7 +269,7 @@ fn is_bridge(conn: NestedHash) -> bool {
         }
     }
 
-    return false;
+    false
 }
 
 /// Cleans up the NestedHash that represents a connection.

--- a/rust/agama-network/src/settings.rs
+++ b/rust/agama-network/src/settings.rs
@@ -114,6 +114,35 @@ impl Default for BondSettings {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BridgeSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stp: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forward_delay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hello_time: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_age: Option<u32>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub ports: Vec<String>,
+}
+
+impl Default for BridgeSettings {
+    fn default() -> Self {
+        Self {
+            stp: None,
+            priority: None,
+            forward_delay: None,
+            hello_time: None,
+            max_age: None,
+            ports: vec![],
+        }
+    }
+}
+
 /// IEEE 802.1x (EAP) settings
 #[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -215,6 +244,9 @@ pub struct NetworkConnection {
     /// Bonding settings if part of a bond
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bond: Option<BondSettings>,
+    /// Bridge settings if part of a bridge
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge: Option<BridgeSettings>,
     /// MAC address of the connection's interface
     #[serde(rename = "mac-address", skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
@@ -250,6 +282,8 @@ impl NetworkConnection {
             DeviceType::Wireless
         } else if self.bond.is_some() {
             DeviceType::Bond
+        } else if self.bridge.is_some() {
+            DeviceType::Bridge
         } else {
             DeviceType::Ethernet
         }

--- a/rust/agama-network/src/system.rs
+++ b/rust/agama-network/src/system.rs
@@ -211,15 +211,12 @@ impl NetworkSystemClient {
 
     pub async fn set_ports(
         &self,
-        connection: Connection,
+        uuid: Uuid,
         ports: Vec<String>,
     ) -> Result<(), NetworkSystemError> {
         let (tx, rx) = oneshot::channel();
-        self.actions.send(Action::SetPorts(
-            connection.uuid,
-            Box::new(ports.clone()),
-            tx,
-        ))?;
+        self.actions
+            .send(Action::SetPorts(uuid, Box::new(ports.clone()), tx))?;
         let result = rx.await?;
         Ok(result?)
     }

--- a/rust/agama-network/src/system.rs
+++ b/rust/agama-network/src/system.rs
@@ -209,6 +209,21 @@ impl NetworkSystemClient {
         Ok(result?)
     }
 
+    pub async fn set_ports(
+        &self,
+        connection: Connection,
+        ports: Vec<String>,
+    ) -> Result<(), NetworkSystemError> {
+        let (tx, rx) = oneshot::channel();
+        self.actions.send(Action::SetPorts(
+            connection.uuid,
+            Box::new(ports.clone()),
+            tx,
+        ))?;
+        let result = rx.await?;
+        Ok(result?)
+    }
+
     /// Applies the network configuration.
     pub async fn apply(&self) -> Result<(), NetworkSystemError> {
         let (tx, rx) = oneshot::channel();

--- a/rust/agama-server/src/network/web.rs
+++ b/rust/agama-server/src/network/web.rs
@@ -259,8 +259,8 @@ async fn add_connection(
     State(state): State<NetworkServiceState>,
     Json(net_conn): Json<NetworkConnection>,
 ) -> Result<Json<Connection>, NetworkError> {
-    let bond = net_conn.clone().bond;
-    let bridge = net_conn.clone().bridge;
+    let bond = net_conn.bond.clone();
+    let bridge = net_conn.bridge.clone();
     let conn = Connection::try_from(net_conn)?;
     let id = conn.id.clone();
 
@@ -340,8 +340,8 @@ async fn update_connection(
         .get_connection(&id)
         .await?
         .ok_or_else(|| NetworkError::UnknownConnection(id.clone()))?;
-    let bond = conn.clone().bond;
-    let bridge = conn.clone().bridge;
+    let bond = conn.bond.clone();
+    let bridge = conn.bridge.clone();
 
     let mut conn = Connection::try_from(conn)?;
     if orig_conn.id != id {

--- a/rust/agama-server/src/network/web.rs
+++ b/rust/agama-server/src/network/web.rs
@@ -270,10 +270,10 @@ async fn add_connection(
         None => Err(NetworkError::CannotAddConnection(id.clone())),
         Some(conn) => {
             if let Some(bond) = bond {
-                state.network.set_ports(conn.clone(), bond.ports).await?;
+                state.network.set_ports(conn.uuid, bond.ports).await?;
             }
             if let Some(bridge) = bridge {
-                state.network.set_ports(conn.clone(), bridge.ports).await?;
+                state.network.set_ports(conn.uuid, bridge.ports).await?;
             }
             Ok(Json(conn))
         }
@@ -354,10 +354,10 @@ async fn update_connection(
     state.network.update_connection(conn.clone()).await?;
 
     if let Some(bond) = bond {
-        state.network.set_ports(conn.clone(), bond.ports).await?;
+        state.network.set_ports(conn.uuid, bond.ports).await?;
     }
     if let Some(bridge) = bridge {
-        state.network.set_ports(conn.clone(), bridge.ports).await?;
+        state.network.set_ports(conn.uuid, bridge.ports).await?;
     }
 
     Ok(StatusCode::NO_CONTENT)

--- a/rust/agama-server/src/web/docs/network.rs
+++ b/rust/agama-server/src/web/docs/network.rs
@@ -50,6 +50,7 @@ impl ApiDocBuilder for NetworkApiDocBuilder {
     fn components(&self) -> Components {
         ComponentsBuilder::new()
             .schema_from::<agama_lib::network::settings::BondSettings>()
+            .schema_from::<agama_lib::network::settings::BridgeSettings>()
             .schema_from::<agama_lib::network::settings::IEEE8021XSettings>()
             .schema_from::<agama_lib::network::settings::MatchSettings>()
             .schema_from::<agama_lib::network::settings::NetworkConnection>()

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May 14 15:20:42 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Add support for bridge connections (gh#openSUSE/agama#2258).
+
+-------------------------------------------------------------------
 Mon May 19 14:02:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when network events do not contain "addresses",


### PR DESCRIPTION
## Problem

Although there is a bridge model in the backend, there is no way to configure it through the CLI or through the HTTP api.

- https://trello.com/c/LoDehu4m/4559-1-agama-add-support-for-configuring-a-bridge


## Solution

Added bridge support similar to what was added for bonding in (https://github.com/agama-project/agama/pull/885) and also fix it because looks like we broke the bonding handling when moved to the HTTP Api (https://github.com/agama-project/agama/pull/1064).

An example of the json bridge configuration looks like:

```json
{
  "network": {
    "connections": [
      {
        "id": "Bridge0",
        "method4": "manual",
        "interface": "br0",
        "addresses": ["192.168.1.100/24"],
        "gateway4": "192.168.1.1",
        "nameservers": ["192.168.1.1"],
        "bridge": {
          "ports": ["eth0", "eth1"],
          "stp": false
        }
      }
    ]
  }
}
```

## Testing

- *Added a new unit test*
- *Tested manually*
