### PR TITLE
fix(web): prevent MenuButton from opening on focus loss

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  8 13:43:53 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- MenuButton no longer opens unexpectedly when navigating
+  with the keyboard (gh#agama-project/agama#2345).
+
+-------------------------------------------------------------------
 Wed May  7 13:46:05 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Add "Skip to content" link for easing navigation for keyboard-only

--- a/web/src/components/core/MenuButton.tsx
+++ b/web/src/components/core/MenuButton.tsx
@@ -134,9 +134,13 @@ export default function MenuButton({
     if (!isOpen) setMenuHeights({ ...menuHeights, [rootId]: undefined });
   };
 
+  const onOpenChange = (nextState) => {
+    setIsOpen(nextState);
+  };
+
   const toggle = () => {
-    setIsOpen(!isOpen);
     resetState();
+    setIsOpen(!isOpen);
   };
 
   const drillIn = (
@@ -176,7 +180,7 @@ export default function MenuButton({
   return (
     <MenuContainer
       isOpen={isOpen}
-      onOpenChange={toggle}
+      onOpenChange={onOpenChange}
       toggleRef={toggleRef}
       popperProps={{ direction: "down", enableFlip: false, ...menuProps.popperProps }}
       toggle={


### PR DESCRIPTION
Avoid reusing the `toggle` callback from `MenuToggle#onClick` as the `MenuContainer#onOpenChange` handler. These two callbacks serve different purposes:
  - `toggle` is intended to handle events and receives a `SyntheticEvent`.
  - `onOpenChange` is triggered by focus-related events and receives a boolean indicating the next `isOpen` state.

Using `toggle` for `onOpenChange` led to incorrect behavior, such as the menu opening when focus was lost.

## Screencasts

Before

https://github.com/user-attachments/assets/0e7ac964-a5c7-4074-819f-ba834487fb9f


After

https://github.com/user-attachments/assets/22f1a4df-2bb1-4f38-82d0-c1f3e8a241cd
