### PR TITLE
Simple Rescue System

### DIFF
--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -97,6 +97,13 @@ menuentry "Check Installation Medium" --class os --unrestricted {
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
 }
+menuentry "Rescue System" --class os --unrestricted {
+    set gfxpayload=keep
+    echo Loading kernel...
+    linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} $rescue_system_boot_settings
+    echo Loading initrd...
+    initrd (\$root)/boot/aarch64/loader/initrd
+}
 menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
   exit
 }

--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -109,6 +109,13 @@ menuentry "Check Installation Medium" --class os --unrestricted {
   initrd /boot/ppc64le/initrd
 }
 
+menuentry "Rescue System" --class os --unrestricted {
+  echo 'Loading kernel...'
+  linux /boot/ppc64le/linux $rescue_system_boot_settings
+  echo 'Loading initrd...'
+  initrd /boot/ppc64le/initrd
+}
+
 menuentry 'local' {
   exit
 }

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -97,6 +97,13 @@ menuentry "Check Installation Medium" --class os --unrestricted {
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }
+menuentry "Rescue System" --class os --unrestricted {
+    set gfxpayload=keep
+    echo Loading kernel...
+    linux (\$root)/boot/x86_64/loader/linux \${extra_cmdline} \${isoboot} $rescue_system_boot_settings
+    echo Loading initrd...
+    initrd (\$root)/boot/x86_64/loader/initrd
+}
 menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
   if search --no-floppy --file /efi/boot/fallback.efi --set ; then
     for os in opensuse sles leap suse; do

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -97,6 +97,17 @@ arch=$(uname -m)
 # keep in sync with ISO Volume ID set in the fix_bootconfig script
 profile=$(echo "$kiwi_profiles" | tr "_" "-")
 label="Install-$profile-$arch"
+# the simple rescue system reuses the installation live media
+# but boots to the text-mode only and disables the Agama server
+rescue_system_boot_settings="systemd.unit=multi-user.target
+systemd.mask=agama.service
+systemd.mask=agama-dbus-monitor.service
+systemd.mask=agama-ssh-issue.service
+systemd.mask=agama-avahi-issue.service
+systemd.mask=agama-welcome-issue.service
+systemd.mask=agama-url-issue.service
+systemd.mask=agama-certificate-issue.service
+systemd.mask=agama-certificate-wait.service"
 
 # Set the default live root except for PXE images
 if [[ "$kiwi_profiles" != *PXE* ]]; then


### PR DESCRIPTION
- Implements a rescue system by booting to the Installer Live Media image with special systemd parameters that disable booting to the graphical mode and starting Agama service
- Some services are kept, such as DUD, Self-Update, root password

## Problem

The current media do not have a Rescue System but users are asking for it

- https://trello.com/c/Kgaovgu8

## Solution

This PR does not implement any special Rescue System. It only reuses what we already have and prevents Agama from starting. 

## Testing

- Parameters were tested manually on a Kernel command line
