### PR TITLE
feat(storage): add boot checks

### DIFF
--- a/service/lib/agama/storage/config.rb
+++ b/service/lib/agama/storage/config.rb
@@ -197,9 +197,9 @@ module Agama
       # Configs directly using the given alias as target device.
       #
       # @param device_alias [String]
-      # @return [Array<Configs::VolumeGroup>]
+      # @return [Array<Configs::Boot, Configs::VolumeGroup>]
       def target_users(device_alias)
-        vg_target_users(device_alias)
+        [boot_target_user(device_alias), vg_target_users(device_alias)].flatten.compact
       end
 
     private
@@ -224,6 +224,16 @@ module Agama
         return [] unless device
 
         volume_groups.select { |v| v.physical_volumes.include?(device_alias) }
+      end
+
+      # Boot config if it uses the given alias as target for creating the boot partition.
+      #
+      # @param device_alias [String]
+      # @return [Configs::Boot, nil]
+      def boot_target_user(device_alias)
+        return unless boot_device&.alias?(device_alias)
+
+        boot
       end
 
       # Volume groups using the given alias as target for physical volumes.

--- a/service/lib/agama/storage/config_checkers/alias.rb
+++ b/service/lib/agama/storage/config_checkers/alias.rb
@@ -63,7 +63,12 @@ module Agama
         # @return [Issue, nil]
         def overused_alias_issue
           return unless config.alias
