### PR TITLE
fix(ruby): set stopOnBootMenu=true for negative timeouts

### DIFF
--- a/service/lib/agama/autoyast/bootloader_reader.rb
+++ b/service/lib/agama/autoyast/bootloader_reader.rb
@@ -42,8 +42,17 @@ module Agama
         return {} if global.empty?
 
         bootloader = {}
-        bootloader["timeout"] = global["timeout"] if global["timeout"].is_a?(Integer)
+
+        if global["timeout"].is_a?(Integer)
+          if global["timeout"] >= 0
+            bootloader["timeout"] = global["timeout"]
+          else
+            bootloader["stopOnBootMenu"] = true
+          end
+        end
+
         bootloader["extraKernelParams"] = global["append"] unless global["append"].to_s.empty?
+
         { "bootloader" => bootloader }
       end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 26 09:44:54 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set stopOnBootMenu to "true" when a negative timeout is
+  set in the bootloader section of an AutoYaST profile
+  (bsc#1243623).
+
+-------------------------------------------------------------------
 Fri May 23 12:37:31 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add checks to the storage config to avoid using wrong devices as

--- a/service/test/agama/autoyast/bootloader_reader_test.rb
+++ b/service/test/agama/autoyast/bootloader_reader_test.rb
@@ -64,6 +64,18 @@ describe Agama::AutoYaST::BootloaderReader do
           "timeout" => 5
         )
       end
+
+      context "and it is a negative number" do
+        let(:global) do
+          { "timeout" => -1 }
+        end
+
+        it "sets the 'stopOnBootMenu' to 'true'" do
+          expect(subject.read["bootloader"]).to include(
+            "stopOnBootMenu" => true
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

When an AutoYaST profile contains "-1" as the value for the timeout, Agama does not handle it properly.

## Solution

Convert negative timeout numbers to `stopOnBootMenu=true`.
