### PR TITLE
fix(rust): validate the product/addons section

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -225,6 +225,7 @@
               },
               "version": {
                 "title": "Version of the add-on",
+                "description": "It is mandatory if there are multiple available versions",
                 "type": "string"
               },
               "registrationCode": {

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -209,6 +209,30 @@
         "registrationUrl": {
           "title": "URL of the registration server",
           "type": "string"
+        },
+        "addons": {
+          "title": "List of add-ons to activate",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "title": "Add-on identifier",
+                "type": "string",
+                "examples": ["sle-ha"]
+              },
+              "version": {
+                "title": "Version of the add-on",
+                "type": "string"
+              },
+              "registrationCode": {
+                "title": "Add-on registration code",
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May  7 12:52:42 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add validation of the product/addons section (gh#agama-project/agama#2336).
+
+-------------------------------------------------------------------
 Wed May  7 06:35:19 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add MD RAIDs to the storage schema (gh#agama-project/agama#2286).


### PR DESCRIPTION
The `product/addons` section is not included in the schema so it is considered as invalid. Hence, a profile like the one below will not validate:

```json
{
  "id": "SLES",
  "registrationCode": "SOME-REG-CODE",
  "addons": [
    {
      "id": "sle-ha",
      "registrationCode": "SOME-REG-CODE"
    }
  ]
}
```

This PR adds this element to the validation. Manually tested.