### PR TITLE
feat(rust): add more info to the monitor

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -27,10 +27,13 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "crossterm 0.29.0",
  "fluent-uri",
+ "futures-util",
  "home",
  "indicatif",
  "inquire",
+ "ratatui",
  "regex",
  "reqwest",
  "serde_json",
@@ -65,7 +68,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "strum",
+ "strum 0.27.1",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -104,7 +107,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_with",
- "strum",
+ "strum 0.27.1",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -210,6 +213,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -826,6 +835,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1010,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
  "async-trait",
- "convert_case",
+ "convert_case 0.6.0",
  "json5",
  "pathdiff",
  "ron",
@@ -1051,6 +1089,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1135,6 +1182,41 @@ dependencies = [
  "libc",
  "mio 0.8.11",
  "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "mio 1.0.3",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "futures-core",
+ "mio 1.0.3",
+ "parking_lot",
+ "rustix 1.0.5",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1244,6 +1326,27 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1748,6 +1851,8 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -2224,19 +2329,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
  "bitflags 2.9.0",
- "crossterm",
+ "crossterm 0.25.0",
  "dyn-clone",
  "fxhash",
  "newline-converter",
  "once_cell",
  "unicode-segmentation",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2265,6 +2389,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2522,6 +2655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "macaddr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -3011,6 +3154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,6 +3496,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3850,6 +4020,7 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
+ "mio 1.0.3",
  "signal-hook",
 ]
 
@@ -3949,11 +4120,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4561,6 +4754,17 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "unicode-width"

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -26,6 +26,9 @@ chrono = "0.4.38"
 regex = "1.11.1"
 home = "0.5.11"
 fluent-uri = "0.3.2"
+ratatui = "0.29.0"
+crossterm = { version = "0.29.0", features = ["event-stream"] }
+futures-util = "0.3.31"
 
 [[bin]]
 name = "agama"

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -26,6 +26,7 @@ use anyhow::Context;
 use auth_tokens_file::AuthTokensFile;
 use clap::{Args, Parser};
 use fluent_uri::UriRef;
+use monitor::start_monitor;
 
 mod auth;
 mod auth_tokens_file;
@@ -34,6 +35,7 @@ mod config;
 mod error;
 mod events;
 mod logs;
+mod monitor;
 mod profile;
 mod progress;
 mod questions;
