### PR TITLE
Added inst.copy_network to kernel cmdline and config server no-auto-default 

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+[ -e /dracut-state.sh ] && . /dracut-state.sh
+
+. /lib/dracut-lib.sh
+. /lib/net-lib.sh
+
+if _val=$(getargs ip=); then
+  mkdir -p /run/agama/
+  : >/run/agama/copy_network
+fi

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/module-setup.sh
@@ -18,5 +18,6 @@ installkernel() {
 install() {
   inst_hook cmdline 99 "$moddir/agama-cmdline-conf.sh"
   inst_hook cmdline 99 "$moddir/agama-network-compat.sh"
+  inst_hook cmdline 99 "$moddir/agama-network.sh"
   inst_hook pre-pivot 99 "$moddir/save-agama-conf.sh"
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
@@ -7,3 +7,15 @@
 if [ -e /etc/hostname ]; then
   cp /etc/hostname "$NEWROOT/etc/hostname"
 fi
+
+if [ -e /run/agama/copy_network ]; then
+  if getargbool 1 inst.copy_network; then
+    mkdir -p /run/NetworkManager/conf.d
+    echo '[main]' >/run/NetworkManager/conf.d/00-agama-server.conf
+    echo 'no-auto-default=*' >>/run/NetworkManager/conf.d/00-agama-server.conf
+    echo 'ignore-carrier=*' >>/run/NetworkManager/conf.d/00-agama-server.conf
+
+    mkdir -p "$NEWROOT/etc/NetworkManager/system-connections/"
+    cp /run/NetworkManager/system-connections/* "$NEWROOT/etc/NetworkManager/system-connections/"
+  fi
+fi

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
@@ -8,6 +8,10 @@ if [ -e /etc/hostname ]; then
   cp /etc/hostname "$NEWROOT/etc/hostname"
 fi
 
+# If there is some explicit network configuration provided through the ip= kernel cmdline option
+# then we set the config server configuration diabling the DHCP auto configuration for ethernet
+# devices and also copying the configuration persistently (bsc#1241224, bsc#122486, bsc#1239777,
+# bsc#1236885).
 if [ -e /run/agama/copy_network ]; then
   if getargbool 1 inst.copy_network; then
     mkdir -p /run/NetworkManager/conf.d

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Thu Apr 24 16:40:41 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1239777, bsc#1236885 gh#agama-project/agama#2291.
+  - Persist the NetworkManager runtime config created by 
+    nm-initrd-generator when given explicitlly with the 'ip=' 
+    kernel cmdline argument.
+  - Allow to disable the copy of the persistent configuration with
+    the inst.copy_network kernel cmdline argument.
+  - Do not copy the NetworkManager runtime configuration to the 
+    target system anymore.
+
+-------------------------------------------------------------------
 Thu Apr 24 15:11:35 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Filter out the special PXE boot parameters, do not pass them

--- a/service/lib/agama/network.rb
+++ b/service/lib/agama/network.rb
@@ -73,6 +73,7 @@ module Agama
 
     HOSTNAME = "/etc/hostname"
     RESOLV = "/etc/resolv.conf"
+    COPY_NETWORK = "/run/agama/copy_network"
     RESOLV_FLAG = "/run/agama/manage_resolv"
     ETC_NM_DIR = "/etc/NetworkManager"
     RUN_NM_DIR = "/run/NetworkManager"
@@ -93,13 +94,7 @@ module Agama
       copy(HOSTNAME)
 
       return unless Dir.exist?(ETC_NM_DIR)
-
-      # runtime configuration is copied first, so in case of later modification
-      # on same interface it gets overwriten (bsc#1210541).
-      copy_directory(
-        File.join(RUN_NM_DIR, "system-connections"),
-        File.join(Yast::Installation.destdir, ETC_NM_DIR, "system-connections")
-      )
+      return unless File.exist?(COPY_NETWORK)
 
       copy_directory(
         File.join(ETC_NM_DIR, "system-connections"),

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 24 17:18:04 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Copy only the NetworkManager connnections from /etc and just
+  in case the copy has not been disabled 
+  (gh#agama-project/agama#2291).
+
+-------------------------------------------------------------------
 Thu Apr 24 14:10:46 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow to specify SSL certificate fingerprint to handle self-signed

--- a/service/test/agama/network_test.rb
+++ b/service/test/agama/network_test.rb
@@ -31,11 +31,15 @@ describe Agama::Network do
   let(:targetdir) { File.join(rootdir, "mnt") }
   let(:fixtures) { File.join(FIXTURES_PATH, "root_dir") }
   let(:hostname_path) { File.join(fixtures, "etc", "hostname") }
+  let(:agama_dir) { File.join(rootdir, "run", "agama") }
+  let(:copy_network) { File.join(agama_dir, "copy_network") }
 
   before do
     allow(Yast::Installation).to receive(:destdir).and_return(targetdir)
     stub_const("Agama::Network::HOSTNAME", hostname_path)
     stub_const("Agama::Network::RUN_NM_DIR", File.join(rootdir, "run", "NetworkManager"))
+    stub_const("Agama::Network::COPY_NETWORK", copy_network)
+    FileUtils.mkdir_p(agama_dir)
   end
 
   after do
@@ -48,6 +52,7 @@ describe Agama::Network do
     let(:etcdir) do
       File.join(rootdir, "etc", "NetworkManager", "system-connections")
     end
+
     let(:service) { instance_double(Yast2::Systemd::Service, enable: nil) }
 
     before do
@@ -61,11 +66,27 @@ describe Agama::Network do
         FileUtils.touch(File.join(etcdir, "system-connections", "wired.nmconnection"))
       end
 
-      it "copies the configuration files" do
-        network.install
-        expect(File).to exist(
-          File.join(targetdir, etcdir, "system-connections", "wired.nmconnection")
-        )
+      context "and the /run/agama/copy_network file exists" do
+        around do |block|
+          FileUtils.mkdir_p(agama_dir)
+          FileUtils.touch(copy_network)
+          block.call
+          FileUtils.rm_f(copy_network)
+        end
+
+        it "copies the configuration files" do
+          network.install
+          expect(File).to exist(
+            File.join(targetdir, etcdir, "system-connections", "wired.nmconnection")
+          )
+        end
+      end
+
+      context "and the /run/agama/copy_network file does not exist" do
+        it "does not try to copy any file" do
+          expect(FileUtils).to_not receive(:cp_r)
+          network.install
+        end
       end
     end
 


### PR DESCRIPTION
## Problem

The network configuration is a crucial part of the installation process. In some cases it is even required to start the installation. The problem is that, in some cases, the network configuration used during the installation could differ to the one wanted in the target system.

It will be nice to be able to configure completely the "picture" of the network after the installation as we started to design in YaST but as a primary step at least would be nice to select if the installation network configuration should be kept or not allowing to disable the copy of the connections completely. Currently that is not possible and the running and persistent configuration are always copied to the target system as well as we probe DHCP over all the ethernet devices even when there is some explicit configuration given.

- [bsc#1236885](https://bugzilla.suse.com/show_bug.cgi?id=1236885)
- [bsc#1239777](https://bugzilla.suse.com/show_bug.cgi?id=1239777)
- https://trello.com/c/YqZmKHAs/4639-2-agama-allow-to-switch-between-copy-or-not-the-network-configuration-to-the-target-system
- https://trello.com/c/fyE0VwAQ/4558-3-copy-network-configuration-to-the-installed-system-only-in-some-cases

## Solution

We proposed some changes in the current behavior. 

First of all, only the persistent configuration will be copied to the target system (default), this copy can be omitted using the `inst.copy_network=0` kernel cmdline argument although we are considering to define it as an enum allowing `none, persistent, all and maybe a comma separated name of connections` but just keep it simple by now only supporting 0 or 1.

During the boot process **(dracut)**, if an explicit **NetworkManager** configuration is given through the **'ip='** kernel cmdline option then the running configuration will be copied persistently before switching the rootfs and we will also set the **no-auto-default=*** to not run DHCP over all the ethernet devices when the installer is started.

## Testing

- *Added a new unit test*
- *Tested manually*

![Screenshot From 2025-04-24 12-39-08](https://github.com/user-attachments/assets/c40db415-e981-4973-8158-f355b28baaf9)
