### PR TITLE
fix(storage): correct candidate drives

### DIFF
--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -303,9 +303,6 @@ module Agama
 
         # List of disks available for installation
         #
-        # Each device is represented by an array containing the name of the device and the label to
-        # represent that device in the UI when further information is needed.
-        #
         # @return [Array<::DBus::ObjectPath>]
         def available_devices
           proposal.available_devices.map { |d| system_devices_tree.path_for(d) }

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/space_policy.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/space_policy.rb
@@ -89,7 +89,7 @@ module Agama
           # @return [Boolean]
           def search_all?(partition_config)
             !partition_config.search.nil? &&
-              partition_config.search.always_match? &&
+              !partition_config.search.condition? &&
               partition_config.search.max.nil?
           end
         end

--- a/service/lib/agama/storage/config_solver.rb
+++ b/service/lib/agama/storage/config_solver.rb
@@ -20,7 +20,6 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_solvers"
-require "y2storage/disk_analyzer"
 
 module Agama
   module Storage
@@ -34,13 +33,10 @@ module Agama
     # generated from a profile.
     class ConfigSolver
       # @param product_config [Agama::Config] configuration of the product to install
-      # @param devicegraph [Y2Storage::Devicegraph] initial layout of the system
-      # @param disk_analyzer [Y2Storage::DiskAnalyzer, nil] extra information about the initial
-      #   layout of the system
-      def initialize(product_config, devicegraph, disk_analyzer: nil)
+      # @param storage_system [Storage::System]
+      def initialize(product_config, storage_system)
         @product_config = product_config
-        @devicegraph = devicegraph
-        @disk_analyzer = disk_analyzer || Y2Storage::DiskAnalyzer.new(devicegraph)
+        @storage_system = storage_system
       end
 
       # Solves the config according to the product and the system.
@@ -52,10 +48,10 @@ module Agama
         ConfigSolvers::Boot.new(product_config).solve(config)
         ConfigSolvers::Encryption.new(product_config).solve(config)
         ConfigSolvers::Filesystem.new(product_config).solve(config)
-        ConfigSolvers::DrivesSearch.new(devicegraph, disk_analyzer).solve(config)
-        ConfigSolvers::MdRaidsSearch.new(devicegraph, disk_analyzer).solve(config)
+        ConfigSolvers::DrivesSearch.new(storage_system).solve(config)
+        ConfigSolvers::MdRaidsSearch.new(storage_system).solve(config)
         # Sizes must be solved once the searches are solved.
-        ConfigSolvers::Size.new(product_config, devicegraph).solve(config)
+        ConfigSolvers::Size.new(product_config).solve(config)
       end
 
     private
@@ -63,11 +59,8 @@ module Agama
       # @return [Agama::Config]
       attr_reader :product_config
 
-      # @return [Y2Storage::Devicegraph]
-      attr_reader :devicegraph
-
-      # @return [Y2Storage::DiskAnalyzer]
-      attr_reader :disk_analyzer
+      # @return [Storage::System]
+      attr_reader :storage_system
     end
   end
 end

--- a/service/lib/agama/storage/config_solvers/base.rb
+++ b/service/lib/agama/storage/config_solvers/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,9 +33,11 @@ module Agama
 
         # Solves a given config.
         #
+        # @note Derived classes must implement this method.
+        #
         # @param _config [Config]
         def solve(_config)
-          raise "#solve is not defined"
+          raise NotImplementedError
         end
 
       private

--- a/service/lib/agama/storage/config_solvers/drives_search.rb
+++ b/service/lib/agama/storage/config_solvers/drives_search.rb
@@ -31,12 +31,10 @@ module Agama
         include SearchMatchers
         include WithPartitionsSearch
 
-        # @param devicegraph [Y2Storage::Devicegraph]
-        # @param disk_analyzer [Y2Storage::DiskAnalyzer]
-        def initialize(devicegraph, disk_analyzer)
+        # @param storage_system [Storage::System]
+        def initialize(storage_system)
           super()
