### PR TITLE
Added debugging GitHub Action

### DIFF
--- a/.github/workflows/obs-staging-debug.yml
+++ b/.github/workflows/obs-staging-debug.yml
@@ -1,0 +1,31 @@
+# This is a helper action for debugging the conditions used for starting the
+# automatic OBS submission.
+
+name: Debug obs2branch
+
+permissions:
+  contents: read
+
+on:
+  push:
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Debug
+        run: |
+          echo 'Current GitHub Action variables and values:'
+          echo 'vars.OBS_USER: ${{ vars.OBS_USER }}'
+          echo 'vars.OBS_PROJECTS: ${{ vars.OBS_PROJECTS }}'
+          echo 'parsed vars.OBS_PROJECTS: ${{ fromJson(vars.OBS_PROJECTS) }}'
+          echo 'github.ref_name: ${{ github.ref_name }}'
+          echo 'Target OBS project: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}'
+          echo 'Submit condition: ${{ vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER }}'
+          echo 'Submit would start: ${{ !contains(fromJSON('[false, 0, -0, "", null]'), vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER) }}'
+


### PR DESCRIPTION
## Problem

- The automatic submission to OBS is sometimes skipped.
- [Example run](https://github.com/agama-project/agama/actions/runs/15445158320/job/43472639418)
- For some reason the condition to start the action is not evaluated to `true`.
- But because the condition is not trivial and involves JSON parsing it is hard find the reason why the action was skipped.

## Solution

- Added a debugging action which prints the details of the autosubmission configuration and the final result.
- [Example run](https://github.com/agama-project/agama/actions/runs/15530373856/job/43717861767#step:2:25)
- It takes just few seconds and it should never fail so it should not block development or merging pul requests.
- The action should be removed when we find and fix the problem.