### PR TITLE
Fixed missing drivers in ppc64le images (bsc#1241887)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Apr 28 12:14:51 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed missing drivers in ppc64le initrd, fixes broken
+  installation via PXE (bsc#1241887)
+- Removed the workaroung for adding the xhci-pci-renesas driver,
+  now it is included in the default dracut drivers
+
+-------------------------------------------------------------------
 Fri Apr 25 14:10:04 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Display Firefox devtool in fullscreen window, display the

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -98,26 +98,17 @@ echo 'add_dracutmodules+=" dracut-menu agama-cmdline "' >>/etc/dracut.conf.d/10-
 # decrease the kernel logging on the console, use a dracut module to do it early in the boot process
 echo 'add_dracutmodules+=" agama-logging "' > /etc/dracut.conf.d/10-agama-logging.conf
 
-# add xhci-pci-renesas to initrd if available (workaround for bsc#1237235)
-# FIXME: remove when the module is included in the default driver list in
-# in /usr/lib/dracut/modules.d/90kernel-modules/module-setup.sh, see
-# https://github.com/openSUSE/dracut/blob/7559201e7480a65b0da050263d96a1cd8f15f50d/modules.d/90kernel-modules/module-setup.sh#L42-L46
-for file in /lib/modules/*/kernel/drivers/usb/host/xhci-pci-renesas.ko*
-do
-  if [ -f "$file" ]; then
-    echo "Adding xhci-pci-renesas driver to initrd..."
-    echo 'add_drivers+=" xhci-pci-renesas "' >> /etc/dracut.conf.d/10-extra-drivers.conf
-    break
-  fi
-done
+# the ipmi drivers to the initrd (bsc#1237354)
+extra_drivers=(acpi_ipmi ipmi_devintf ipmi_poweroff ipmi_si ipmi_ssif ipmi_watchdog)
 
-# add ipmi drivers (bsc#1237354)
-for dir in /lib/modules/*/kernel/drivers/char/ipmi
+for driver in "${extra_drivers[@]}"
 do
-  if [ -d "$dir" ]; then
-    echo "Adding ipmi drivers to initrd..."
-    echo 'add_drivers+=" acpi_ipmi ipmi_devintf ipmi_poweroff ipmi_si ipmi_ssif ipmi_watchdog "' >> /etc/dracut.conf.d/10-extra-drivers.conf
-    break
+  # check if the driver is present (allow a suffix like .zstd or .xz for optionally compressed drivers)
+  if find /lib/modules -type f -name "$driver.ko*" -print0 | grep -qz .; then
+    echo "Adding $driver driver to initrd..."
+    echo "add_drivers+=\" $driver \"" >> /etc/dracut.conf.d/10-extra-drivers.conf
+  else
+    echo "Skipping driver $driver, not found in the system"
   fi
 done
 


### PR DESCRIPTION
## Problem

- The installer does not boot via PXE on ppc64le architecture
- https://bugzilla.suse.com/show_bug.cgi?id=1241887
- During boot this error message is printed and booting is aborted:
  ```
  dracut-pre-mount[1075]: modprobe: FATAL: Module brd not found in directory
  /usr/lib/modules/6.12.0-160000.5-default
  ```
- The generated initrd does not contain the `brd` driver which is need by Kiwi for PXE boot
- The build log contains this error:
  ```
  dracut[E]: FAILED:  /usr/lib/dracut/dracut-install -D  /var/tmp/dracut.ZzQ4qS/initramfs
  -N ^i2o_scsi$ --kerneldir /lib/modules/6.12.0-160000.9-default/ -m xhci_pci-renesas
  acpi_ipmi ipmi_devintf ipmi_poweroff ipmi_si ipmi_ssif ipmi_watchdog brd
  ```
- Despite the error dracut reports success so the problem can be easily overlooked :worried: 

## Solution

- It turned out that dracut gives up at the first missing driver (`acpi_ipmi`) and does not add the other remaining drivers
- The original check tested only the presence of the `ipmi` directory but the content can be actually different on different architectures
- So rather explicitly check presence of each driver

## Additional fix

- Removed the workaround for adding the `xhci-pci-renesas` driver,  now it is included in the default dracut drivers
- See https://github.com/openSUSE/dracut/pull/406

## Testing

- Build tested in https://build.opensuse.org/package/show/systemsmanagement:Agama:branches:pxe_build_fix_ppc64/agama-installer
- The build output snippet on ppc64le, the `acpi_ipmi` driver was skipped (on x86_64 all drivers are found and added to initrd)
```
[  314s] [ DEBUG   ]: 14:11:17 | Skipping driver acpi_ipmi, not found in the system
[  314s] [ DEBUG   ]: 14:11:17 | Adding ipmi_devintf driver to initrd...
[  314s] [ DEBUG   ]: 14:11:17 | Adding ipmi_poweroff driver to initrd...
[  314s] [ DEBUG   ]: 14:11:17 | Adding ipmi_si driver to initrd...
[  314s] [ DEBUG   ]: 14:11:17 | Adding ipmi_ssif driver to initrd...
[  314s] [ DEBUG   ]: 14:11:17 | Adding ipmi_watchdog driver to initrd...
```
- All required drivers are present in the created initrd:
```
[  611s] dracut[D]: drwxr-xr-x   2 root     root            0 Apr 28 16:12 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi
[  611s] dracut[D]: -rw-r--r--   1 root     root        29763 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi/ipmi_devintf.ko
[  611s] dracut[D]: -rw-r--r--   1 root     root       146051 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi/ipmi_msghandler.ko
[  611s] dracut[D]: -rw-r--r--   1 root     root        33211 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi/ipmi_poweroff.ko
[  611s] dracut[D]: -rw-r--r--   1 root     root       178883 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi/ipmi_si.ko
[  611s] dracut[D]: -rw-r--r--   1 root     root        77371 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi/ipmi_ssif.ko
[  611s] dracut[D]: -rw-r--r--   1 root     root        59123 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/char/ipmi/ipmi_watchdog.ko
...
[  611s] dracut[D]: -rw-r--r--   1 root     root        38395 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/usb/host/xhci-pci-renesas.ko
...
[  611s] dracut[D]: -rw-r--r--   1 root     root        23387 Apr 14 08:05 usr/lib/modules/6.14.2-1-default/kernel/drivers/block/brd.ko
```

