### PR TITLE
Use the stable toolchain when running tarpaulin

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -39,6 +39,9 @@ on:
   # allow running manually
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   rust_ci:
     # the default timeout is 6 hours, that's too much if the job gets stuck
@@ -110,6 +113,10 @@ jobs:
 
     - name: Run the tests
       run: cargo tarpaulin --all --doc --out xml -- --nocapture
+      env:
+        # use the "stable" tool chain (installed above) instead of the "nightly" default in tarpaulin
+        RUSTC_BOOTSTRAP: 1
+        RUSTUP_TOOLCHAIN: stable
 
     - name: Generate and validate the OpenAPI specification
       run: |


### PR DESCRIPTION
## Problem

- The Rust CI fails with a tarpaulin error when it wants to download the "nightly" Rust toolchain ([example](https://github.com/agama-project/agama/actions/runs/15186922557/job/42709716428#step:13:14))

## Solution

- Force the tarpaulin to use the already installed "stable" toolchain

## Testing

- :white_check_mark: The CI is green now!