### PR TITLE
Extra kernel params

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -68,7 +68,7 @@
           "minimum": 0
         },
         "extraKernelParams": {
-          "title": "Specify additional kernel parameters that are added beside proposed ones.",
+          "title": "Specify additional kernel parameters that are added beside ones added by the installer.",
           "type": "string"
         }
       },

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -66,6 +66,10 @@
           "title": "Specify how long bootloader should wait on menu before going with default entry.",
           "type": "integer",
           "minimum": 0
+        },
+        "extraKernelParams": {
+          "title": "Specify additional kernel parameters that are added beside proposed ones.",
+          "type": "string"
         }
       },
       "oneOf": [

--- a/rust/agama-lib/src/bootloader/model.rs
+++ b/rust/agama-lib/src/bootloader/model.rs
@@ -36,7 +36,10 @@ pub struct BootloaderSettings {
 
 impl BootloaderSettings {
     pub fn to_option(self) -> Option<Self> {
-        if self.stop_on_boot_menu.is_none() && self.timeout.is_none() && self.extra_kernel_params.is_none() {
+        if self.stop_on_boot_menu.is_none()
+            && self.timeout.is_none()
+            && self.extra_kernel_params.is_none()
+        {
             None
         } else {
             Some(self)

--- a/rust/agama-lib/src/bootloader/model.rs
+++ b/rust/agama-lib/src/bootloader/model.rs
@@ -30,11 +30,13 @@ pub struct BootloaderSettings {
     pub stop_on_boot_menu: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_kernel_params: Option<String>,
 }
 
 impl BootloaderSettings {
     pub fn to_option(self) -> Option<Self> {
-        if self.stop_on_boot_menu.is_none() && self.timeout.is_none() {
+        if self.stop_on_boot_menu.is_none() && self.timeout.is_none() && self.extra_kernel_params.is_none() {
             None
         } else {
             Some(self)

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 10 20:24:06 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Allow to specify extra kernel parameters in profile
+  (jsc#PED-10810)
+
+-------------------------------------------------------------------
 Wed Apr  9 09:06:18 UTC 2025 - Martin Vidner <mvidner@suse.com>
 
 - Made `--api URL` work with `agama profile`

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 10 20:26:29 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Allow to specify extra kernel parameters for bootloader
+  (jsc#PED-10810)
+
+-------------------------------------------------------------------
 Wed Apr  9 06:52:58 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add auto-installation support for iSCSI

--- a/service/test/agama/storage/bootloader_test.rb
+++ b/service/test/agama/storage/bootloader_test.rb
@@ -45,8 +45,8 @@ describe Agama::Storage::Bootloader::Config do
 
     it "exports only what was previously set" do
       expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
-      config.load_json({ "timeout" => 10 }.to_json)
-      expect(config.to_json).to eq "{\"timeout\":10}"
+      config.load_json({ "timeout" => 10, "extraKernelParams" => "verbose" }.to_json)
+      expect(config.to_json).to eq "{\"timeout\":10,\"extraKernelParams\":\"verbose\"}"
     end
   end
 


### PR DESCRIPTION
## Problem
We have no problem, but some users can find useful to define additional kernel parameters for target system and it is currently not possible in agama.

- https://jira.suse.com/browse/PED-12592
- https://jira.suse.com/browse/AGM-149
- https://trello.com/c/FzwSWtdU/4562-1-allow-in-unattended-mode-to-provide-extra-kernel-parameters-for-target-system

## Solution

Implement solution for unattended mode.
For autoyast conversion, it is tracked at https://trello.com/c/ZGFCbPo8/1325-bootloader-error-reporting-custom-timeout-and-conversion-from-autoyast