-          return unless storage_config.users(config.alias).size > 1
+
+          users = storage_config.users(config.alias)
+          target_users = storage_config.target_users(config.alias)
+
+          overused = users.size > 1 || (users.any? && target_users.any?)
+          return unless overused
 
           error(
             format(_("The device with alias '%s' is used by more than one device"), config.alias),

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Fri May 23 12:37:31 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Add checks to the storage config to avoid using wrong devices as
+  target for boot partitions (gh#agama-project/agama#2390).
+
+-------------------------------------------------------------------
 Fri May 23 11:59:20 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Introduce a new ProgressChanged signal which should be used
   instead of PropertiesChanged (gh#agama-project/agama#2389).
-  
+
 -------------------------------------------------------------------
 Fri May 23 10:39:21 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 

--- a/service/test/agama/storage/config_checkers/alias_test.rb
+++ b/service/test/agama/storage/config_checkers/alias_test.rb
@@ -77,6 +77,71 @@ shared_examples "several users" do
   end
 end
 
+shared_examples "MD RAID user and target user" do
+  context "if it is used by a MD RAID and it is target for boot partitions" do
+    let(:boot) do
+      {
+        configure: true,
+        device:    device_alias
+      }
+    end
+
+    let(:md_raids) do
+      [
+        { devices: [device_alias] }
+      ]
+    end
+
+    include_examples "overused alias issue"
+  end
+
+  context "if it is used by a MD RAID and it is target for physical volumes" do
+    let(:md_raids) do
+      [
+        { devices: [device_alias] }
+      ]
+    end
+
+    let(:volume_groups) do
+      [
+        { physicalVolumes: [{ generate: [device_alias] }] }
+      ]
+    end
+
+    include_examples "overused alias issue"
+  end
+end
+
+shared_examples "Volume group user and target user" do
+  context "if it is used by a volume group and it is target for boot partitions" do
+    let(:boot) do
+      {
+        configure: true,
+        device:    device_alias
+      }
+    end
+
+    let(:volume_groups) do
+      [
+        { physicalVolumes: [device_alias] }
+      ]
+    end
+
+    include_examples "overused alias issue"
+  end
+
+  context "if it is used by a volume group and it is target for physical volumes" do
+    let(:volume_groups) do
+      [
+        { physicalVolumes: [device_alias] },
+        { physicalVolumes: [{ generate: [device_alias] }] }
+      ]
+    end
+
+    include_examples "overused alias issue"
+  end
+end
+
 shared_examples "formatted and used issue" do
   it "includes the expected issue" do
     issues = subject.issues
@@ -238,6 +303,8 @@ describe Agama::Storage::ConfigCheckers::Alias do
       include_examples "several MD RAID users"
       include_examples "several volume group users"
       include_examples "several users"
+      include_examples "MD RAID user and target user"
+      include_examples "Volume group user and target user"
       include_examples "formatted and MD RAID user"
       include_examples "formatted and volume group user"
       include_examples "formatted and volume group target user"
@@ -302,6 +369,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
       let(:device_config) { config.md_raids.first }
 
       include_examples "several volume group users"
+      include_examples "Volume group user and target user"
       include_examples "formatted and volume group user"
       include_examples "formatted and volume group target user"
       include_examples "formatted and boot target user"

--- a/service/test/agama/storage/config_checkers/alias_test.rb
+++ b/service/test/agama/storage/config_checkers/alias_test.rb
@@ -136,6 +136,23 @@ shared_examples "formatted and volume group target user" do
   end
 end
 
+shared_examples "formatted and boot target user" do
+  context "if it is formatted" do
+    let(:filesystem) { { path: "/" } }
+
+    context "and it is used as target for boot partitions" do
+      let(:boot) do
+        {
+          configure: true,
+          device:    device_alias
+        }
+      end
+
+      include_examples "formatted and used issue"
+    end
+  end
+end
+
 shared_examples "partitioned and used issue" do
   it "includes the expected issue" do
     issues = subject.issues
@@ -196,6 +213,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
     context "for a drive" do
       let(:config_json) do
         {
+          boot:         boot,
           drives:       [
             {
               alias:      device_alias,
@@ -208,6 +226,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
         }
       end
 
+      let(:boot) { nil }
       let(:device_alias) { "disk1" }
       let(:filesystem) { nil }
       let(:partitions) { nil }
@@ -222,6 +241,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
       include_examples "formatted and MD RAID user"
       include_examples "formatted and volume group user"
       include_examples "formatted and volume group target user"
+      include_examples "formatted and boot target user"
       include_examples "partitioned and MD RAID user"
       include_examples "partitioned and volume group user"
     end
@@ -261,6 +281,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
     context "for a MD RAID" do
       let(:config_json) do
         {
+          boot:         boot,
           mdRaids:      [
             {
               alias:      device_alias,
@@ -272,6 +293,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
         }
       end
 
+      let(:boot) { nil }
       let(:device_alias) { "md1" }
       let(:filesystem) { nil }
       let(:partitions) { nil }
@@ -282,6 +304,7 @@ describe Agama::Storage::ConfigCheckers::Alias do
       include_examples "several volume group users"
       include_examples "formatted and volume group user"
       include_examples "formatted and volume group target user"
+      include_examples "formatted and boot target user"
       include_examples "partitioned and volume group user"
     end
 

--- a/service/test/agama/storage/config_test.rb
+++ b/service/test/agama/storage/config_test.rb
@@ -1007,13 +1007,34 @@ describe Agama::Storage::Config do
           ]
         end
 
-        it "returns the volume groups" do
+        it "includes the volume groups" do
           users = subject.target_users(device_alias)
           expect(users).to contain_exactly(subject.volume_groups[0], subject.volume_groups[2])
         end
       end
 
-      context "and it is not used as target for physical volumes" do
+      context "and it is used as target for boot partitions" do
+        let(:boot) do
+          {
+            configure: true,
+            device:    device_alias
+          }
+        end
+
+        it "includes the boot config" do
+          users = subject.target_users(device_alias)
+          expect(users).to contain_exactly(subject.boot)
+        end
+      end
+
+      context "and it is not used as target for physical volumes or boot" do
+        let(:boot) do
+          {
+            configure: false,
+            device:    device_alias
+          }
+        end
+
         let(:volume_groups) do
           [
             { name: "vg1" }
@@ -1029,12 +1050,14 @@ describe Agama::Storage::Config do
 
     let(:config_json) do
       {
+        boot:         boot,
         drives:       drives,
         mdRaids:      md_raids,
         volumeGroups: volume_groups
       }
     end
 
+    let(:boot) { nil }
     let(:drives) { nil }
     let(:md_raids) { nil }
     let(:volume_groups) { nil }


### PR DESCRIPTION
Add checks to the storage config to avoid using wrong devices as target for boot partitions. For example:

* The device is directly formatted.
* The device is a member of a drive.
* The device is a physical volume.
 