### PR TITLE
Fixed UI event handling

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  5 11:26:05 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- The "InstallationPhaseChanged", "ProductChanged" and
+  "IssuesChanged" events were ignored in some situation
+  (possibly causing bug bsc#1241208)
+
+-------------------------------------------------------------------
 Thu Jun  5 10:35:40 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Updated Node.js dependencies to their latest available versions

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -55,25 +55,37 @@ function App() {
     if (error) return <ServerError />;
 
     if (phase === InstallationPhase.Install) {
+      console.log("Navigating to the installation progress page");
       return <Navigate to={ROOT.installationProgress} />;
     }
 
     if (phase === InstallationPhase.Finish) {
+      console.log("Navigating to the finished page");
       return <Navigate to={ROOT.installationFinished} />;
     }
 
-    if (!products || !connected || (selectedProduct === undefined && isBusy))
+    if (!products || !connected || (selectedProduct === undefined && isBusy)) {
+      console.log("Loading screen: Initialization", {
+        products,
+        connected,
+        selectedProduct,
+        isBusy,
+      });
       return <Loading listenQuestions />;
+    }
 
     if (phase === InstallationPhase.Startup && isBusy) {
+      console.log("Loading screen: Installer start phase");
       return <Loading listenQuestions />;
     }
 
     if (selectedProduct === undefined && location.pathname !== PRODUCT.root) {
+      console.log("Navigating to the product selection page");
       return <Navigate to={PRODUCT.root} />;
     }
 
     if (phase === InstallationPhase.Config && isBusy && location.pathname !== PRODUCT.progress) {
+      console.log("Navigating to the probing progress page");
       return <Navigate to={PRODUCT.progress} />;
     }
 

--- a/web/src/queries/status.ts
+++ b/web/src/queries/status.ts
@@ -65,26 +65,32 @@ const useInstallerStatusChanges = () => {
     return client.onEvent((event) => {
       const { type } = event;
       const data = queryClient.getQueryData(["status"]) as object;
-      if (!data) {
-        return;
-      }
 
-      if (type === "InstallationPhaseChanged") {
-        const { phase } = event;
-        queryClient.setQueryData(["status"], { ...data, phase });
-      }
-
-      if (type === "ServiceStatusChanged" && event.service === MANAGER_SERVICE) {
-        const { status } = event;
-        queryClient.setQueryData(["status"], { ...data, isBusy: status === 1 });
-      }
-
-      if (type === "IssuesChanged") {
-        queryClient.invalidateQueries({ queryKey: ["status"] });
-      }
-
-      if (event.type === "ProductChanged") {
-        queryClient.invalidateQueries({ queryKey: selectedProductQuery().queryKey });
+      switch (type) {
+        case "IssuesChanged":
+          queryClient.invalidateQueries({ queryKey: ["status"] });
+          break;
+        case "ProductChanged":
+          queryClient.invalidateQueries({ queryKey: selectedProductQuery().queryKey });
+          break;
+        case "InstallationPhaseChanged":
+          if (!data) {
+            console.warn("Ignoring InstallationPhaseChanged event", event);
+          } else {
+            const { phase } = event;
+            queryClient.setQueryData(["status"], { ...data, phase });
+          }
+          break;
+        case "ServiceStatusChanged":
+          if (event.service === MANAGER_SERVICE) {
+            if (!data) {
+              console.warn("Ignoring ServiceStatusChanged event", event);
+            } else {
+              const { status } = event;
+              queryClient.setQueryData(["status"], { ...data, isBusy: status === 1 });
+            }
+          }
+          break;
       }
     });
   });


### PR DESCRIPTION
## Problem

- The web UI is stuck and displays the spinner until the installation is finished.
- https://bugzilla.suse.com/show_bug.cgi?id=1241208

## Details

- When the "status" query data was not obtained yet the "InstallationPhaseChanged", "ProductChanged" and "IssuesChanged" web socket events were ignored.
- This could possibly get the UI stuck when the loading screen was displayed because of the `selectedProduct === undefined && isBusy` condition.
- If the "ProductChanged" event was ignored in that case the loading screen would be displayed until the installer is busy (i.e. until the end of installation) because the selected product would not be refreshed.

## Solution

- Handle those events even when the "status" is not defined.
- Add more logging to see more details if this fix is still not enough.

## Testing

- The bug happens only rarely and requires a very specific timing between the web browser requests and the command line starting automatic installation in background so I can not verify that it really fixes the problem.