### PR TITLE
add missing file to spec

### DIFF
--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -200,6 +200,7 @@ echo $PATH
 %{_bindir}/agama
 %dir %{_datadir}/agama-cli
 %{_datadir}/agama-cli/agama.libsonnet
+%{_datadir}/agama-cli/iscsi.schema.json
 %{_datadir}/agama-cli/profile.schema.json
 %{_datadir}/agama-cli/storage.schema.json
 %{_datadir}/agama-cli/storage.model.schema.json


### PR DESCRIPTION
## Problem

`agama profile validate` crashes as iscsi reference is missing.


## Solution

Fix rpm spec file.