### PR TITLE
fix(ruby): fix call to start_progress_with_descriptions

### DIFF
--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -156,7 +156,7 @@ module Agama
           Yast::PackageCallbacks.InitPackageCallbacks(logger)
           progress.step { add_base_repos }
         else
-          start_progress_with_size(*common_steps)
+          start_progress_with_descriptions(*common_steps)
         end
 
         progress.step { repositories.load }


### PR DESCRIPTION
Fix a wrong call to start_progress_with_descriptions (introduced in #2389).
