### PR TITLE
fix(web): keep left margin for main container in xl breakpoint

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 19 13:38:16 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Keep margin between sidebar and main content in all breakpoints
+  (gh/agama-project/agama#2370).
+
+-------------------------------------------------------------------
 Fri May 16 07:46:22 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Rework the installer l10n settings (gh#agama-project/agama#2359):

--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -136,6 +136,10 @@
 
 // Reserve the sidebar space also for "lg" breakpoint
 @media (width >= 64rem) {
+  .pf-v6-c-page__main-container {
+    --pf-v6-c-page__main-container--MarginInlineStart: var(--pf-v6-c-page--inset);
+  }
+
   .pf-v6-c-page.agm-full-layout {
     --pf-v6-c-page__sidebar--Width: 12rem; // var(--pf-v6-c-page__sidebar--xl--Width);
     grid-template-areas:


### PR DESCRIPTION
To be precise, overrides the "margin-inline-start" for resolutions bigger than 64rem.

See
https://github.com/agama-project/agama/issues/2367#issuecomment-2891042985

| Before | After |
|-|-|
| ![localhost_8080_ (55)](https://github.com/user-attachments/assets/b2ca93fa-720c-4a03-830c-7d1923ff2562) | ![localhost_8080_ (57)](https://github.com/user-attachments/assets/33ec8219-761b-48b9-97f4-f481ed85854b)
