### PR TITLE
fix(rust): fix handling of secure WebSocket connections

### DIFF
--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -273,7 +273,7 @@ async fn build_clients(
     insecure: bool,
 ) -> anyhow::Result<(BaseHTTPClient, MonitorClient)> {
     let client = build_http_client(api_url.clone(), insecure, true).await?;
-    let ws_client = build_ws_client(api_url, true).await?;
+    let ws_client = build_ws_client(api_url, insecure).await?;
     let monitor = Monitor::connect(client.clone(), ws_client).await?;
     Ok((client, monitor))
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 23 13:22:15 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Proper handling of WebSocket secure connections (gh#agama-project/agama#2391):
+  - "agama monitor" does not use "insecure" by default.
+  - Do not encrypt the connection when using ws: URLs.
+
+-------------------------------------------------------------------
 Fri May 23 10:17:32 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Cache progress reporting to avoid blocking the clients


### PR DESCRIPTION
## Problem

Handling of the WebSocket was plain wrong:

- The "agama monitor" was always ignoring SSL problems.
- The "events monitor" was always trying to use TLS.

## Solution

- Rewrite the WebSocket::connect method to handle ws: and wss: as expected.
- Disable `--insecure` for `agama monitor` by default.

## Testing

- *Tested manually*