-          @devicegraph = devicegraph
-          @disk_analyzer = disk_analyzer
+          @storage_system = storage_system
         end
 
         # Solves the search of the drive configs and solves the searches of their partitions.
@@ -46,18 +44,15 @@ module Agama
         # @param config [Storage::Config]
         # @return [Storage::Config]
         def solve(config)
-          config.drives = super(config.drives, candidate_drives)
+          config.drives = super(config.drives, storage_system.candidate_drives)
           solve_partitions_search(config.drives)
           config
         end
 
       private
 
-        # @return [Y2Storage::Devicegraph]
-        attr_reader :devicegraph
-
-        # @return [Y2Storage::DiskAnalyzer]
-        attr_reader :disk_analyzer
+        # @return [Storage::System]
+        attr_reader :storage_system
 
         # @see DevicesSearch#match_condition?
         # @param drive_config [Configs::Drive]
@@ -66,14 +61,6 @@ module Agama
         # @return [Boolean]
         def match_condition?(drive_config, drive)
           match_name?(drive_config, drive) && match_size?(drive_config, drive)
-        end
-
-        # Candidate drives for solving the search of drive configs.
-        #
-        # @return [Array<Y2Storage::Drive, Y2Storage::StrayBlkDevice>]
-        def candidate_drives
-          drives = devicegraph.disk_devices + devicegraph.stray_blk_devices
-          drives.select { |d| disk_analyzer.candidate_device?(d) }
         end
       end
     end

--- a/service/lib/agama/storage/config_solvers/md_raids_search.rb
+++ b/service/lib/agama/storage/config_solvers/md_raids_search.rb
@@ -31,12 +31,10 @@ module Agama
         include SearchMatchers
         include WithPartitionsSearch
 
-        # @param devicegraph [Y2Storage::Devicegraph]
-        # @param disk_analyzer [Y2Storage::DiskAnalyzer]
-        def initialize(devicegraph, disk_analyzer)
+        # @param storage_system [Storage::System]
+        def initialize(storage_system)
           super()
-          @devicegraph = devicegraph
-          @disk_analyzer = disk_analyzer
+          @storage_system = storage_system
         end
 
         # Solves the search of the MD RAID configs and solves the searches of their partitions.
@@ -46,18 +44,15 @@ module Agama
         # @param config [Storage::Config]
         # @return [Storage::Config]
         def solve(config)
-          config.md_raids = super(config.md_raids, candidate_md_raids)
+          config.md_raids = super(config.md_raids, storage_system.candidate_md_raids)
           solve_partitions_search(config.md_raids)
           config
         end
 
       private
 
-        # @return [Y2Storage::Devicegraph]
-        attr_reader :devicegraph
-
-        # @return [Y2Storage::DiskAnalyzer]
-        attr_reader :disk_analyzer
+        # @return [Storage::System]
+        attr_reader :storage_system
 
         # @see DevicesSearch#match_condition?
         # @param md_raid_config [Configs::MdRaid]
@@ -66,13 +61,6 @@ module Agama
         # @return [Boolean]
         def match_condition?(md_raid_config, md_raid)
           match_name?(md_raid_config, md_raid) && match_size?(md_raid_config, md_raid)
-        end
-
-        # Candidate MD RAIDs for solving the search of the configs.
-        #
-        # @return [Array<Y2Storage::Md]
-        def candidate_md_raids
-          devicegraph.md_raids.select { |d| disk_analyzer.candidate_device?(d) }
         end
       end
     end

--- a/service/lib/agama/storage/config_solvers/size.rb
+++ b/service/lib/agama/storage/config_solvers/size.rb
@@ -29,13 +29,6 @@ module Agama
       #
       # It assigns proper size values according to the product and the system.
       class Size < Base
-        # @param product_config [Agama::Config]
-        # @param devicegraph [Y2Storage::Devicegraph]
-        def initialize(product_config, devicegraph)
-          super(product_config)
-          @devicegraph = devicegraph
-        end
-
         # Solves all the size configs within a given config.
         #
         # @note The config object is modified.
@@ -49,9 +42,6 @@ module Agama
         end
 
       private
