### PR TITLE
Specify permissions for the GitHub Actions

### DIFF
--- a/.github/workflows/ci-devel.yml
+++ b/.github/workflows/ci-devel.yml
@@ -1,5 +1,8 @@
 name: CI - Devel scripts
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -1,5 +1,8 @@
 name: "CI - Documentation Check"
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -1,5 +1,8 @@
 name: "CI - Integration Tests"
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # at 9:45 UTC every day from Monday to Friday

--- a/.github/workflows/ci-live.yml
+++ b/.github/workflows/ci-live.yml
@@ -1,5 +1,8 @@
 name: CI - ISO definition
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/ci-rubocop.yml
+++ b/.github/workflows/ci-rubocop.yml
@@ -1,5 +1,8 @@
 name: "CI - Rubocop"
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,6 +1,8 @@
 name: CI - Rust
+
 permissions:
   contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -1,6 +1,8 @@
 name: CI - Service
+
 permissions:
   contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -1,6 +1,8 @@
 name: CI - Web
+
 permissions:
   contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/obs-service-shared.yml
+++ b/.github/workflows/obs-service-shared.yml
@@ -2,6 +2,9 @@
 
 name: Update OBS Service Package
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/obs-staging-autoinstallation.yml
+++ b/.github/workflows/obs-staging-autoinstallation.yml
@@ -1,5 +1,8 @@
 name: Submit agama-auto
 
+permissions:
+  contents: read
+
 on:
   # runs on pushes targeting the default branch
   push:

--- a/.github/workflows/obs-staging-live.yml
+++ b/.github/workflows/obs-staging-live.yml
@@ -1,5 +1,8 @@
 name: Submit agama-installer
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/obs-staging-products.yml
+++ b/.github/workflows/obs-staging-products.yml
@@ -1,5 +1,8 @@
 name: Submit agama-products
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/obs-staging-rust.yml
+++ b/.github/workflows/obs-staging-rust.yml
@@ -1,5 +1,8 @@
 name: Submit agama
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/obs-staging-service.yml
+++ b/.github/workflows/obs-staging-service.yml
@@ -1,5 +1,8 @@
 name: Submit rubygem-agama-yast
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -2,6 +2,9 @@
 
 name: Update OBS Packages
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/obs-staging-web.yml
+++ b/.github/workflows/obs-staging-web.yml
@@ -1,5 +1,8 @@
 name: Submit agama-web-ui
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -1,5 +1,10 @@
 name: Weblate Merge PO
 
+permissions:
+  # it merges the updated translations and creates a pull request with the changes
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     # run every Monday at 2:42AM UTC

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -1,5 +1,10 @@
 name: Weblate Merge Product PO
 
+permissions:
+  # it merges the updated translations and creates a pull request with the changes
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     # run every Monday at 2:45AM UTC

--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -1,5 +1,10 @@
 name: Weblate Merge Service PO
 
+permissions:
+  # it merges the updated translations and creates a pull request with the changes
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     # run every Monday at 2:45AM UTC

--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -1,5 +1,9 @@
 name: Weblate Update POT
 
+permissions:
+  # this action uploads the updated POT files to the agama-weblate repository
+  contents: write
+
 on:
   schedule:
     # run every working day (Monday-Friday) at 1:42AM UTC


### PR DESCRIPTION
## Problem

- The GitHub security scanner complains about missing permissions in the GitHub Actions
- Example: https://github.com/agama-project/agama/security/code-scanning/25

## Solution

- Specify the permissions
- In the most cases the minimum `contents: read` is enough, that allows just reading the Git content and history
- The Actions which deal with translations needs push permissions and permissions for creating a new pull request

