### PR TITLE
Filter out the special PXE boot parameters

### DIFF
--- a/live/live-root/usr/bin/kernel-cmdline-conf.sh
+++ b/live/live-root/usr/bin/kernel-cmdline-conf.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # Script to clean kernel command line from agama specific parameters. Result is later used for bootloader proposal.
 
@@ -12,6 +12,8 @@ write_kernel_args() {
   # if there is no kernel params
   touch "${TARGET}"
 
+  # silence the "To read lines rather than words..." hint
+  # shellcheck disable=SC2013
   for _i in $(cat "${SOURCE}"); do
     case ${_i} in
     # remove all agama kernel params
@@ -19,11 +21,23 @@ write_kernel_args() {
     LIBSTORAGE_* | YAST_* | inst* | agama* | live* | Y2* | ZYPP_* | autoyast*)
       _found=1
       ;;
+    # remove the Kiwi PXE boot options
+    rd.kiwi.* | ramdisk_size=* | initrd=* | BOOT_IMAGE=*)
+      _found=1
+      ;;
+    # remove the network configuration options
+    # https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html
+    ip=* | rd.route=* | bootdev=* | BOOTIF=* | rd.bootif=* | nameserver=* | \
+    rd.peerdns=* | rd.neednet=* | vlan=* | bond=* | team=* | bridge=*)
+      _found=1
+      ;;
     esac
 
     if [ -z "$_found" ]; then
-      echo "Non-Agama parameter found ($_i)"
+      echo "Using boot parameter \"$_i\""
       echo -n " $_i" >>"${TARGET}"
+    else
+      echo "Ignoring boot parameter \"$_i\""
     fi
     unset _found
   done

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 24 15:11:35 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Filter out the special PXE boot parameters, do not pass them
+  to the installed system. Remove also most of the network
+  settings (gh#agama-project/agama#2280)
+
+-------------------------------------------------------------------
 Wed Apr 23 08:39:34 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Rename "root" source directory to "live-root" to avoid confusion

--- a/live/test/fixtures/expected/cmdline
+++ b/live/test/fixtures/expected/cmdline
@@ -1,1 +1,1 @@
- BOOT_IMAGE=/boot/vmlinuz splash=silent mitigations=auto quiet nosimplefb=1
+ splash=silent mitigations=auto quiet nosimplefb=1


### PR DESCRIPTION
## Problem

- The special PXE boot parameters are passed to the installed system, that's wrong
- https://github.com/agama-project/agama/issues/2280

## Solution

- Enhance the filtering code to ignore the specific PXE boot parameters
- Remove also most of the network settings

## Testing

- The unit test has been updated
- Tested manually

## Screenshots

After booting the installer via PXE the extra parameters can be seen in the `/proc/cmdline` file. But the `/run/agama/cmdline.d/kernel.conf` does not include them and and journal log shows they were ignored:
![agama-boot-params](https://github.com/user-attachments/assets/362fec5c-d35e-4006-9078-8e0e67eef21c)

After booting the installed system no PXE boot option is present on the `linux` line:
![agama-boot-params-installed](https://github.com/user-attachments/assets/b05b96e5-4453-4b04-90de-2022d7710315)
