### PR TITLE
fix(web): prevent Webpack from failing on linter warnings in development

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -62,7 +62,7 @@ if (eslint) {
       configType: "flat",
       extensions: ["js", "jsx", "ts", "tsx"],
       failOnError: production,
-      failOnWarning: true,
+      failOnWarning: production,
     }),
   );
 }


### PR DESCRIPTION
Ensure Webpack doesn't crash on linter warnings during development, similar to how linter errors were handled in PR #2440, commit a7f9c45.