### PR TITLE
feat(web) Improve logging to pair the server request and the response

### DIFF
--- a/rust/agama-server/src/web/service.rs
+++ b/rust/agama-server/src/web/service.rs
@@ -25,14 +25,12 @@ use axum::http::HeaderValue;
 use axum::{
     body::Body,
     extract::Request,
-    http::Uri,
-    middleware::{self, Next},
+    middleware,
     response::{IntoResponse, Response},
     routing::{get, post},
     Router,
 };
 use hyper::header::CACHE_CONTROL;
-use hyper::Method;
 use std::time::Duration;
 use std::{
     convert::Infallible,
@@ -41,6 +39,7 @@ use std::{
 use tower::Service;
 use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::{compression::CompressionLayer, services::ServeDir, trace::TraceLayer};
+use tracing::span::Id;
 use tracing::Span;
 
 /// Builder for Agama main service.
@@ -58,13 +57,6 @@ pub struct MainServiceBuilder {
     api_router: Router<ServiceState>,
     public_dir: PathBuf,
 }
-
-/// Original request URI
-#[derive(Clone)]
-struct RequestUri(Uri);
-/// Original request method
-#[derive(Clone)]
-struct RequestMethod(Method);
 
 impl MainServiceBuilder {
     /// Returns a new service builder.
@@ -113,19 +105,6 @@ impl MainServiceBuilder {
             public_dir: self.public_dir.clone(),
         };
 
-        // middleware function for storing the original request URI
-        async fn uri_middleware(request: Request<axum::body::Body>, next: Next) -> Response {
-            // remember the request parameters
-            let uri = request.uri().clone();
-            let method = request.method().clone();
-
-            let mut response = next.run(request).await;
-
-            response.extensions_mut().insert(RequestUri(uri));
-            response.extensions_mut().insert(RequestMethod(method));
-            response
-        }
-
         let api_router = self
             .api_router
             .route_layer(middleware::from_extractor_with_state::<TokenClaims, _>(
@@ -141,19 +120,21 @@ impl MainServiceBuilder {
             .nest_service("/", serve)
             .route("/login", get(login_from_query))
             .nest("/api", api_router)
-            .layer(axum::middleware::from_fn(uri_middleware))
             .layer(
                 TraceLayer::new_for_http()
-                    .on_request(|request: &Request<Body>, _span: &Span| {
-                        tracing::info!("request: {} {}", request.method(), request.uri().path())
+                    .on_request(|request: &Request<Body>, span: &Span| {
+                        tracing::info!(
+                            "request {}: {} {}",
+                            span.id().unwrap_or(Id::from_u64(1)).into_u64(),
+                            request.method(),
+                            request.uri().path()
+                        )
                     })
                     .on_response(
-                        |response: &Response<Body>, latency: Duration, _span: &Span| {
+                        |response: &Response<Body>, latency: Duration, span: &Span| {
                             tracing::info!(
-                                "response for {:?} {:?}: {} {:?}",
-                                // the original request method and URI
-                                response.extensions().get::<RequestMethod>().map(|r| &r.0).unwrap(),
-                                response.extensions().get::<RequestUri>().map(|r| &r.0).unwrap(),
+                                "response for {}: {} {:?}",
+                                span.id().unwrap_or(Id::from_u64(1)).into_u64(),
                                 response.status(),
                                 latency
                             )


### PR DESCRIPTION
## Problem

- It is difficult to pair the request and response lines in the web server log

## Solution

- Log the span ID, it is the same for the request and its response  which contains the 

## Testing

- Tested manually
- Example run with updated web server but without updated service, that results in an error. The ID helps to easily match the correct request with the failed response:
  ```
  request 2252624447406110: GET /api/software/config
  request 9008023888461846: GET /api/software/products
  response for 9008023888461846: 200 OK 79.348912ms
  Server return error Agama service error: D-Bus service error... <shortened>
  response for 2252624447406110: 400 Bad Request 385.138335ms
  ```