-
-        # @return [Y2Storage::Devicegraph]
-        attr_reader :devicegraph
 
         def solve_default_sizes
           configs_with_default_product_size.each { |c| solve_default_product_size(c) }

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -83,11 +83,12 @@ module Agama
           @solved = true
         end
 
-        # Whether the search does not define any specific condition.
+        # Whether the search defines any condition.
         #
         # @return [Boolean]
-        def always_match?
-          name.nil?
+        def condition?
+          condition = name || size || partition_number
+          !condition.nil?
         end
 
         # Whether the section containing the search should be skipped

--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -167,7 +167,7 @@ module Agama
       def calculate_guided(settings)
         logger.info("Calculating proposal with guided strategy: #{settings.inspect}")
         reset
-        @strategy = ProposalStrategies::Guided.new(product_config, logger, settings)
+        @strategy = ProposalStrategies::Guided.new(product_config, storage_system, settings, logger)
         calculate
       end
 
@@ -179,7 +179,7 @@ module Agama
         logger.info("Calculating proposal with agama strategy: #{config.inspect}")
         reset
         @source_config = config.copy
-        @strategy = ProposalStrategies::Agama.new(product_config, storage_system, logger, config)
+        @strategy = ProposalStrategies::Agama.new(product_config, storage_system, config, logger)
         calculate
       end
 
@@ -193,7 +193,8 @@ module Agama
         reset
         # Ensures keys are strings.
         partitioning = JSON.parse(partitioning.to_json)
-        @strategy = ProposalStrategies::Autoyast.new(product_config, logger, partitioning)
+        @strategy = ProposalStrategies::Autoyast
+          .new(product_config, storage_system, partitioning, logger)
         calculate
       end
 

--- a/service/lib/agama/storage/proposal_strategies/agama.rb
+++ b/service/lib/agama/storage/proposal_strategies/agama.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,12 +34,14 @@ module Agama
         alias_method :settings, :config
 
         # @param product_config [Agama::Config]
+        # @param storage_system [Storage::System]
         # @param logger [Logger]
         # @param config [Agama::Storage::Config]
-        def initialize(product_config, logger, config)
+        def initialize(product_config, storage_system, logger, config)
           textdomain "agama"
 
           super(product_config, logger)
+          @storage_system = storage_system
           @config = config
         end
 
@@ -60,6 +62,9 @@ module Agama
 
       private
 
+        # @return [Storage::System]
+        attr_reader :storage_system
+
         # @return [Y2Storage::AgamaProposal, nil] Proposal used.
         attr_reader :proposal
 
@@ -67,11 +72,12 @@ module Agama
         #
         # @return [Y2Storage::AgamaProposal]
         def agama_proposal
-          Y2Storage::AgamaProposal.new(config,
+          Y2Storage::AgamaProposal.new(
+            config,
+            storage_system,
             product_config: product_config,
-            devicegraph:    probed_devicegraph,
-            disk_analyzer:  disk_analyzer,
-            issues_list:    [])
+            issues_list:    []
+          )
         end
       end
     end

--- a/service/lib/agama/storage/proposal_strategies/agama.rb
+++ b/service/lib/agama/storage/proposal_strategies/agama.rb
@@ -35,13 +35,12 @@ module Agama
 
         # @param product_config [Agama::Config]
         # @param storage_system [Storage::System]
-        # @param logger [Logger]
         # @param config [Agama::Storage::Config]
-        def initialize(product_config, storage_system, logger, config)
+        # @param logger [Logger]
+        def initialize(product_config, storage_system, config, logger)
           textdomain "agama"
 
-          super(product_config, logger)
-          @storage_system = storage_system
+          super(product_config, storage_system, logger)
           @config = config
         end
 
@@ -61,9 +60,6 @@ module Agama
         end
 
       private
-
-        # @return [Storage::System]
-        attr_reader :storage_system
 
         # @return [Y2Storage::AgamaProposal, nil] Proposal used.
         attr_reader :proposal

--- a/service/lib/agama/storage/proposal_strategies/autoyast.rb
+++ b/service/lib/agama/storage/proposal_strategies/autoyast.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -31,12 +31,13 @@ module Agama
         include Yast::I18n
 
         # @param product_config [Config] Product config
