### PR TITLE
fix(web): fix a long string definition

### DIFF
--- a/web/src/components/network/NoPersistentConnectionsAlert.tsx
+++ b/web/src/components/network/NoPersistentConnectionsAlert.tsx
@@ -39,7 +39,7 @@ export default function NoPersistentConnectionsAlert() {
     <Alert variant="warning" title={_("Installed system may not have network connections")}>
       {_(
         "All network connections managed through this interface are currently set to be \
-        used only during installation and will not be copied to the installed system",
+used only during installation and will not be copied to the installed system",
       )}
     </Alert>
   );


### PR DESCRIPTION
## Problem

We are getting some extra spaces in the po files:

https://github.com/agama-project/agama/pull/2448/files#diff-5c553ee4a645767c484a958facfdbc7fce64e9076e34538c7951eb4ecec4ac81R153

## Solution

Remove the spaces from the sources.