@@ -335,7 +337,8 @@ pub async fn run_command(cli: Cli) -> Result<(), ServiceError> {
         }
         Commands::Monitor => {
             let (_client, monitor) = build_clients(api_url, cli.opts.insecure).await?;
-            show_progress(monitor, false).await;
+            // show_progress(monitor, false).await;
+            start_monitor(monitor).await?;
         }
         Commands::Events { pretty } => {
             let ws_client = build_ws_client(api_url, cli.opts.insecure).await?;

--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -1,0 +1,32 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+mod app;
+use agama_lib::monitor::MonitorClient;
+use app::App;
+use ratatui::{TerminalOptions, Viewport};
+
+pub async fn start_monitor(monitor: MonitorClient) -> anyhow::Result<()> {
+    let viewport = Viewport::Inline(16);
+    let terminal = ratatui::init_with_options(TerminalOptions { viewport });
+    let result = App::new(monitor).run(terminal).await;
+    ratatui::restore();
+    result
+}

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -1,0 +1,176 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+#![allow(dead_code)]
+
+use agama_lib::{
+    manager::InstallationPhase,
+    monitor::{MonitorClient, MonitorStatus},
+};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent};
+use futures_util::{FutureExt, StreamExt};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Style, Stylize},
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, Paragraph, Widget},
+    DefaultTerminal,
+};
+
+pub struct App {
+    /// whether the application is running
+    running: bool,
+    /// monitor client
+    monitor: MonitorClient,
+    /// monitor status
+    status: MonitorStatus,
+    /// crossterm events stream
+    events: EventStream,
+}
+
+impl App {
+    pub fn new(monitor: MonitorClient) -> App {
+        App {
+            running: true,
+            status: Default::default(),
+            monitor,
+            events: Default::default(),
+        }
+    }
+
+    pub async fn run(mut self, mut terminal: DefaultTerminal) -> anyhow::Result<()> {
+        let mut updates = self.monitor.subscribe();
+        self.status = self.monitor.get_status().await?;
+
+        while self.running {
+            terminal.draw(|frame| frame.render_widget(&self, frame.area()))?;
+
+            tokio::select! {
+                Some(event) = self.events.next().fuse() => {
+                    match event {
+                        Ok(Event::Key(key)) => self.handle_key(key),
+                        _ => {}
+                    }
+                }
+
+               Ok(status) = updates.recv() => {
+                   self.status = status;
+               }
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key_event: KeyEvent) {
+        match key_event.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.running = false,
+            _ => {}
+        };
+    }
+
+    fn render_issues(&self, area: Rect, buf: &mut Buffer) {
+        if self.status.issues.is_empty() {
+            return;
+        }
+
+        let mut content = vec![
+            "You need to solve the following issues before installing:".to_string(),
+            "".to_string(),
+        ];
+        let mut issues: Vec<String> = self
+            .status
+            .issues
+            .values()
+            .flatten()
+            .map(|i| format!("  * {}", &i.description))
+            .collect();
+        content.append(&mut issues);
+        let text = Text::from(content.join("\n"));
+        text.render(area, buf);
+    }
+
+    fn render_progress(&self, area: Rect, buf: &mut Buffer) {
+        let layout =
+            Layout::vertical(vec![Constraint::Length(1), Constraint::Length(1)]).vertical_margin(1);
+
+        let [main, detail] = layout.areas(area);
+
+        if let Some(progress) = self.status.progress.get(MANAGER_PROGRESS_OBJECT_PATH) {
+            let steps = Span::styled(
+                format!("[{}/{}] ", progress.current_step, progress.max_steps),
+                Style::new().bold().fg(Color::Green),
+            );
+            let description = Span::raw(progress.current_title.as_str());
+            let line = Line::from(vec![steps, description]);
+            line.render(main, buf);
+        }
+
+        if let Some(progress) = self.status.progress.get(SOFTWARE_PROGRESS_OBJECT_PATH) {
+            let steps = Span::styled(
+                format!("[{}/{}] ", progress.current_step, progress.max_steps),
+                Style::new().bold(),
+            );
+            let description = Span::raw(progress.current_title.as_str());
+            let line = Line::from(vec![steps, description]);
+            line.render(detail, buf);
+        }
+    }
+}
+
+const MANAGER_PROGRESS_OBJECT_PATH: &str = "/org/opensuse/Agama/Manager1";
+const SOFTWARE_PROGRESS_OBJECT_PATH: &str = "/org/opensuse/Agama/Software1";
+
+impl Widget for &App {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let installer_status = &self.status.installer_status;
+        let phase = match installer_status.phase {
+            InstallationPhase::Startup => "Initializing",
+            InstallationPhase::Config => "Configuration",
+            InstallationPhase::Install => "Installing",
+            InstallationPhase::Finish => "Finished",
+        };
+
+        let layout = Layout::vertical(vec![Constraint::Length(4), Constraint::Min(1)]);
+        let [top, content] = layout.areas(area);
+
+        let idle = self.status.progress.is_empty();
+        let status = if idle { "Idle" } else { "Running" };
+
+        let text = vec![
+            Line::raw(format!("Phase: {}", phase)),
+            Line::raw(format!("Status: {}", status)),
+        ];
+
+        let title = Line::from("Agama (press 'q' to exit)").centered();
+        let para = Paragraph::new(text).block(
+            Block::new()
+                .borders(Borders::BOTTOM | Borders::TOP)
+                .title(title),
+        );
+        para.render(top, buf);
+
+        if idle {
+            self.render_issues(content, buf);
+        } else {
+            self.render_progress(content, buf);
+        }
+    }
+}

--- a/rust/agama-lib/src/issue.rs
+++ b/rust/agama-lib/src/issue.rs
@@ -22,11 +22,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct Issue {
-    description: String,
-    details: Option<String>,
-    source: u32,
-    severity: u32,
-    kind: String,
+    pub description: String,
+    pub details: Option<String>,
+    pub source: u32,
+    pub severity: u32,
+    pub kind: String,
 }
 
 impl Issue {


### PR DESCRIPTION
## Problem

The "agama monitor" is good at displaying the progress line by line, but not that good to display the current status.

## Solution

This PR is an experiment to build a new monitor which offers more (and better) information.

![Displaying the issues](https://github.com/user-attachments/assets/a872ad04-0e2e-4093-ad03-143091a5c466)

![Displaying the progress](https://github.com/user-attachments/assets/cc7630cf-c224-42c6-9710-3a01e591473c)

## Testing

- *Tested manually*