-        # @param logger [Logger]
+        # @param storage_system [Storage::System]
         # @param partitioning [Array<Hash>]
-        def initialize(product_config, logger, partitioning)
+        # @param logger [Logger]
+        def initialize(product_config, storage_system, partitioning, logger)
           textdomain "agama"
 
-          super(product_config, logger)
+          super(product_config, storage_system, logger)
           @partitioning = partitioning
         end
 
@@ -52,8 +53,8 @@ module Agama
           proposal = Y2Storage::AutoinstProposal.new(
             partitioning:      partitioning,
             proposal_settings: proposal_settings,
-            devicegraph:       probed_devicegraph,
-            disk_analyzer:     disk_analyzer,
+            devicegraph:       storage_system.devicegraph,
+            disk_analyzer:     storage_system.analyzer,
             issues_list:       ay_issues
           )
           proposal.propose

--- a/service/lib/agama/storage/proposal_strategies/base.rb
+++ b/service/lib/agama/storage/proposal_strategies/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -71,6 +71,8 @@ module Agama
         end
 
         # Available devices for installation.
+        #
+        # @deprecated Only used by Guided strategy.
         #
         # @return [Array<Y2Storage::Device>]
         def available_devices

--- a/service/lib/agama/storage/proposal_strategies/base.rb
+++ b/service/lib/agama/storage/proposal_strategies/base.rb
@@ -29,9 +29,11 @@ module Agama
       # Base class for the strategies used by the Agama proposal.
       class Base
         # @param product_config [Config] Product config
+        # @param storage_system [Storage::System]
         # @param logger [Logger]
-        def initialize(product_config, logger)
+        def initialize(product_config, storage_system, logger)
           @product_config = product_config
+          @storage_system = storage_system
           @logger = logger
         end
 
@@ -60,33 +62,11 @@ module Agama
         # @return [Config]
         attr_reader :product_config
 
+        # @return [Storage::System]
+        attr_reader :storage_system
+
         # @return [Logger]
         attr_reader :logger
-
-        # @return [Y2Storage::DiskAnalyzer, nil] nil if the system is not probed yet.
-        def disk_analyzer
-          return nil unless storage_manager.probed?
-
-          storage_manager.probed_disk_analyzer
-        end
-
-        # Available devices for installation.
-        #
-        # @deprecated Only used by Guided strategy.
-        #
-        # @return [Array<Y2Storage::Device>]
-        def available_devices
-          disk_analyzer&.candidate_disks || []
-        end
-
-        # Devicegraph representing the system
-        #
-        # @return [Y2Storage::Devicegraph, nil] nil if the system is not probed yet.
-        def probed_devicegraph
-          return nil unless storage_manager.probed?
-
-          storage_manager.probed
-        end
 
         # @return [Y2Storage::StorageManager]
         def storage_manager

--- a/service/lib/agama/storage/proposal_strategies/guided.rb
+++ b/service/lib/agama/storage/proposal_strategies/guided.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -31,12 +31,13 @@ module Agama
         include Yast::I18n
 
         # @param product_config [Config] Product config
-        # @param logger [Logger]
+        # @param storage_system [Storage::System]
         # @param input_settings [ProposalSettings]
-        def initialize(product_config, logger, input_settings)
+        # @param logger [Logger]
+        def initialize(product_config, storage_system, input_settings, logger)
           textdomain "agama"
 
-          super(product_config, logger)
+          super(product_config, storage_system, logger)
           @input_settings = input_settings
         end
 
@@ -76,6 +77,13 @@ module Agama
         # @return [ProposalSettings]
         attr_reader :input_settings
 
+        # Available devices for installation.
+        #
+        # @return [Array<Y2Storage::Device>]
+        def available_devices
+          storage_system.analyzer&.candidate_disks || []
+        end
+
         # Selects the first available device as target device for installation.
         #
         # @param settings [ProposalSettings]
