### PR TITLE
Add documentation about storage plans

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -105,6 +105,268 @@ technical point of view, that translates into the following:
  - If the product does not specify a default volume, the behavior is still not defined (there are
    several reasonable options).
 
+## Planned features
+
+This section of the document recaps features and subsections of the schema that are planned but
+still not implemented. Moved away from the user documentation to avoid confusion.
+
+### Missing sections
+
+The final plan is to offer this schema for the `storage` section.
+
+```
+"storage": {
+  "drives": [ ... ],
+  "volumeGroups": [ ... ],
+  "mdRaids": [ ... ],
+  "btrfsRaids": [ ... ],
+  "nfsMounts": [ ... ]
+  "boot": { ... }
+}
+```
+
+So it will be possible to define (or reuse) multi-device Btrfs file systems using the future
+`btrfsRaids` section.
+
+```
+{
+  "alias": "...",
+  "search": { ... },
+  "dataRaidlevel": "...",
+  "metaDataRaidLevel": "..." ,
+  "devices": [ ... ],
+  "label": "...",
+  "mkfsOptions": { ... },
+  "subvolumePrefix": "...",
+  "subvolumes": [ ... ],
+  "snapshots": ...,
+  "quotas": ...,
+  "delete": ...
+}
+```
+
+And NFS shares could be mounted as entries at `nfsMounts`.
+
+```
+{
+  "alias": "...",
+  "path": "...",
+  "mount": "..."
+}
+```
+
+### Searching existing devices
+
+The ability to select one or several existing devices using a `search` section is still on its early
+stages. The following example shows how several `search` sections could be used in the future to
+find the three biggest disks in the system, delete all Linux partitions bigger than 1 GiB within
+them and create new partitions of type RAID. That includes features not implemented yet like the
+`and` operator and the usage of `sort` to order the matching devices.
+
+```json
+"storage": {
+  "drives": [
+    {
+      "search": {
+        "sort": { "size": "desc" },
+        "max": 3
+      },
+      "partitions": [
+        {
+          "search": {
+            "condition": {
+              "and": [
+                { "partition_id": "linux" },
+                { "size": { "greater": "1 GiB" } }
+              ]
+            }
+          },
+          "delete": true
+        },
+        {
+          "alias": "newRaidPart",
+          "id": "raid",
+          "size": { "min": "1 GiB" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Devices are matched in the order the sections appear on the profile. The usefulness of that will
+increase once `sort` is implemented. It will be possible to use `sort` to select the biggest disks
+like in the following example.
+
+```json
+"storage": {
+  "drives": [
+    {
+      "search": {
+        "sort": { "size": "desc" },
+        "max": 1
+      },
+      "alias": "biggest"
+    },
+    {
+      "search": {
+        "sort": { "size": "desc" },
+        "max": 1
+      },
+      "alias": "secondBiggest"
+    }
+  ]
+}
+```
+
+If `search` is omitted for a drive, it will be considered to contain the following section.
+
+```json
+{
+  "search": {
+    "sort": { "name": "asc" },
+    "max": 1,
+    "ifNotFound": "error"
+  }
+}
+```
+
+The attribute `ifNotFound` can be used to control what happens if nothing matches a certain
+`search`. In the future the value "create", which will never work drives, will cause the `search`
+section to be ignored if no device matches. As a consequence, a new logical device (partition, LVM,
+etc.) will be created.
+
+### Specifying or omitting the size of a device
+
+If the size is omitted for a device that will be created, Agama will determine the size limits when
+possible. There will be basically two kinds of situations in which that automatic size calculation
+can be performed.
+
+On the one hand, the device may directly contain a `filesystem` entry specifying a mount point.
+Agama will then use the settings of the product to set the size limits. That's already implemented.
+
+On the other hand, the size limits of some devices can be omitted if they can be inferred from other
+related devices following some rules.
+
+- For an MD RAID defined on top of new partitions, it is possible to specify the size of all the
+  partitions that will become members of the RAID but is also possible to specify the desired size
+  for the resulting MD RAID and then the size limits of each partition will be automatically
+  inferred with a small margin of error of a few MiBs.
+- Something similar happens with a partition that acts as the **only** physical volume of a new LVM
+  volume group. Specifying the sizes of the logical volumes could be enough, the size limits of the
+  underlying partition will match the necessary values to make the logical volumes fit. In this
+  case the calculated partition size is fully accurate.
+- The two previous scenarios can be combined. For a new MD RAID that acts as the **only** physical
+  volume of a new LVM volume group, the sizes of the logical volumes can be used to precisely
+  determine what should be the size of the MD and, based on that, what should be the almost
+  exact size of the underlying new partitions defined to act as members of the RAID.
+
+The two described mechanisms to automatically determine size limits can be combined. Even creating
+a configuration with no explicit sizes at all like the following example.
+
+```json
+"storage": {
+  "drives": [
+    {
+      "partitions": [
+        { "alias": "pv" }
+       ]
+    }
+  ],
+  "volumeGroups": [
+    {
+      "name": "system",
+      "physicalVolumes": [ "pv" ],
+      "logicalVolumes": [
+        { "filesystem": { "path": "/" } },
+        { "filesystem": { "path": "swap" } }
+      ]
+    }
+  ]
+}
+```
+
+Assuming the product configuration specifies a root filesystem with a minimum size of 5 GiB and a
+max of 20 GiB and sets that the swap must have a size equivalent to the RAM on the system, then
+those values would be applied to the logical volumes and the partition with alias "pv" would be
+sized accordingly, taking into account all the overheads and roundings introduced by the different
+technologies like LVM or the used partition table type.
+
+### Generating Partitions as MD RAID members
+
+Right now, MD arrays can be configured to explicitly use a set of devices by adding their aliases
+to the `devices` property.
+
+In the future, the partitions acting as members could be automatically generated by simply
+indicating the target disks that will hold the partitions. For that, the `devices` section will
+contain a `generate` entry.
+
+```json
+"storage": {
+  "drives": [
+    { "search": "/dev/sda", "alias": "sda" },
+    { "search": "/dev/sdb", "alias": "sdb" },
+  ],
+  "mdRaids": [
+    {
+      "devices": [
+        {
+          "generate": {
+            "targetDisks": ["sda", "sdb" ],
+            "size": "40 GiB"
+          }
+        }
+      ]
+      "level": "raid0"
+    }
+  ]
+}
+```
+
+As explained at the section about sizes, it will be also possible to set the size for the new RAID
+letting Agama calculate the corresponding sizes of the partitions used as members. That allows to use
+the short syntax for `generate`.
+
+```json
+"storage": {
+  "drives": [
+    { "search": "/dev/sda", "alias": "sda" },
+    { "search": "/dev/sdb", "alias": "sdb" },
+  ],
+  "mdRaids": [
+    {
+      "devices": [ { "generate": ["sda", "sdb" ] } ],
+      "level": "raid0",
+      "size": "40 GiB"
+    }
+  ]
+}
+```
+
+The _default_ and _mandatory_ keywords could also be used to generate a set of formatted MD arrays.
+Assuming the default volumes are "/", "/home" and "swap", the following snippet would generate three
+RAIDs of the appropriate sizes and the corresponding six partitions needed to support them.
+
+```json
+"storage": {
+  "drives": [
+    { "search": "/dev/sda", "alias": "sda" },
+    { "search": "/dev/sdb", "alias": "sdb" },
+  ],
+  "mdRaids": [
+    {
+      "generate": {
+        "mdRaids": "default",
+        "level": "raid0",
+        "devices": [
+          { "generate": ["sda", "sdb"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
 ## Schema sections under discussion
 
 This section summarizes several aspects of the Agama storage schema that have been considered
@@ -125,7 +387,7 @@ Strings may be used as value for `search` to locate a device by its name or to s
 devices using "\*". But strings may be useful in other situations.
 
 For example, "next" (or any similar term) could be used to represent the default search for drives
-(which is something like `{ "sort": { "property": "name" }, "max": 1, "ifNotFound": "error" }`.
+(which is something like `{ "sort": { "name": "asc" }, "max": 1, "ifNotFound": "error" }`.
 
 If a simple string like "next" could be used to specify the standard search entry for drives, it
 would make sense to simply make `search` mandatory for all drives instead of assuming a default one.
@@ -141,31 +403,6 @@ But regular expressions would not play well with libstorage-ng. Since not all de
 stored in the devicegraph, it is is necessary to use functions like `find_by_any_name` in order to
 perform an exhaustive search by name.
 
-Another aspect under discussion is the format to specify conditions. Instead of the format described
-above, it would be possible to use the key as name of the property, resulting in something like this.
-
-```json
-{
-    "search": {
-        "condition": { "sizeGib": 1, "operator": "greater" }
-    }
-}
-```
-
-More formats for the conditions are being considered, like the one displayed at the next examples.
-
-```json
-"condition": { "size": { "greater": "1 GiB" } }
-```
-
-```json
-"condition": { "size": { "greater": "1 GiB", "smaller": "10 GiB" } }
-```
-
-```json
-"condition": { "name": { "match": "^/dev/system" } }
-```
-
 ### Referencing Other Devices
 
 In addition to aliases, a `search` section could be accepted in all the places in which an alias can
@@ -179,7 +416,7 @@ system (so the same conditions can be matched by a disk, a partition, an LVM dev
         {
             "name": "newVG",
             "physicalVolumes": [
-                { "search": { "condition": { "property": "name", "value": "/dev/sda2" } } }
+                { "search": { "condition": { "name": "/dev/sda2" } } }
             ],
             "logicalVolumes": [ { "name": "data", "size": "20 GiB" } ]
         }


### PR DESCRIPTION
## Problem

The documentation about storage available at the at the public Agama site is a mixture of current features and design decisions that are only partially implemented (or not implemented at all).

## Solution

The combination of this pull request and the corresponding https://github.com/agama-project/agama-project.github.io/pull/83 fix the situation by moving here the parts explaining stuff that is still not implemented.

The information will be moved back to the public site little by little as the features are actually implemented.