### PR TITLE
fix(rust): fix automatic answer of questions with password

### DIFF
--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -220,8 +220,8 @@ impl Questions {
         let mut question = questions::WithPassword::new(base);
         let object_path = ObjectPath::try_from(question.base.object_path()).unwrap();
 
-        let base_question = question.base.clone();
         self.fill_answer_with_password(&mut question);
+        let base_question = question.base.clone();
         let base_object = GenericQuestionObject(base_question);
 
         self.connection

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed May  7 21:04:24 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix automatic answer of questions with password (gh#agama-project/agama#2332).
+
+-------------------------------------------------------------------
+Wed May  7 15:08:36 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix agama-dbus-server to write to journald logs (gh#agama-project/agama#2339).
+
+-------------------------------------------------------------------
 Wed May  7 12:52:42 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add validation of the product/addons section (gh#agama-project/agama#2336).


### PR DESCRIPTION
## Problem

Automatic handling of questions with password does not work.

- Fixes https://github.com/agama-project/agama/issues/2332
- https://bugzilla.suse.com/show_bug.cgi?id=1242441

## Solution

Read the password after the question is updated.

Note: the PR includes an entry in the changes file for #2339.

## Testing

- *Tested manually*