@@ -113,8 +121,8 @@ module Agama
         def guided_proposal(settings)
           Y2Storage::MinGuidedProposal.new(
             settings:      settings.to_y2storage(config: product_config),
-            devicegraph:   probed_devicegraph,
-            disk_analyzer: disk_analyzer
+            devicegraph:   storage_system.devicegraph,
+            disk_analyzer: storage_system.analyzer
           )
         end
 

--- a/service/lib/agama/storage/system.rb
+++ b/service/lib/agama/storage/system.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/storage_manager"
+require "y2storage/disk_analyzer"
+
+module Agama
+  module Storage
+    # Helper class for asking about the system devices.
+    class System
+      # @param devicegraph [Y2Storage::Divecegraph, nil] Devicegraph representing the system. Probed
+      #   is used by default.
+      def initialize(devicegraph = nil)
+        return unless devicegraph
+
+        @devicegraph = devicegraph
+        @disk_analizer = Y2Storage::DiskAnalyzer.new(devicegraph)
+      end
+
+      # Candidate drives for installation.
+      #
+      # @return [Array<Y2Storage::Drive, Y2Storage::StrayBlkDevice>]
+      def candidate_drives
+        return [] unless devicegraph
+
+        drives = devicegraph.disk_devices + devicegraph.stray_blk_devices
+        drives.select { |d| analyzer.candidate_device?(d) }
+      end
+
+      # Candidate MD RAIDs for installation.
+      #
+      # @return [Array<Y2Storage::Md]
+      def candidate_md_raids
+        return [] unless devicegraph
+
+        devicegraph.md_raids.select { |d| analyzer.candidate_device?(d) }
+      end
+
+      # Devicegraph representing the system.
+      #
+      # @return [Y2Storage::Devicegraph]
+      def devicegraph
+        @devicegraph || storage_manager.probed
+      end
+
+      # Analyzer of the devicegraph representing the system.
+      #
+      # @return [Y2Storage::DiskAnalyzer]
+      def analyzer
+        @disk_analyzer || storage_manager.probed_disk_analyzer
+      end
+
+    private
+
+      # @return [Y2Storage::StorageManager]
+      def storage_manager
+        Y2Storage::StorageManager.instance
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/system.rb
+++ b/service/lib/agama/storage/system.rb
@@ -26,7 +26,7 @@ module Agama
   module Storage
     # Helper class for asking about the system devices.
     class System
