### PR TITLE
fix(rust): fix setting of the questions mode

### DIFF
--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -281,7 +281,7 @@ impl Questions {
 
     #[zbus(property)]
     fn set_interactive(&mut self, value: bool) {
-        if value != self.interactive() {
+        if value == self.interactive() {
             tracing::info!("interactive value unchanged - {}", value);
             return;
         }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 13 09:28:46 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix setting the mode for questions (bsc#1242441).
+
+-------------------------------------------------------------------
 Mon May 12 12:55:40 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Remove the delay between selecting the product and registering it,


### PR DESCRIPTION
## Problem

It is not possible to set the questions mode to `non-interactive`.

## Solution

Fix the condition.

## Testing

- *Tested manually*