### PR TITLE
Do not include the root= dracut config in PXE images

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 21 12:42:34 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not set root= dracut configuration in PXE images
+  (gh#agama-project/agama2377).
+
+-------------------------------------------------------------------
 Tue May 20 08:42:29 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Disable sending Firefox usage data to Mozilla for increased

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -98,13 +98,16 @@ arch=$(uname -m)
 profile=$(echo "$kiwi_profiles" | tr "_" "-")
 label="Install-$profile-$arch"
 
-echo "Setting default live root: live:LABEL=$label"
-mkdir /etc/cmdline.d
-echo "root=live:LABEL=$label" >/etc/cmdline.d/10-liveroot.conf
-echo "root_disk=live:LABEL=$label" >>/etc/cmdline.d/10-liveroot.conf
-# if there's a default network location, add it here
-# echo "root_net=" >> /etc/cmdline.d/10-liveroot.conf
-echo 'install_items+=" /etc/cmdline.d/10-liveroot.conf "' >/etc/dracut.conf.d/10-liveroot-file.conf
+# Extra cleanup for the PXE images
+if [[ "$kiwi_profiles" == *PXE* ]]; then
+  echo "Setting default live root: live:LABEL=$label"
+  mkdir /etc/cmdline.d
+  echo "root=live:LABEL=$label" >/etc/cmdline.d/10-liveroot.conf
+  echo "root_disk=live:LABEL=$label" >>/etc/cmdline.d/10-liveroot.conf
+  # if there's a default network location, add it here
+  # echo "root_net=" >> /etc/cmdline.d/10-liveroot.conf
+  echo 'install_items+=" /etc/cmdline.d/10-liveroot.conf "' >/etc/dracut.conf.d/10-liveroot-file.conf
+fi
 echo 'add_dracutmodules+=" dracut-menu agama-cmdline "' >>/etc/dracut.conf.d/10-liveroot-file.conf
 
 # decrease the kernel logging on the console, use a dracut module to do it early in the boot process


### PR DESCRIPTION
## Problem

The unconditional set of root= setting in the initrd is problematic in case of PXE images.

From the bug report:

> .... while this might work for live ISO's booting via the dracut live (livenet) module it is a wrong and conflicting setting for the kiwi-dump module code which is active if you are not building a live image but an oem image with installpxe="true". 
> 
> The unconditional setting for root=live:... causes the dracut live module code to be called and not the actual expected kiwi-dump code. When mixing the kernel cmdline parameters for both modules there is also a timing issue on the probing of the network such that sometimes one or the other module wins.
> 
> In short this unconditional root= setting causes a lot of issues and should only be done in the live ISO builds of agama and nowhere else.
> 

- https://bugzilla.suse.com/show_bug.cgi?id=1242976

## Solution

Remove the root= configuration for PXE images.