### PR TITLE
chore: bump to version 16.pre in master

### DIFF
--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -21,7 +21,7 @@
         <profile name="Leap_16.0_PXE" description="openSUSE Leap OEM image for remote installation" import="true" />
     </profiles>
     <preferences>
-        <version>15.0.0</version>
+        <version>16.pre.0.0</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
         <keytable>us</keytable>


### PR DESCRIPTION
Bump to version 16.pre in the `master` branch. The `rc1` branch contains the code for Agama 15.
