### PR TITLE
fix(rust): add iscsi.schema.json to agama-cli package

### DIFF
--- a/rust/install.sh
+++ b/rust/install.sh
@@ -40,6 +40,7 @@ install -D -t "${DESTDIR}${bindir}" "${SRCDIR}"/target/${RUST_TARGET}/agama-web-
 
 install6 -D -p "${SRCDIR}"/share/agama.pam "${DESTDIR}${pamvendordir}"/agama
 
+install6 -D -t "${DESTDIR}${datadir}"/agama-cli "${SRCDIR}"/agama-lib/share/iscsi.schema.json
 install6 -D -t "${DESTDIR}${datadir}"/agama-cli "${SRCDIR}"/agama-lib/share/profile.schema.json
 install6 -D -t "${DESTDIR}${datadir}"/agama-cli "${SRCDIR}"/agama-lib/share/storage.schema.json
 install6 -D -t "${DESTDIR}${datadir}"/agama-cli "${SRCDIR}"/agama-lib/share/storage.model.schema.json

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May  5 06:38:07 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the iscsi.schema.json to the agama-cli package (gh#agama-project/agama#2324).
+
+-------------------------------------------------------------------
 Fri May  2 07:42:21 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update dependencies (gh#agama-project/agama#2317).


### PR DESCRIPTION
## Problem

It is not possible to validate a profile since the `iscsi.schema.json`, introduced recently, is missing from the package.

## Solution

Add the ìscsi.schema.json file to the `agama-cli` package. Now that the validation is performed in the client side, we might consider moving those files to another package. But, by now, let's fix the auto-installation.
