### PR TITLE
Ensure the NetworkManager persistent connections are copied unless disabled explicitly

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network.sh
@@ -7,5 +7,5 @@
 
 if _val=$(getargs ip=); then
   mkdir -p /run/agama/
-  : >/run/agama/copy_network
+  : >/run/agama/custom_dracut_network
 fi

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
@@ -9,7 +9,6 @@ if [ -e /etc/hostname ]; then
 fi
 
 if getargbool 1 inst.copy_network; then
-  : >/run/agama/copy_network
   # If there is some explicit network configuration provided through the ip= kernel cmdline option
   # then we set the config server configuration diabling the DHCP auto configuration for ethernet
   # devices and also copying the configuration persistently (bsc#1241224, bsc#122486, bsc#1239777,
@@ -23,4 +22,6 @@ if getargbool 1 inst.copy_network; then
     mkdir -p "$NEWROOT/etc/NetworkManager/system-connections/"
     cp /run/NetworkManager/system-connections/* "$NEWROOT/etc/NetworkManager/system-connections/"
   fi
+else
+  : >/run/agama/not_copy_network
 fi

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
@@ -8,12 +8,13 @@ if [ -e /etc/hostname ]; then
   cp /etc/hostname "$NEWROOT/etc/hostname"
 fi
 
-# If there is some explicit network configuration provided through the ip= kernel cmdline option
-# then we set the config server configuration diabling the DHCP auto configuration for ethernet
-# devices and also copying the configuration persistently (bsc#1241224, bsc#122486, bsc#1239777,
-# bsc#1236885).
-if [ -e /run/agama/copy_network ]; then
-  if getargbool 1 inst.copy_network; then
+if getargbool 1 inst.copy_network; then
+  : >/run/agama/copy_network
+  # If there is some explicit network configuration provided through the ip= kernel cmdline option
+  # then we set the config server configuration diabling the DHCP auto configuration for ethernet
+  # devices and also copying the configuration persistently (bsc#1241224, bsc#122486, bsc#1239777,
+  # bsc#1236885).
+  if [ -e /run/agama/custom_dracut_network ]; then
     mkdir -p /run/NetworkManager/conf.d
     echo '[main]' >/run/NetworkManager/conf.d/00-agama-server.conf
     echo 'no-auto-default=*' >>/run/NetworkManager/conf.d/00-agama-server.conf

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/save-agama-conf.sh
@@ -10,7 +10,7 @@ fi
 
 if getargbool 1 inst.copy_network; then
   # If there is some explicit network configuration provided through the ip= kernel cmdline option
-  # then we set the config server configuration diabling the DHCP auto configuration for ethernet
+  # then we set the config server configuration disabling the DHCP auto configuration for ethernet
   # devices and also copying the configuration persistently (bsc#1241224, bsc#122486, bsc#1239777,
   # bsc#1236885).
   if [ -e /run/agama/custom_dracut_network ]; then

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 28 16:40:41 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Always create the /run/agama/copy_network file if not explicitly
+  disabled (related to gh#agama-project/agama#2291).
+
+-------------------------------------------------------------------
 Mon Apr 28 12:14:51 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed missing drivers in ppc64le initrd, fixes broken

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Thu Apr 28 16:40:41 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
-- Always create the /run/agama/copy_network file if not explicitly
-  disabled (related to gh#agama-project/agama#2291).
+- Ensure the persistent NetworkManager connections are copied if 
+  not explicitlly disabled (related to gh#agama-project/agama#2291)
 
 -------------------------------------------------------------------
 Mon Apr 28 12:14:51 UTC 2025 - Ladislav Slezák <lslezak@suse.com>

--- a/service/lib/agama/network.rb
+++ b/service/lib/agama/network.rb
@@ -73,7 +73,7 @@ module Agama
 
     HOSTNAME = "/etc/hostname"
     RESOLV = "/etc/resolv.conf"
-    COPY_NETWORK = "/run/agama/copy_network"
+    NOT_COPY_NETWORK = "/run/agama/not_copy_network"
     RESOLV_FLAG = "/run/agama/manage_resolv"
     ETC_NM_DIR = "/etc/NetworkManager"
     RUN_NM_DIR = "/run/NetworkManager"
@@ -94,7 +94,7 @@ module Agama
       copy(HOSTNAME)
 
       return unless Dir.exist?(ETC_NM_DIR)
-      return unless File.exist?(COPY_NETWORK)
+      return if File.exist?(NOT_COPY_NETWORK)
 
       copy_directory(
         File.join(ETC_NM_DIR, "system-connections"),

--- a/service/test/agama/network_test.rb
+++ b/service/test/agama/network_test.rb
@@ -32,13 +32,13 @@ describe Agama::Network do
   let(:fixtures) { File.join(FIXTURES_PATH, "root_dir") }
   let(:hostname_path) { File.join(fixtures, "etc", "hostname") }
   let(:agama_dir) { File.join(rootdir, "run", "agama") }
-  let(:copy_network) { File.join(agama_dir, "copy_network") }
+  let(:not_copy_network) { File.join(agama_dir, "not_copy_network") }
 
   before do
     allow(Yast::Installation).to receive(:destdir).and_return(targetdir)
     stub_const("Agama::Network::HOSTNAME", hostname_path)
     stub_const("Agama::Network::RUN_NM_DIR", File.join(rootdir, "run", "NetworkManager"))
-    stub_const("Agama::Network::COPY_NETWORK", copy_network)
+    stub_const("Agama::Network::NOT_COPY_NETWORK", not_copy_network)
     FileUtils.mkdir_p(agama_dir)
   end
 
@@ -66,14 +66,7 @@ describe Agama::Network do
         FileUtils.touch(File.join(etcdir, "system-connections", "wired.nmconnection"))
       end
 
-      context "and the /run/agama/copy_network file exists" do
-        around do |block|
-          FileUtils.mkdir_p(agama_dir)
-          FileUtils.touch(copy_network)
-          block.call
-          FileUtils.rm_f(copy_network)
-        end
-
+      context "and the /run/agama/not_copy_network file does not exist" do
         it "copies the configuration files" do
           network.install
           expect(File).to exist(
@@ -82,7 +75,14 @@ describe Agama::Network do
         end
       end
 
-      context "and the /run/agama/copy_network file does not exist" do
+      context "and the /run/agama/not_copy_network file exists" do
+        around do |block|
+          FileUtils.mkdir_p(agama_dir)
+          FileUtils.touch(not_copy_network)
+          block.call
+          FileUtils.rm_f(not_copy_network)
+        end
+
         it "does not try to copy any file" do
           expect(FileUtils).to_not receive(:cp_r)
           network.install


### PR DESCRIPTION
## Problem

If there is no network configuration specified through the kernel cmdline then the /run/agama/copy_network is not created and that is wrong as the network configuration written persistently during installation will not be copied to the target system.

- related to #2291 


## Solution

Modify the check discarding the copy of the network files if disabled explicitly (it will check if the **/run/agama/not_copy_network** file exists).

## Testing

- *Tested manually*

