### PR TITLE
fix(registration): Change the SLES and SLES_SAP version from "16-0" to "16.0" (bsc#1243788)

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 29 14:41:10 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Change the SLES and SLES_SAP version from "16-0" to "16.0",
+  that is accepted by RMT (SCC accepts that as well) (bsc#1243788)
+
+-------------------------------------------------------------------
 Wed May 28 15:04:21 UTC 2025 - Andreas Jaeger <aj@suse.com>
 
 - Add all SLES 16.0 patterns to SLES for SAP 16.0 as well (bsc#1243757).

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -1,7 +1,7 @@
 id: SLES
 name: SUSE Linux Enterprise Server 16.0 Beta
 registration: true
-version: "16-0"
+version: "16.0"
 license: "license.beta"
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -2,7 +2,7 @@ id: SLES_SAP
 name: SUSE Linux Enterprise Server for SAP applications 16.0 Beta
 archs: x86_64,ppc
 registration: true
-version: "16-0"
+version: "16.0"
 license: "license.beta"
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located


### PR DESCRIPTION
## Problem

- Registration against RMT server fails with "No product found" error
- https://bugzilla.suse.com/show_bug.cgi?id=1243788

## Details

- When registering the system the registration target was set to `SLES-16-0-x86_64`, although that works fine with SCC it does not work with RMT. It accepts only the `SLES-16-x86_64` identifier. That works fine with SCC as well.
- In the past (SLES15) there were some problems regarding the dash separator in the data, maybe SCC accepts it but it can be missing. RMT seems to be more strict and does not accept it.

## Solution

- Remove the dash, use version "16.0"
- The minor version is removed by [this code](https://github.com/agama-project/agama/blob/9c32c11820910c8eb23ab4ab7d22ab580d017ae6/service/lib/agama/registration.rb#L255) so the `SLES-16-x86_64` identifier is sent to the server in the end.
- Added some more logging to see what exactly has been sent to the registration server.

## Testing

- Tested manually against both RMT and SCC, works fine in both cases.
- Tested also in Full SLES medium, works fine as well (but I tested it in some older image, the Full image is huge to download).