### PR TITLE
(Hacky) Improvements at the storage menus

### DIFF
--- a/web/src/components/storage/ConfigureDeviceMenu.test.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.test.tsx
@@ -73,6 +73,7 @@ const mockAddDriveFn = jest.fn();
 jest.mock("~/queries/storage", () => ({
   ...jest.requireActual("~/queries/storage"),
   useAvailableDevices: () => [vda, vdb],
+  useLongestDiskTitle: () => 20,
 }));
 
 jest.mock("~/queries/storage/config-model", () => ({

--- a/web/src/components/storage/ConfigureDeviceMenu.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.tsx
@@ -25,7 +25,7 @@ import { useNavigate } from "react-router-dom";
 import { Split, Flex, Label, Divider } from "@patternfly/react-core";
 import MenuButton, { MenuButtonItem } from "~/components/core/MenuButton";
 import MenuDeviceDescription from "./MenuDeviceDescription";
-import { useAvailableDevices } from "~/queries/storage";
+import { useAvailableDevices, useLongestDiskTitle } from "~/queries/storage";
 import { useConfigModel, useModel } from "~/queries/storage/config-model";
 import { deviceLabel } from "~/components/storage/utils";
 import { STORAGE as PATHS } from "~/routes/paths";
@@ -115,6 +115,7 @@ export default function ConfigureDeviceMenu(): React.ReactNode {
   const drivesNames = model.drives.map((d) => d.name);
   const drivesCount = drivesNames.length;
   const devices = allDevices.filter((d) => !drivesNames.includes(d.name));
+  const longestTitle = useLongestDiskTitle();
 
   const lvmDescription = allDevices.length
     ? _("Define a new LVM on top of one or several disks")
@@ -124,7 +125,7 @@ export default function ConfigureDeviceMenu(): React.ReactNode {
     <MenuButton
       menuProps={{
         "aria-label": _("Configure device menu"),
-        popperProps: { minWidth: "300px", width: "max-content" },
+        popperProps: { minWidth: `min(${longestTitle * 0.75}em, 75vw)`, width: "max-content" },
       }}
       items={[
         <DisksDrillDownMenuItem

--- a/web/src/components/storage/ConfigureDeviceMenu.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.tsx
@@ -79,7 +79,7 @@ const DisksDrillDownMenuItem = ({
           onClick={() => onDeviceClick(device.name)}
         >
           <Split hasGutter>
-            {deviceLabel(device)}
+            {deviceLabel(device, true)}
             <Flex columnGap={{ default: "columnGapXs" }}>
               {device.systems.map((s, i) => (
                 <Label key={i} isCompact>

--- a/web/src/components/storage/DriveDeviceMenu.tsx
+++ b/web/src/components/storage/DriveDeviceMenu.tsx
@@ -24,7 +24,7 @@ import React from "react";
 import { Split, Flex, Label } from "@patternfly/react-core";
 import MenuButton, { MenuButtonItem } from "~/components/core/MenuButton";
 import MenuDeviceDescription from "./MenuDeviceDescription";
-import { useAvailableDevices } from "~/queries/storage";
+import { useAvailableDevices, useLongestDiskTitle } from "~/queries/storage";
 import { useDrive, useModel } from "~/queries/storage/config-model";
 import { useDrive as useDriveModel } from "~/hooks/storage/drive";
 import { useConvertToVolumeGroup } from "~/hooks/storage/volume-group";
@@ -368,12 +368,13 @@ export default function DriveDeviceMenu({
   const changeDriveTarget = (newDriveName: string) => {
     driveHandler.switch(newDriveName);
   };
+  const longestTitle = useLongestDiskTitle();
 
   return (
     <MenuButton
       menuProps={{
         "aria-label": sprintf(_("Device %s menu"), drive.name),
-        popperProps: { minWidth: "300px", width: "max-content" },
+        popperProps: { minWidth: `min(${longestTitle * 0.75}em, 75vw)`, width: "max-content" },
       }}
       toggleProps={{
         className: "agm-inline-toggle",

--- a/web/src/components/storage/DriveDeviceMenu.tsx
+++ b/web/src/components/storage/DriveDeviceMenu.tsx
@@ -36,6 +36,7 @@ import { sprintf } from "sprintf-js";
 import { _, n_, formatList } from "~/i18n";
 
 const driveBaseName = (device: StorageDevice): string => deviceBaseName(device, true);
+const driveLabel = (device: StorageDevice): string => deviceLabel(device, true);
 
 const UseOnlyOneOption = (drive: apiModel.Drive): boolean => {
   const driveModel = useDrive(drive.name);
@@ -53,7 +54,7 @@ const DiskSelectorTitle = ({
   device,
   isSelected = false,
 }: DiskSelectorTitleProps): React.ReactNode => {
-  const Name = () => (isSelected ? <b>{deviceLabel(device)}</b> : deviceLabel(device));
+  const Name = () => (isSelected ? <b>{driveLabel(device)}</b> : driveLabel(device));
   const Systems = () => (
     <Flex columnGap={{ default: "columnGapXs" }}>
       {device.systems.map((s, i) => (
@@ -388,7 +389,7 @@ export default function DriveDeviceMenu({
         <RemoveDriveOption key="delete-disk-option" drive={drive} />,
       ]}
     >
-      {<b>{deviceLabel(selected, true)}</b>}
+      {<b>{driveLabel(selected)}</b>}
     </MenuButton>
   );
 }

--- a/web/src/components/storage/DriveEditor.test.tsx
+++ b/web/src/components/storage/DriveEditor.test.tsx
@@ -169,6 +169,7 @@ jest.mock("~/queries/storage", () => ({
   useAvailableDevices: () => [sda],
   useVolume: (mountPath: string): Volume =>
     [volume1, volume2, volume3].find((v) => v.mountPath === mountPath),
+  useLongestDiskTitle: () => 20,
 }));
 
 jest.mock("~/queries/storage/config-model", () => ({

--- a/web/src/queries/storage.ts
+++ b/web/src/queries/storage.ts
@@ -40,6 +40,7 @@ import { useInstallerClient } from "~/context/installer";
 import { config, apiModel, ProductParams, Volume } from "~/api/storage/types";
 import { Action, StorageDevice } from "~/types/storage";
 import { QueryHookOptions } from "~/types/queries";
+import { deviceLabel } from "~/components/storage/utils";
 
 const configQuery = {
   queryKey: ["storage", "config"],
@@ -170,6 +171,30 @@ const useAvailableDevices = (): StorageDevice[] => {
   }, [devices, usableDevices]);
 
   return availableDevices;
+};
+
+/**
+ * Temporary hook that calculates the longest string the UI could need to use to identify a disk.
+ *
+ * FIXME: This is part of a very hacky solution used to enforce the width of the drill-down menus.
+ * That is needed because our MenuButton widget is somehow buggy and it cannot properly set the
+ * width of its elements. This hook is totally coupled to the format used in those menus to
+ * represent the devices (with a first line including name, size and operating systems).
+ */
+const useLongestDiskTitle = (): number => {
+  const availableDevices = useAvailableDevices();
+
+  const longest = useMemo(() => {
+    const titles = availableDevices.map((dev) => {
+      const label = deviceLabel(dev, true).length;
+      const systems = dev.systems.join(" ").length;
+      return label + systems;
+    });
+
+    return Math.max(...titles);
+  }, [availableDevices]);
+
+  return longest;
 };
 
 /**
@@ -323,4 +348,5 @@ export {
   useDeprecated,
   useDeprecatedChanges,
   useReprobeMutation,
+  useLongestDiskTitle,
 };


### PR DESCRIPTION
## Problem

We recently introduced a `MenuButton` component that offers menus with a drill-down sub-menu. We use it to allow the user to select a given disk.

But that component does not calculate the width of the drill-down menu based on its content. Instead it takes the width of the parent menu entry (which may not be the longest menu entry on its own level of menus). See how that's a problem here for the second disk because the text "Select a disk to configure" is too short and that entry does not contain any description to make the entry longer.

![broken](https://github.com/user-attachments/assets/e1404cca-df27-420f-9048-8c0e846673b3)

## Solution

This introduces a dirty hack to make sure the submenus used to select a disk are not too small. See how the drill-menus are now big enough to accommodate all disks.

![fixed](https://github.com/user-attachments/assets/483f5fab-f28a-4a4d-9170-6d8ec5cafe0c)

Additionally, this introduces truncation of device names for those drill-down submenus. Just to help to keep everything under control.

## Testing

This is a purely visual thing, so tested manually as proven by the GIFs.
