### PR TITLE
web/storage: prevent submission of sizes without units 

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 29 09:31:28 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Requires a unit when entering sizes to avoid confusion and
+  accidental sizes in bytes (gh#agama-project/agama#2421).
+
+-------------------------------------------------------------------
 Mon May 26 19:51:54 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 15
@@ -7,7 +13,7 @@ Mon May 26 19:51:54 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 Thu May 22 17:16:40 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Handle reused MD RAIDs that are already included at the storage
-  configuration (gh/agama-project/agama#2346).
+  configuration (gh#agama-project/agama#2346).
 
 -------------------------------------------------------------------
 Thu May 22 16:20:38 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
@@ -24,7 +30,7 @@ Thu May 22 09:07:28 UTC 2025 - David Diaz <dgonzalez@suse.com>
 Mon May 19 13:38:16 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Keep margin between sidebar and main content in all breakpoints
-  (gh/agama-project/agama#2370).
+  (gh#agama-project/agama#2370).
 
 -------------------------------------------------------------------
 Fri May 16 07:46:22 UTC 2025 - David Diaz <dgonzalez@suse.com>

--- a/web/src/components/storage/PartitionPage.test.tsx
+++ b/web/src/components/storage/PartitionPage.test.tsx
@@ -35,7 +35,7 @@ jest.mock("~/queries/issues", () => ({
 }));
 
 jest.mock("./ProposalResultSection", () => () => <div>result section</div>);
-jest.mock("./ProposalTransactionalInfo", () => () => <div>trasactional info</div>);
+jest.mock("./ProposalTransactionalInfo", () => () => <div>transactional info</div>);
 
 const mockGetPartition = jest.fn();
 

--- a/web/src/components/storage/PartitionPage.test.tsx
+++ b/web/src/components/storage/PartitionPage.test.tsx
@@ -247,6 +247,44 @@ describe("PartitionPage", () => {
     expect(size).toBeDisabled();
   });
 
+  it("does not allow sending sizes without units", async () => {
+    const { user } = installerRender(<PartitionPage />);
+    screen.getByRole("form", { name: "Configure partition at /dev/sda" });
+    const mountPoint = screen.getByRole("button", { name: "Mount point toggle" });
+    const size = screen.getByRole("button", { name: "Size" });
+    const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+    await user.click(mountPoint);
+    const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
+    const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
+    await user.click(homeMountPoint);
+    // Display available size options
+    await user.click(size);
+    const sizeOptions = screen.getByRole("listbox", { name: "Size options" });
+    // Display custom size
+    const customSize = within(sizeOptions).getByRole("option", { name: /Custom/ });
+    await user.click(customSize);
+    const minSizeInput = screen.getByRole("textbox", { name: "Minimum size value" });
+    const maxSizeModeToggle = screen.getByRole("button", { name: "Maximum size mode" });
+    await user.click(maxSizeModeToggle);
+    const maxSizeOptions = screen.getByRole("listbox", { name: "Maximum size options" });
+    const limitedMaxSizeOption = within(maxSizeOptions).getByRole("option", { name: /Limited/ });
+    await user.click(limitedMaxSizeOption);
+    const maxSizeInput = screen.getByRole("textbox", { name: "Maximum size value" });
+
+    await user.clear(minSizeInput);
+    await user.type(minSizeInput, "1");
+    screen.getByText(/The minimum must be.*followed by a unit/);
+    await user.clear(maxSizeInput);
+    await user.type(maxSizeInput, "3");
+    screen.getByText(/Size limits must be.*followed by a unit/);
+    await user.type(minSizeInput, " GiB");
+    await user.type(maxSizeInput, " TiB");
+    expect(screen.queryByText(/The minimum must be.*followed by a unit/)).toBeNull();
+    expect(screen.queryByText(/Size limits must be.*followed by a unit/)).toBeNull();
+    expect(acceptButton).toBeEnabled();
+  });
+
   describe("if editing a partition", () => {
     beforeEach(() => {
       mockParams({ list: "drives", listIndex: "0", partitionId: "/home" });

--- a/web/src/components/storage/PartitionPage.tsx
+++ b/web/src/components/storage/PartitionPage.tsx
@@ -340,7 +340,7 @@ function useSizeError(value: FormValue): Error | undefined {
     };
   }
 
-  const regexp = /^[0-9]+(\.[0-9]+)?(\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])?$/;
+  const regexp = /^[0-9]+(\.[0-9]+)?(\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])$/;
   const validMin = regexp.test(min);
   const validMax = max ? regexp.test(max) : true;
 
@@ -357,7 +357,7 @@ function useSizeError(value: FormValue): Error | undefined {
   if (validMin) {
     return {
       id: "customSize",
-      message: _("The maximum must be a number optionally followed by a unit like GiB or GB"),
+      message: _("The maximum must be a number followed by a unit like GiB or GB"),
       isVisible: true,
     };
   }
@@ -365,14 +365,14 @@ function useSizeError(value: FormValue): Error | undefined {
   if (validMax) {
     return {
       id: "customSize",
-      message: _("The minimum must be a number optionally followed by a unit like GiB or GB"),
+      message: _("The minimum must be a number followed by a unit like GiB or GB"),
       isVisible: true,
     };
   }
 
   return {
     id: "customSize",
-    message: _("Size limits must be numbers optionally followed by a unit like GiB or GB"),
+    message: _("Size limits must be numbers followed by a unit like GiB or GB"),
     isVisible: true,
   };
 }
@@ -826,11 +826,8 @@ function CustomSize({ value, onChange }: CustomSizeProps) {
     <Stack hasGutter>
       <Stack>
         <SubtleContent>
-          {_("Sizes must be entered as a numbers optionally followed by a unit.")}
-        </SubtleContent>
-        <SubtleContent>
           {_(
-            "If the unit is omitted, bytes (B) will be used. Greater units can be of \
+            "Sizes must be entered as a numbers followed by a unit of \
               the form GiB (power of 2) or GB (power of 10).",
           )}
         </SubtleContent>

--- a/web/src/components/storage/PartitionPage.tsx
+++ b/web/src/components/storage/PartitionPage.tsx
@@ -468,7 +468,7 @@ function useAutoRefreshFilesystem(handler, value: FormValue) {
     // Select default filesystem for the mount point if the partition has no filesystem.
     if (mountPoint !== NO_VALUE && target !== NEW_PARTITION && !partitionFilesystem)
       handler(defaultFilesystem);
-    // Reuse the filesystem from the partition if possble.
+    // Reuse the filesystem from the partition if possible.
     if (mountPoint !== NO_VALUE && target !== NEW_PARTITION && partitionFilesystem) {
       // const reuse = usableFilesystems.includes(partitionFilesystem);
       const reuse = usableFilesystems.includes(partitionFilesystem);


### PR DESCRIPTION
In Agama’s storage configuration, omitting a unit defaults to bytes. However, allowing this in the UI has proven confusing because:

  * Users almost never intend to specify a size in bytes
  * It’s easy to accidentally enter a raw number (e.g., “2”) expecting it to be interpreted as “2 GiB”

This PR addresses it by disallowing size inputs without explicit units, helping to prevent user frustration.

---

Related to https://trello.com/c/1hcYodEX (private link)