### PR TITLE
feat(rust): replace --api option by --host

### DIFF
--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -58,10 +58,9 @@ use url::Url;
 /// Agama's CLI global options
 #[derive(Args)]
 pub struct GlobalOpts {
-    #[clap(long, default_value = "http://localhost/api")]
-    /// URI pointing to Agama's remote API. If not provided, default https://localhost/api is
-    /// used
-    pub api: String,
+    #[clap(long, default_value = "http://localhost")]
+    /// URI pointing to Agama's remote host. If not provided, default http://localhost is used
+    pub host: String,
 
     #[clap(long, default_value = "false")]
     /// Whether to accept invalid (self-signed, ...) certificates or not
@@ -248,10 +247,24 @@ async fn build_http_client(
     }
 }
 
+/// Build the API url from the host.
+///
+/// * `host`: ip or host name. The protocol is optional, using https if omitted (e.g, "myserver",
+/// "http://myserver", "192.168.100.101").
+fn api_url(host: String) -> String {
+    let sanitized_host = host.trim_end_matches('/').to_string();
+
+    if sanitized_host.starts_with("http://") || sanitized_host.starts_with("https://") {
+        format!("{}/api", sanitized_host)
+    } else {
+        format!("https://{}/api", sanitized_host)
+    }
+}
+
 pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
     // somehow check whether we need to ask user for self-signed certificate acceptance
 
-    let api_url = cli.opts.api.trim_end_matches('/').to_string();
+    let api_url = api_url(cli.opts.host);
 
     match cli.command {
         Commands::Config(subcommand) => {

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -59,7 +59,9 @@ use url::Url;
 #[derive(Args)]
 pub struct GlobalOpts {
     #[clap(long, default_value = "http://localhost")]
-    /// URI pointing to Agama's remote host. If not provided, default http://localhost is used
+    /// URI pointing to Agama's remote host.
+    ///
+    /// Examples: https://my-server.lan my-server.local localhost:10443
     pub host: String,
 
     #[clap(long, default_value = "false")]

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr 16 05:40:39 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Replace --api option by --host (gh#agama-project/agama#2271).
+
+-------------------------------------------------------------------
 Fri Apr 11 06:53:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Prevent agama-web-server from getting stuck in the POST


### PR DESCRIPTION
## Problem

The CLI allows connecting to a different server by using the `--api <URL>` option, but that URL differs from the URL you use in the browser (*https://localhost* vs *https://localhost/api*). Ideally, the same URL should be used for both CLI and browser clients.

## Solution

The `--api` option is replaced by `--host`, which allows indicating a host name or IP address without the */api* suffix. The protocol is optional, using *https* if omitted. The default host is *http://localhost*.

Examples:

~~~
$ agama --host https://my-server.lan config show
$ agama --host my-server.lan config show
$ agama --host 192.168.100.101 config show
~~~

## Documentation

mvidner:
The `--api` option is only once mentioned in a blog post, nothing to adjust IMHO.
Put the examples directly in the --help` output (long only, not for `-h`)

