### PR TITLE
fix(rust): do not crash on empty vectors in IpConfig

### DIFF
--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -803,22 +803,22 @@ impl From<InvalidMacAddress> for zbus::fdo::Error {
 pub struct IpConfig {
     pub method4: Ipv4Method,
     pub method6: Ipv6Method,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schema(schema_with = schemas::ip_inet_array)]
     pub addresses: Vec<IpInet>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schema(schema_with = schemas::ip_addr_array)]
     pub nameservers: Vec<IpAddr>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dns_searchlist: Vec<String>,
     pub ignore_auto_dns: bool,
     #[schema(schema_with = schemas::ip_addr)]
     pub gateway4: Option<IpAddr>,
     #[schema(schema_with = schemas::ip_addr)]
     pub gateway6: Option<IpAddr>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub routes4: Vec<IpRoute>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub routes6: Vec<IpRoute>,
     pub dhcp4_settings: Option<Dhcp4Settings>,
     pub dhcp6_settings: Option<Dhcp6Settings>,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 19 14:02:04 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when network events do not contain "addresses",
+  "nameservers", "dnsSearchlist", "routes4" or "routes6"
+  (gh#agama-project/agama#2371).
+
+-------------------------------------------------------------------
 Mon May 19 12:02:46 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adapt "install", "probe" and "finish" to use the HTTP API


### PR DESCRIPTION
## Problem

The "agama events" might crash with the following error:

```
Error: missing field `dnsSearchlist`
```

## Solution

Use a default value for the vector in IpConfig.

## Testing

- *Tested manually*