### PR TITLE
Added .bash_history with some useful commands

### DIFF
--- a/live/live-root/root/.bash_history
+++ b/live/live-root/root/.bash_history
@@ -1,0 +1,8 @@
+systemctl restart agama.service agama-web-server.service && sleep 2 && systemctl restart x11-autologin.service
+less /var/log/YaST2/y2log
+journalctl -u agama-web-server.service
+journalctl -u agama.service
+systemctl status agama-web-server.service
+systemctl status agama.service
+agama config show | jq
+agama logs store

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 29 11:30:59 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Predefine some useful commands in the default bash history for
+  easier use. It can serve also as a hint how to save logs, etc...
+
+-------------------------------------------------------------------
 Tue Apr 29 11:08:16 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Add "/usr/bin/chroot" tool to the initrd to allow manually


### PR DESCRIPTION
## Problem

- It is annoying to type the debugging commands in a VM again and again.

## Solution

- What about preloading some useful commands in the `.bash_history` file?
- It can serve also as a hint how to save logs, etc...

## Notes

- The list of commands is definitely not complete, more ideas are welcome.

## Testing

- Tested manually
