### PR TITLE
fix(rust): document finish options

### DIFF
--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -114,7 +114,7 @@ pub enum Commands {
     Finish {
         /// What to do after finishing the installation. Possible values:
         ///
-        /// stop - do not reboot and the system continues running.
+        /// stop - do not reboot and the Agama backend continues running.
         ///
         /// reboot - reboot into the installed system.
         ///

--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -110,14 +110,17 @@ pub enum Commands {
         /// File name
         destination: PathBuf,
     },
-    /// Finish the installation rebooting the system by default.
-    ///
-    /// This command finishes the installation by performing a set of tasks and rebooting the system by
-    /// default if the installation is completed successfully.
-    ///
-    /// Optionally an argument can be given for determining whether the system should be rebooted,
-    /// poweroff, halt or just stop at the of the installation. Values: [stop|reboot|poweroff|halt]
+    /// Finish the installation.
     Finish {
+        /// What to do after finishing the installation. Possible values:
+        ///
+        /// stop - do not reboot and the system continues running.
+        ///
+        /// reboot - reboot into the installed system.
+        ///
+        /// halt - halt the installed machine.
+        ///
+        /// poweroff - poweroff the installed machine.
         #[clap(default_value = "reboot")]
         method: Option<FinishMethod>,
     },

--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -120,7 +120,7 @@ pub enum Commands {
         ///
         /// halt - halt the installed machine.
         ///
-        /// poweroff - poweroff the installed machine.
+        /// poweroff - power off the installed machine.
         #[clap(default_value = "reboot")]
         method: Option<FinishMethod>,
     },

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr 16 10:45:33 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Add missing help to finish command (gh#agama-project/agama#2272).
+
+-------------------------------------------------------------------
 Wed Apr 16 05:40:39 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Replace --api option by --host (gh#agama-project/agama#2271).

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -28,6 +28,9 @@ mod tasks {
         Ok(())
     }
 
+    const GENERATED: &'static str =
+        "---\nNOTE: This documentation is generated. Run `cargo xtask markdown` to update it.\n";
+
     /// Generate Agama's CLI documentation in markdown format.
     pub fn generate_markdown() -> std::io::Result<()> {
         let out_dir = create_output_dir("markdown")?;
@@ -40,6 +43,7 @@ mod tasks {
         let filename = out_dir.join("agama.md");
         let mut file = File::create(&filename)?;
         file.write_all(markdown.as_bytes())?;
+        file.write_all(GENERATED.as_bytes())?;
 
         println!("Generate Markdown documentation at {}.", filename.display());
         Ok(())


### PR DESCRIPTION
## Problem

The explanation about the possible options of the `agama finish` command was manually added to the Agama CLI documentation, see https://github.com/agama-project/agama-project.github.io/pull/50/files. This implies that:

* `agama finish --help` does not contain such as explanation.
* The documentation has to be manually restored after updating `cli.md` with the `cargo xtask markdown` output.

## Solution

Extend the `agama finish` help.
