### PR TITLE
fix(web): make hostname strings fully translatable

### DIFF
--- a/web/src/components/system/HostnamePage.test.tsx
+++ b/web/src/components/system/HostnamePage.test.tsx
@@ -100,7 +100,7 @@ describe("HostnamePage", () => {
         static: "",
       });
       screen.getByText("Success alert:");
-      screen.getByText("Hostname successfully updated.");
+      screen.getByText("Hostname successfully updated");
     });
   });
 
@@ -135,7 +135,7 @@ describe("HostnamePage", () => {
         static: "testing-server",
       });
       screen.getByText("Success alert:");
-      screen.getByText("Hostname successfully updated.");
+      screen.getByText("Hostname successfully updated");
     });
 
     it("renders an error when static hostname is selected but left empty", async () => {
@@ -163,7 +163,7 @@ describe("HostnamePage", () => {
       });
 
       screen.getByText("Warning alert:");
-      screen.getByText(/Something went wrong/);
+      screen.getByText(/Hostname could not be updated/);
     });
   });
 

--- a/web/src/components/system/HostnamePage.tsx
+++ b/web/src/components/system/HostnamePage.tsx
@@ -46,6 +46,7 @@ export default function HostnamePage() {
   const hasTransientHostname = isEmpty(staticHostname);
   const [success, setSuccess] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
   const [settingHostname, setSettingHostname] = useState(!hasTransientHostname);
   const [hostname, setHostname] = useState(staticHostname);
 
@@ -55,6 +56,7 @@ export default function HostnamePage() {
   const submit = async (e: SyntheticEvent) => {
     e.preventDefault();
     setError(null);
+    setRequestError(null);
     setSuccess(null);
 
     if (settingHostname && isEmpty(hostname)) {
@@ -63,10 +65,8 @@ export default function HostnamePage() {
     }
 
     updateHostname({ static: settingHostname ? hostname : "" })
-      .then(() => setSuccess("Hostname successfully updated."))
-      .catch(() =>
-        setError("Something went wrong while updating the hostname. Please, try again."),
-      );
+      .then(() => setSuccess(_("Hostname successfully updated")))
+      .catch(() => setRequestError(_("Hostname could not be updated")));
   };
 
   // TRANSLATORS: The title for a notification shown when the static hostname
@@ -99,6 +99,7 @@ export default function HostnamePage() {
 
         <Form id="hostnameForm" onSubmit={submit}>
           {success && <Alert variant="success" isInline title={success} />}
+          {requestError && <Alert variant="warning" isInline title={requestError} />}
           {error && (
             <Alert variant="warning" isInline title={_("Check the following before continuing")}>
               {error}


### PR DESCRIPTION
## Problem

@ancorgs detected and reported some not translatable strings at HostnamePage.tsx

>  \<ancorgs\> dgdavid: retrospective code review. These strings are not translatable https://github.com/agama-project/agama/blob/master/web/src/components/system/HostnamePage.tsx#L66


## Solution

Make them translatable and take the opportunity for avoid the usage of "please" word according to SUSE documentation style guide, https://documentation.suse.com/style/current/single-html/docu_styleguide/index.html#sec-vocabulary

## Notes

A new `setRequestError` has been added for simplicity, since it make no sense to render something like 

> **Check the following before continuing**
> 
> Hostname could not be updated.

Even when such an error will likely not happen. So, better to go for

> Hostname could not be updated

The presence or not presence of the dot at the end of the sentence it is also intentional: it's not used in titles

Of course, it is needed a better error reporting for forms to easily distinguish between validation warnings and request errors, but sadly Agama is not there at the time of sending this hotfix to make possible the translation of these texts. Thus, skipping further improvements in this form until such a goal can be achieved.