-      # @param devicegraph [Y2Storage::Divecegraph, nil] Devicegraph representing the system. Probed
+      # @param devicegraph [Y2Storage::Devicegraph, nil] Devicegraph representing the system. Probed
       #   is used by default.
       def initialize(devicegraph = nil)
         return unless devicegraph

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 16 08:45:58 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Fix list of candidate drives and candidate MD RAIDs for
+  installation (gh#agama-project/agama#2362).
+
+-------------------------------------------------------------------
 Wed May 14 15:15:47 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add search conditions to storage (gh#agama-project/agama#2338).
@@ -26,7 +32,7 @@ Wed May  7 10:24:14 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 Wed May  7 06:33:28 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add support for creating and reusing MD RAID devices
-  (gh#agama-project/agama#2286).
+  (gh#agama-project/agama#2286, bsc#1241958).
 
 -------------------------------------------------------------------
 Tue May  6 11:33:52 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/service/test/agama/storage/config_checkers/context.rb
+++ b/service/test/agama/storage/config_checkers/context.rb
@@ -23,16 +23,17 @@ require_relative "../storage_helpers"
 require "agama/config"
 require "agama/storage/config_conversions/from_json"
 require "agama/storage/config_solver"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/encryption_method/tpm_fde"
 
 shared_context "checker" do
   # Solves the config.
   def solve_config
-    devicegraph = Y2Storage::StorageManager.instance.probed
+    storage_system = Agama::Storage::System.new
 
     Agama::Storage::ConfigSolver
-      .new(product_config, devicegraph)
+      .new(product_config, storage_system)
       .solve(config)
   end
 

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -24,6 +24,9 @@ require_relative "../../../test_helper"
 require "agama/storage/config_conversions/from_json"
 require "agama/storage/config_solver"
 require "agama/storage/model_support_checker"
+require "agama/storage/system"
+require "y2storage/blk_device"
+require "y2storage/encryption_method"
 require "y2storage/refinements"
 
 using Y2Storage::Refinements::SizeCasts
@@ -94,13 +97,13 @@ describe Agama::Storage::ModelSupportChecker do
 
   let(:product_config) { Agama::Config.new(product_data) }
 
-  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
+  let(:storage_system) { Agama::Storage::System.new }
 
   let(:config) do
     Agama::Storage::ConfigConversions::FromJSON
       .new(config_json)
       .convert
-      .tap { |c| Agama::Storage::ConfigSolver.new(product_config, devicegraph).solve(c) }
+      .tap { |c| Agama::Storage::ConfigSolver.new(product_config, storage_system).solve(c) }
   end
 
   before do
@@ -109,6 +112,8 @@ describe Agama::Storage::ModelSupportChecker do
     allow(Y2Storage::EncryptionMethod::TPM_FDE)
       .to(receive(:possible?))
       .and_return(true)
+    # Speed-up fallback search (and make sure it fails)
+    allow(Y2Storage::BlkDevice).to receive(:find_by_any_name)
   end
 
   subject { described_class.new(config) }

--- a/service/test/agama/storage/config_conversions/to_model_test.rb
+++ b/service/test/agama/storage/config_conversions/to_model_test.rb
@@ -23,6 +23,9 @@ require_relative "../storage_helpers"
 require_relative "../../../test_helper"
 require "agama/storage/config_conversions"
 require "agama/storage/config_solver"
+require "agama/storage/system"
+require "y2storage/blk_device"
+require "y2storage/encryption_method"
 require "y2storage/refinements"
 
 using Y2Storage::Refinements::SizeCasts
@@ -595,13 +598,15 @@ describe Agama::Storage::ConfigConversions::ToModel do
 
   let(:product_config) { Agama::Config.new(product_data) }
 
-  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
+  let(:storage_system) { Agama::Storage::System.new }
+
+  let(:devicegraph) { storage_system.devicegraph }
 
   let(:config) do
     Agama::Storage::ConfigConversions::FromJSON
       .new(config_json)
       .convert
-      .tap { |c| Agama::Storage::ConfigSolver.new(product_config, devicegraph).solve(c) }
+      .tap { |c| Agama::Storage::ConfigSolver.new(product_config, storage_system).solve(c) }
   end
 
   before do
@@ -610,6 +615,8 @@ describe Agama::Storage::ConfigConversions::ToModel do
     allow(Y2Storage::EncryptionMethod::TPM_FDE)
       .to(receive(:possible?))
       .and_return(true)
+    # Speed-up fallback search (and make sure it fails)
+    allow(Y2Storage::BlkDevice).to receive(:find_by_any_name)
   end
 
   subject { described_class.new(config) }

--- a/service/test/agama/storage/config_solver_test.rb
+++ b/service/test/agama/storage/config_solver_test.rb
@@ -23,6 +23,7 @@ require_relative "./storage_helpers"
 require "agama/config"
 require "agama/storage/config_conversions"
 require "agama/storage/config_solver"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/refinements"
 
@@ -99,7 +100,7 @@ describe Agama::Storage::ConfigSolver do
       .convert
   end
 
-  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
+  let(:storage_system) { Agama::Storage::System.new }
 
   before do
     mock_storage(devicegraph: scenario)
@@ -109,7 +110,7 @@ describe Agama::Storage::ConfigSolver do
       .and_return(true)
   end
 
-  subject { described_class.new(product_config, devicegraph) }
+  subject { described_class.new(product_config, storage_system) }
 
   describe "#solve" do
     let(:scenario) { "empty-hd-50GiB.yaml" }

--- a/service/test/agama/storage/config_solvers/drives_search_test.rb
+++ b/service/test/agama/storage/config_solvers/drives_search_test.rb
@@ -22,15 +22,15 @@
 require_relative "../storage_helpers"
 require "agama/storage/config_conversions/from_json"
 require "agama/storage/config_solvers/drives_search"
+require "agama/storage/system"
 require "y2storage"
 
 describe Agama::Storage::ConfigSolvers::DrivesSearch do
   include Agama::RSpec::StorageHelpers
 
-  subject { described_class.new(devicegraph, disk_analyzer) }
+  subject { described_class.new(storage_system) }
 
-  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
-  let(:disk_analyzer) { Y2Storage::StorageManager.instance.probed_disk_analyzer }
+  let(:storage_system) { Agama::Storage::System.new }
 
   before do
     mock_storage(devicegraph: scenario)
@@ -71,7 +71,7 @@ describe Agama::Storage::ConfigSolvers::DrivesSearch do
 
       context "and any of the devices is not a candidate device" do
         before do
-          allow(disk_analyzer).to receive(:candidate_device?) { |d| d.name != "/dev/vda" }
+          allow(storage_system.analyzer).to receive(:candidate_device?) { |d| d.name != "/dev/vda" }
         end
 
         it "sets the first unassigned candidate device to the drive config" do

--- a/service/test/agama/storage/config_solvers/md_raids_search_test.rb
+++ b/service/test/agama/storage/config_solvers/md_raids_search_test.rb
@@ -22,15 +22,15 @@
 require_relative "../storage_helpers"
 require "agama/storage/config_conversions/from_json"
 require "agama/storage/config_solvers/md_raids_search"
+require "agama/storage/system"
 require "y2storage"
 
 describe Agama::Storage::ConfigSolvers::MdRaidsSearch do
   include Agama::RSpec::StorageHelpers
 
-  subject { described_class.new(devicegraph, disk_analyzer) }
+  subject { described_class.new(storage_system) }
 
-  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
-  let(:disk_analyzer) { Y2Storage::StorageManager.instance.probed_disk_analyzer }
+  let(:storage_system) { Agama::Storage::System.new }
 
   before do
     mock_storage(devicegraph: scenario)
@@ -68,7 +68,7 @@ describe Agama::Storage::ConfigSolvers::MdRaidsSearch do
 
       context "and any of the devices is not a candidate device" do
         before do
-          allow(disk_analyzer).to receive(:candidate_device?) { |d| d.name != "/dev/md0" }
+          allow(storage_system.analyzer).to receive(:candidate_device?) { |d| d.name != "/dev/md0" }
         end
 
         it "sets the first unassigned candidate device to the MD RAID config" do
@@ -287,7 +287,7 @@ describe Agama::Storage::ConfigSolvers::MdRaidsSearch do
         let(:size) { { equal: value } }
 
         context "and there is a MD RAID with equal size" do
-          let(:value) { devicegraph.find_by_name("/dev/md2").size }
+          let(:value) { storage_system.devicegraph.find_by_name("/dev/md2").size }
           include_examples "find device", "/dev/md2"
         end
 

--- a/service/test/agama/storage/system_test.rb
+++ b/service/test/agama/storage/system_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "./storage_helpers"
+require "agama/storage/system"
+
+describe Agama::Storage::System do
+  include Agama::RSpec::StorageHelpers
+
+  before { mock_storage(devicegraph: scenario) }
+
+  let(:disk_analyzer) { Y2Storage::StorageManager.instance.probed_disk_analyzer }
+
+  describe "#candidate_drives" do
+    let(:scenario) { "disks.yaml" }
+
+    before do
+      allow(disk_analyzer).to receive(:candidate_device?) { |d| d.name != "/dev/vdb" }
+    end
+
+    it "includes all drives suitable for installation" do
+      expect(subject.candidate_drives.map(&:name)).to contain_exactly("/dev/vda", "/dev/vdc")
+    end
+
+    context "if there are MD RAIDs" do
+      let(:scenario) { "md_raids.yaml" }
+
+      before do
+        allow(disk_analyzer).to receive(:candidate_device?).and_call_original
+      end
+
+      it "does not include MD RAIDs" do
+        expect(subject.candidate_drives.map(&:name)).to contain_exactly("/dev/vda", "/dev/vdb")
+      end
+    end
+  end
+
+  describe "#candidate_md_raids" do
+    let(:scenario) { "md_raids.yaml" }
+
+    before do
+      allow(disk_analyzer).to receive(:candidate_device?) { |d| d.name != "/dev/md0" }
+    end
+
+    it "includes all MD RAIDs suitable for installation" do
+      expect(subject.candidate_md_raids.map(&:name)).to contain_exactly("/dev/md1", "/dev/md2")
+    end
+  end
+end

--- a/service/test/y2storage/agama_proposal_lvm_test.rb
+++ b/service/test/y2storage/agama_proposal_lvm_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,7 @@ require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
 require "agama/storage/config_conversions/from_json"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -31,8 +32,10 @@ describe Y2Storage::AgamaProposal do
   include Agama::RSpec::StorageHelpers
 
   subject(:proposal) do
-    described_class.new(config, issues_list: issues_list)
+    described_class.new(config, storage_system, issues_list: issues_list)
   end
+
+  let(:storage_system) { Agama::Storage::System.new }
 
   let(:config) { config_from_json }
 

--- a/service/test/y2storage/agama_proposal_md_lvm_test.rb
+++ b/service/test/y2storage/agama_proposal_md_lvm_test.rb
@@ -23,6 +23,7 @@ require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
 require "agama/storage/config_conversions/from_json"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -31,8 +32,10 @@ describe Y2Storage::AgamaProposal do
   include Agama::RSpec::StorageHelpers
 
   subject(:proposal) do
-    described_class.new(config, issues_list: issues_list)
+    described_class.new(config, storage_system, issues_list: issues_list)
   end
+
+  let(:storage_system) { Agama::Storage::System.new }
 
   let(:config) { config_from_json }
 

--- a/service/test/y2storage/agama_proposal_md_test.rb
+++ b/service/test/y2storage/agama_proposal_md_test.rb
@@ -23,6 +23,7 @@ require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
 require "agama/storage/config_conversions/from_json"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -31,8 +32,10 @@ describe Y2Storage::AgamaProposal do
   include Agama::RSpec::StorageHelpers
 
   subject(:proposal) do
-    described_class.new(config, issues_list: issues_list)
+    described_class.new(config, storage_system, issues_list: issues_list)
   end
+
+  let(:storage_system) { Agama::Storage::System.new }
 
   let(:config) { config_from_json }
 

--- a/service/test/y2storage/agama_proposal_search_test.rb
+++ b/service/test/y2storage/agama_proposal_search_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,7 @@ require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
 require "agama/storage/config_conversions"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -31,8 +32,10 @@ describe Y2Storage::AgamaProposal do
   include Agama::RSpec::StorageHelpers
 
   subject(:proposal) do
-    described_class.new(config, issues_list: issues_list)
+    described_class.new(config, storage_system, issues_list: issues_list)
   end
+
+  let(:storage_system) { Agama::Storage::System.new }
 
   let(:config) { config_from_json }
 

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,7 @@ require_relative "../agama/storage/storage_helpers"
 require "agama/config"
 require "agama/storage/config"
 require "agama/storage/config_conversions"
+require "agama/storage/system"
 require "y2storage"
 require "y2storage/agama_proposal"
 
@@ -75,8 +76,15 @@ describe Y2Storage::AgamaProposal do
   include Agama::RSpec::StorageHelpers
 
   subject(:proposal) do
-    described_class.new(config, product_config: product_config, issues_list: issues_list)
+    described_class.new(
+      config,
+      storage_system,
+      product_config: product_config,
+      issues_list:    issues_list
+    )
   end
+
+  let(:storage_system) { Agama::Storage::System.new }
 
   let(:config) { config_json ? config_from_json : default_config }
 


### PR DESCRIPTION
## Problem

The list of candidate drives for installation includes some specific MD RAIDs that are considered as BIOS RAID by YaST. Moreover, the search of MD RAIDs do not discard the devices with mounted content or with installation repositories. 

## Solution

Fix candidate drives to avoid including any MD RAID.
Fix candidate MD RAIDs to avoid including devices with mounted content or with installation repositories.
