### PR TITLE
Do not set the root option in /boot/grub2/grub.cfg (bsc#1236873)

### DIFF
--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -20,7 +20,7 @@ fi
 test -f $dst/.profile && . $dst/.profile
 
 arch=`uname -m`
-profile=$(echo "$kiwi_profiles" | tr "-" " ")
+profile=$(echo "$kiwi_profiles" | tr "_" " ")
 label="$profile ($arch)"
 
 if [ -d "$dst/boot/grub2/themes/SLE" ]; then
@@ -36,7 +36,6 @@ cat >$dst/boot/grub2/grub.cfg <<XXX
 # Agama generated grub2 config file
 set btrfs_relative_path="y"
 export btrfs_relative_path
-search --file --set=root /boot/0x11cebed2
 set default=0
 if [ -n "\$extra_cmdline" ]; then
   submenu "Bootable snapshot \$snapshot_num" {

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -20,7 +20,7 @@ fi
 test -f $dst/.profile && . $dst/.profile
 
 arch=`uname -m`
-profile=$(echo "$kiwi_profiles" | tr "-" " ")
+profile=$(echo "$kiwi_profiles" | tr "_" " ")
 label="$profile ($arch)"
 
 if [ -d "$dst/boot/grub2/themes/SLE" ]; then
@@ -36,7 +36,6 @@ cat >$dst/boot/grub2/grub.cfg <<XXX
 # Agama generated grub2 config file
 set btrfs_relative_path="y"
 export btrfs_relative_path
-search --file --set=root /boot/0xebe87947
 set default=0
 if [ -n "\$extra_cmdline" ]; then
   submenu "Bootable snapshot \$snapshot_num" {

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May 13 16:56:56 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not set the root in /boot/grub2/grub.cfg file, it was wrong
+  and the root is already set in the /boot/grub2/earlyboot.cfg
+  file (bsc#1236873)
+- Replace underscores in the boot menu label by spaces
+
+-------------------------------------------------------------------
 Wed May  7 07:07:33 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed locale cleanup to not delete all locales


### PR DESCRIPTION
## Problem

- The root option in `/boot/grub2/grub.cfg` points to a non-existing file, the target name is not constant and is changed
- But the root is already set in the `/boot/grub2/earlyboot.cfg` file, this line is not needed actually
- See https://bugzilla.suse.com/show_bug.cgi?id=1236873

## Solution

- Remove that unnecessary and invalid line

## Testing

- Tested manually, the Live ISO still boots :smiley: 

## Additional fix

- Replace underscores in the boot menu label by spaces
- The separator in the Kiwi profile names was changed from dash to underscore in the past without updating this transformation
- It changes the "Install SUSE_SLE_16 (x86_64)" boot menu label to "Install SUSE SLE 16 (x86_64)" which looks better
