### PR TITLE
fix(rust): enable serde suppor for uuid and update changes

### DIFF
--- a/rust/agama-network/Cargo.toml
+++ b/rust/agama-network/Cargo.toml
@@ -23,5 +23,5 @@ tokio-stream = "0.1.17"
 tokio-test = "0.4.4"
 tracing = "0.1.41"
 utoipa = { version = "5.3.1", features = ["uuid"] }
-uuid = { version = "1.16.0", features = ["v4"] }
+uuid = { version = "1.16.0", features = ["v4", "serde"] }
 zbus = { version = "5", default-features = false, features = ["tokio"] }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 14 12:28:57 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Extract network and utilities to the new agama-network and agama-utils
+  packages (gh#agama-project/agama#2357).
+
+-------------------------------------------------------------------
 Tue May 13 09:28:46 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix setting the mode for questions (bsc#1242441).


### PR DESCRIPTION
Follow up of #2357.

- Enable serde support for uuid. The package is building in OBS, but failing locally from a clean build.
- Update the changes file for #2357.
