### PR TITLE
Fix History API loop

### DIFF
--- a/rust/agama-lib/src/product/store.rs
+++ b/rust/agama-lib/src/product/store.rs
@@ -24,7 +24,6 @@ use crate::{
     base_http_client::BaseHTTPClient,
     manager::http_client::{ManagerHTTPClient, ManagerHTTPClientError},
 };
-use std::{thread, time};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProductStoreError {
@@ -92,16 +91,6 @@ impl ProductStore {
         }
         if let Some(reg_code) = &settings.registration_code {
             let email = settings.registration_email.as_deref().unwrap_or("");
-
-            if probe {
-                // give the UI a short time for processing the events related to changing the
-                // product before starting registration because it triggers another pile of events
-                // in the Web UI as well (workaround for gh#agama-project#2274)
-                // even 1 second should be enough, but rather be safe and use 5s for slow networks,
-                // in autoinstallation it does not hurt
-                let delay = time::Duration::from_secs(5);
-                thread::sleep(delay);
-            }
 
             self.product_client.register(reg_code, email).await?;
             // TODO: avoid reprobing if the system has been already registered with the same code?

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 12 12:55:40 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Remove the delay between selecting the product and registering it,
+  the problem has been fixed in the web UI
+  (removed workaround for gh#agama-project/agama#2274)
+
+-------------------------------------------------------------------
 Wed May  7 21:04:24 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix automatic answer of questions with password (gh#agama-project/agama#2332).

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon May 12 12:47:46 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed React router navigation to avoid quickly switching between
+  two paths in a loop causing "Too many calls to Location or
+  History APIs within a short timeframe" error in Firefox and
+  crashing the UI (the proper fix for gh#agama-project/agama#2274)
+
+-------------------------------------------------------------------
 Thu May  8 13:43:53 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - MenuButton no longer opens unexpectedly when navigating

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,7 +62,8 @@ function App() {
       return <Navigate to={ROOT.installationFinished} />;
     }
 
-    if (!products || !connected) return <Loading listenQuestions />;
+    if (!products || !connected || (selectedProduct === undefined && isBusy))
+      return <Loading listenQuestions />;
 
     if (phase === InstallationPhase.Startup && isBusy) {
       return <Loading listenQuestions />;

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -112,7 +112,7 @@ function ProductSelectionPage() {
   const [showLicense, setShowLicense] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  if (!isEmpty(registration?.key)) return <Navigate to={PATHS.root} />;
+  if (!isEmpty(registration?.key) && selectedProduct) return <Navigate to={PATHS.root} />;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Problem

- When registering the product from CLI the web UI was broken in Firefox
  ![Image](https://github.com/user-attachments/assets/90c12b88-14ed-4c83-9ae7-9fa006b0084c)
- See https://github.com/agama-project/agama/issues/2274
- It was fixed by a workaround: https://github.com/agama-project/agama/pull/2281
- But we should find the real fix and remove that ugly workaround

## Debugging

To debug the issue I have reverted the #2281 fix and added a small snippet which tracks using the History API into the `web/src/index.tsx` file:

```js
let counter = 1;
const original = window.history.pushState;
window.history.pushState = function (data, unused, url) {
  console.log("pushState: ", counter, data, url);
  counter += 1;
  original.apply(this, [data, unused, url]);
};
```

That revealed that the History API was switching quickly between the product selection page and the probing progress page:

![agama-too-many-push-states-orig](https://github.com/user-attachments/assets/380ffc30-12e7-44fe-aff1-883feb329d0c)

The Firefox browser has a limit of 200 History API calls within 10 seconds. After that an error is reported and an exception is raised. That exception causes a crash in the React router resulting in empty screen.

The problematic code was in the main application router:

```tsx
if (selectedProduct === undefined && location.pathname !== PRODUCT.root) {
  return <Navigate to={PRODUCT.root} />;
}

if (phase === InstallationPhase.Config && isBusy && location.pathname !== PRODUCT.progress) {
  return <Navigate to={PRODUCT.progress} />;
}
```

The problem happened when the selected product was not updated yet (`selectedProduct === undefined`) but probing was already in progress (`isBusy === true`). In that case these conditions caused switching between the two paths as fast as possible. On my machine it was switching about 1000 times per second as displayed in the log above.

A similar problem was present in the product selection page.

## Solution

- Handle this case explicitly, if that happens display the loading page until the selected product is updated.

## Testing

- Tested manually, registration from CLI works fine even without that delay workaround
- There are just few calls to the History API
  ![agama-too-many-push-states-fix1](https://github.com/user-attachments/assets/4f161cc8-3554-4444-89a6-149c5371f1f9)

