### PR TITLE
feat(live): Disable sending Firefox usage data

### DIFF
--- a/live/live-root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/live-root/root/.mozilla/firefox/profile/user.js.template
@@ -16,6 +16,11 @@ user_pref("browser.startup.couldRestoreSession.count", 0);
 // disable homepage override on updates
 user_pref("browser.startup.homepage_override.mstone", "ignore");
 
+// disable sending Firefox usage and telemetry data for increased privacy
+user_pref("datareporting.healthreport.uploadEnabled", false);
+user_pref("datareporting.usage.uploadEnabled", false);
+user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+
 // workaround for non working file picker, disable XDG portal, use the FF native popup
 // TODO: make the XDG portal working again, it has more features (mounting USB flash)
 user_pref("widget.use-xdg-desktop-portal.file-picker", 0);

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 20 08:42:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Disable sending Firefox usage data to Mozilla for increased
+  privacy, disable installing studies
+
+-------------------------------------------------------------------
 Tue May 13 16:56:56 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Do not set the root in /boot/grub2/grub.cfg file, it was wrong


### PR DESCRIPTION
## Problem

- Some customers might be concerned about sending the Firefox usage data to Mozilla or [installing studies](https://support.mozilla.org/en-US/kb/shield)
  ![agama-ff-privacy](https://github.com/user-attachments/assets/a0d850a2-d16a-4c9a-968d-fabf1162b076)


## Solution

- Disable those options in the Firefox config
  ![agama-ff-privacy-fixed](https://github.com/user-attachments/assets/0b3d271d-e7ea-4300-a13b-56d00545d7fb)


## Testing

- Tested manually

