### PR TITLE
Fixed broken Web UI after registering the product from CLI

### DIFF
--- a/rust/agama-lib/src/product/store.rs
+++ b/rust/agama-lib/src/product/store.rs
@@ -23,6 +23,7 @@ use super::{ProductHTTPClient, ProductSettings};
 use crate::base_http_client::BaseHTTPClient;
 use crate::error::ServiceError;
 use crate::manager::http_client::ManagerHTTPClient;
+use std::{thread, time};
 
 /// Loads and stores the product settings from/to the D-Bus service.
 pub struct ProductStore {
@@ -76,6 +77,17 @@ impl ProductStore {
         }
         if let Some(reg_code) = &settings.registration_code {
             let email = settings.registration_email.as_deref().unwrap_or("");
+
+            if probe {
+                // give the UI a short time for processing the events related to changing the
+                // product before starting registration because it triggers another pile of events
+                // in the Web UI as well (workaround for gh#agama-project#2274)
+                // even 1 second should be enough, but rather be safe and use 5s for slow networks,
+                // in autoinstallation it does not hurt
+                let delay = time::Duration::from_secs(5);
+                thread::sleep(delay);
+            }
+
             self.product_client.register(reg_code, email).await?;
             // TODO: avoid reprobing if the system has been already registered with the same code?
             probe = true;

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 22 11:16:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- CLI: wait a bit between selecting the product to install and
+  registering it so the Web UI has enough time to process all
+  events (gh#agama-project/agama#2274)
+
+-------------------------------------------------------------------
 Mon Apr 21 13:42:13 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow to log in into multiple systems (gh#agama-project/agama#2261).

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 22 11:18:03 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Process the product changed event so the UI can better react on
+  registering the product shortly after that
+  (gh#agama-project/agama#2274)
+
+-------------------------------------------------------------------
 Mon Apr 21 12:37:20 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rework the network page to (gh#agama-project/agama#2247):

--- a/web/src/queries/status.ts
+++ b/web/src/queries/status.ts
@@ -26,6 +26,7 @@ import { fetchInstallerStatus } from "~/api/status";
 import { useInstallerClient } from "~/context/installer";
 import { InstallerStatus } from "~/types/status";
 import { QueryHookOptions } from "~/types/queries";
+import { selectedProductQuery } from "./software";
 
 const MANAGER_SERVICE = "org.opensuse.Agama.Manager1";
 
@@ -80,6 +81,10 @@ const useInstallerStatusChanges = () => {
 
       if (type === "IssuesChanged") {
         queryClient.invalidateQueries({ queryKey: ["status"] });
+      }
+
+      if (event.type === "ProductChanged") {
+        queryClient.invalidateQueries({ queryKey: selectedProductQuery().queryKey });
       }
     });
   });


### PR DESCRIPTION
## Problem

- When registering the product from CLI (or using autoinstallation) the Web UI gets broken and displays an empty screen
- It happens only in the Firefox browser (does not not matter whether locally or remotely), Chromium/Chrome work fine
- #2274 

[agama-auto-registration-broken.webm](https://github.com/user-attachments/assets/50cc3efc-0171-4592-bce9-0f41a2404caa)

<details>
<summary>Firefox console log</summary>

```
Too many calls to Location or History APIs within a short timeframe. router.js:377:20
Too many calls to Location or History APIs within a short timeframe. router.js:388:22
Uncaught (in promise) DOMException: The operation is insecure.
    push router.js:388
    ve router.js:1739
    <anonymous> router.js:2215
    Ee router.js:2015
    n router.js:1862
    o index.js:917
    Ct index.js:1152
    React 3
    O scheduler.production.min.js:13
    D scheduler.production.min.js:14
index.js:2
Too many calls to Location or History APIs within a short timeframe. router.js:377:20
Too many calls to Location or History APIs within a short timeframe. router.js:388:22
Uncaught (in promise) DOMException: The operation is insecure.
    push router.js:388
    ve router.js:1739
    <anonymous> router.js:2215
    Ee router.js:2015
    n router.js:1862
    o index.js:917
    Ct index.js:1152
    React 11
    ql notifyManager.js:55
    n notifyManager.js:7
    batch notifyManager.js:29
    batch notifyManager.js:28
    r notifyManager.js:10
    batch notifyManager.js:27
    setTimeout handler*Gl notifyManager.js:2
    batch notifyManager.js:26
    batch notifyManager.js:44
    #s query.js:345
    setData query.js:52
    onSuccess query.js:247
    s retryer.js:45
    promise callback*f retryer.js:84
    start retryer.js:121
    fetch query.js:275
    #A queryObserver.js:179
    onSubscribe queryObserver.js:56
    subscribe subscribable.js:9
    Qs useBaseQuery.js:59
    React 12
    ql notifyManager.js:55
    n notifyManager.js:7
    batch notifyManager.js:29
    batch notifyManager.js:28
    r notifyManager.js:10
    batch notifyManager.js:27
    setTimeout handler*Gl notifyManager.js:2
    batch notifyManager.js:26
    batch notifyManager.js:44
    #s query.js:345
    setData query.js:52
    setQueryData queryClient.js:103
    ch status.ts:69
    dispatchEvent ws.ts:166
    dispatchEvent ws.ts:166
    onmessage ws.ts:82
index.js:2
```
</details>

## Solution

- It seems that the CLI tool is sending the changes too quickly so the Web UI uses History API a lot and Firefox browser denies the access. Add a short delay between selecting the product and registering it. In the web UI you cannot register until the UI processes all events and updates the screen, that takes some time. The CLI can send the requests much faster.
- Handle the changed product event in Web UI, that helps to process it before registering the product so less events happen later. (It would be processed when registering the product but there would be too many events in a short time frame.)

## Testing

- Tested manually, works fine:

[agama-auto-registration-fixed.webm](https://github.com/user-attachments/assets/9b4604c2-9252-4edb-875c-fa67d484c314)

