### PR TITLE
web: fix package build in OBS

### DIFF
--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -42,7 +42,7 @@ rm -f package-lock.json
 local-npm-registry %{_sourcedir} install --with=dev --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
 
 %build
-NODE_ENV="production" npm run build
+ESLINT=0 NODE_ENV="production" npm run build
 
 %install
 install -D -m 0644 --target-directory=%{buildroot}%{_datadir}/agama/web_ui %{_builddir}/agama/dist/*.{css,gz,html,js,json,map,svg}


### PR DESCRIPTION
## Problem

- The package does not build in OBS
- It fails with error `ERROR in [eslint] Cannot find module 'eslint'`

## Solution

- Disable Eslint checks in RPM builds

## Testing

- Tested manually in a local build
