### PR TITLE
fix(web): properly navigate to a Wi-Fi network

### DIFF
--- a/web/src/components/network/WifiNetworksList.test.tsx
+++ b/web/src/components/network/WifiNetworksList.test.tsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender } from "~/test-utils";
+import { installerRender, mockNavigateFn } from "~/test-utils";
 import WifiNetworksList from "~/components/network/WifiNetworksList";
 import {
   Connection,
@@ -130,6 +130,16 @@ describe("WifiNetworksList", () => {
       installerRender(<WifiNetworksList />);
       screen.getByLabelText("Secured network Network 2 Excellent signal");
       screen.getByRole("progressbar", { name: "Connecting to Network 2" });
+    });
+
+    describe("and user selects a network", () => {
+      it("navigates to the Wi-Fi network path including the expected SSID", async () => {
+        // @ts-expect-error: you need to specify the aria-label
+        const { user } = installerRender(<WifiNetworksList />);
+        const network1 = screen.getByLabelText("Secured network Network 1 Weak signal");
+        await user.click(network1);
+        expect(mockNavigateFn).toHaveBeenCalledWith(expect.stringContaining("Network 1"));
+      });
     });
 
     describe.skip("and user selects a connected network", () => {

--- a/web/src/components/network/WifiNetworksList.tsx
+++ b/web/src/components/network/WifiNetworksList.tsx
@@ -113,7 +113,7 @@ const NetworkListItem = ({ network, connection, showIp }: NetworkListItemProps) 
   const ipId = useId();
 
   return (
-    <DataListItem>
+    <DataListItem id={network.ssid}>
       <DataListItemRow>
         <DataListItemCells
           dataListCells={[


### PR DESCRIPTION
By adding the missing SSID to the generated path when users clicks on a Wi-Fi network from the list.

It fixes https://bugzilla.suse.com/show_bug.cgi?id=1243415 (private link)
