### PR TITLE
refactor(web): update l10n query keys to use array form

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  2 22:29:03 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Fix out-of-sync translations by improving localization cache
+  and its invalidation (gh#agama-project/agama#2428).
+
+-------------------------------------------------------------------
 Thu May 29 09:31:28 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Requires a unit when entering sizes to avoid confusion and

--- a/web/src/queries/l10n.ts
+++ b/web/src/queries/l10n.ts
@@ -30,7 +30,7 @@ import { fetchConfig, fetchKeymaps, fetchLocales, fetchTimezones, updateConfig }
  */
 const configQuery = () => {
   return {
-    queryKey: ["l10n/config"],
+    queryKey: ["l10n", "config"],
     queryFn: fetchConfig,
   };
 };
@@ -39,7 +39,7 @@ const configQuery = () => {
  * Returns a query for retrieving the list of known locales
  */
 const localesQuery = () => ({
-  queryKey: ["l10n/locales"],
+  queryKey: ["l10n", "locales"],
   queryFn: fetchLocales,
   staleTime: Infinity,
 });
@@ -48,7 +48,7 @@ const localesQuery = () => ({
  * Returns a query for retrieving the list of known timezones
  */
 const timezonesQuery = () => ({
-  queryKey: ["l10n/timezones"],
+  queryKey: ["l10n", "timezones"],
   queryFn: fetchTimezones,
   staleTime: Infinity,
 });
@@ -57,7 +57,7 @@ const timezonesQuery = () => ({
  * Returns a query for retrieving the list of known keymaps
  */
 const keymapsQuery = () => ({
-  queryKey: ["l10n/keymaps"],
+  queryKey: ["l10n", "keymaps"],
   queryFn: fetchKeymaps,
   staleTime: Infinity,
 });
@@ -88,7 +88,7 @@ const useL10nConfigChanges = () => {
 
     return client.onEvent((event) => {
       if (event.type === "L10nConfigChanged") {
-        queryClient.invalidateQueries({ queryKey: ["l10n/config"] });
+        queryClient.invalidateQueries({ queryKey: ["l10n"] });
       }
     });
   }, [client, queryClient]);


### PR DESCRIPTION
## Problem

When switching the web interface language, the language and keyboard selectors display outdated content unless the user performs a full "force refresh". This was caused by incomplete cache invalidation: the L10nConfigChanged event handler [only invalidates the "l10n/config" cache entry](https://github.com/agama-project/agama/blob/cffc743906c32667d7bf6041f1f67d44fff865bb/web/src/queries/l10n.ts#L91), leaving related data like _locales_ and _keymaps_ translations stale.

## Solution

* Replaced string-based query keys (e.g. "l10n/config") with array-based keys (e.g. ["l10n", "config"]) to align with TanStack Query best practices. This enables partial matching and more flexible cache invalidation.

* Updated the L10nConfigChanged event handler to invalidate the broader ["l10n"] namespace instead of just ["l10n", "config"], ensuring all related localization queries are refreshed correctly.

## Testing

- Tested manually

## Screenshots

Find below how the interface looks before and after this fix when switching from Català to English.
Note how, despite the selected language being English and most of the interface reflecting that, some values remained in Català due to stale cached translations.

| Before | After |
|-|-|
| ![localhost_8080_](https://github.com/user-attachments/assets/fa4df26b-6730-4dcc-b3ae-7b274cc4e6d7) | ![localhost_8080_ (2)](https://github.com/user-attachments/assets/496d8284-3bff-4e36-a5ad-123ef40bcc29) |
| ![localhost_8080_ (1)](https://github.com/user-attachments/assets/71bb75ab-d3d2-4fec-8083-fdc161bbbac3) | ![localhost_8080_ (3)](https://github.com/user-attachments/assets/a6e16aaf-1ed5-428c-a132-b8648e4f1be5) |

