### PR TITLE
fix(ruby): fix network and hostname conversion from AutoYaST

### DIFF
--- a/service/lib/agama/autoyast/bootloader_reader.rb
+++ b/service/lib/agama/autoyast/bootloader_reader.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2users/config"
+require "y2users/autoinst/reader"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Builds the Agama "root" section from an AutoYaST profile.
+    class BootloaderReader
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # Returns a hash that corresponds to Agama "root" section.
+      #
+      # @return [Hash] Agama "root" section
+      def read
+        global = profile.fetch_as_hash("bootloader")
+          .fetch_as_hash("global")
+        return {} if global.empty?
+
+        bootloader = {}
+        bootloader["timeout"] = global["timeout"] if global["timeout"].is_a?(Integer)
+        bootloader["extraKernelParams"] = global["append"] unless global["append"].to_s.empty?
+        { "bootloader" => bootloader }
+      end
+
+    private
+
+      attr_reader :profile
+    end
+  end
+end

--- a/service/lib/agama/autoyast/bootloader_reader.rb
+++ b/service/lib/agama/autoyast/bootloader_reader.rb
@@ -26,16 +26,16 @@ require "y2users/autoinst/reader"
 # :nodoc:
 module Agama
   module AutoYaST
-    # Builds the Agama "root" section from an AutoYaST profile.
+    # Builds the Agama "bootloader" section from an AutoYaST profile.
     class BootloaderReader
       # @param profile [ProfileHash] AutoYaST profile
       def initialize(profile)
         @profile = profile
       end
 
-      # Returns a hash that corresponds to Agama "root" section.
+      # Returns a hash that corresponds to Agama "bootloader" section.
       #
-      # @return [Hash] Agama "root" section
+      # @return [Hash] Agama "bootloader" section
       def read
         global = profile.fetch_as_hash("bootloader")
           .fetch_as_hash("global")

--- a/service/lib/agama/autoyast/connections_reader.rb
+++ b/service/lib/agama/autoyast/connections_reader.rb
@@ -65,7 +65,7 @@ module Agama
       # @return [Hash]
       def read_connection(interface)
         conn = {}
-        conn["interface"] = interface.device if interface.device
+        conn["interface"] = interface.device unless interface.device.to_s.empty?
         conn["id"] = interface.name if interface.name
 
         addresses = read_addresses(interface)

--- a/service/lib/agama/autoyast/connections_reader.rb
+++ b/service/lib/agama/autoyast/connections_reader.rb
@@ -65,7 +65,7 @@ module Agama
       # @return [Hash]
       def read_connection(interface)
         conn = {}
-        conn["device"] = interface.device if interface.device
+        conn["interface"] = interface.device if interface.device
         conn["id"] = interface.name if interface.name
 
         addresses = read_addresses(interface)
@@ -74,7 +74,7 @@ module Agama
         conn["method6"] = method6
         conn["addresses"] = addresses
         wireless = Agama::AutoYaST::WirelessReader.new(interface).read
