### PR TITLE
Coveralls fixes

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -38,6 +38,8 @@ on:
 
 jobs:
   rust_ci:
+    # the default timeout is 6 hours, that's too much if the job gets stuck
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
       COVERAGE: 1
@@ -59,6 +61,9 @@ jobs:
 
     - name: Git Checkout
       uses: actions/checkout@v4
+
+    - name: Configure git
+      run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Configure and refresh repositories
       # disable unused repositories to have faster refresh
@@ -108,12 +113,38 @@ jobs:
         cargo xtask openapi
         openapi-spec-validator out/openapi/*
 
+    - name: Upload coverage result
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage_rust
+        if-no-files-found: error
+        path: rust/cobertura.xml
+
+  # The coveralls action for some unknown reason gets stuck when running inside
+  # a container. As a workaround save the coverage data and send it in a
+  # separate job running directly in the Ubuntu host, that works fine.
+  # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#passing-data-between-jobs-in-a-workflow
+  coveralls:
+    # the default timeout is 6 hours, this should take just few seconds
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs: rust_ci
+    defaults:
+      run:
+        working-directory: ./rust
+
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+
+    - name: Download coverage result
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage_rust
+
     # send the code coverage for the Rust part to the coveralls.io
     - name: Coveralls GitHub Action
-      # ignore errors in this step
-      continue-on-error: true
       uses: coverallsapp/github-action@v2
-      # ignore errors in this step
       with:
         base-path: ./rust
         format: cobertura
@@ -124,10 +155,7 @@ jobs:
     # Web parts (it needs a separate step, the "carryforward" flag can be used
     # only with the "parallel-finished: true" option)
     - name: Coveralls Finished
-      # ignore errors in this step
-      continue-on-error: true
       uses: coverallsapp/github-action@v2
-      # ignore errors in this step
       with:
         parallel-finished: true
-        carryforward: "service,web"
+        carryforward: "rust,service,web"

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,5 +1,6 @@
 name: CI - Rust
-
+permissions:
+  contents: read
 on:
   push:
     paths:

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -38,6 +38,8 @@ on:
 
 jobs:
   ruby_tests:
+    # the default timeout is 6 hours, that's too much if the job gets stuck
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
       COVERAGE: 1
@@ -58,6 +60,9 @@ jobs:
 
     - name: Git Checkout
       uses: actions/checkout@v4
+
+    - name: Configure git
+      run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Configure and refresh repositories
       # disable unused repositories to have faster refresh
@@ -94,10 +99,37 @@ jobs:
     - name: Run the tests and generate coverage report
       run: bundle exec rspec
 
+    - name: Upload coverage result
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage_service
+        if-no-files-found: error
+        path: service/coverage/lcov.info
+
+  # The coveralls action for some unknown reason gets stuck when running inside
+  # a container. As a workaround save the coverage data and send it in a
+  # separate job running directly in the Ubuntu host, that works fine.
+  # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#passing-data-between-jobs-in-a-workflow
+  coveralls:
+    # the default timeout is 6 hours, this should take just few seconds
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs: ruby_tests
+    defaults:
+      run:
+        working-directory: ./service
+
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v4
+
+    - name: Download coverage result
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage_service
+
     # send the code coverage for the Ruby part to the coveralls.io
     - name: Coveralls GitHub Action
-      # ignore errors in this step
-      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         base-path: ./service
@@ -108,9 +140,7 @@ jobs:
     # Rust parts (it needs a separate step, the "carryforward" flag can be used
     # only with the "parallel-finished: true" option)
     - name: Coveralls Finished
-      # ignore errors in this step
-      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true
-        carryforward: "rust,web"
+        carryforward: "rust,service,web"

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -1,5 +1,6 @@
 name: CI - Service
-
+permissions:
+  contents: read
 on:
   push:
     paths:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -34,6 +34,8 @@ on:
 
 jobs:
   frontend_build:
+    # the default timeout is 6 hours, that's too much if the job gets stuck
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     defaults:
@@ -72,20 +74,20 @@ jobs:
 
     - name: Run the tests and generate coverage report
       run: npm test -- --coverage --silent
-#
-#    # send the code coverage for the web part to the coveralls.io
-#    - name: Coveralls GitHub Action
-#      uses: coverallsapp/github-action@v2
-#      with:
-#        base-path: ./web
-#        flag-name: web
-#        parallel: true
-#
-#    # close the code coverage and inherit the previous coverage for the Ruby and
-#    # Rust parts (it needs a separate step, the "carryforward" flag can be used
-#    # only with the "parallel-finished: true" option)
-#    - name: Coveralls Finished
-#      uses: coverallsapp/github-action@v2
-#      with:
-#        parallel-finished: true
-#        carryforward: "service,rust"
+
+    # send the code coverage for the web part to the coveralls.io
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@v2
+      with:
+        base-path: ./web
+        flag-name: web
+        parallel: true
+
+    # close the code coverage and inherit the previous coverage for the Ruby and
+    # Rust parts (it needs a separate step, the "carryforward" flag can be used
+    # only with the "parallel-finished: true" option)
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true
+        carryforward: "rust,service,web"

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,5 +1,6 @@
 name: CI - Web
-
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
## Problem

- The Coveralls reporting step in the GitHub Actions got stuck ([example job](https://github.com/agama-project/agama/actions/runs/15013186385/job/42185530706#step:9:170))
- And because the default timeout is 6 hours then the CI was stuck for 6 hours
- The number of the assigned Action runners is limited so after reaching the limit new CI actions were not started and were waiting until some previous job is finished.

## Debugging

- At first I noticed an error in the Coveralls output:
  `⚠️ git log -1 --pretty=format:'%H%n%aN%n%aE%n%cN%n%cE%n%s' (return code 128)`
  see https://github.com/agama-project/agama/actions/runs/15023225072/job/42217441468#step:14:166
- Running this command in a separate step showed that it was failing because of a different file owner:
  `fatal: detected dubious ownership in repository at '/__w/agama/agama'`
  see https://github.com/agama-project/agama/actions/runs/15020310724/job/42207691974#step:9:9
- But even after adding that config command it got still stuck
- After enabling the Coveralls steps in the web frontend again I noticed that it works fine without any problem so I tested moving the Coveralls step outside the container and it worked.
- Very likely there is some incompatibility in the Coveralls action and it does not work well when running inside a container with openSUSE Tumbleweed (Different `git` CLI tool? Different glibc, nodejs or something else?)

## Solution

- Enable back the code coverage reporting in the web frontend
- Configure `git` so a different owner is OK (this was not the root of the problem in the end but this could cause troubles elsewhere later so I'm keeping this change anyway.)
- Run the coverage actions outside container, run them in the Ubuntu host directly
  (That's a bit tricky, if a job runs in a container then all steps run in the container, you cannot run a command outside the container. The workaround is to define a dependent job which runs outside the container and pass the coverage data as an artifact which is uploaded/downloaded.)
- Decrease the timeout, explicitly set 1 hour for CI and 20 minutes for Coveralls to not block for too long if the job gets stuck for whatever reason.
- Limit the permissions as suggested by the GitHub scanner to only read the repository content.

## Testing

- Works fine, see the green marks for this pull request, the Coveralls reports were correctly sent.
