### PR TITLE
add bootloader as mandatory pattern for SLES 16.0

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 11 13:02:30 UTC 2025 - Frederic Crozat <fcrozat@suse.com>
+
+- Ensure bootloader pattern is always installed on SLES 16.0
+  (bsc#1240015).
+
+-------------------------------------------------------------------
 Thu Mar 27 12:35:32 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Patterns from extensions are always displayed, the HA extension

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -66,6 +66,7 @@ software:
 
   mandatory_patterns:
     - enhanced_base
+    - bootloader
   optional_patterns: null # no optional pattern shared
   user_patterns:
     - cockpit


### PR DESCRIPTION
Ensure bootloader pattern is always installed on SLES 16.0 (bsc#1240015).
