### PR TITLE
feat(live): Add "/usr/bin/chroot" tool to the initrd

### DIFF
--- a/live/live-root/etc/dracut.conf.d/90-usr-bin-chroot.conf
+++ b/live/live-root/etc/dracut.conf.d/90-usr-bin-chroot.conf
@@ -1,0 +1,3 @@
+# include the chroot binary in the initrd, it is useful for manually running the
+# tools from the root image before switching into it
+install_items+=" /usr/bin/chroot "

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 29 11:08:16 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Add "/usr/bin/chroot" tool to the initrd to allow manually
+  running the tools from the root image before switching into it
+
+-------------------------------------------------------------------
 Thu Apr 28 16:40:41 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Ensure the persistent NetworkManager connections are copied if 


### PR DESCRIPTION
## Problem

- The `/usr/bin/chroot` tool is not included in the initrd image anymore (it was in the past, probably some change in dracut...)

## Solution

- Explicitly include it in the dracut configuration

## Usage

It can be used for editing the file in the root image before booting the system. We could include an editor like `vim`, `joe` or `nano` in the initrd but those tools are quite big. In most cases you can just use the editor from the root image itself, you just need a `chroot` command for that.

- Boot with `rd.break=cleanup` option
- When the dracut maintenance prompt appears just press `Enter`
- Then run `chroot /sysroot` (that's the place where the future root is mounted at this point)
- Run the editor from the root image simply by using `vim ...` command
- Exit chroot (`Ctrl+D`)
- Exit maintenance mode (`Ctrl+D`)
- The boot continues using the modified files

The initrd size increase is tiny (~30kB uncompressed) compared to adding a full editor.

## Testing

- Tested manually

