### PR TITLE
Include kernel-default-optional in the Live ISO to support more hardware (bsc#1241099)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 23 05:47:23 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Include the kernel-default-optional package in the Live ISO
+  to support more hardware (bsc#1241099)
+
+-------------------------------------------------------------------
 Tue Apr 22 14:14:54 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 14

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -187,6 +187,7 @@
         <package name="staging-build-key"/>
         <package name="openSUSE-build-key"/>
         <package name="kernel-default-extra"/>
+        <package name="kernel-default-optional"/>
     </packages>
     <packages type="image" profiles="Leap_16.0">
         <package name="MozillaFirefox-branding-openSUSE"/>
@@ -213,6 +214,7 @@
     <packages type="image" profiles="SUSE_SLE_16,SUSE_SLE_16_PXE">
         <package name="MozillaFirefox-branding-SLE"/>
         <package name="kernel-default-extra"/>
+        <package name="kernel-default-optional"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
## Problem

- The `pl330.ko` driver is missing in the Live ISO
- See https://bugzilla.suse.com/show_bug.cgi?id=1241099

## Solution

- That driver is in SLE16/Leap16 in a separate `kernel-default-optional` package (in Tumbleweed that package does not exist and the drivers are part of the `kernel-default` package.)


## Testing

- Tested manually

<details>
 <summary>These drivers were added to the x86_64 Live ISO:</summary>

```diff
--- drivers_default	2025-04-22 17:49:14.154427895 +0200
+++ drivers_optional	2025-04-22 17:48:56.250557620 +0200
@@ -13,6 +13,7 @@
 kernel/arch/x86/crypto/chacha-x86_64.ko
 kernel/arch/x86/crypto/crc32c-intel.ko
 kernel/arch/x86/crypto/crc32-pclmul.ko
+kernel/arch/x86/crypto/crct10dif-pclmul.ko
 kernel/arch/x86/crypto/curve25519-x86_64.ko
 kernel/arch/x86/crypto/des3_ede-x86_64.ko
 kernel/arch/x86/crypto/ghash-clmulni-intel.ko
@@ -53,6 +54,7 @@
 kernel/crypto/async_tx/async_raid6_recov.ko
 kernel/crypto/async_tx/async_tx.ko
 kernel/crypto/async_tx/async_xor.ko
+kernel/crypto/async_tx/raid6test.ko
 kernel/crypto/authencesn.ko
 kernel/crypto/authenc.ko
 kernel/crypto/blake2b_generic.ko
@@ -160,6 +162,8 @@
 kernel/drivers/base/regmap/regmap-sdw.ko
 kernel/drivers/base/regmap/regmap-sdw-mbq.ko
 kernel/drivers/base/regmap/regmap-spi.ko
+kernel/drivers/base/regmap/regmap-spmi.ko
+kernel/drivers/base/regmap/regmap-w1.ko
 kernel/drivers/bcma/bcma.ko
 kernel/drivers/block/aoe/aoe.ko
 kernel/drivers/block/brd.ko
@@ -208,6 +212,7 @@
 kernel/drivers/firmware/edd.ko
 kernel/drivers/firmware/efi/capsule-loader.ko
 kernel/drivers/firmware/efi/efibc.ko
+kernel/drivers/firmware/efi/efi-pstore.ko
 kernel/drivers/firmware/iscsi_ibft.ko
 kernel/drivers/firmware/qemu_fw_cfg.ko
 kernel/drivers/fpga/dfl.ko
@@ -222,6 +227,7 @@
 kernel/drivers/gpio/gpio-amd8111.ko
 kernel/drivers/gpio/gpio-amd-fch.ko
 kernel/drivers/gpio/gpio-amdpt.ko
+kernel/drivers/gpio/gpio-cros-ec.ko
 kernel/drivers/gpio/gpio-dln2.ko
 kernel/drivers/gpio/gpio-ds4520.ko
 kernel/drivers/gpio/gpio-elkhartlake.ko
@@ -235,6 +241,7 @@
 kernel/drivers/gpio/gpio-ich.ko
 kernel/drivers/gpio/gpio-idio-16.ko
 kernel/drivers/gpio/gpio-it87.ko
+kernel/drivers/gpio/gpio-kempld.ko
 kernel/drivers/gpio/gpio-latch.ko
 kernel/drivers/gpio/gpio-ljca.ko
 kernel/drivers/gpio/gpio-lp3943.ko
@@ -280,10 +287,13 @@
 kernel/drivers/gpu/drm/drm_ttm_helper.ko
 kernel/drivers/gpu/drm/drm_vram_helper.ko
 kernel/drivers/gpu/drm/gma500/gma500_gfx.ko
+kernel/drivers/gpu/drm/gud/gud.ko
 kernel/drivers/gpu/drm/hisilicon/hibmc/hibmc-drm.ko
 kernel/drivers/gpu/drm/hyperv/hyperv_drm.ko
 kernel/drivers/gpu/drm/i2c/ch7006.ko
 kernel/drivers/gpu/drm/i2c/sil164.ko
+kernel/drivers/gpu/drm/i2c/tda9950.ko
+kernel/drivers/gpu/drm/i2c/tda998x.ko
 kernel/drivers/gpu/drm/i915/i915.ko
 kernel/drivers/gpu/drm/i915/kvmgt.ko
 kernel/drivers/gpu/drm/mgag200/mgag200.ko
@@ -295,6 +305,9 @@
 kernel/drivers/gpu/drm/qxl/qxl.ko
 kernel/drivers/gpu/drm/radeon/radeon.ko
 kernel/drivers/gpu/drm/scheduler/gpu-sched.ko
+kernel/drivers/gpu/drm/solomon/ssd130x-i2c.ko
+kernel/drivers/gpu/drm/solomon/ssd130x.ko
+kernel/drivers/gpu/drm/solomon/ssd130x-spi.ko
 kernel/drivers/gpu/drm/tiny/bochs.ko
 kernel/drivers/gpu/drm/tiny/cirrus.ko
 kernel/drivers/gpu/drm/tiny/gm12u320.ko
@@ -312,7 +325,9 @@
 kernel/drivers/gpu/drm/vboxvideo/vboxvideo.ko
 kernel/drivers/gpu/drm/vgem/vgem.ko
 kernel/drivers/gpu/drm/virtio/virtio-gpu.ko
+kernel/drivers/gpu/drm/vkms/vkms.ko
 kernel/drivers/gpu/drm/vmwgfx/vmwgfx.ko
+kernel/drivers/gpu/drm/xen/drm_xen_front.ko
 kernel/drivers/gpu/drm/xe/xe.ko
 kernel/drivers/hid/amd-sfh-hid/amd_sfh.ko
 kernel/drivers/hid/hid-a4tech.ko
@@ -332,6 +347,7 @@
 kernel/drivers/hid/hid-corsair.ko
 kernel/drivers/hid/hid-cougar.ko
 kernel/drivers/hid/hid-cp2112.ko
+kernel/drivers/hid/hid-creative-sb0540.ko
 kernel/drivers/hid/hid-cypress.ko
 kernel/drivers/hid/hid-dr.ko
 kernel/drivers/hid/hid-elan.ko
@@ -340,11 +356,14 @@
 kernel/drivers/hid/hid-emsff.ko
 kernel/drivers/hid/hid-evision.ko
 kernel/drivers/hid/hid-ezkey.ko
+kernel/drivers/hid/hid-ft260.ko
 kernel/drivers/hid/hid-gaff.ko
 kernel/drivers/hid/hid-gembird.ko
 kernel/drivers/hid/hid-generic.ko
 kernel/drivers/hid/hid-gfrm.ko
+kernel/drivers/hid/hid-glorious.ko
 kernel/drivers/hid/hid-goodix-spi.ko
+kernel/drivers/hid/hid-google-hammer.ko
 kernel/drivers/hid/hid-google-stadiaff.ko
 kernel/drivers/hid/hid-gt683r.ko
 kernel/drivers/hid/hid-gyration.ko
@@ -362,6 +381,7 @@
 kernel/drivers/hid/hid-led.ko
 kernel/drivers/hid/hid-lenovo.ko
 kernel/drivers/hid/hid-letsketch.ko
+kernel/drivers/hid/hid-lg-g15.ko
 kernel/drivers/hid/hid-logitech-dj.ko
 kernel/drivers/hid/hid-logitech-hidpp.ko
 kernel/drivers/hid/hid-logitech.ko
@@ -369,11 +389,13 @@
 kernel/drivers/hid/hid-magicmouse.ko
 kernel/drivers/hid/hid-maltron.ko
 kernel/drivers/hid/hid-mcp2200.ko
+kernel/drivers/hid/hid-mcp2221.ko
 kernel/drivers/hid/hid-megaworld.ko
 kernel/drivers/hid/hid-mf.ko
 kernel/drivers/hid/hid-microsoft.ko
 kernel/drivers/hid/hid-monterey.ko
 kernel/drivers/hid/hid-multitouch.ko
+kernel/drivers/hid/hid-nintendo.ko
 kernel/drivers/hid/hid-nti.ko
 kernel/drivers/hid/hid-ntrig.ko
 kernel/drivers/hid/hid-nvidia-shield.ko
@@ -382,8 +404,11 @@
 kernel/drivers/hid/hid-petalynx.ko
 kernel/drivers/hid/hid-picolcd.ko
 kernel/drivers/hid/hid-plantronics.ko
+kernel/drivers/hid/hid-playstation.ko
 kernel/drivers/hid/hid-pl.ko
 kernel/drivers/hid/hid-primax.ko
+kernel/drivers/hid/hid-pxrc.ko
+kernel/drivers/hid/hid-razer.ko
 kernel/drivers/hid/hid-redragon.ko
 kernel/drivers/hid/hid-retrode.ko
 kernel/drivers/hid/hid-rmi.ko
@@ -401,14 +426,17 @@
 kernel/drivers/hid/hid-roccat-savu.ko
 kernel/drivers/hid/hid-saitek.ko
 kernel/drivers/hid/hid-samsung.ko
+kernel/drivers/hid/hid-semitek.ko
 kernel/drivers/hid/hid-sensor-custom.ko
 kernel/drivers/hid/hid-sensor-hub.ko
+kernel/drivers/hid/hid-sigmamicro.ko
 kernel/drivers/hid/hid-sjoy.ko
 kernel/drivers/hid/hid-sony.ko
 kernel/drivers/hid/hid-speedlink.ko
 kernel/drivers/hid/hid-steam.ko
 kernel/drivers/hid/hid-steelseries.ko
 kernel/drivers/hid/hid-sunplus.ko
+kernel/drivers/hid/hid-thrustmaster.ko
 kernel/drivers/hid/hid-tivo.ko
 kernel/drivers/hid/hid-tmff.ko
 kernel/drivers/hid/hid-topre.ko
@@ -418,9 +446,13 @@
 kernel/drivers/hid/hid-uclogic.ko
 kernel/drivers/hid/hid-udraw-ps3.ko
 kernel/drivers/hid/hid-viewsonic.ko
+kernel/drivers/hid/hid-vivaldi-common.ko
+kernel/drivers/hid/hid-vivaldi.ko
+kernel/drivers/hid/hid-vrc2.ko
 kernel/drivers/hid/hid-waltop.ko
 kernel/drivers/hid/hid-wiimote.ko
 kernel/drivers/hid/hid-winwing.ko
+kernel/drivers/hid/hid-xiaomi.ko
 kernel/drivers/hid/hid-xinmo.ko
 kernel/drivers/hid/hid-zpff.ko
 kernel/drivers/hid/hid-zydacron.ko
@@ -431,6 +463,9 @@
 kernel/drivers/hid/intel-ish-hid/intel-ishtp-hid.ko
 kernel/drivers/hid/intel-ish-hid/intel-ishtp.ko
 kernel/drivers/hid/intel-ish-hid/intel-ishtp-loader.ko
+kernel/drivers/hid/surface-hid/surface_hid_core.ko
+kernel/drivers/hid/surface-hid/surface_hid.ko
+kernel/drivers/hid/surface-hid/surface_kbd.ko
 kernel/drivers/hid/uhid.ko
 kernel/drivers/hid/usbhid/usbhid.ko
 kernel/drivers/hid/wacom.ko
@@ -438,6 +473,7 @@
 kernel/drivers/hv/hv_utils.ko
 kernel/drivers/hv/hv_vmbus.ko
 kernel/drivers/i2c/algos/i2c-algo-bit.ko
+kernel/drivers/i2c/algos/i2c-algo-pca.ko
 kernel/drivers/i2c/busses/i2c-ali1535.ko
 kernel/drivers/i2c/busses/i2c-ali1563.ko
 kernel/drivers/i2c/busses/i2c-ali15x3.ko
@@ -446,8 +482,10 @@
 kernel/drivers/i2c/busses/i2c-amd8111.ko
 kernel/drivers/i2c/busses/i2c-amd-mp2-pci.ko
 kernel/drivers/i2c/busses/i2c-amd-mp2-plat.ko
+kernel/drivers/i2c/busses/i2c-cbus-gpio.ko
 kernel/drivers/i2c/busses/i2c-ccgx-ucsi.ko
 kernel/drivers/i2c/busses/i2c-cp2615.ko
+kernel/drivers/i2c/busses/i2c-cros-ec-tunnel.ko
 kernel/drivers/i2c/busses/i2c-designware-core.ko
 kernel/drivers/i2c/busses/i2c-designware-pci.ko
 kernel/drivers/i2c/busses/i2c-designware-platform.ko
@@ -458,13 +496,16 @@
 kernel/drivers/i2c/busses/i2c-isch.ko
 kernel/drivers/i2c/busses/i2c-ismt.ko
 kernel/drivers/i2c/busses/i2c-keba.ko
+kernel/drivers/i2c/busses/i2c-kempld.ko
 kernel/drivers/i2c/busses/i2c-ljca.ko
 kernel/drivers/i2c/busses/i2c-mchp-pci1xxxx.ko
 kernel/drivers/i2c/busses/i2c-mlxcpld.ko
 kernel/drivers/i2c/busses/i2c-nforce2.ko
 kernel/drivers/i2c/busses/i2c-nforce2-s4985.ko
 kernel/drivers/i2c/busses/i2c-nvidia-gpu.ko
+kernel/drivers/i2c/busses/i2c-ocores.ko
 kernel/drivers/i2c/busses/i2c-parport.ko
+kernel/drivers/i2c/busses/i2c-pca-platform.ko
 kernel/drivers/i2c/busses/i2c-piix4.ko
 kernel/drivers/i2c/busses/i2c-robotfuzz-osif.ko
 kernel/drivers/i2c/busses/i2c-scmi.ko
@@ -478,6 +519,7 @@
 kernel/drivers/i2c/busses/i2c-viapro.ko
 kernel/drivers/i2c/busses/i2c-viperboard.ko
 kernel/drivers/i2c/busses/i2c-virtio.ko
+kernel/drivers/i2c/busses/i2c-xiic.ko
 kernel/drivers/i2c/i2c-dev.ko
 kernel/drivers/i2c/i2c-mux.ko
 kernel/drivers/i2c/i2c-smbus.ko
@@ -529,8 +571,12 @@
 kernel/drivers/input/joydev.ko
 kernel/drivers/input/keyboard/adp5588-keys.ko
 kernel/drivers/input/keyboard/adp5589-keys.ko
+kernel/drivers/input/keyboard/applespi.ko
+kernel/drivers/input/keyboard/cros_ec_keyb.ko
+kernel/drivers/input/keyboard/cypress-sf.ko
 kernel/drivers/input/keyboard/gpio_keys.ko
 kernel/drivers/input/keyboard/gpio_keys_polled.ko
+kernel/drivers/input/keyboard/iqs62x-keys.ko
 kernel/drivers/input/keyboard/lm8323.ko
 kernel/drivers/input/keyboard/lm8333.ko
 kernel/drivers/input/keyboard/matrix_keypad.ko
@@ -538,6 +584,7 @@
 kernel/drivers/input/keyboard/mpr121_touchkey.ko
 kernel/drivers/input/keyboard/newtonkbd.ko
 kernel/drivers/input/keyboard/opencores-kbd.ko
+kernel/drivers/input/keyboard/pinephone-keyboard.ko
 kernel/drivers/input/keyboard/qt1050.ko
 kernel/drivers/input/keyboard/qt1070.ko
 kernel/drivers/input/keyboard/qt2160.ko
@@ -554,19 +601,28 @@
 kernel/drivers/input/misc/ati_remote2.ko
 kernel/drivers/input/misc/atlas_btns.ko
 kernel/drivers/input/misc/axp20x-pek.ko
+kernel/drivers/input/misc/bma150.ko
 kernel/drivers/input/misc/cm109.ko
 kernel/drivers/input/misc/cma3000_d0x_i2c.ko
 kernel/drivers/input/misc/cma3000_d0x.ko
+kernel/drivers/input/misc/da7280.ko
 kernel/drivers/input/misc/da9063_onkey.ko
 kernel/drivers/input/misc/drv260x.ko
 kernel/drivers/input/misc/drv2665.ko
 kernel/drivers/input/misc/drv2667.ko
 kernel/drivers/input/misc/gpio_decoder.ko
 kernel/drivers/input/misc/ideapad_slidebar.ko
+kernel/drivers/input/misc/ims-pcu.ko
+kernel/drivers/input/misc/iqs269a.ko
+kernel/drivers/input/misc/iqs626a.ko
+kernel/drivers/input/misc/iqs7222.ko
 kernel/drivers/input/misc/keyspan_remote.ko
+kernel/drivers/input/misc/kxtj9.ko
+kernel/drivers/input/misc/mma8450.ko
 kernel/drivers/input/misc/pcf8574_keypad.ko
 kernel/drivers/input/misc/pcspkr.ko
 kernel/drivers/input/misc/powermate.ko
+kernel/drivers/input/misc/pwm-beeper.ko
 kernel/drivers/input/misc/pwm-vibra.ko
 kernel/drivers/input/misc/regulator-haptic.ko
 kernel/drivers/input/misc/rotary_encoder.ko
@@ -607,24 +663,49 @@
 kernel/drivers/input/touchscreen/ad7879-i2c.ko
 kernel/drivers/input/touchscreen/ad7879.ko
 kernel/drivers/input/touchscreen/atmel_mxt_ts.ko
+kernel/drivers/input/touchscreen/auo-pixcir-ts.ko
 kernel/drivers/input/touchscreen/bu21013_ts.ko
 kernel/drivers/input/touchscreen/bu21029_ts.ko
 kernel/drivers/input/touchscreen/chipone_icn8505.ko
 kernel/drivers/input/touchscreen/colibri-vf50-ts.ko
+kernel/drivers/input/touchscreen/cy8ctma140.ko
 kernel/drivers/input/touchscreen/cy8ctmg110_ts.ko
+kernel/drivers/input/touchscreen/cyttsp5.ko
+kernel/drivers/input/touchscreen/cyttsp_core.ko
+kernel/drivers/input/touchscreen/cyttsp_i2c.ko
+kernel/drivers/input/touchscreen/dynapro.ko
+kernel/drivers/input/touchscreen/edt-ft5x06.ko
 kernel/drivers/input/touchscreen/eeti_ts.ko
 kernel/drivers/input/touchscreen/egalax_ts_serial.ko
 kernel/drivers/input/touchscreen/ektf2127.ko
 kernel/drivers/input/touchscreen/elants_i2c.ko
+kernel/drivers/input/touchscreen/elo.ko
 kernel/drivers/input/touchscreen/exc3000.ko
+kernel/drivers/input/touchscreen/fujitsu_ts.ko
 kernel/drivers/input/touchscreen/goodix_berlin_core.ko
 kernel/drivers/input/touchscreen/goodix_berlin_i2c.ko
 kernel/drivers/input/touchscreen/goodix_berlin_spi.ko
 kernel/drivers/input/touchscreen/goodix_ts.ko
+kernel/drivers/input/touchscreen/gunze.ko
+kernel/drivers/input/touchscreen/hampshire.ko
 kernel/drivers/input/touchscreen/hideep.ko
+kernel/drivers/input/touchscreen/himax_hx83112b.ko
+kernel/drivers/input/touchscreen/hycon-hy46xx.ko
+kernel/drivers/input/touchscreen/hynitron_cstxxx.ko
+kernel/drivers/input/touchscreen/ili210x.ko
+kernel/drivers/input/touchscreen/ilitek_ts_i2c.ko
+kernel/drivers/input/touchscreen/imagis.ko
+kernel/drivers/input/touchscreen/inexio.ko
 kernel/drivers/input/touchscreen/iqs5xx.ko
+kernel/drivers/input/touchscreen/iqs7211.ko
 kernel/drivers/input/touchscreen/max11801_ts.ko
 kernel/drivers/input/touchscreen/melfas_mip4.ko
+kernel/drivers/input/touchscreen/mms114.ko
+kernel/drivers/input/touchscreen/msg2638.ko
+kernel/drivers/input/touchscreen/mtouch.ko
+kernel/drivers/input/touchscreen/novatek-nvt-ts.ko
+kernel/drivers/input/touchscreen/penmount.ko
+kernel/drivers/input/touchscreen/pixcir_i2c_ts.ko
 kernel/drivers/input/touchscreen/raydium_i2c_ts.ko
 kernel/drivers/input/touchscreen/resistive-adc-touch.ko
 kernel/drivers/input/touchscreen/rohm_bu21023.ko
@@ -633,16 +714,24 @@
 kernel/drivers/input/touchscreen/sis_i2c.ko
 kernel/drivers/input/touchscreen/st1232.ko
 kernel/drivers/input/touchscreen/sur40.ko
+kernel/drivers/input/touchscreen/surface3_spi.ko
 kernel/drivers/input/touchscreen/sx8654.ko
+kernel/drivers/input/touchscreen/touchit213.ko
+kernel/drivers/input/touchscreen/touchright.ko
+kernel/drivers/input/touchscreen/touchwin.ko
 kernel/drivers/input/touchscreen/tps6507x-ts.ko
 kernel/drivers/input/touchscreen/tsc2004.ko
 kernel/drivers/input/touchscreen/tsc2007.ko
 kernel/drivers/input/touchscreen/tsc200x-core.ko
+kernel/drivers/input/touchscreen/tsc40.ko
 kernel/drivers/input/touchscreen/usbtouchscreen.ko
+kernel/drivers/input/touchscreen/wacom_i2c.ko
+kernel/drivers/input/touchscreen/wacom_w8001.ko
 kernel/drivers/input/touchscreen/wdt87xx_i2c.ko
 kernel/drivers/input/touchscreen/wm97xx-ts.ko
 kernel/drivers/input/touchscreen/zet6223.ko
 kernel/drivers/input/touchscreen/zforce_ts.ko
+kernel/drivers/input/touchscreen/zinitix.ko
 kernel/drivers/leds/led-class-multicolor.ko
 kernel/drivers/md/bcache/bcache.ko
 kernel/drivers/md/dm-bio-prison.ko
@@ -704,6 +793,7 @@
 kernel/drivers/message/fusion/mptspi.ko
 kernel/drivers/mfd/axp20x-i2c.ko
 kernel/drivers/mfd/axp20x.ko
+kernel/drivers/mfd/cros_ec_dev.ko
 kernel/drivers/mfd/cs42l43-i2c.ko
 kernel/drivers/mfd/cs42l43.ko
 kernel/drivers/mfd/cs42l43-sdw.ko
@@ -715,13 +805,22 @@
 kernel/drivers/mfd/intel_pmc_bxt.ko
 kernel/drivers/mfd/intel_quark_i2c_gpio.ko
 kernel/drivers/mfd/intel_soc_pmic_bxtwc.ko
+kernel/drivers/mfd/intel_soc_pmic_mrfld.ko
+kernel/drivers/mfd/iqs62x.ko
+kernel/drivers/mfd/kempld-core.ko
+kernel/drivers/mfd/lm3533-core.ko
+kernel/drivers/mfd/lm3533-ctrlbank.ko
 kernel/drivers/mfd/lp3943.ko
 kernel/drivers/mfd/lpc_ich.ko
 kernel/drivers/mfd/lpc_sch.ko
 kernel/drivers/mfd/madera-i2c.ko
 kernel/drivers/mfd/madera.ko
 kernel/drivers/mfd/madera-spi.ko
+kernel/drivers/mfd/max8907.ko
 kernel/drivers/mfd/mfd-core.ko
+kernel/drivers/mfd/ocelot-soc.ko
+kernel/drivers/mfd/rt4831.ko
+kernel/drivers/mfd/simple-mfd-i2c.ko
 kernel/drivers/mfd/ti-lmu.ko
 kernel/drivers/mfd/tps65010.ko
 kernel/drivers/mfd/tps6507x.ko
@@ -748,6 +847,7 @@
 kernel/drivers/mmc/host/cb710-mmc.ko
 kernel/drivers/mmc/host/cqhci.ko
 kernel/drivers/mmc/host/mmc_hsq.ko
+kernel/drivers/mmc/host/mmc_spi.ko
 kernel/drivers/mmc/host/mtk-sd.ko
 kernel/drivers/mmc/host/of_mmc_spi.ko
 kernel/drivers/mmc/host/rtsx_pci_sdmmc.ko
@@ -771,8 +871,13 @@
 kernel/drivers/net/amt.ko
 kernel/drivers/net/bareudp.ko
 kernel/drivers/net/bonding/bonding.ko
+kernel/drivers/net/caif/caif_serial.ko
+kernel/drivers/net/caif/caif_virtio.ko
+kernel/drivers/net/can/can327.ko
 kernel/drivers/net/can/c_can/c_can.ko
 kernel/drivers/net/can/c_can/c_can_pci.ko
+kernel/drivers/net/can/ctucanfd/ctucanfd.ko
+kernel/drivers/net/can/ctucanfd/ctucanfd_pci.ko
 kernel/drivers/net/can/dev/can-dev.ko
 kernel/drivers/net/can/esd/esd_402_pci.ko
 kernel/drivers/net/can/ifi_canfd/ifi_canfd.ko
@@ -780,14 +885,18 @@
 kernel/drivers/net/can/m_can/m_can.ko
 kernel/drivers/net/can/m_can/m_can_pci.ko
 kernel/drivers/net/can/m_can/m_can_platform.ko
+kernel/drivers/net/can/m_can/tcan4x5x.ko
 kernel/drivers/net/can/peak_canfd/peak_pciefd.ko
 kernel/drivers/net/can/sja1000/ems_pci.ko
+kernel/drivers/net/can/sja1000/f81601.ko
 kernel/drivers/net/can/sja1000/kvaser_pci.ko
 kernel/drivers/net/can/sja1000/peak_pci.ko
 kernel/drivers/net/can/sja1000/plx_pci.ko
 kernel/drivers/net/can/sja1000/sja1000.ko
 kernel/drivers/net/can/slcan/slcan.ko
+kernel/drivers/net/can/softing/softing.ko
 kernel/drivers/net/can/spi/hi311x.ko
+kernel/drivers/net/can/spi/mcp251xfd/mcp251xfd.ko
 kernel/drivers/net/can/usb/ems_usb.ko
 kernel/drivers/net/can/usb/esd_usb.ko
 kernel/drivers/net/can/usb/etas_es58x/etas_es58x.ko
@@ -802,18 +911,29 @@
 kernel/drivers/net/can/vxcan.ko
 kernel/drivers/net/dsa/b53/b53_common.ko
 kernel/drivers/net/dsa/bcm-sf2.ko
+kernel/drivers/net/dsa/dsa_loop_bdinfo.ko
+kernel/drivers/net/dsa/dsa_loop.ko
 kernel/drivers/net/dsa/hirschmann/hellcreek_sw.ko
+kernel/drivers/net/dsa/lan9303-core.ko
+kernel/drivers/net/dsa/lan9303_i2c.ko
+kernel/drivers/net/dsa/lan9303_mdio.ko
 kernel/drivers/net/dsa/lantiq_gswip.ko
 kernel/drivers/net/dsa/microchip/ksz8863_smi.ko
 kernel/drivers/net/dsa/microchip/ksz9477_i2c.ko
 kernel/drivers/net/dsa/microchip/ksz_spi.ko
 kernel/drivers/net/dsa/microchip/ksz_switch.ko
+kernel/drivers/net/dsa/mt7530.ko
+kernel/drivers/net/dsa/mt7530-mdio.ko
+kernel/drivers/net/dsa/mt7530-mmio.ko
 kernel/drivers/net/dsa/mv88e6060.ko
 kernel/drivers/net/dsa/mv88e6xxx/mv88e6xxx.ko
 kernel/drivers/net/dsa/ocelot/mscc_felix_dsa_lib.ko
 kernel/drivers/net/dsa/ocelot/mscc_ocelot_ext.ko
+kernel/drivers/net/dsa/ocelot/mscc_seville.ko
 kernel/drivers/net/dsa/qca/ar9331.ko
+kernel/drivers/net/dsa/qca/qca8k.ko
 kernel/drivers/net/dsa/realtek/realtek_dsa.ko
+kernel/drivers/net/dsa/sja1105/sja1105.ko
 kernel/drivers/net/dsa/vitesse-vsc73xx-core.ko
 kernel/drivers/net/dsa/vitesse-vsc73xx-platform.ko
 kernel/drivers/net/dsa/vitesse-vsc73xx-spi.ko
@@ -824,19 +944,25 @@
 kernel/drivers/net/eql.ko
 kernel/drivers/net/ethernet/3com/3c59x.ko
 kernel/drivers/net/ethernet/3com/typhoon.ko
+kernel/drivers/net/ethernet/8390/8390.ko
+kernel/drivers/net/ethernet/8390/ne2k-pci.ko
 kernel/drivers/net/ethernet/adaptec/starfire.ko
+kernel/drivers/net/ethernet/adi/adin1110.ko
 kernel/drivers/net/ethernet/agere/et131x.ko
 kernel/drivers/net/ethernet/alacritech/slicoss.ko
 kernel/drivers/net/ethernet/alteon/acenic.ko
 kernel/drivers/net/ethernet/amazon/ena/ena.ko
 kernel/drivers/net/ethernet/amd/amd8111e.ko
+kernel/drivers/net/ethernet/amd/pcnet32.ko
 kernel/drivers/net/ethernet/amd/pds_core/pds_core.ko
 kernel/drivers/net/ethernet/amd/xgbe/amd-xgbe.ko
 kernel/drivers/net/ethernet/aquantia/atlantic/atlantic.ko
+kernel/drivers/net/ethernet/asix/ax88796c.ko
 kernel/drivers/net/ethernet/atheros/alx/alx.ko
 kernel/drivers/net/ethernet/atheros/atl1c/atl1c.ko
 kernel/drivers/net/ethernet/atheros/atl1e/atl1e.ko
 kernel/drivers/net/ethernet/atheros/atlx/atl1.ko
+kernel/drivers/net/ethernet/atheros/atlx/atl2.ko
 kernel/drivers/net/ethernet/broadcom/b44.ko
 kernel/drivers/net/ethernet/broadcom/bcmsysport.ko
 kernel/drivers/net/ethernet/broadcom/bnx2.ko
@@ -855,13 +981,21 @@
 kernel/drivers/net/ethernet/chelsio/inline_crypto/ch_ktls/ch_ktls.ko
 kernel/drivers/net/ethernet/chelsio/libcxgb/libcxgb.ko
 kernel/drivers/net/ethernet/cisco/enic/enic.ko
+kernel/drivers/net/ethernet/dec/tulip/de2104x.ko
+kernel/drivers/net/ethernet/dec/tulip/dmfe.ko
+kernel/drivers/net/ethernet/dec/tulip/tulip.ko
+kernel/drivers/net/ethernet/dec/tulip/uli526x.ko
+kernel/drivers/net/ethernet/dec/tulip/winbond-840.ko
 kernel/drivers/net/ethernet/dlink/dl2k.ko
 kernel/drivers/net/ethernet/dlink/sundance.ko
 kernel/drivers/net/ethernet/dnet.ko
 kernel/drivers/net/ethernet/ec_bhf.ko
 kernel/drivers/net/ethernet/emulex/benet/be2net.ko
+kernel/drivers/net/ethernet/engleder/tsnep.ko
 kernel/drivers/net/ethernet/ethoc.ko
 kernel/drivers/net/ethernet/fealnx.ko
+kernel/drivers/net/ethernet/fungible/funcore/funcore.ko
+kernel/drivers/net/ethernet/fungible/funeth/funeth.ko
 kernel/drivers/net/ethernet/google/gve/gve.ko
 kernel/drivers/net/ethernet/huawei/hinic/hinic.ko
 kernel/drivers/net/ethernet/intel/e1000/e1000.ko
@@ -921,6 +1055,7 @@
 kernel/drivers/net/ethernet/rdc/r6040.ko
 kernel/drivers/net/ethernet/realtek/8139cp.ko
 kernel/drivers/net/ethernet/realtek/8139too.ko
+kernel/drivers/net/ethernet/realtek/atp.ko
 kernel/drivers/net/ethernet/realtek/r8169.ko
 kernel/drivers/net/ethernet/realtek/rtase/rtase.ko
 kernel/drivers/net/ethernet/rocker/rocker.ko
@@ -929,6 +1064,8 @@
 kernel/drivers/net/ethernet/sfc/siena/sfc-siena.ko
 kernel/drivers/net/ethernet/silan/sc92031.ko
 kernel/drivers/net/ethernet/sis/sis190.ko
+kernel/drivers/net/ethernet/sis/sis900.ko
+kernel/drivers/net/ethernet/smsc/epic100.ko
 kernel/drivers/net/ethernet/smsc/smsc911x.ko
 kernel/drivers/net/ethernet/smsc/smsc9420.ko
 kernel/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.ko
@@ -937,13 +1074,19 @@
 kernel/drivers/net/ethernet/sun/cassini.ko
 kernel/drivers/net/ethernet/sun/niu.ko
 kernel/drivers/net/ethernet/sun/sungem.ko
+kernel/drivers/net/ethernet/sun/sunhme.ko
 kernel/drivers/net/ethernet/synopsys/dwc-xlgmac.ko
 kernel/drivers/net/ethernet/tehuti/tehuti.ko
 kernel/drivers/net/ethernet/tehuti/tn40xx.ko
 kernel/drivers/net/ethernet/ti/tlan.ko
+kernel/drivers/net/ethernet/vertexcom/mse102x.ko
 kernel/drivers/net/ethernet/via/via-rhine.ko
 kernel/drivers/net/ethernet/via/via-velocity.ko
+kernel/drivers/net/ethernet/wangxun/libwx/libwx.ko
+kernel/drivers/net/ethernet/wangxun/ngbe/ngbe.ko
+kernel/drivers/net/ethernet/wangxun/txgbe/txgbe.ko
 kernel/drivers/net/ethernet/wiznet/w5100.ko
+kernel/drivers/net/ethernet/wiznet/w5100-spi.ko
 kernel/drivers/net/ethernet/wiznet/w5300.ko
 kernel/drivers/net/ethernet/xilinx/ll_temac.ko
 kernel/drivers/net/ethernet/xilinx/xilinx_emac.ko
@@ -954,6 +1097,11 @@
 kernel/drivers/net/gtp.ko
 kernel/drivers/net/hippi/rrunner.ko
 kernel/drivers/net/hyperv/hv_netvsc.ko
+kernel/drivers/net/ieee802154/adf7242.ko
+kernel/drivers/net/ieee802154/ca8210.ko
+kernel/drivers/net/ieee802154/fakelb.ko
+kernel/drivers/net/ieee802154/mac802154_hwsim.ko
+kernel/drivers/net/ieee802154/mcr20a.ko
 kernel/drivers/net/ifb.ko
 kernel/drivers/net/ipvlan/ipvlan.ko
 kernel/drivers/net/ipvlan/ipvtap.ko
@@ -970,6 +1118,8 @@
 kernel/drivers/net/mdio/mdio-gpio.ko
 kernel/drivers/net/mdio/mdio-i2c.ko
 kernel/drivers/net/mdio/mdio-mscc-miim.ko
+kernel/drivers/net/mdio/mdio-mvusb.ko
+kernel/drivers/net/mhi_net.ko
 kernel/drivers/net/mii.ko
 kernel/drivers/net/netconsole.ko
 kernel/drivers/net/netdevsim/netdevsim.ko
@@ -980,6 +1130,7 @@
 kernel/drivers/net/pcs/pcs-mtk-lynxi.ko
 kernel/drivers/net/pcs/pcs_xpcs.ko
 kernel/drivers/net/pfcp.ko
+kernel/drivers/net/phy/adin1100.ko
 kernel/drivers/net/phy/adin.ko
 kernel/drivers/net/phy/air_en8811h.ko
 kernel/drivers/net/phy/amd.ko
@@ -1008,6 +1159,7 @@
 kernel/drivers/net/phy/lxt.ko
 kernel/drivers/net/phy/marvell10g.ko
 kernel/drivers/net/phy/marvell-88q2xxx.ko
+kernel/drivers/net/phy/marvell-88x2222.ko
 kernel/drivers/net/phy/marvell.ko
 kernel/drivers/net/phy/mdio_devres.ko
 kernel/drivers/net/phy/mediatek-ge.ko
@@ -1015,9 +1167,13 @@
 kernel/drivers/net/phy/microchip.ko
 kernel/drivers/net/phy/microchip_t1.ko
 kernel/drivers/net/phy/microchip_t1s.ko
+kernel/drivers/net/phy/motorcomm.ko
 kernel/drivers/net/phy/mscc/mscc.ko
 kernel/drivers/net/phy/mxl-gpy.ko
 kernel/drivers/net/phy/national.ko
+kernel/drivers/net/phy/ncn26000.ko
+kernel/drivers/net/phy/nxp-c45-tja.ko
+kernel/drivers/net/phy/nxp-cbtx.ko
 kernel/drivers/net/phy/nxp-tja11xx.ko
 kernel/drivers/net/phy/phylink.ko
 kernel/drivers/net/phy/qcom/at803x.ko
@@ -1057,6 +1213,7 @@
 kernel/drivers/net/usb/cdc_ether.ko
 kernel/drivers/net/usb/cdc_mbim.ko
 kernel/drivers/net/usb/cdc_ncm.ko
+kernel/drivers/net/usb/cdc-phonet.ko
 kernel/drivers/net/usb/cdc_subset.ko
 kernel/drivers/net/usb/ch9200.ko
 kernel/drivers/net/usb/cx82310_eth.ko
@@ -1123,6 +1280,9 @@
 kernel/drivers/net/wireless/intel/iwlwifi/dvm/iwldvm.ko
 kernel/drivers/net/wireless/intel/iwlwifi/iwlwifi.ko
 kernel/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko
+kernel/drivers/net/wireless/intersil/p54/p54common.ko
+kernel/drivers/net/wireless/intersil/p54/p54pci.ko
+kernel/drivers/net/wireless/intersil/p54/p54usb.ko
 kernel/drivers/net/wireless/marvell/libertas/libertas.ko
 kernel/drivers/net/wireless/marvell/libertas/libertas_sdio.ko
 kernel/drivers/net/wireless/marvell/libertas_tf/libertas_tf.ko
@@ -1155,8 +1315,12 @@
 kernel/drivers/net/wireless/mediatek/mt76/mt7915/mt7915e.ko
 kernel/drivers/net/wireless/mediatek/mt76/mt7921/mt7921-common.ko
 kernel/drivers/net/wireless/mediatek/mt76/mt7921/mt7921e.ko
+kernel/drivers/net/wireless/mediatek/mt76/mt7921/mt7921s.ko
+kernel/drivers/net/wireless/mediatek/mt76/mt7921/mt7921u.ko
 kernel/drivers/net/wireless/mediatek/mt76/mt792x-lib.ko
 kernel/drivers/net/wireless/mediatek/mt76/mt792x-usb.ko
+kernel/drivers/net/wireless/mediatek/mt76/mt7996/mt7996e.ko
+kernel/drivers/net/wireless/purelifi/plfxlc/plfxlc.ko
 kernel/drivers/net/wireless/quantenna/qtnfmac/qtnfmac.ko
 kernel/drivers/net/wireless/quantenna/qtnfmac/qtnfmac_pcie.ko
 kernel/drivers/net/wireless/ralink/rt2x00/rt2400pci.ko
@@ -1230,6 +1394,7 @@
 kernel/drivers/net/wireless/rsi/rsi_91x.ko
 kernel/drivers/net/wireless/rsi/rsi_sdio.ko
 kernel/drivers/net/wireless/rsi/rsi_usb.ko
+kernel/drivers/net/wireless/silabs/wfx/wfx.ko
 kernel/drivers/net/wireless/st/cw1200/cw1200_core.ko
 kernel/drivers/net/wireless/st/cw1200/cw1200_wlan_sdio.ko
 kernel/drivers/net/wireless/ti/wl1251/wl1251.ko
@@ -1241,6 +1406,12 @@
 kernel/drivers/net/wireless/virtual/mac80211_hwsim.ko
 kernel/drivers/net/wireless/virtual/virt_wifi.ko
 kernel/drivers/net/wireless/zydas/zd1211rw/zd1211rw.ko
+kernel/drivers/net/wwan/iosm/iosm.ko
+kernel/drivers/net/wwan/mhi_wwan_ctrl.ko
+kernel/drivers/net/wwan/mhi_wwan_mbim.ko
+kernel/drivers/net/wwan/rpmsg_wwan_ctrl.ko
+kernel/drivers/net/wwan/t7xx/mtk_t7xx.ko
+kernel/drivers/net/wwan/wwan_hwsim.ko
 kernel/drivers/net/xen-netfront.ko
 kernel/drivers/ntb/ntb.ko
 kernel/drivers/ntb/ntb_transport.ko
@@ -1258,6 +1429,7 @@
 kernel/drivers/nvme/host/nvme.ko
 kernel/drivers/nvme/host/nvme-rdma.ko
 kernel/drivers/nvme/host/nvme-tcp.ko
+kernel/drivers/nvmem/nvmem_qcom-spmi-sdam.ko
 kernel/drivers/nvme/target/nvme-fcloop.ko
 kernel/drivers/nvme/target/nvme-loop.ko
 kernel/drivers/nvme/target/nvmet-fc.ko
@@ -1297,13 +1469,52 @@
 kernel/drivers/pinctrl/intel/pinctrl-tigerlake.ko
 kernel/drivers/pinctrl/pinctrl-cy8c95x0.ko
 kernel/drivers/pinctrl/pinctrl-da9062.ko
+kernel/drivers/platform/chrome/chromeos_acpi.ko
+kernel/drivers/platform/chrome/chromeos_laptop.ko
+kernel/drivers/platform/chrome/chromeos_privacy_screen.ko
+kernel/drivers/platform/chrome/chromeos_pstore.ko
+kernel/drivers/platform/chrome/chromeos_tbmc.ko
+kernel/drivers/platform/chrome/cros_ec_chardev.ko
+kernel/drivers/platform/chrome/cros_ec_debugfs.ko
+kernel/drivers/platform/chrome/cros_ec_i2c.ko
+kernel/drivers/platform/chrome/cros_ec_ishtp.ko
+kernel/drivers/platform/chrome/cros_ec.ko
+kernel/drivers/platform/chrome/cros_ec_lightbar.ko
+kernel/drivers/platform/chrome/cros_ec_lpcs.ko
+kernel/drivers/platform/chrome/cros-ec-sensorhub.ko
+kernel/drivers/platform/chrome/cros_ec_spi.ko
+kernel/drivers/platform/chrome/cros_ec_sysfs.ko
+kernel/drivers/platform/chrome/cros-ec-typec.ko
+kernel/drivers/platform/chrome/cros_ec_uart.ko
+kernel/drivers/platform/chrome/cros_hps_i2c.ko
+kernel/drivers/platform/chrome/cros_kbd_led_backlight.ko
+kernel/drivers/platform/chrome/cros_typec_switch.ko
+kernel/drivers/platform/chrome/cros_usbpd_logger.ko
+kernel/drivers/platform/chrome/cros_usbpd_notify.ko
+kernel/drivers/platform/chrome/wilco_ec/wilco_ec_events.ko
+kernel/drivers/platform/chrome/wilco_ec/wilco_ec.ko
+kernel/drivers/platform/chrome/wilco_ec/wilco_ec_telem.ko
 kernel/drivers/platform/mellanox/mlxreg-hotplug.ko
 kernel/drivers/platform/mellanox/mlxreg-io.ko
 kernel/drivers/platform/mellanox/mlxreg-lc.ko
 kernel/drivers/platform/mellanox/nvsw-sn2201.ko
+kernel/drivers/platform/surface/aggregator/surface_aggregator.ko
+kernel/drivers/platform/surface/surface3_power.ko
+kernel/drivers/platform/surface/surface3-wmi.ko
+kernel/drivers/platform/surface/surface_acpi_notify.ko
+kernel/drivers/platform/surface/surface_aggregator_cdev.ko
+kernel/drivers/platform/surface/surface_aggregator_hub.ko
+kernel/drivers/platform/surface/surface_aggregator_registry.ko
+kernel/drivers/platform/surface/surface_aggregator_tabletsw.ko
+kernel/drivers/platform/surface/surface_dtx.ko
+kernel/drivers/platform/surface/surface_gpe.ko
+kernel/drivers/platform/surface/surface_hotplug.ko
+kernel/drivers/platform/surface/surface_platform_profile.ko
+kernel/drivers/platform/surface/surfacepro3_button.ko
 kernel/drivers/platform/x86/acerhdf.ko
 kernel/drivers/platform/x86/acer-wireless.ko
 kernel/drivers/platform/x86/acer-wmi.ko
+kernel/drivers/platform/x86/adv_swbutton.ko
 kernel/drivers/platform/x86/amd/amd_hsmp.ko
 kernel/drivers/platform/x86/amd/pmc/amd-pmc.ko
 kernel/drivers/platform/x86/amd/pmf/amd-pmf.ko
@@ -1311,10 +1522,13 @@
 kernel/drivers/platform/x86/apple-gmux.ko
 kernel/drivers/platform/x86/asus-laptop.ko
 kernel/drivers/platform/x86/asus-nb-wmi.ko
+kernel/drivers/platform/x86/asus-tf103c-dock.ko
 kernel/drivers/platform/x86/asus-wireless.ko
 kernel/drivers/platform/x86/asus-wmi.ko
+kernel/drivers/platform/x86/barco-p50-gpio.ko
 kernel/drivers/platform/x86/classmate-laptop.ko
 kernel/drivers/platform/x86/compal-laptop.ko
+kernel/drivers/platform/x86/dell/alienware-wmi.ko
 kernel/drivers/platform/x86/dell/dcdbas.ko
 kernel/drivers/platform/x86/dell/dell-laptop.ko
 kernel/drivers/platform/x86/dell/dell-pc.ko
@@ -1346,10 +1560,15 @@
 kernel/drivers/platform/x86/inspur_platform_profile.ko
 kernel/drivers/platform/x86/intel/ifs/intel_ifs.ko
 kernel/drivers/platform/x86/intel/int1092/intel_sar.ko
+kernel/drivers/platform/x86/intel/int3472/intel_skl_int3472_common.ko
+kernel/drivers/platform/x86/intel/int3472/intel_skl_int3472_discrete.ko
+kernel/drivers/platform/x86/intel/int3472/intel_skl_int3472_tps68470.ko
 kernel/drivers/platform/x86/intel/intel_bxtwc_tmu.ko
 kernel/drivers/platform/x86/intel/intel_chtwc_int33fe.ko
+kernel/drivers/platform/x86/intel/intel_crystal_cove_charger.ko
 kernel/drivers/platform/x86/intel/intel-hid.ko
 kernel/drivers/platform/x86/intel/intel_int0002_vgpio.ko
+kernel/drivers/platform/x86/intel/intel_mrfld_pwrbtn.ko
 kernel/drivers/platform/x86/intel/intel_oaktrail.ko
 kernel/drivers/platform/x86/intel/intel_plr_tpmi.ko
 kernel/drivers/platform/x86/intel/intel_punit_ipc.ko
@@ -1384,10 +1603,12 @@
 kernel/drivers/platform/x86/intel/wmi/intel-wmi-sbl-fw-update.ko
 kernel/drivers/platform/x86/intel/wmi/intel-wmi-thunderbolt.ko
 kernel/drivers/platform/x86/lenovo-wmi-camera.ko
+kernel/drivers/platform/x86/lenovo-ymc.ko
 kernel/drivers/platform/x86/lenovo-yogabook.ko
 kernel/drivers/platform/x86/lenovo-yoga-tab2-pro-1380-fastcharger.ko
 kernel/drivers/platform/x86/lg-laptop.ko
 kernel/drivers/platform/x86/meegopad_anx7428.ko
+kernel/drivers/platform/x86/meraki-mx100.ko
 kernel/drivers/platform/x86/mlx-platform.ko
 kernel/drivers/platform/x86/msi-ec.ko
 kernel/drivers/platform/x86/msi-laptop.ko
@@ -1406,18 +1627,23 @@
 kernel/drivers/platform/x86/siemens/simatic-ipc-batt-elkhartlake.ko
 kernel/drivers/platform/x86/siemens/simatic-ipc-batt-f7188x.ko
 kernel/drivers/platform/x86/siemens/simatic-ipc-batt.ko
+kernel/drivers/platform/x86/siemens/simatic-ipc.ko
 kernel/drivers/platform/x86/silicom-platform.ko
 kernel/drivers/platform/x86/sony-laptop.ko
 kernel/drivers/platform/x86/system76_acpi.ko
+kernel/drivers/platform/x86/think-lmi.ko
 kernel/drivers/platform/x86/thinkpad_acpi.ko
 kernel/drivers/platform/x86/topstar-laptop.ko
+kernel/drivers/platform/x86/toshiba_acpi.ko
 kernel/drivers/platform/x86/toshiba_bluetooth.ko
 kernel/drivers/platform/x86/toshiba_haps.ko
 kernel/drivers/platform/x86/toshiba-wmi.ko
 kernel/drivers/platform/x86/uv_sysfs.ko
+kernel/drivers/platform/x86/winmate-fm07-keys.ko
 kernel/drivers/platform/x86/wireless-hotkey.ko
 kernel/drivers/platform/x86/wmi-bmof.ko
 kernel/drivers/platform/x86/wmi.ko
+kernel/drivers/platform/x86/x86-android-tablets/x86-android-tablets.ko
 kernel/drivers/platform/x86/xiaomi-wmi.ko
 kernel/drivers/ptp/ptp_clockmatrix.ko
 kernel/drivers/ptp/ptp_dfl_tod.ko
@@ -1451,25 +1677,49 @@
 kernel/drivers/regulator/ltc3589.ko
 kernel/drivers/regulator/ltc3676.ko
 kernel/drivers/regulator/max1586.ko
+kernel/drivers/regulator/max20086-regulator.ko
+kernel/drivers/regulator/max20411-regulator.ko
 kernel/drivers/regulator/max77503-regulator.ko
+kernel/drivers/regulator/max77826-regulator.ko
 kernel/drivers/regulator/max77857-regulator.ko
 kernel/drivers/regulator/max8649.ko
 kernel/drivers/regulator/max8660.ko
+kernel/drivers/regulator/max8893.ko
+kernel/drivers/regulator/max8907-regulator.ko
 kernel/drivers/regulator/max8952.ko
+kernel/drivers/regulator/mp8859.ko
 kernel/drivers/regulator/mt6311-regulator.ko
+kernel/drivers/regulator/mt6315-regulator.ko
 kernel/drivers/regulator/pca9450-regulator.ko
 kernel/drivers/regulator/pv88060-regulator.ko
 kernel/drivers/regulator/pv88080-regulator.ko
 kernel/drivers/regulator/pv88090-regulator.ko
 kernel/drivers/regulator/pwm-regulator.ko
+kernel/drivers/regulator/qcom-labibb-regulator.ko
+kernel/drivers/regulator/qcom_spmi-regulator.ko
+kernel/drivers/regulator/qcom_usb_vbus-regulator.ko
 kernel/drivers/regulator/raa215300.ko
+kernel/drivers/regulator/rt4801-regulator.ko
+kernel/drivers/regulator/rt4803.ko
+kernel/drivers/regulator/rt4831-regulator.ko
+kernel/drivers/regulator/rt5190a-regulator.ko
+kernel/drivers/regulator/rt5739.ko
+kernel/drivers/regulator/rt5759-regulator.ko
+kernel/drivers/regulator/rt6160-regulator.ko
+kernel/drivers/regulator/rt6190-regulator.ko
+kernel/drivers/regulator/rt6245-regulator.ko
+kernel/drivers/regulator/rtmv20-regulator.ko
+kernel/drivers/regulator/rtq2134-regulator.ko
 kernel/drivers/regulator/rtq2208-regulator.ko
+kernel/drivers/regulator/rtq6752-regulator.ko
 kernel/drivers/regulator/slg51000-regulator.ko
 kernel/drivers/regulator/tps51632-regulator.ko
 kernel/drivers/regulator/tps62360-regulator.ko
 kernel/drivers/regulator/tps65023-regulator.ko
 kernel/drivers/regulator/tps6507x-regulator.ko
 kernel/drivers/regulator/tps65132-regulator.ko
+kernel/drivers/regulator/tps6524x-regulator.ko
+kernel/drivers/regulator/tps68470-regulator.ko
 kernel/drivers/regulator/userspace-consumer.ko
 kernel/drivers/regulator/virtual.ko
 kernel/drivers/rpmsg/rpmsg_core.ko
@@ -1486,6 +1736,7 @@
 kernel/drivers/rtc/rtc-m41t80.ko
 kernel/drivers/rtc/rtc-max31335.ko
 kernel/drivers/rtc/rtc-max6900.ko
+kernel/drivers/rtc/rtc-max8907.ko
 kernel/drivers/rtc/rtc-pcf2127.ko
 kernel/drivers/rtc/rtc-pcf85063.ko
 kernel/drivers/rtc/rtc-pcf8523.ko
@@ -1502,6 +1753,7 @@
 kernel/drivers/rtc/rtc-sd2405al.ko
 kernel/drivers/rtc/rtc-sd3078.ko
 kernel/drivers/rtc/rtc-tps6594.ko
+kernel/drivers/rtc/rtc-wilco-ec.ko
 kernel/drivers/rtc/rtc-x1205.ko
 kernel/drivers/scsi/3w-9xxx.ko
 kernel/drivers/scsi/3w-sas.ko
@@ -1571,15 +1823,32 @@
 kernel/drivers/scsi/xen-scsifront.ko
 kernel/drivers/soc/qcom/qmi_helpers.ko
 kernel/drivers/soundwire/soundwire-bus.ko
+kernel/drivers/spi/spi-altera-core.ko
+kernel/drivers/spi/spi-altera-dfl.ko
 kernel/drivers/spi/spi-amd.ko
 kernel/drivers/spi/spi-bitbang.ko
 kernel/drivers/spi/spi-cs42l43.ko
+kernel/drivers/spi/spi-dln2.ko
+kernel/drivers/spi/spi-intel.ko
+kernel/drivers/spi/spi-intel-pci.ko
+kernel/drivers/spi/spi-intel-platform.ko
 kernel/drivers/spi/spi-ljca.ko
+kernel/drivers/spi/spi-loopback-test.ko
+kernel/drivers/spi/spi-microchip-core.ko
+kernel/drivers/spi/spi-microchip-core-qspi.ko
 kernel/drivers/spi/spi-mux.ko
 kernel/drivers/spi/spi-pxa2xx-core.ko
+kernel/drivers/spi/spi-pxa2xx-pci.ko
 kernel/drivers/spi/spi-pxa2xx-platform.ko
 kernel/drivers/spi/spi-xilinx.ko
+kernel/drivers/spmi/spmi.ko
 kernel/drivers/ssb/ssb.ko
+kernel/drivers/staging/rtl8192e/rtl8192e/r8192e_pci.ko
+kernel/drivers/staging/rtl8192e/rtllib_crypt_ccmp.ko
+kernel/drivers/staging/rtl8192e/rtllib_crypt_tkip.ko
+kernel/drivers/staging/rtl8192e/rtllib_crypt_wep.ko
+kernel/drivers/staging/rtl8192e/rtllib.ko
+kernel/drivers/staging/rtl8712/r8712u.ko
 kernel/drivers/staging/rtl8723bs/r8723bs.ko
 kernel/drivers/target/iscsi/iscsi_target_mod.ko
 kernel/drivers/target/target_core_mod.ko
@@ -1597,14 +1866,20 @@
 kernel/drivers/usb/dwc3/dwc3-haps.ko
 kernel/drivers/usb/dwc3/dwc3.ko
 kernel/drivers/usb/dwc3/dwc3-pci.ko
+kernel/drivers/usb/host/bcma-hcd.ko
 kernel/drivers/usb/host/ehci-fsl.ko
 kernel/drivers/usb/host/ehci-hcd.ko
 kernel/drivers/usb/host/ehci-pci.ko
 kernel/drivers/usb/host/ehci-platform.ko
 kernel/drivers/usb/host/fsl-mph-dr-of.ko
+kernel/drivers/usb/host/isp116x-hcd.ko
 kernel/drivers/usb/host/ohci-hcd.ko
 kernel/drivers/usb/host/ohci-pci.ko
 kernel/drivers/usb/host/ohci-platform.ko
+kernel/drivers/usb/host/oxu210hp-hcd.ko
+kernel/drivers/usb/host/r8a66597-hcd.ko
+kernel/drivers/usb/host/sl811-hcd.ko
+kernel/drivers/usb/host/ssb-hcd.ko
 kernel/drivers/usb/host/uhci-hcd.ko
 kernel/drivers/usb/host/xen-hcd.ko
 kernel/drivers/usb/host/xhci-hcd.ko
@@ -1689,6 +1964,7 @@
 kernel/drivers/usb/typec/mux/intel_pmc_mux.ko
 kernel/drivers/usb/typec/mux/it5205.ko
 kernel/drivers/usb/typec/mux/nb7vpq904m.ko
+kernel/drivers/usb/typec/mux/pi3usb30532.ko
 kernel/drivers/usb/typec/mux/ptn36502.ko
 kernel/drivers/usb/typec/mux/wcd939x-usbss.ko
 kernel/drivers/usb/typec/rt1719.ko
@@ -1698,6 +1974,7 @@
 kernel/drivers/usb/typec/tcpm/tcpci_maxim.ko
 kernel/drivers/usb/typec/tcpm/tcpci_rt1711h.ko
 kernel/drivers/usb/typec/tcpm/tcpm.ko
+kernel/drivers/usb/typec/tcpm/typec_wcove.ko
 kernel/drivers/usb/typec/tipd/tps6598x.ko
 kernel/drivers/usb/typec/typec.ko
 kernel/drivers/usb/typec/ucsi/typec_ucsi.ko
@@ -1714,15 +1991,24 @@
 kernel/drivers/video/backlight/adp8870_bl.ko
 kernel/drivers/video/backlight/apple_bl.ko
 kernel/drivers/video/backlight/arcxcnn_bl.ko
+kernel/drivers/video/backlight/bd6107.ko
+kernel/drivers/video/backlight/gpio_backlight.ko
 kernel/drivers/video/backlight/kb3886_bl.ko
+kernel/drivers/video/backlight/ktd253-backlight.ko
 kernel/drivers/video/backlight/ktd2801-backlight.ko
+kernel/drivers/video/backlight/ktz8866.ko
 kernel/drivers/video/backlight/lcd.ko
 kernel/drivers/video/backlight/lm3509_bl.ko
+kernel/drivers/video/backlight/lm3533_bl.ko
 kernel/drivers/video/backlight/lm3630a_bl.ko
+kernel/drivers/video/backlight/lm3639_bl.ko
 kernel/drivers/video/backlight/lp855x_bl.ko
+kernel/drivers/video/backlight/lv5207lp.ko
 kernel/drivers/video/backlight/mp3309c.ko
 kernel/drivers/video/backlight/platform_lcd.ko
 kernel/drivers/video/backlight/pwm_bl.ko
+kernel/drivers/video/backlight/qcom-wled.ko
+kernel/drivers/video/backlight/rt4831-backlight.ko
 kernel/drivers/video/fbdev/xen-fbfront.ko
 kernel/drivers/virtio/virtio_balloon.ko
 kernel/drivers/virtio/virtio_dma_buf.ko
@@ -1731,15 +2017,18 @@
 kernel/drivers/virtio/virtio_mmio.ko
 kernel/drivers/virtio/virtio_vdpa.ko
 kernel/drivers/virt/vboxguest/vboxguest.ko
+kernel/drivers/w1/wire.ko
 kernel/drivers/watchdog/acquirewdt.ko
 kernel/drivers/watchdog/advantech_ec_wdt.ko
 kernel/drivers/watchdog/advantechwdt.ko
 kernel/drivers/watchdog/alim1535_wdt.ko
 kernel/drivers/watchdog/alim7101_wdt.ko
 kernel/drivers/watchdog/cpu5wdt.ko
+kernel/drivers/watchdog/cros_ec_wdt.ko
 kernel/drivers/watchdog/da9062_wdt.ko
 kernel/drivers/watchdog/ebc-c384_wdt.ko
 kernel/drivers/watchdog/eurotechwdt.ko
+kernel/drivers/watchdog/exar_wdt.ko
 kernel/drivers/watchdog/f71808e_wdt.ko
 kernel/drivers/watchdog/hpwdt.ko
 kernel/drivers/watchdog/i6300esb.ko
@@ -1749,6 +2038,7 @@
 kernel/drivers/watchdog/it87_wdt.ko
 kernel/drivers/watchdog/iTCO_vendor_support.ko
 kernel/drivers/watchdog/iTCO_wdt.ko
+kernel/drivers/watchdog/kempld_wdt.ko
 kernel/drivers/watchdog/lenovo_se10_wdt.ko
 kernel/drivers/watchdog/machzwd.ko
 kernel/drivers/watchdog/mei_wdt.ko
@@ -1766,10 +2056,12 @@
 kernel/drivers/watchdog/sbc_fitpc2_wdt.ko
 kernel/drivers/watchdog/sc1200wdt.ko
 kernel/drivers/watchdog/sch311x_wdt.ko
+kernel/drivers/watchdog/simatic-ipc-wdt.ko
 kernel/drivers/watchdog/smsc37b787_wdt.ko
 kernel/drivers/watchdog/softdog.ko
 kernel/drivers/watchdog/sp5100_tco.ko
 kernel/drivers/watchdog/tqmx86_wdt.ko
+kernel/drivers/watchdog/via_wdt.ko
 kernel/drivers/watchdog/w83627hf_wdt.ko
 kernel/drivers/watchdog/w83877f_wdt.ko
 kernel/drivers/watchdog/w83977f_wdt.ko
@@ -1778,6 +2070,7 @@
 kernel/drivers/watchdog/wdt_pci.ko
 kernel/drivers/watchdog/xen_wdt.ko
 kernel/drivers/watchdog/ziirave_wdt.ko
+kernel/drivers/xen/xen-front-pgdir-shbuf.ko
 kernel/fs/9p/9p.ko
 kernel/fs/binfmt_misc.ko
 kernel/fs/btrfs/btrfs.ko
@@ -1882,14 +2175,20 @@
 kernel/lib/crypto/libcurve25519.ko
 kernel/lib/crypto/libdes.ko
 kernel/lib/crypto/libpoly1305.ko
+kernel/lib/interval_tree_test.ko
 kernel/lib/libcrc32c.ko
 kernel/lib/lz4/lz4_compress.ko
 kernel/lib/lz4/lz4hc_compress.ko
 kernel/lib/math/cordic.ko
+kernel/lib/memory-notifier-error-inject.ko
+kernel/lib/netdev-notifier-error-inject.ko
+kernel/lib/notifier-error-inject.ko
 kernel/lib/objagg.ko
 kernel/lib/parman.ko
+kernel/lib/pm-notifier-error-inject.ko
 kernel/lib/polynomial.ko
 kernel/lib/raid6/raid6_pq.ko
+kernel/lib/rbtree_test.ko
 kernel/lib/reed_solomon/reed_solomon.ko
 kernel/lib/ts_bm.ko
 kernel/lib/ts_fsm.ko
@@ -1911,19 +2210,25 @@
 kernel/net/dns_resolver/dns_resolver.ko
 kernel/net/dsa/dsa_core.ko
 kernel/net/hsr/hsr.ko
+kernel/net/ieee802154/ieee802154.ko
 kernel/net/ipv4/gre.ko
 kernel/net/ipv4/ip_tunnel.ko
 kernel/net/ipv4/udp_tunnel.ko
 kernel/net/ipv6/ip6_tunnel.ko
 kernel/net/ipv6/ip6_udp_tunnel.ko
 kernel/net/ipv6/tunnel6.ko
+kernel/net/llc/llc2.ko
 kernel/net/llc/llc.ko
 kernel/net/mac80211/mac80211.ko
+kernel/net/mac802154/mac802154.ko
 kernel/net/packet/af_packet_diag.ko
 kernel/net/packet/af_packet.ko
+kernel/net/phonet/phonet.ko
 kernel/net/psample/psample.ko
 kernel/net/qrtr/qrtr.ko
 kernel/net/qrtr/qrtr-mhi.ko
+kernel/net/qrtr/qrtr-smd.ko
+kernel/net/qrtr/qrtr-tun.ko
 kernel/net/rfkill/rfkill.ko
 kernel/net/sched/sch_mqprio_lib.ko
 kernel/net/sched/sch_taprio.ko
```

</details>

- I was thinking whether we should include this package only on aarch64 or everywhere.  I have checked the content of the Leap 15.6 x86_64 initrd and these drivers are present there. So to be backward compatible with SLE15/Leap15 we should add the package on all architectures.
- The size of the x86_64 Live ISO increased by ~10MB, that's not bad
- The drivers are not added to the SLE MINI PXE image to keep it small
