### PR TITLE
Added NetworkManager config server as mandatory package for SLES and SLES SAP

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 22 14:27:59 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Add NetworkManager-config-server package to SLES 16.0 and 
+  SLES_SAP 16.0 as mandatory (bsc#1241224, bsc#1224868).
+
+-------------------------------------------------------------------
 Tue Apr 22 14:14:53 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 14

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -88,6 +88,7 @@ software:
     - gnome
   mandatory_packages:
     - NetworkManager
+    # bsc#1241224, bsc#1224868 avoid probe DHCP over all ethernet devices and ignore carrier
     - NetworkManager-config-server
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_packages: null

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -88,6 +88,7 @@ software:
     - gnome
   mandatory_packages:
     - NetworkManager
+    - NetworkManager-config-server
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_packages: null
   base_product: SLES

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -42,6 +42,7 @@ software:
     - sles_sap_gui
   mandatory_packages:
     - NetworkManager
+    # bsc#1241224, bsc#1224868 avoid probe DHCP over all ethernet devices and ignore carrier
     - NetworkManager-config-server
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_packages: null

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -42,6 +42,7 @@ software:
     - sles_sap_gui
   mandatory_packages:
     - NetworkManager
+    - NetworkManager-config-server
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_packages: null
   base_product: SLES_SAP


### PR DESCRIPTION
## Problem

It was agreed to install the NetworkManager config server package for both products avoiding the ethernet devices probing and automatic configuration.

- https://bugzilla.suse.com/show_bug.cgi?id=1241224

## Solution

Define the NetworkManager-config-server package as mandatory for SLES-16 and SLES_SAP-16. (see also #2291)