### PR TITLE
fix(rust): do not freeze when trying to use profiles in OEMDRV

### DIFF
--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -23,12 +23,7 @@ use anyhow::Context;
 use jsonschema::JSONSchema;
 use log::info;
 use serde_json;
-use std::{
-    fs::{self, File},
-    io::Write,
-    path::Path,
-    process::Command,
-};
+use std::{fs, io::Write, path::Path, process::Command};
 use tempfile::{tempdir, TempDir};
 use url::Url;
 
@@ -62,16 +57,6 @@ impl AutoyastProfileImporter {
             autoinst_json
         ))?;
         Ok(Self { content })
-    }
-
-    pub fn write(&self, mut file: impl Write) -> anyhow::Result<()> {
-        file.write_all(self.content.as_bytes())?;
-        Ok(())
-    }
-
-    pub fn write_file<P: AsRef<Path>>(&self, path: P) -> anyhow::Result<()> {
-        let mut file = File::create(path)?;
-        self.write(&mut file)
     }
 }
 

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -38,7 +38,7 @@ pub struct AutoyastProfileImporter {
 }
 
 impl AutoyastProfileImporter {
-    pub fn read(url: &Url) -> anyhow::Result<Self> {
+    pub async fn read(url: &Url) -> anyhow::Result<Self> {
         let path = url.path();
         if !path.ends_with(".xml") && !path.ends_with(".erb") && !path.ends_with('/') {
             let msg = format!("Unsupported AutoYaST format at {}", url);
@@ -49,9 +49,10 @@ impl AutoyastProfileImporter {
         const AUTOINST_JSON: &str = "autoinst.json";
 
         let tmp_dir = TempDir::with_prefix(TMP_DIR_PREFIX)?;
-        Command::new("agama-autoyast")
+        tokio::process::Command::new("agama-autoyast")
             .args([url.as_str(), &tmp_dir.path().to_string_lossy()])
             .status()
+            .await
             .context("Failed to run agama-autoyast")?;
 
         let autoinst_json = tmp_dir.path().join(AUTOINST_JSON);

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -50,6 +50,7 @@ impl AutoyastProfileImporter {
 
         let tmp_dir = TempDir::with_prefix(TMP_DIR_PREFIX)?;
         tokio::process::Command::new("agama-autoyast")
+            .env("YAST_SKIP_PROFILE_FETCH_ERROR", "1")
             .args([url.as_str(), &tmp_dir.path().to_string_lossy()])
             .status()
             .await

--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -224,7 +224,7 @@ async fn autoyast(
     }
 
     let url = Url::parse(query.url.as_ref().unwrap()).map_err(anyhow::Error::new)?;
-    let importer_res = AutoyastProfileImporter::read(&url);
+    let importer_res = AutoyastProfileImporter::read(&url).await;
     match importer_res {
         Ok(importer) => Ok(importer.content),
         Err(error) => {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 11 06:53:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Prevent agama-web-server from getting stuck in the POST
+  /api/profile/autoyast calls (gh#agama-project/agama#2259).
+- Temporarily disable AutoYaST profiles fetch errors.
+
+-------------------------------------------------------------------
 Thu Apr 10 20:24:06 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow to specify extra kernel parameters in profile


### PR DESCRIPTION
## Problem

The `agama-auto` service does not work after introducing some changes to make it possible to use the `agama profile` command from an remote system (see #2103). The call to the `POST /api/profile/autoyast` endpoint freezes the whole server.

## Solution

* Make the code that takes care of importing the AutoYaST profile async (`AutoyastImporter::read`).
* Temporarily disable AutoYaST fetch errors because now they are not properly handled in the `OEMDRV` feature (it does not pass the `YAST_SKIP_PROFILE_FETCH_ERROR` env-var). Consider this a temporary workaround to have a working development image again.