### PR TITLE
Update sles_sap_160.yaml

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May 28 15:04:21 UTC 2025 - Andreas Jaeger <aj@suse.com>
+
+- Add all SLES 16.0 patterns to SLES for SAP 16.0 as well (bsc#1243757).
+
+-------------------------------------------------------------------
 Mon May 26 19:51:54 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 15

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -31,6 +31,25 @@ software:
     - sles_sap_base_sap_server
   optional_patterns: null # no optional pattern shared
   user_patterns:
+    # First all patterns from file sles_160.yaml
+    - cockpit
+    - sles_sap_minimal_sap
+    - fips
+    - selinux
+    - documentation
+    - sw_management
+    - container_runtime_podman
+    - dhcp_dns_server
+    - directory_server
+    - file_server
+    - gateway_server
+    - kvm_server
+    - kvm_tools
+    - lamp_server
+    - mail_server
+    - printing
+    - gnome
+    # Second, all patterns for SAP only
     - sles_sap_DB
     - sles_sap_HADB
     - sles_sap_APP


### PR DESCRIPTION
Add SLES patterns to SLES for SAP


## Problem

SLES for SAP pattern selection only shows the SLES for SAP specific ones but misses the base SLES patterns.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1243757

## Solution

Copy over patterns from SLES to SLES for SAP

