### PR TITLE
feat(web): improve storage/ProposalFailedInfo

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May  5 14:50:48 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Improve storage proposal warning to mention mount paths when
+  logical volume space allocation fails (gh#agama-project/agama#2323).
+
+-------------------------------------------------------------------
 Tue Apr 22 14:14:53 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 14

--- a/web/src/components/storage/ProposalFailedInfo.test.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { installerRender } from "~/test-utils";
+import ProposalFailedInfo from "./ProposalFailedInfo";
+import { LogicalVolume } from "~/types/storage/data";
+
+const mockApiModel = jest.fn();
+
+jest.mock("~/hooks/storage/api-model", () => ({
+  ...jest.requireActual("~/hooks/storage/api-model"),
+  useApiModel: () => mockApiModel,
+}));
+
+// eslint-disable-next-line
+const fakeLogicalVolume: LogicalVolume = {
+  // @ts-expect-error: The #name property is used to distinguish new "devices"
+  // in the API model, but it is not yet exposed for logical volumes since they
+  // are currently not reusable. This directive exists to ensure developers
+  // don't overlook updating the ProposalFailedInfo component in the future,
+  // when logical volumes become reusable and the #name property is exposed. See
+  // the FIXME in the ProposalFailedInfo component for more context.
+  name: "Reusable LV",
+  lvName: "helpful",
+};
+
+describe("ProposalFailedInfo", () => {
+  it("renders nothing if there are no config errors", () => {
+    const { container } = installerRender(<ProposalFailedInfo />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing if there are no storage errors", () => {
+    const { container } = installerRender(<ProposalFailedInfo />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe("when there are neither, new partitions nor new logical volumes", () => {
+    it.todo("renders a generic warning");
+  });
+
+  describe("when there are only new partitions", () => {
+    it.todo("renders an specific warning refering to partitions");
+  });
+
+  describe("when there are only new logical volumes", () => {
+    it.todo("renders specific warning refering to volumes");
+  });
+
+  describe("when there are both, new partitions and new logical volumes", () => {
+    it.todo("renders more generic warning refering to file systems");
+  });
+});

--- a/web/src/components/storage/ProposalFailedInfo.test.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.test.tsx
@@ -49,47 +49,17 @@ const storageIssue: Issue = {
 
 const mockApiModel: apiModel.Config = {
   boot: {
-    configure: false,
+    configure: true,
+    device: {
+      default: true,
+      name: "/dev/vdb",
+    },
   },
   drives: [
     {
       name: "/dev/vdb",
       spacePolicy: "delete",
       partitions: [
-        {
-          mountPath: "/",
-          filesystem: {
-            reuse: false,
-            default: true,
-            type: "btrfs",
-            snapshots: true,
-          },
-          size: {
-            default: true,
-            min: 13421772800,
-          },
-          delete: false,
-          deleteIfNeeded: false,
-          resize: false,
-          resizeIfNeeded: false,
-        },
-        {
-          mountPath: "swap",
-          filesystem: {
-            reuse: false,
-            default: true,
-            type: "swap",
-          },
-          size: {
-            default: true,
-            min: 1073741824,
-            max: 2147483648,
-          },
-          delete: false,
-          deleteIfNeeded: false,
-          resize: false,
-          resizeIfNeeded: false,
-        },
         {
           name: "/dev/vdb1",
           size: {
@@ -116,8 +86,66 @@ const mockApiModel: apiModel.Config = {
         },
       ],
     },
+    {
+      name: "/dev/vdc",
+      spacePolicy: "delete",
+      partitions: [
+        {
+          mountPath: "/documents",
+          filesystem: {
+            reuse: false,
+            default: false,
+            type: "xfs",
+            label: "",
+          },
+          size: {
+            default: false,
+            min: 136365211648,
+          },
+          delete: false,
+          deleteIfNeeded: false,
+          resize: false,
+          resizeIfNeeded: false,
+        },
+      ],
+    },
   ],
-  volumeGroups: [],
+  volumeGroups: [
+    {
+      vgName: "system",
+      targetDevices: ["/dev/vdb"],
+      logicalVolumes: [
+        {
+          lvName: "root",
+          mountPath: "/",
+          filesystem: {
+            reuse: false,
+            default: true,
+            type: "btrfs",
+            snapshots: true,
+          },
+          size: {
+            default: true,
+            min: 13421772800,
+          },
+        },
+        {
+          lvName: "swap",
+          mountPath: "swap",
+          filesystem: {
+            reuse: false,
+            default: true,
+            type: "swap",
+          },
+          size: {
+            default: true,
+            min: 1073741824,
+            max: 2147483648,
+          },
+        },
+      ],
+    },
+  ],
 };
 
 jest.mock("~/hooks/storage/api-model", () => ({

--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -22,17 +22,114 @@
 
 import React from "react";
 import { Alert, Content } from "@patternfly/react-core";
-import { _, n_, formatList } from "~/i18n";
-import { useIssues, useConfigErrors } from "~/queries/issues";
-import { useConfigModel } from "~/queries/storage/config-model";
 import { IssueSeverity } from "~/types/issues";
+import { useApiModel } from "~/hooks/storage/api-model";
+import { useIssues, useConfigErrors } from "~/queries/issues";
 import * as partitionUtils from "~/components/storage/utils/partition";
+import { _, n_, formatList } from "~/i18n";
 import { sprintf } from "sprintf-js";
 
-function Description({ partitions, booting }) {
-  const newPartitions = partitions.filter((p) => !p.name);
+const UnallocatablePartitions = ({ partitions, hasBoot }) => {
+  const mountPaths = partitions.map((p) => partitionUtils.pathWithSize(p));
 
-  if (!newPartitions.length) {
+  return hasBoot
+    ? sprintf(
+        // TRANSLATORS: %s is a list of formatted mount points with size like
+        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)' (or a
+        // single mount point in the singular case).
+        n_(
+          "It is not possible to allocate the requested partition for booting and for %s.",
+          "It is not possible to allocate the requested partitions for booting, %s.",
+          mountPaths.length,
+        ),
+        formatList(mountPaths),
+      )
+    : sprintf(
+        // TRANSLATORS: %s is a list of formatted mount points with size like
+        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)' (or a
+        // single mount point in the singular case).
+        n_(
+          "It is not possible to allocate the requested partition for %s.",
+          "It is not possible to allocate the requested partitions for %s.",
+          mountPaths.length,
+        ),
+        formatList(mountPaths),
+      );
+};
+
+const UnallocatableVolumes = ({ logicalVolumes, hasBoot }) => {
+  const mountPaths = logicalVolumes.map((lv) => partitionUtils.pathWithSize(lv));
+
+  return hasBoot
+    ? sprintf(
+        // TRANSLATORS: %s is a list of formatted mount points with size like
+        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)' (or a
+        // single mount point in the singular case).
+        n_(
+          "It is not possible to allocate the requested partition for booting and volume for %s.",
+          "It is not possible to allocate the requested partition for booting and volumes %s.",
+          mountPaths.length,
+        ),
+        formatList(mountPaths),
+      )
+    : sprintf(
+        // TRANSLATORS: %s is a list of formatted mount points with size like
+        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)' (or a
+        // single mount point in the singular case).
+        n_(
+          "It is not possible to allocate the requested volume for %s.",
+          "It is not possible to allocate the requested volumes for %s.",
+          mountPaths.length,
+        ),
+        formatList(mountPaths),
+      );
+};
+
+const UnallocatableFileSystems = ({ devices, hasBoot }) => {
+  const mountPaths = devices.map((d) => partitionUtils.pathWithSize(d));
+
+  return hasBoot
+    ? sprintf(
+        // TRANSLATORS: %s is a list of formatted mount points with size like
+        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)' (or a
+        // single mount point in the singular case).
+        n_(
+          "It is not possible to allocate the requested partition for booting and file system for %s.",
+          "It is not possible to allocate the requested partition for booting and file systems %s.",
+          mountPaths.length,
+        ),
+        formatList(mountPaths),
+      )
+    : sprintf(
+        // TRANSLATORS: %s is a list of formatted mount points with size like
+        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)' (or a
+        // single mount point in the singular case).
+        n_(
+          "It is not possible to allocate the requested file system for %s.",
+          "It is not possible to allocate the requested file systems for %s.",
+          mountPaths.length,
+        ),
+        formatList(mountPaths),
+      );
+};
+
+const Description = () => {
+  const model = useApiModel({ suspense: true });
+  const partitions = model.drives.flatMap((d) => d.partitions || []);
+  const logicalVolumes = model.volumeGroups.flatMap((vg) => vg.logicalVolumes || []);
+
+  const newPartitions = partitions.filter((p) => !p.name);
+  // FIXME: Currently, it's not possible to reuse a logical volume, so all
+  // volumes are treated as new. This code cannot be made future-proof due to an
+  // internal decision not to expose unused properties, even though "#name" is
+  // used to infer whether a "device" is new or not.
+  // const newLogicalVolumes = logicalVolumes.filter((lv) => !lv.name);
+
+  const hasBoot = !!model.boot?.configure;
+  const hasPartitions = newPartitions.length !== 0;
+  const hasVolumes = logicalVolumes.length !== 0;
+
+  if (!hasPartitions && !hasVolumes) {
     return (
       <Content component="p">
         {_(
@@ -42,40 +139,28 @@ function Description({ partitions, booting }) {
     );
   }
 
-  const mountPaths = newPartitions.map((p) => partitionUtils.pathWithSize(p));
-  const msg1 = booting
-    ? sprintf(
-        // TRANSLATORS: %s is a list of formatted mount points with a partition size like
-        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)'
-        // (or a single mount point in the singular case).
-        n_(
-          "It is not possible to allocate the requested partitions for booting and for %s.",
-          "It is not possible to allocate the requested partitions for booting, %s.",
-          mountPaths.length,
-        ),
-        formatList(mountPaths),
-      )
-    : sprintf(
-        // TRANSLATORS: %s is a list of formatted mount points with a partition size like
-        // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)'
-        // (or a single mount point in the singular case).
-        n_(
-          "It is not possible to allocate the requested partition for %s.",
-          "It is not possible to allocate the requested partitions for %s.",
-          mountPaths.length,
-        ),
-        formatList(mountPaths),
-      );
-
   return (
     <>
-      <Content component="p">{msg1}</Content>
+      <Content component="p">
+        {hasPartitions && !hasVolumes && (
+          <UnallocatablePartitions partitions={newPartitions} hasBoot={hasBoot} />
+        )}
+        {!hasPartitions && hasVolumes && (
+          <UnallocatableVolumes logicalVolumes={logicalVolumes} hasBoot={hasBoot} />
+        )}
+        {hasPartitions && hasVolumes && (
+          <UnallocatableFileSystems
+            devices={[newPartitions, logicalVolumes].flat()}
+            hasBoot={hasBoot}
+          />
+        )}
+      </Content>
       <Content component="p">
         {_("Adjust the settings below to make the new system fit into the available space.")}
       </Content>
     </>
   );
-}
+};
 
 /**
  * Information about a failed storage proposal
@@ -84,17 +169,13 @@ function Description({ partitions, booting }) {
 export default function ProposalFailedInfo() {
   const configErrors = useConfigErrors("storage");
   const errors = useIssues("storage").filter((s) => s.severity === IssueSeverity.Error);
-  const model = useConfigModel({ suspense: true });
 
   if (configErrors.length) return;
   if (!errors.length) return;
 
-  const modelPartitions = model.drives.flatMap((d) => d.partitions || []);
-  const booting = !!model.boot?.configure;
-
   return (
     <Alert variant="warning" title={_("Failed to calculate a storage layout")}>
-      <Description partitions={modelPartitions} booting={booting} />
+      <Description />
     </Alert>
   );
 }

--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -88,8 +88,8 @@ export default function ProposalFailedInfo() {
   const configErrors = useConfigErrors("storage");
   const errors = useIssues("storage").filter((s) => s.severity === IssueSeverity.Error);
 
-  if (configErrors.length) return;
-  if (!errors.length) return;
+  if (configErrors.length !== 0) return;
+  if (errors.length === 0) return;
 
   return (
     <Alert variant="warning" title={_("Failed to calculate a storage layout")}>

--- a/web/src/components/storage/ProposalFailedInfo.tsx
+++ b/web/src/components/storage/ProposalFailedInfo.tsx
@@ -61,11 +61,14 @@ const Description = () => {
     <>
       <Content component="p">
         {sprintf(
-          // TRANSLATORS: %s is a list that includes "boot partition" and one or
-          // more formatted mount points with size like: '"/" (at least 10 GiB),
-          // "/var" (20 GiB), and "swap" (2 GiB)'.
-          _("It is not possible to allocate space for %s."),
-          formatList(isBootConfigured ? [_("boot partition"), ...mountPaths] : mountPaths),
+          isBootConfigured
+            ? // TRANSLATORS: %s is a list of formatted mount points with a partition size like
+              // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)'
+              _("It is not possible to allocate space for the boot partition and for %s.")
+            : // TRANSLATORS: %s is a list of formatted mount points with a partition size like
+              // '"/" (at least 10 GiB), "/var" (20 GiB) and "swap" (2 GiB)'
+              _("It is not possible to allocate space for %s."),
+          formatList(mountPaths),
         )}
       </Content>
       <Content component="p">
@@ -80,7 +83,7 @@ const Description = () => {
  * could not be generated with the current configuration.
  *
  * Renders nothing if:
- *   - The proposal could not be generated at all (known by the presense of
+ *   - The proposal could not be generated at all (known by the presence of
  *     configuration errors in the storage scope)
  *   - The generated proposal contains no errors.
  */


### PR DESCRIPTION
## Problem

When a proposal fails because not able to allocate space for an logical volume, the warning alert shown to users does not provide enough information because it is only aware of such a situation for partitions.

## Solution

To make such an alert aware of logical volumes but avoiding to entering in details and just mentioning affected mount paths.

## Testing

- Added a new unit test
- Tested manually


## Screenshots

|Before|After|
|-|-|
| ![localhost_8080_ (51)](https://github.com/user-attachments/assets/c4547fe6-32c0-4601-9754-159174071626) | ![localhost_8080_ (50)](https://github.com/user-attachments/assets/fe11bca0-d067-4e0e-8422-fa17be5fe6cc) |


---

Related to https://trello.com/c/vE4qvtDl (private link)