### PR TITLE
feat(live): add perl-XML-Simple for backward compatibility

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May  6 14:14:50 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add perl-XML-Simple for backward compatibility (gh#agama-project/agama#2331).
+
+-------------------------------------------------------------------
 Tue Apr 29 11:30:59 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Predefine some useful commands in the default bash history for

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Tue May  6 14:14:50 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Add perl-XML-Simple for backward compatibility (gh#agama-project/agama#2331).
+- Add perl-XML-Simple for backward compatibility (jsc#PED-10122,
+  gh#agama-project/agama#2331).
 
 -------------------------------------------------------------------
 Tue Apr 29 11:30:59 UTC 2025 - Ladislav Slezák <lslezak@suse.com>

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -156,6 +156,8 @@
         <package name="qrencode"/>
         <package name="qemu-guest-agent" />
         <package name="aaa_base-extras"/>
+        <!-- it can be used by users in AutoYaST pre-scripts -->
+        <package name="perl-XML-Simple"/>
         <archive name="live-root.tar.xz"/>
     </packages>
 


### PR DESCRIPTION
The perl-XML-Simple library can be used to tweak the AutoYaST profile using pre-scripts. For that reason, it should be included in the installation media.