### PR TITLE
doc(rust): adjust description of bridge/ports/title

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -466,7 +466,7 @@
                   "ports": {
                     "type": "array",
                     "items": {
-                      "title": "A list of the interfaces or connections to be part of the bridge",
+                      "title": "A list of the interface(s) or connection(s) to be part of the bridge",
                       "type": "string"
                     }
                   }


### PR DESCRIPTION
A bridge can have just a single interface, which is common for a virtualization host. Individual interfaces will be added and removed at runtime.