-        conn["wireless"] = wireless unless wireless.empty?
+        conn.merge!(wireless) unless wireless.empty?
         bond = Agama::AutoYaST::BondReader.new(interface).read
         conn["bond"] = bond unless bond.empty?
         conn.merge!(dns)

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -53,6 +53,7 @@ module Agama
       # Sections which have a corresponding reader. The reader is expected to be
       # named in Pascal case and adding "Reader" as suffix (e.g., "L10nReader").
       SECTIONS = [
+        "bootloader",
         "files",
         "localization",
         "product",

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -55,7 +55,9 @@ module Agama
       SECTIONS = [
         "bootloader",
         "files",
+        "hostname",
         "localization",
+        "network",
         "product",
         "root",
         "scripts",

--- a/service/lib/agama/autoyast/network_reader.rb
+++ b/service/lib/agama/autoyast/network_reader.rb
@@ -40,10 +40,7 @@ module Agama
 
         section = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(networking)
         dns = read_dns_settings(section.dns)
-        connections_reader = Agama::AutoYaST::ConnectionsReader.new(
-          section.interfaces, ipv6: ipv6?, dns: dns
-        )
-        connections = connections_reader.read
+        connections = read_connections(section.interfaces, dns)
         return {} if connections.empty?
 
         { "network" => connections }
@@ -57,12 +54,25 @@ module Agama
         profile.fetch_as_hash("networking").fetch("ipv6", false)
       end
 
+      # @param section [Y2Network::AutoinstProfile::Interfaces, nil] AutoYaST interfaces section.
+      # @param dns [Hash] Agama DNS settings.
+      def read_connections(interfaces, dns)
+        return [] if interfaces.nil?
+
+        connections_reader = Agama::AutoYaST::ConnectionsReader.new(
+          interfaces, ipv6: ipv6?, dns: dns
+        )
+        connections_reader.read
+      end
+
       # Reads an AutoYaST DNS section and builds its equivalent hash.
       #
-      # @param dns_section [Y2Network::AutoinstProfile::DNSSection] DNS section.
+      # @param dns_section [Y2Network::AutoinstProfile::DNSSection, nil] DNS section.
       # @return [Hash]
       def read_dns_settings(dns_section)
         dns = {}
+        return dns if dns_section.nil?
+
         dns["dns_searchlist"] = dns_section.searchlist unless dns_section.searchlist.empty?
         dns["nameservers"] = dns_section.nameservers unless dns_section.nameservers.empty?
         dns

--- a/service/lib/agama/autoyast/profile_checker.rb
+++ b/service/lib/agama/autoyast/profile_checker.rb
@@ -58,7 +58,7 @@ module Agama
               elements_from(e, "#{parent}#{ProfileDescription::SEPARATOR}#{k}[#{i}]")
             end
           else
-            elements_from(v, k)
+            elements_from(v, current)
           end
 
           [current, *children]

--- a/service/lib/agama/autoyast/wireless_reader.rb
+++ b/service/lib/agama/autoyast/wireless_reader.rb
@@ -39,12 +39,15 @@ module Agama
       #
       # @return [Hash]
       def read
-        wireless = {}
+        wireless = {
+          "ssid" => section.wireless_essid.to_s
+        }
+        return {} if wireless["ssid"].empty?
+
         security = security_from(section.wireless_auth_mode)
         wireless["security"] = security if security
         mode = mode_from(section.wireless_mode)
         wireless["mode"] = mode if mode
-        wireless["ssid"] = section.wireless_essid.to_s
 
         case security
         when "wpa-psk"

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  9 15:37:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Convert the bootloader section to JSON (gh#agama-project/agama#2349).
+- Fix the conversion of the hostname and the networking sections to JSON
+  (gh#agama-project/agama#2349).
+
+-------------------------------------------------------------------
 Wed May  7 10:24:14 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Convert AutoYaST DNS section to JSON (gh#agama-project/agama#2335).

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -2,6 +2,44 @@
   { "key": "add-on", "support": "planned" },
   { "key": "audit-laf", "support": "no" },
   { "key": "auth-client", "support": "no" },
+  {
+    "key": "bootloader",
+    "children": [
+      { "key": "device_map", "support": "no" },
+      {
+        "key": "global",
+        "children": [
+          { "key": "activate", "support": "no" },
+          {
+            "key": "append",
+            "support": "yes",
+            "agama": "bootloader.extraKernelParams"
+          },
+          { "key": "boot_boot", "support": "no" },
+          { "key": "boot_custom", "support": "no" },
+          { "key": "boot_extended", "support": "no" },
+          { "key": "boot_mbr", "support": "no" },
+          { "key": "boot_root", "support": "no" },
+          { "key": "cpu_mitigations", "support": "no" },
+          { "key": "generic_mbr", "support": "no" },
+          { "key": "gfxmode", "support": "no" },
+          { "key": "os_prober", "support": "no" },
+          { "key": "password", "support": "no" },
+          { "key": "suse_btrfs", "support": "no" },
+          { "key": "serial", "support": "no" },
+          { "key": "secure_boot", "support": "no" },
+          { "key": "terminal", "support": "no" },
+          { "key": "timeout", "support": "yes", "agama": "bootloader.timeout" },
+          { "key": "trusted_boot", "support": "no" },
+          { "key": "update_nvram", "support": "no" },
+          { "key": "vgamode", "support": "no" },
+          { "key": "xen_append", "support": "no" },
+          { "key": "xen_kernel_append", "support": "no" }
+        ]
+      },
+      { "key": "loader_type", "support": "no" }
+    ]
+  },
   { "key": "configuration_management", "support": "no" },
   { "key": "deploy_image", "support": "no" },
   { "key": "dhcp-server", "support": "no" },

--- a/service/test/agama/autoyast/bootloader_reader_test.rb
+++ b/service/test/agama/autoyast/bootloader_reader_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/bootloader_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::BootloaderReader do
+  let(:profile) do
+    { "bootloader" => { "global" => global } }
+  end
+  let(:global) { {} }
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'bootloader' section" do
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    context "when kernel parameters are defined" do
+      let(:global) do
+        { "append" => "param0 param1" }
+      end
+
+      it "returns a hash including the 'extraKernelParams'" do
+        expect(subject.read["bootloader"]).to include(
+          "extraKernelParams" => "param0 param1"
+        )
+      end
+    end
+
+    context "when a timeout is given" do
+      let(:global) do
+        { "timeout" => 5 }
+      end
+
+      it "returns a hash containing the 'timeout' " do
+        expect(subject.read["bootloader"]).to include(
+          "timeout" => 5
+        )
+      end
+    end
+  end
+end

--- a/service/test/agama/autoyast/connections_reader_test.rb
+++ b/service/test/agama/autoyast/connections_reader_test.rb
@@ -176,7 +176,7 @@ describe Agama::AutoYaST::ConnectionsReader do
 
     context "when there are wireless settings" do
       let(:eth0) do
-        { "name" => "eth0", "wireless_mode" => "wpa-psk" }
+        { "name" => "eth0", "wireless_essid" => "mywifi" }
       end
 
       it "includes a 'wireless' key containing those settings" do


### PR DESCRIPTION
## Problem

* The network and the hostname sections are not processed either (although the readers are implemented).
* The bootloader section is not processed when importing the AutoYaST profile.

## Solution

Add support for just a few bootloader parameters and enable network (with fixes) and hostname sections.

## Testing

- Added a new unit test
- Tested manually