### PR TITLE
fix(web): render topbar keymap only in local connections

### DIFF
--- a/web/src/components/core/InstallerOptions.test.tsx
+++ b/web/src/components/core/InstallerOptions.test.tsx
@@ -243,6 +243,15 @@ describe("InstallerOptions", () => {
         jest.spyOn(utils, "localConnection").mockReturnValue(false);
       });
 
+      it("does not render keymap value in the toggle button", () => {
+        installerRender(<InstallerOptions />, { withL10n: true });
+        const toggle = screen.getByRole("button", {
+          name: "Change display language",
+        });
+        expect(toggle).toHaveTextContent("Deutsch");
+        expect(toggle).not.toHaveTextContent("us");
+      });
+
       it("does not allow setting the keyboard layout", async () => {
         const { user } = await renderAndOpen();
         const dialog = screen.getByRole("dialog");

--- a/web/src/components/core/InstallerOptions.tsx
+++ b/web/src/components/core/InstallerOptions.tsx
@@ -469,19 +469,6 @@ const CenteredContent = ({
   </Flex>
 );
 
-/** Toggle button for accessing both language and keyboard layout settings. */
-const AllSettingsToggle = ({ onClick, language, keymap }: ToggleProps) => (
-  <Button
-    onClick={onClick}
-    aria-label={_("Change display language and keyboard layout")}
-    variant="plain"
-  >
-    <CenteredContent>
-      <LanguageIcon /> {language} <KeyboardIcon /> <code>{keymap}</code>
-    </CenteredContent>
-  </Button>
-);
-
 /** Toggle button for accessing only language settings. */
 const LanguageOnlyToggle = ({ onClick, language }: ToggleProps) => (
   <Button onClick={onClick} aria-label={_("Change display language")} variant="plain">
@@ -499,6 +486,23 @@ const KeyboardOnlyToggle = ({ onClick, keymap }: ToggleProps) => (
     </CenteredContent>
   </Button>
 );
+
+/** Toggle button for accessing both language and keyboard layout settings. */
+const AllSettingsToggle = ({ onClick, language, keymap }: ToggleProps) => {
+  if (!localConnection()) return <LanguageOnlyToggle onClick={onClick} language={language} />;
+
+  return (
+    <Button
+      onClick={onClick}
+      aria-label={_("Change display language and keyboard layout")}
+      variant="plain"
+    >
+      <CenteredContent>
+        <LanguageIcon /> {language} <KeyboardIcon /> <code>{keymap}</code>
+      </CenteredContent>
+    </Button>
+  );
+};
 
 /**
  * Maps each dialog variant to its corresponding React component.


### PR DESCRIPTION
Part of https://github.com/agama-project/agama/pull/2359: render current keymap set for installer only in local connections.

| Before | After |
|-|-|
| ![Screenshot From 2025-05-19 08-57-05](https://github.com/user-attachments/assets/abcaa93a-97a3-4066-91d0-ee16683bf4fe) | ![Screenshot From 2025-05-19 08-57-13](https://github.com/user-attachments/assets/67491c87-fa14-4e5b-89fb-673eb59d3961) |

