### PR TITLE
fix(rust): use tracing instead of log in agama-server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -108,7 +108,6 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "libsystemd",
- "log",
  "macaddr",
  "openssl",
  "pam",

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 anyhow = "1.0"
 agama-locale-data = { path = "../agama-locale-data" }
 agama-lib = { path = "../agama-lib" }
-log = "0.4"
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 thiserror = "2.0.12"

--- a/rust/agama-server/src/agama-dbus-server.rs
+++ b/rust/agama-server/src/agama-dbus-server.rs
@@ -42,9 +42,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // When adding more services here, the order might be important.
     questions::export_dbus_objects(&connection).await?;
-    log::info!("Started questions interface");
+    tracing::info!("Started questions interface");
     l10n::export_dbus_objects(&connection, &locale).await?;
-    log::info!("Started locale interface");
+    tracing::info!("Started locale interface");
 
     connection
         .request_name(SERVICE_NAME)

--- a/rust/agama-server/src/l10n/helpers.rs
+++ b/rust/agama-server/src/l10n/helpers.rs
@@ -43,6 +43,6 @@ pub fn init_locale() -> Result<LocaleId, Box<dyn std::error::Error>> {
 ///
 pub fn set_service_locale(locale: &LocaleId) {
     if setlocale(LocaleCategory::LcAll, locale.to_string()).is_none() {
-        log::warn!("Could not set the locale");
+        tracing::warn!("Could not set the locale");
     }
 }

--- a/rust/agama-server/src/l10n/model/keyboard.rs
+++ b/rust/agama-server/src/l10n/model/keyboard.rs
@@ -101,7 +101,7 @@ fn get_keymaps() -> anyhow::Result<Vec<Keymap>> {
         if let Some(description) = xkb_descriptions.get(&keymap_id_str) {
             keymaps.push(Keymap::new(keymap_id, description));
         } else {
-            log::debug!("Keyboard '{}' not found in xkb database", keymap_id_str);
+            tracing::debug!("Keyboard '{}' not found in xkb database", keymap_id_str);
         }
     }
 

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -175,7 +175,7 @@ async fn set_config(
     }
 
     if let Err(e) = update_dbus(&state.proxy, &changes).await {
-        log::warn!("Could not synchronize settings in the localization D-Bus service: {e}");
+        tracing::warn!("Could not synchronize settings in the localization D-Bus service: {e}");
     }
     _ = state.events.send(Event::L10nConfigChanged(changes));
 

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -74,7 +74,7 @@ pub async fn manager_stream(
                 match InstallationPhase::try_from(phase) {
                     Ok(phase) => Some(Event::InstallationPhaseChanged { phase }),
                     Err(error) => {
-                        log::warn!("Ignoring the installation phase change. Error: {}", error);
+                        tracing::warn!("Ignoring the installation phase change. Error: {}", error);
                         None
                     }
                 }

--- a/rust/agama-server/src/network/nm/adapter.rs
+++ b/rust/agama-server/src/network/nm/adapter.rs
@@ -27,7 +27,6 @@ use crate::network::{
 use agama_lib::error::ServiceError;
 use async_trait::async_trait;
 use core::time;
-use log;
 use std::thread;
 
 /// An adapter for NetworkManager
@@ -109,7 +108,7 @@ impl Adapter for NetworkManagerAdapter<'_> {
             .await
             .map_err(NetworkAdapterError::Checkpoint)?;
 
-        log::info!("Updating the general state {:?}", &network.general_state);
+        tracing::info!("Updating the general state {:?}", &network.general_state);
 
         let result = self
             .client
@@ -122,7 +121,7 @@ impl Adapter for NetworkManagerAdapter<'_> {
                 .await
                 .map_err(NetworkAdapterError::Checkpoint)?;
 
-            log::error!(
+            tracing::error!(
                 "Could not update the general state {:?}: {}",
                 &network.general_state,
                 &e
@@ -136,7 +135,7 @@ impl Adapter for NetworkManagerAdapter<'_> {
                     continue;
                 }
             } else if conn.is_removed() {
-                log::info!(
+                tracing::info!(
                     "Connection {} ({}) does not need to be removed",
                     conn.id,
                     conn.uuid
@@ -144,7 +143,7 @@ impl Adapter for NetworkManagerAdapter<'_> {
                 continue;
             }
 
-            log::info!("Updating connection {} ({})", conn.id, conn.uuid);
+            tracing::info!("Updating connection {} ({})", conn.id, conn.uuid);
             let result = if conn.is_removed() {
                 self.client.remove_connection(conn.uuid).await
             } else {
@@ -159,7 +158,7 @@ impl Adapter for NetworkManagerAdapter<'_> {
                     .rollback_checkpoint(&checkpoint.as_ref())
                     .await
                     .map_err(NetworkAdapterError::Checkpoint)?;
-                log::error!("Could not process the connection {}: {}", conn.id, &e);
+                tracing::error!("Could not process the connection {}: {}", conn.id, &e);
                 return Err(NetworkAdapterError::Write(e));
             }
         }

--- a/rust/agama-server/src/network/nm/builder.rs
+++ b/rust/agama-server/src/network/nm/builder.rs
@@ -229,7 +229,7 @@ impl<'a> DeviceFromProxyBuilder<'a> {
         match MacAddress::from_str(mac) {
             Ok(mac) => mac,
             Err(_) => {
-                log::warn!("Unable to parse mac {}", &mac);
+                tracing::warn!("Unable to parse mac {}", &mac);
                 MacAddress::Unset
             }
         }

--- a/rust/agama-server/src/network/nm/client.rs
+++ b/rust/agama-server/src/network/nm/client.rs
@@ -37,7 +37,6 @@ use crate::network::model::{
 use agama_lib::dbus::get_optional_property;
 use agama_lib::error::ServiceError;
 use agama_lib::network::types::{DeviceType, SSID};
-use log;
 use uuid::Uuid;
 use zbus;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath};
@@ -199,7 +198,7 @@ impl<'a> NetworkManagerClient<'a> {
             let flags = proxy.flags().await?;
             // https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMSettingsConnectionFlags
             if flags & 8 != 0 {
-                log::warn!("Skipped connection because of flags: {}", flags);
+                tracing::warn!("Skipped connection because of flags: {}", flags);
                 continue;
             }
 
@@ -241,7 +240,7 @@ impl<'a> NetworkManagerClient<'a> {
             if let Some(uuid) = uuids_map.get(interface_name) {
                 conn.controller = Some(*uuid);
             } else {
-                log::warn!(
+                tracing::warn!(
                     "Could not found a connection for the interface '{}' (required by connection '{}')",
                     interface_name,
                     conn.id

--- a/rust/agama-server/src/network/nm/dbus.rs
+++ b/rust/agama-server/src/network/nm/dbus.rs
@@ -70,7 +70,7 @@ pub fn connection_to_dbus<'a>(
             ConnectionConfig::Bond(_) => BOND_KEY,
             ConnectionConfig::Bridge(_) => BRIDGE_KEY,
             _ => {
-                log::error!("Controller {} has unhandled config type", controller.id);
+                tracing::error!("Controller {} has unhandled config type", controller.id);
                 ""
             }
         };

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -21,7 +21,6 @@
 use std::collections::HashMap;
 
 use agama_lib::questions::{self, GenericQuestion, WithPassword};
-use log;
 use zbus::{fdo::ObjectManager, interface, zvariant::ObjectPath, Connection};
 
 mod answers;
@@ -172,7 +171,7 @@ impl Questions {
         default_option: &str,
         data: HashMap<String, String>,
     ) -> zbus::fdo::Result<ObjectPath> {
-        log::info!("Creating new question with text: {}.", text);
+        tracing::info!("Creating new question with text: {}.", text);
         let id = self.last_id;
         self.last_id += 1; // TODO use some thread safety
         let options = options.iter().map(|o| o.to_string()).collect();
@@ -205,7 +204,7 @@ impl Questions {
         default_option: &str,
         data: HashMap<String, String>,
     ) -> zbus::fdo::Result<ObjectPath> {
-        log::info!("Creating new question with password with text: {}.", text);
+        tracing::info!("Creating new question with password with text: {}.", text);
         let id = self.last_id;
         self.last_id += 1; // TODO use some thread safety
                            // TODO: share code better
@@ -283,11 +282,11 @@ impl Questions {
     #[zbus(property)]
     fn set_interactive(&mut self, value: bool) {
         if value != self.interactive() {
-            log::info!("interactive value unchanged - {}", value);
+            tracing::info!("interactive value unchanged - {}", value);
             return;
         }
 
-        log::info!("set interactive to {}", value);
+        tracing::info!("set interactive to {}", value);
         if value {
             self.answer_strategies.pop();
         } else {
@@ -296,7 +295,7 @@ impl Questions {
     }
 
     fn add_answer_file(&mut self, path: String) -> zbus::fdo::Result<()> {
-        log::info!("Adding answer file {}", path);
+        tracing::info!("Adding answer file {}", path);
         let answers = answers::Answers::new_from_file(path.as_str())
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         self.answer_strategies.push(Box::new(answers));

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -120,7 +120,7 @@ async fn patterns_changed_stream(
                 return match reason_to_selected_by(patterns) {
                     Ok(patterns) => Some(patterns),
                     Err(error) => {
-                        log::warn!("Ignoring the list of changed patterns. Error: {}", error);
+                        tracing::warn!("Ignoring the list of changed patterns. Error: {}", error);
                         None
                     }
                 };

--- a/rust/agama-server/src/storage/web/dasd/stream.rs
+++ b/rust/agama-server/src/storage/web/dasd/stream.rs
@@ -174,7 +174,7 @@ impl Stream for DASDDeviceStream {
                     if let Ok(event) = Self::handle_change(pinned.cache, &change) {
                         Some(event)
                     } else {
-                        log::warn!("Could not process change {:?}", &change);
+                        tracing::warn!("Could not process change {:?}", &change);
                         None
                     }
                 }
@@ -221,7 +221,7 @@ impl DASDFormatJobStream {
         let id = inner.header().path()?.to_string();
         let event = Self::to_event(id, &args);
         if event.is_none() {
-            log::warn!("Could not decode the DASDFormatJobChanged event");
+            tracing::warn!("Could not decode the DASDFormatJobChanged event");
         }
         event
     }

--- a/rust/agama-server/src/storage/web/iscsi.rs
+++ b/rust/agama-server/src/storage/web/iscsi.rs
@@ -88,7 +88,7 @@ async fn initiator_stream(
         .filter_map(|change| match handle_initiator_change(change) {
             Ok(event) => event,
             Err(error) => {
-                log::warn!("Could not read the initiator change: {}", error);
+                tracing::warn!("Could not read the initiator change: {}", error);
                 None
             }
         });

--- a/rust/agama-server/src/storage/web/iscsi/stream.rs
+++ b/rust/agama-server/src/storage/web/iscsi/stream.rs
@@ -161,7 +161,7 @@ impl Stream for ISCSINodeStream {
                     if let Ok(event) = Self::handle_change(pinned.cache, &change) {
                         Some(event)
                     } else {
-                        log::warn!("Could not process change {:?}", &change);
+                        tracing::warn!("Could not process change {:?}", &change);
                         None
                     }
                 }

--- a/rust/agama-server/src/storage/web/zfcp/stream.rs
+++ b/rust/agama-server/src/storage/web/zfcp/stream.rs
@@ -164,7 +164,7 @@ impl Stream for ZFCPDiskStream {
                     if let Ok(event) = Self::handle_change(pinned.cache, &change) {
                         Some(event)
                     } else {
-                        log::warn!("Could not process change {:?}", &change);
+                        tracing::warn!("Could not process change {:?}", &change);
                         None
                     }
                 }
@@ -297,7 +297,7 @@ impl Stream for ZFCPControllerStream {
                     if let Ok(event) = Self::handle_change(pinned.cache, &change) {
                         Some(event)
                     } else {
-                        log::warn!("Could not process change {:?}", &change);
+                        tracing::warn!("Could not process change {:?}", &change);
                         None
                     }
                 }

--- a/rust/agama-server/src/web/common/jobs.rs
+++ b/rust/agama-server/src/web/common/jobs.rs
@@ -193,7 +193,7 @@ impl Stream for JobsStream {
                     if let Ok(event) = Self::handle_change(pinned.cache, &change) {
                         Some(event)
                     } else {
-                        log::warn!("Could not process change {:?}", &change);
+                        tracing::warn!("Could not process change {:?}", &change);
                         None
                     }
                 }


### PR DESCRIPTION
## Problem

`agama-dbus-server` is not writing to the logs. The problem is that, in `agama-server` code, we are using [tracing](https://tokio.rs/tokio/topics/tracing). So it is hard to debug problems like #2332.

## Solution

Replace `log` with `tracing` for all code below `agama-server`.

## Testing

- *Tested manually*