### PR TITLE
fix(live): Keep the nvmem kernel drivers (bsc#1243350)

### DIFF
--- a/live/live-root/tmp/README.md
+++ b/live/live-root/tmp/README.md
@@ -3,3 +3,11 @@
 This directory contains some helper file which are needed when building the ISO
 image. The files are deleted at the end of build and are not included in the
 final image.
+
+The [module.list](./module.list) file is copied from the installation-images
+package. To update the file download the latest version from
+https://github.com/openSUSE/installation-images/blob/master/etc/module.list.
+
+Hot fixes or Agama specific changes should be added into the
+[module.list.extra](./module.list.extra) file to keep the original file
+untouched.

--- a/live/live-root/tmp/module.list.extra
+++ b/live/live-root/tmp/module.list.extra
@@ -2,3 +2,7 @@
 # in addition to the module.list file to allow extra overrides or hot fixes
 # without touching the original file. The original file should not be touched to
 # allow easy updates from the installation-images repository.
+
+# keep the nvmem drivers (https://bugzilla.suse.com/show_bug.cgi?id=1243350)
+kernel/drivers/nvmem
+kernel/drivers/dma/fsl-edma.ko

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 29 07:16:11 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Keep the nvmem kernel drivers (bsc#1243350)
+
+-------------------------------------------------------------------
 Mon May 26 21:35:04 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Generate systemd network link files below Agama run folder to 


### PR DESCRIPTION
## Problem

- The  `nvmem-imx-ocotp`,  `nvmem-imx-ocotp-ele` and `fsl-edma` drivers are missing in the installer
- https://bugzilla.suse.com/show_bug.cgi?id=1243350

## Notes

- Keep all `kernel/drivers/nvmem` drivers, there are more for different hardware but they are tiny (all drivers are ~100kB compressed in all aarch64 kernel packages) so let's solve it for all similar hardware.
- I'm not sure if we need to explicitly add those drivers to the initrd or they are added automatically by dracut or it is enough to have them just in the root image. Let's wait for the feedback.