### PR TITLE
feat(live): Configure Firefox devtools to open in fullscreen

### DIFF
--- a/live/live-root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/live-root/root/.mozilla/firefox/profile/user.js.template
@@ -20,6 +20,14 @@ user_pref("browser.startup.homepage_override.mstone", "ignore");
 // TODO: make the XDG portal working again, it has more features (mounting USB flash)
 user_pref("widget.use-xdg-desktop-portal.file-picker", 0);
 
+// configure devtools
+// show devtools in a separate window
+user_pref("devtools.toolbox.host", "window");
+// show the console tab instead of the page inspector after pressing F12
+user_pref("devtools.toolbox.selectedTool", "console");
+// show time stamps in the console
+user_pref("devtools.webconsole.timestampMessages", true);
+
 // start always in the custom homepage
 user_pref("browser.startup.page", 1);
 // custom homepage: the value is expected to be replaced with the login URL by the startup script

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 25 14:10:04 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Display Firefox devtool in fullscreen window, display the
+  console by default after pressing F12, display timestamps
+  in console
+
+-------------------------------------------------------------------
 Thu Apr 24 16:40:41 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1239777, bsc#1236885 gh#agama-project/agama#2291.


### PR DESCRIPTION
## Problem

- The Firefox devtools are displayed at the bottom of the page
- If we need to take a screenshot of the browser console in openQA then some important errors might be hidden (need scrolling to see them)

The original state after pressing F12:
![agama-browser-devtools](https://github.com/user-attachments/assets/6895eace-6c6b-4d92-bc3c-35c9fd717049)


## Solution

- Open devtools in a separate window
- By default display the console tab
- Display timestamps in the console, that can help to match the browser log with the backend log

The new state after pressing F12:
![agama-browser-devtools-fullscreen](https://github.com/user-attachments/assets/58466e90-aa0e-4683-b173-fe17a1faaa15)
