### PR TITLE
feat: non-blocking and centralized progress reporting

### DIFF
--- a/rust/agama-cli/src/progress.rs
+++ b/rust/agama-cli/src/progress.rs
@@ -26,8 +26,8 @@ use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::time::Duration;
 
-const MANAGER_SERVICE: &str = "org.opensuse.Agama.Manager1";
-const SOFTWARE_SERVICE: &str = "org.opensuse.Agama.Software1";
+const MANAGER_PROGRESS_OBJECT_PATH: &str = "/org/opensuse/Agama/Manager1";
+const SOFTWARE_PROGRESS_OBJECT_PATH: &str = "/org/opensuse/Agama/Software1";
 
 /// Displays the progress on the terminal.
 pub struct ProgressMonitor {
@@ -77,14 +77,14 @@ impl ProgressMonitor {
     ///
     /// It returns true if the monitor should continue.
     async fn update(&mut self, status: MonitorStatus) -> bool {
-        if status.progress.get(MANAGER_SERVICE).is_none() && self.running {
+        if status.progress.get(MANAGER_PROGRESS_OBJECT_PATH).is_none() && self.running {
             self.finish();
             if self.stop_on_idle {
                 return false;
             }
         }
 
-        if let Some(progress) = status.progress.get(MANAGER_SERVICE) {
+        if let Some(progress) = status.progress.get(MANAGER_PROGRESS_OBJECT_PATH) {
             self.running = true;
             if self.current_step != progress.current_step {
                 self.update_main(&progress).await;
@@ -92,7 +92,7 @@ impl ProgressMonitor {
             }
         }
 
-        match status.progress.get(SOFTWARE_SERVICE) {
+        match status.progress.get(SOFTWARE_PROGRESS_OBJECT_PATH) {
             Some(progress) => self.update_bar(progress),
             None => self.remove_bar(),
         }

--- a/rust/agama-lib/src/http/event.rs
+++ b/rust/agama-lib/src/http/event.rs
@@ -54,6 +54,11 @@ pub enum Event {
         #[serde(flatten)]
         progress: Progress,
     },
+    ProgressChanged {
+        path: String,
+        #[serde(flatten)]
+        progress: Progress,
+    },
     ProductChanged {
         id: String,
     },

--- a/rust/agama-lib/src/http/event.rs
+++ b/rust/agama-lib/src/http/event.rs
@@ -49,11 +49,6 @@ pub enum Event {
     DevicesDirty {
         dirty: bool,
     },
-    Progress {
-        service: String,
-        #[serde(flatten)]
-        progress: Progress,
-    },
     ProgressChanged {
         path: String,
         #[serde(flatten)]

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -264,8 +264,6 @@ impl MonitorStatusReader {
             "/manager/progress",
         )
         .await?;
-        // FIXME: do not read the software status yet because it might block
-        // the progress. Enable this line when the software service does not block
         self.add_service_progress(
             &mut status,
             SOFTWARE_PROGRESS_OBJECT_PATH,

--- a/rust/agama-lib/src/progress.rs
+++ b/rust/agama-lib/src/progress.rs
@@ -63,3 +63,13 @@ impl Progress {
         })
     }
 }
+
+/// Information about the current progress sequence.
+#[derive(Clone, Debug, Default, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressSequence {
+    /// Sequence steps if known in advance
+    pub steps: Vec<String>,
+    #[serde(flatten)]
+    pub progress: Progress,
+}

--- a/rust/agama-lib/src/proxies.rs
+++ b/rust/agama-lib/src/proxies.rs
@@ -19,7 +19,7 @@
 // find current contact information at www.suse.com.
 
 mod progress;
-pub use progress::ProgressProxy;
+pub use progress::{ProgressChanged, ProgressChangedArgs, ProgressChangedStream, ProgressProxy};
 
 mod service_status;
 pub use service_status::ServiceStatusProxy;

--- a/rust/agama-lib/src/proxies/progress.rs
+++ b/rust/agama-lib/src/proxies/progress.rs
@@ -22,6 +22,16 @@
 use zbus::proxy;
 #[proxy(interface = "org.opensuse.Agama1.Progress", assume_defaults = true)]
 pub trait Progress {
+    /// ProgressChanged signal
+    #[zbus(signal)]
+    fn progress_changed(
+        &self,
+        total_steps: u32,
+        current_step: (u32, &str),
+        finished: bool,
+        steps: Vec<&str>,
+    ) -> zbus::Result<()>;
+
     /// CurrentStep property
     #[zbus(property)]
     fn current_step(&self) -> zbus::Result<(u32, String)>;

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -46,7 +46,7 @@ pub enum Error {
     Locale(#[from] LocaleError),
     #[error("Issues service error: {0}")]
     Issues(#[from] IssuesServiceError),
-    #[error("Issues service error: {0}")]
+    #[error("Progress service error: {0}")]
     Progress(#[from] ProgressServiceError),
 }
 

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -26,7 +26,11 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::{l10n::LocaleError, questions::QuestionsError, web::common::IssuesServiceError};
+use crate::{
+    l10n::LocaleError,
+    questions::QuestionsError,
+    web::common::{IssuesServiceError, ProgressServiceError},
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -42,6 +46,8 @@ pub enum Error {
     Locale(#[from] LocaleError),
     #[error("Issues service error: {0}")]
     Issues(#[from] IssuesServiceError),
+    #[error("Issues service error: {0}")]
+    Progress(#[from] ProgressServiceError),
 }
 
 // This would be nice, but using it for a return type

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -39,7 +39,7 @@ use crate::{
     software::web::{software_service, software_streams},
     storage::web::{iscsi::iscsi_service, storage_service, storage_streams},
     users::web::{users_service, users_streams},
-    web::common::{jobs_stream, progress_stream, service_status_stream},
+    web::common::{jobs_stream, service_status_stream},
 };
 use axum::Router;
 
@@ -147,15 +147,6 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
         )
         .await?,
     );
-    stream.insert(
-        "manager-progress",
-        progress_stream(
-            dbus.clone(),
-            "org.opensuse.Agama.Manager1",
-            "/org/opensuse/Agama/Manager1",
-        )
-        .await?,
-    );
     for (id, user_stream) in users_streams(dbus.clone()).await? {
         stream.insert(id, user_stream);
     }
@@ -175,15 +166,6 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
         .await?,
     );
     stream.insert(
-        "storage-progress",
-        progress_stream(
-            dbus.clone(),
-            "org.opensuse.Agama.Storage1",
-            "/org/opensuse/Agama/Storage1",
-        )
-        .await?,
-    );
-    stream.insert(
         "storage-jobs",
         jobs_stream(
             dbus.clone(),
@@ -196,15 +178,6 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
     stream.insert(
         "software-status",
         service_status_stream(
-            dbus.clone(),
-            "org.opensuse.Agama.Software1",
-            "/org/opensuse/Agama/Software1",
-        )
-        .await?,
-    );
-    stream.insert(
-        "software-progress",
-        progress_stream(
             dbus.clone(),
             "org.opensuse.Agama.Software1",
             "/org/opensuse/Agama/Software1",

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -20,18 +20,12 @@
 
 //! This module defines functions to be used accross all services.
 
-use std::{pin::Pin, task::Poll};
+use std::pin::Pin;
 
-use agama_lib::{
-    error::ServiceError,
-    progress::Progress,
-    proxies::{ProgressProxy, ServiceStatusProxy},
-};
+use agama_lib::{error::ServiceError, proxies::ServiceStatusProxy};
 use axum::{extract::State, routing::get, Json, Router};
-use pin_project::pin_project;
 use serde::Serialize;
 use tokio_stream::{Stream, StreamExt};
-use zbus::proxy::PropertyStream;
 
 use crate::error::Error;
 
@@ -139,133 +133,6 @@ async fn build_service_status_proxy<'a>(
     path: &str,
 ) -> Result<ServiceStatusProxy<'a>, zbus::Error> {
     let proxy = ServiceStatusProxy::builder(dbus)
-        .destination(destination.to_string())?
-        .path(path.to_string())?
-        .build()
-        .await?;
-    Ok(proxy)
-}
-
-/// Builds a router to the `org.opensuse.Agama1.Progress`
-/// interface of the given D-Bus object.
-///
-/// ```no_run
-/// # use axum::{extract::State, routing::get, Json, Router};
-/// # use agama_lib::connection;
-/// # use agama_server::web::common::progress_router;
-/// # use tokio_test;
-///
-/// # tokio_test::block_on(async {
-/// async fn hello(state: State<HelloWorldState>) {};
-///
-/// #[derive(Clone)]
-/// struct HelloWorldState {};
-///
-/// let dbus = connection().await.unwrap();
-/// let progress_router = progress_router(
-///   &dbus, "org.opensuse.HelloWorld", "/org/opensuse/hello"
-/// ).await.unwrap();
-/// let router: Router<HelloWorldState> = Router::new()
-///   .route("/hello", get(hello))
-///   .merge(progress_router)
-///   .with_state(HelloWorldState {});
-/// });
-/// ```
-///
-/// * `dbus`: D-Bus connection.
-/// * `destination`: D-Bus service name.
-/// * `path`: D-Bus object path.
-pub async fn progress_router<T>(
-    dbus: &zbus::Connection,
-    destination: &str,
-    path: &str,
-) -> Result<Router<T>, ServiceError> {
-    let proxy = build_progress_proxy(dbus, destination, path).await?;
-    let state = ProgressState { proxy };
-    Ok(Router::new()
-        .route("/progress", get(progress))
-        .with_state(state))
-}
-
-#[derive(Clone)]
-struct ProgressState<'a> {
-    proxy: ProgressProxy<'a>,
-}
-
-/// Information about the current progress sequence.
-#[derive(Clone, Debug, Default, Serialize, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ProgressSequence {
-    /// Sequence steps if known in advance
-    steps: Vec<String>,
-    #[serde(flatten)]
-    progress: Progress,
-}
-
-async fn progress(State(state): State<ProgressState<'_>>) -> Result<Json<ProgressSequence>, Error> {
-    let proxy = state.proxy;
-    let progress = Progress::from_proxy(&proxy).await?;
-    let steps = proxy.steps().await?;
-    let sequence = ProgressSequence { steps, progress };
-    Ok(Json(sequence))
-}
-
-#[pin_project]
-pub struct ProgressStream<'a> {
-    #[pin]
-    inner: PropertyStream<'a, (u32, String)>,
-    proxy: ProgressProxy<'a>,
-}
-
-pub async fn progress_stream<'a>(
-    dbus: zbus::Connection,
-    destination: &'static str,
-    path: &'static str,
-) -> Result<Pin<Box<impl Stream<Item = Event> + Send>>, zbus::Error> {
-    let proxy = build_progress_proxy(&dbus, destination, path).await?;
-    Ok(Box::pin(ProgressStream::new(proxy).await))
-}
-
-impl<'a> ProgressStream<'a> {
-    pub async fn new(proxy: ProgressProxy<'a>) -> Self {
-        let stream = proxy.receive_current_step_changed().await;
-        ProgressStream {
-            inner: stream,
-            proxy,
-        }
-    }
-}
-
-impl Stream for ProgressStream<'_> {
-    type Item = Event;
-
-    fn poll_next(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let pinned = self.project();
-        match pinned.inner.poll_next(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(_change) => match Progress::from_cached_proxy(pinned.proxy) {
-                Some(progress) => {
-                    let event = Event::Progress {
-                        progress,
-                        service: pinned.proxy.inner().destination().to_string(),
-                    };
-                    Poll::Ready(Some(event))
-                }
-                _ => Poll::Pending,
-            },
-        }
-    }
-}
-
-async fn build_progress_proxy<'a>(
-    dbus: &zbus::Connection,
-    destination: &str,
-    path: &str,
-) -> Result<ProgressProxy<'a>, zbus::Error> {
-    let proxy = ProgressProxy::builder(dbus)
         .destination(destination.to_string())?
         .path(path.to_string())?
         .build()

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -39,6 +39,8 @@ mod jobs;
 pub use jobs::{jobs_service, jobs_stream};
 mod issues;
 pub use issues::{IssuesClient, IssuesRouterBuilder, IssuesService, IssuesServiceError};
+mod progress;
+pub use progress::{ProgressClient, ProgressRouterBuilder, ProgressService, ProgressServiceError};
 
 use super::Event;
 
@@ -191,7 +193,7 @@ struct ProgressState<'a> {
 }
 
 /// Information about the current progress sequence.
-#[derive(Clone, Default, Serialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, Default, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ProgressSequence {
     /// Sequence steps if known in advance

--- a/rust/agama-server/src/web/common/issues.rs
+++ b/rust/agama-server/src/web/common/issues.rs
@@ -24,16 +24,14 @@
 //!
 //! * Querying the issues via D-Bus and keeping them in a cache.
 //! * Listening to D-Bus signals to keep the cache up-to-date.
-//! * Emitting `IssuesChanged` events, replacing
-//!   [issues_stream](crate::web::common::issues_stream).
+//! * Emitting `IssuesChanged` events.
 //!
 //! The following components are included:
 //!
 //! * [IssuesService] that runs on a separate task to hold the status.
 //! * [IssuesClient] that allows querying the [IssuesService] server about the
 //!   issues.
-//! * [IssuesRouter] which allows building a router, replacing
-//!   [issues_router](crate::web::common::issues_router).
+//! * [IssuesRouterBuilder] which allows building a router.
 //!
 //! At this point, it only handles the issues that are exposed through D-Bus.
 

--- a/rust/agama-server/src/web/common/progress.rs
+++ b/rust/agama-server/src/web/common/progress.rs
@@ -1,0 +1,300 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+//! Defines a service that keep tracks of the Agama progress.
+//!
+//! It is responsible for:
+//!
+//! * Querying the progress via D-Bus and keeping them in a cache.
+//! * Listening to D-Bus signals to keep the cache up-to-date.
+//! * Emitting `ProgressChanged` events.
+//!
+//! The following components are included:
+//!
+//! * [ProgressService] that runs on a separate task to hold the status.
+//! * [ProgressClient] that allows querying the [ProgressService] server about the
+//!   progress.
+//! * [ProgressRouterBuilder] which allows building a router.
+//!
+//! At this point, it only handles the progress that are exposed through D-Bus.
+
+use crate::web::EventsSender;
+use agama_lib::{
+    http::Event,
+    progress::Progress,
+    proxies::{ProgressChanged, ProgressProxy},
+};
+use axum::{extract::State, routing::get, Json, Router};
+use std::collections::HashMap;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_stream::StreamExt;
+use zbus::{message::Type as MessageType, MatchRule, MessageStream};
+
+use super::ProgressSequence;
+
+type ProgressServiceResult<T> = Result<T, ProgressServiceError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProgressServiceError {
+    #[error("Could not return the progress")]
+    SendProgress,
+    #[error("Could not get an answer from the service: {0}")]
+    RecvProgress(#[from] oneshot::error::RecvError),
+    #[error("Could not set the command")]
+    SendCommand,
+    #[error("Error parsing progress from D-Bus: {0}")]
+    InvalidProgress(#[from] zbus::zvariant::Error),
+    #[error("Error reading the progress: {0}")]
+    DBus(#[from] zbus::Error),
+    #[error("Invalid D-Bus name: {0}")]
+    DBusName(#[from] zbus::names::Error),
+    #[error("Could not send the event: {0}")]
+    SendEvent(#[from] broadcast::error::SendError<Event>),
+}
+
+#[derive(Debug)]
+enum ProgressCommand {
+    Get(String, String, oneshot::Sender<ProgressSequence>),
+}
+
+/// Implements a Tokio task that holds the progress for each service.
+pub struct ProgressService {
+    cache: HashMap<String, ProgressSequence>,
+    commands: mpsc::Receiver<ProgressCommand>,
+    events: EventsSender,
+    dbus: zbus::Connection,
+}
+
+impl ProgressService {
+    /// Sets up and starts the service as a Tokio task.
+    ///
+    /// Once it is started, the service waits for:
+    ///
+    /// * Commands from a client ([ProgressClient]).
+    /// * Relevant events from D-Bus.
+    pub async fn start(dbus: zbus::Connection, events: EventsSender) -> ProgressClient {
+        let (tx, rx) = mpsc::channel(4);
+        let mut service = ProgressService {
+            cache: HashMap::new(),
+            dbus,
+            events,
+            commands: rx,
+        };
+
+        tokio::spawn(async move {
+            if let Err(e) = service.run().await {
+                tracing::error!("Could not start the progress service: {e:?}")
+            }
+        });
+        ProgressClient(tx)
+    }
+
+    /// Main loop of the service.
+    async fn run(&mut self) -> ProgressServiceResult<()> {
+        let mut messages = build_progress_changed_stream(&self.dbus).await?;
+        loop {
+            tokio::select! {
+                Some(cmd) = self.commands.recv() => {
+                    if let Err(e) = self.handle_command(cmd).await {
+                        tracing::error!("{e}");
+                    }
+                }
+
+                Some(Ok(message)) = messages.next() => {
+                    if let Some(changed) = ProgressChanged::from_message(message) {
+                        if let Err(e) = self.handle_progress_changed(changed).await {
+                            tracing::error!("ProgressService: could not handle change: {:?}", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handles commands from the client.
+    async fn handle_command(&mut self, command: ProgressCommand) -> ProgressServiceResult<()> {
+        match command {
+            ProgressCommand::Get(service, path, tx) => {
+                let progress = self.get(&service, &path).await?;
+                tx.send(progress)
+                    .map_err(|_| ProgressServiceError::SendProgress)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handles ProgressChanged events.
+    ///
+    /// It reports an error if something went work. If the message was processed or skipped
+    /// it returns Ok(()).
+    async fn handle_progress_changed(
+        &mut self,
+        message: ProgressChanged,
+    ) -> ProgressServiceResult<()> {
+        let args = message.args()?;
+        let inner = message.message();
+        let header = inner.header();
+
+        // We are not interested on this message
+        let Some(path) = header.path() else {
+            tracing::warn!("Found a ProgressChanged signal without a path");
+            return Ok(());
+        };
+
+        let (current_step, current_title) = args.current_step();
+        let progress = Progress {
+            current_title: current_title.to_string(),
+            current_step: current_step.clone(),
+            max_steps: args.total_steps,
+            finished: args.finished,
+        };
+        let sequence = ProgressSequence {
+            steps: args.steps().iter().map(ToString::to_string).collect(),
+            progress: progress.clone(),
+        };
+        self.cache.insert(path.to_string(), sequence.clone());
+
+        let event = Event::ProgressChanged {
+            path: path.to_string(),
+            progress,
+        };
+        self.events.send(event)?;
+        Ok(())
+    }
+
+    /// Gets the progress for a given D-Bus service and path.
+    ///
+    /// This method uses a cache to store the values. If the value is not in the cache,
+    /// it asks the D-Bus service about the progress (and cache them).
+    ///
+    /// * `service`: D-Bus service to connect to.
+    /// * `path`: path of the D-Bus object implementing the
+    ///   "org.opensuse.Agama1.Progress" interface.
+    async fn get(&mut self, service: &str, path: &str) -> ProgressServiceResult<ProgressSequence> {
+        if let Some(sequence) = self.cache.get(path) {
+            return Ok(sequence.clone());
+        }
+
+        let proxy = ProgressProxy::builder(&self.dbus)
+            .destination(service)?
+            .path(path)?
+            .build()
+            .await?;
+
+        let progress = Progress::from_proxy(&proxy).await?;
+        let steps = proxy.steps().await?;
+        let sequence = ProgressSequence { steps, progress };
+
+        self.cache.insert(path.to_string(), sequence.clone());
+        Ok(sequence)
+    }
+}
+
+/// It allows querying the [ProgressService].
+///
+/// It is cheap to clone the client and use it from several
+/// places.
+#[derive(Clone)]
+pub struct ProgressClient(mpsc::Sender<ProgressCommand>);
+
+impl ProgressClient {
+    /// Get the progress for the given D-Bus service and path.
+    pub async fn get(&self, service: &str, path: &str) -> ProgressServiceResult<ProgressSequence> {
+        let (tx, rx) = oneshot::channel();
+        self.0
+            .send(ProgressCommand::Get(
+                service.to_string(),
+                path.to_string(),
+                tx,
+            ))
+            .await
+            .map_err(|_| ProgressServiceError::SendCommand)?;
+        Ok(rx.await?)
+    }
+}
+
+/// It allows building an Axum router for the progress service.
+pub struct ProgressRouterBuilder {
+    service: String,
+    path: String,
+    client: ProgressClient,
+}
+
+impl ProgressRouterBuilder {
+    /// Creates a new builder.
+    ///
+    /// * `service`: D-Bus service to connect to.
+    /// * `path`: path of the D-Bus object implementing the
+    ///   "org.opensuse.Agama1.Progress" interface.
+    /// * `client`: client to access the progress.
+    pub fn new(service: &str, path: &str, client: ProgressClient) -> Self {
+        ProgressRouterBuilder {
+            service: service.to_string(),
+            path: path.to_string(),
+            client,
+        }
+    }
+
+    /// Builds the Axum router.
+    pub fn build<T>(self) -> Result<Router<T>, crate::error::Error> {
+        let state = ProgressState {
+            service: self.service,
+            path: self.path,
+            client: self.client,
+        };
+
+        Ok(Router::new()
+            .route("/progress", get(Self::progress))
+            .with_state(state))
+    }
+
+    /// Handler of the GET /progress endpoint.
+    async fn progress(
+        State(state): State<ProgressState>,
+    ) -> Result<Json<ProgressSequence>, crate::error::Error> {
+        let progress = state.client.get(&state.service, &state.path).await?;
+        Ok(Json(progress))
+    }
+}
+
+/// State for the router.
+#[derive(Clone)]
+struct ProgressState {
+    service: String,
+    path: String,
+    client: ProgressClient,
+}
+
+/// Returns a stream of properties changes.
+///
+/// It listens for changes in several objects that are related to a network device.
+pub async fn build_progress_changed_stream(
+    connection: &zbus::Connection,
+) -> Result<MessageStream, zbus::Error> {
+    let rule = MatchRule::builder()
+        .msg_type(MessageType::Signal)
+        .interface("org.opensuse.Agama1.Progress")?
+        .member("ProgressChanged")?
+        .build();
+    // The third parameter corresponds to the max_queue. We rely on the default (64).
+    let stream = MessageStream::for_match_rule(rule, connection, None).await?;
+    Ok(stream)
+}

--- a/rust/agama-server/src/web/common/progress.rs
+++ b/rust/agama-server/src/web/common/progress.rs
@@ -38,7 +38,7 @@
 use crate::web::EventsSender;
 use agama_lib::{
     http::Event,
-    progress::Progress,
+    progress::{Progress, ProgressSequence},
     proxies::{ProgressChanged, ProgressProxy},
 };
 use axum::{extract::State, routing::get, Json, Router};
@@ -46,8 +46,6 @@ use std::collections::HashMap;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::StreamExt;
 use zbus::{message::Type as MessageType, MatchRule, MessageStream};
-
-use super::ProgressSequence;
 
 type ProgressServiceResult<T> = Result<T, ProgressServiceError>;
 

--- a/rust/agama-server/src/web/common/progress.rs
+++ b/rust/agama-server/src/web/common/progress.rs
@@ -151,7 +151,7 @@ impl ProgressService {
         let inner = message.message();
         let header = inner.header();
 
-        // We are not interested on this message
+        // Given that it is a ProcessChanged, it should not happen.
         let Some(path) = header.path() else {
             tracing::warn!("Found a ProgressChanged signal without a path");
             return Ok(());

--- a/rust/agama-server/src/web/common/progress.rs
+++ b/rust/agama-server/src/web/common/progress.rs
@@ -55,8 +55,8 @@ pub enum ProgressServiceError {
     SendProgress,
     #[error("Could not get an answer from the service: {0}")]
     RecvProgress(#[from] oneshot::error::RecvError),
-    #[error("Could not set the command")]
-    SendCommand,
+    #[error("Could not set the command: {0}")]
+    SendCommand(#[from] mpsc::error::SendError<ProgressCommand>),
     #[error("Error parsing progress from D-Bus: {0}")]
     InvalidProgress(#[from] zbus::zvariant::Error),
     #[error("Error reading the progress: {0}")]
@@ -68,7 +68,7 @@ pub enum ProgressServiceError {
 }
 
 #[derive(Debug)]
-enum ProgressCommand {
+pub enum ProgressCommand {
     Get(String, String, oneshot::Sender<ProgressSequence>),
 }
 
@@ -223,8 +223,7 @@ impl ProgressClient {
                 path.to_string(),
                 tx,
             ))
-            .await
-            .map_err(|_| ProgressServiceError::SendCommand)?;
+            .await?;
         Ok(rx.await?)
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 23 10:17:32 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Cache progress reporting to avoid blocking the clients
+  (gh#agama-project/agama#2389).
+
+-------------------------------------------------------------------
 Thu May 22 17:19:10 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Update schema of the storage model (gh#agama-project/agama#2346).

--- a/service/lib/agama/dbus/interfaces/progress.rb
+++ b/service/lib/agama/dbus/interfaces/progress.rb
@@ -92,10 +92,16 @@ module Agama
         def register_progress_callbacks
           progress_manager.on_change do
             dbus_properties_changed(PROGRESS_INTERFACE, progress_properties, [])
+            ProgressChanged(
+              progress_total_steps, progress_current_step, progress_finished, progress_steps
+            )
           end
 
           progress_manager.on_finish do
             dbus_properties_changed(PROGRESS_INTERFACE, progress_properties, [])
+            ProgressChanged(
+              progress_total_steps, progress_current_step, progress_finished, progress_steps
+            )
           end
         end
 
@@ -106,6 +112,8 @@ module Agama
               dbus_reader :progress_current_step, "(us)", dbus_name: "CurrentStep"
               dbus_reader :progress_finished, "b", dbus_name: "Finished"
               dbus_reader :progress_steps, "as", dbus_name: "Steps"
+              dbus_signal :ProgressChanged,
+                "total_steps:u, current_step:(us), finished:b, steps:as"
             end
           end
         end

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -143,16 +143,22 @@ module Agama
 
         logger.info "Probing software"
 
+        common_steps = [
+          _("Refreshing repositories metadata"),
+          _("Calculating the software proposal")
+        ]
         if repositories.empty?
-          start_progress_with_size(3)
+          start_progress_with_descriptions(
+            _("Initializing sources"), *common_steps
+          )
           Yast::PackageCallbacks.InitPackageCallbacks(logger)
-          progress.step(_("Initializing sources")) { add_base_repos }
+          progress.step { add_base_repos }
         else
-          start_progress_with_size(2)
+          start_progress_with_size(*common_steps)
         end
 
-        progress.step(_("Refreshing repositories metadata")) { repositories.load }
-        progress.step(_("Calculating the software proposal")) { propose }
+        progress.step { repositories.load }
+        progress.step { propose }
 
         update_issues
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 23 10:17:28 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Introduce a new ProgressChanged signal which should be used
+  instead of PropertiesChanged (gh#agama-project/agama#2389).
+
+-------------------------------------------------------------------
 Thu May 22 17:21:24 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Include RAIDs at the model for the storage UI

--- a/service/test/agama/dbus/interfaces/progress_test.rb
+++ b/service/test/agama/dbus/interfaces/progress_test.rb
@@ -176,6 +176,8 @@ describe DBusObjectWithProgressInterface do
 
       expect(subject).to receive(:dbus_properties_changed)
         .with(progress_interface, anything, anything)
+      expect(subject).to receive(:ProgressChanged)
+        .with(2, [1, "step 1"], false, [])
 
       progress.step("step 1")
     end
@@ -186,6 +188,8 @@ describe DBusObjectWithProgressInterface do
 
       expect(subject).to receive(:dbus_properties_changed)
         .with(progress_interface, anything, anything)
+      expect(subject).to receive(:ProgressChanged)
+        .with(2, [0, ""], true, [])
 
       progress.finish
     end

--- a/web/src/queries/progress.ts
+++ b/web/src/queries/progress.ts
@@ -28,9 +28,9 @@ import { QueryHookOptions } from "~/types/queries";
 import { fetchProgress } from "~/api/progress";
 
 const servicesMap = {
-  "org.opensuse.Agama.Manager1": "manager",
-  "org.opensuse.Agama.Software1": "software",
-  "org.opensuse.Agama.Storage1": "storage",
+  "/org/opensuse/Agama/Manager1": "manager",
+  "/org/opensuse/Agama/Software1": "software",
+  "/org/opensuse/Agama/Storage1": "storage",
 };
 
 /**
@@ -76,10 +76,10 @@ const useProgressChanges = () => {
     if (!client) return;
 
     return client.onEvent((event) => {
-      if (event.type === "Progress") {
-        const service = servicesMap[event.service];
+      if (event.type === "ProgressChanged") {
+        const service = servicesMap[event.path];
         if (!service) {
-          console.warn("Unknown service", event.service);
+          console.warn("Unknown progress path", event.path);
           return;
         }
 

--- a/web/src/types/progress.ts
+++ b/web/src/types/progress.ts
@@ -26,7 +26,7 @@ type APIProgress = {
   currentTitle: string;
   finished: boolean;
   steps?: string[];
-  service: string;
+  path: string;
 };
 
 class Progress {


### PR DESCRIPTION
## Problem

Follow-up of #2379.

It is a known problem that the software service can get blocked at several stages and it has an impact in the UI and the CLI. We handled part of that problem in #2364 and #2379, but there are still some cases that are not handled properly.

For instance, during software probing, Agama is not able to return the current progress.

## Solution

This PR implements a new `ProgressService` which handles and caches the progress for any service.

Apart from caching the progress, it offers a centralized way of keeping track of the progress, listening for changes in single place (instead of building and processing an stream of events for each of the services).

The service uses [Tokio channels](https://tokio.rs/tokio/tutorial/channels) and message passing to [share the state](https://tokio.rs/tokio/tutorial/shared-state).

As part of this change, I have decided to introduce a new `ProgressChanged` signal, which carries the information we need, instead of relying on the generic `PropertiesChanged`.

## Testing

- Tested manually
- An ISO is [temporarily available](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/non-blocking-progress/images/iso/).