### PR TITLE
Revert "Add "/usr/bin/chroot" tool to the initrd"

### DIFF
--- a/live/live-root/etc/dracut.conf.d/90-usr-bin-chroot.conf
+++ b/live/live-root/etc/dracut.conf.d/90-usr-bin-chroot.conf
@@ -1,3 +1,0 @@
-# include the chroot binary in the initrd, it is useful for manually running the
-# tools from the root image before switching into it
-install_items+=" /usr/bin/chroot "

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -5,12 +5,6 @@ Tue Apr 29 11:30:59 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
   easier use. It can serve also as a hint how to save logs, etc...
 
 -------------------------------------------------------------------
-Tue Apr 29 11:08:16 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
-
-- Add "/usr/bin/chroot" tool to the initrd to allow manually
-  running the tools from the root image before switching into it
-
--------------------------------------------------------------------
 Thu Apr 28 16:40:41 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Ensure the persistent NetworkManager connections are copied if 


### PR DESCRIPTION
- This reverts commit c084ee0589d91a86a2bd8ca1979d5ddf61c02c4c.
- Actually it is possible to use the `chroot` tool from the chroot itself:
  ```sh
  /sysroot/usr/bin/chroot /sysroot
  ```
- So the `chroot` in initrd is not needed, it just needs to be properly documented