### PR TITLE
Refactoring the Rubocop CI

### DIFF
--- a/.github/workflows/ci-rubocop.yml
+++ b/.github/workflows/ci-rubocop.yml
@@ -40,18 +40,27 @@ jobs:
       run:
         working-directory: ./service
 
-    strategy:
-      fail-fast: false
-      matrix:
-        distro: [ "leap_latest" ]
-
-    container:
-      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
-
     steps:
 
     - name: Git Checkout
       uses: actions/checkout@v4
 
+    - name: Rubygem cache
+      id:   rubygem-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.local/share/gem
+        key: ${{ runner.os }}-rubocop-${{ hashFiles('.github/workflows/ci-rubocop.yml') }}
+
+    - name: Install Rubocop
+      # install Rubocop if it was not restored from the cache
+      if: steps.rubygem-cache.outputs.cache-hit != 'true'
+      run: gem install --user-install rubocop:1.24.1
+
+    - name: Modify Rubocop config
+      # read the shared configuration directly from the GitHub repository
+      run: sed -i -e "s#/usr/share/YaST2/data/devtools/data/#https://raw.githubusercontent.com/yast/yast-devtools/refs/heads/master/ytools/y2tool/#" .rubocop.yml
+
     - name: Rubocop
-      run: /usr/bin/rubocop.*-1.24.1
+      run: ~/.local/share/gem/ruby/*/bin/rubocop


### PR DESCRIPTION
## Problem

- Downloading the container from OBS sometimes take a lot of time (in [this case](https://github.com/agama-project/agama/actions/runs/15465918106/job/43537840827#step:2:30)  even more than 11 minutes)


## Solution

- Lets run the Rubocop directly in the Ubuntu runner without any container
- Cache the downloaded gems for faster runs


## Testing

- Tested manually, the Rubocop check takes less than 30 seconds (even when the image was downloaded quickly it took more than 40 seconds)
- [Example run](https://github.com/lslezak/agama/actions/runs/15351319331/job/43200084788)
