### PR TITLE
Disable Rust incremental builds in CI

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -46,6 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COVERAGE: 1
+      # disable support for incremental builds, we always build from scratch anyway
+      # this makes the build slightly faster
+      CARGO_INCREMENTAL: 0
 
     defaults:
       run:


### PR DESCRIPTION
## Problem

- The incremental builds add about 15-20% overhead and because the CI in GitHub Actions always runs from scratch then it is useless.

## Solution

- Disable the incremental builds in CI

## Ideas

Maybe we could later use some [Rust caching action](https://github.com/marketplace/actions/rust-cache) to speed up the Rust builds even more... (Very likely I'll spend some learning&innovation time with that.)