### PR TITLE
feat(web): add post-installation feedback

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Jun 10 16:51:15 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
-- Improve post-installation user experience by adding a feedback
-  message that confirms system restart/power-off (bsc#1237410,
+- Improve post-installation user experience by providing feedback
+  that confirms the system restart (bsc#1237410,
   gh#agama-project/agama#2462).
 
 -------------------------------------------------------------------

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 10 16:51:15 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Improve post-installation user experience by adding a feedback
+  message that confirms system restart/power-off (bsc#1237410,
+  gh#agama-project/agama#2462).
+
+-------------------------------------------------------------------
 Mon Jun  9 06:24:08 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Allow selecting bootable MD RAIDs as boot device

--- a/web/src/components/core/InstallationExit.test.tsx
+++ b/web/src/components/core/InstallationExit.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
+import InstallationExit from "./InstallationExit";
+
+describe("InstallationExit", () => {
+  it("makes users aware system is rebooting", () => {
+    plainRender(<InstallationExit />);
+    screen.getByRole("heading", { name: "Your system is rebooting", level: 1 });
+  });
+
+  it("makes users aware installer is no longer useful", () => {
+    plainRender(<InstallationExit />);
+    screen.getByText(/The installer interface is no longer available/);
+  });
+
+  it("invites users to close the installer", () => {
+    plainRender(<InstallationExit />);
+    screen.getByText(/you can safely close this window/);
+  });
+});

--- a/web/src/components/core/InstallationExit.tsx
+++ b/web/src/components/core/InstallationExit.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import {
+  Bullseye,
+  Card,
+  CardBody,
+  Content,
+  EmptyState,
+  EmptyStateBody,
+  Grid,
+  GridItem,
+} from "@patternfly/react-core";
+import { _ } from "~/i18n";
+
+export default function InstallationExit() {
+  return (
+    <Bullseye>
+      <Grid hasGutter>
+        <GridItem sm={8} smOffset={2}>
+          <Card>
+            <CardBody>
+              <EmptyState variant="xl" titleText={_("Your system is rebooting")} headingLevel="h1">
+                <EmptyStateBody>
+                  <Content component="p">
+                    {_(
+                      "The installer interface is no longer available, so you can safely close this window.",
+                    )}
+                  </Content>
+                </EmptyStateBody>
+              </EmptyState>
+            </CardBody>
+          </Card>
+        </GridItem>
+      </Grid>
+    </Bullseye>
+  );
+}

--- a/web/src/components/core/InstallationFinished.test.tsx
+++ b/web/src/components/core/InstallationFinished.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2024] SUSE LLC
+ * Copyright (c) [2022-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -119,6 +119,9 @@ describe("InstallationFinished", () => {
     const rebootButton = screen.getByRole("button", { name: "Reboot" });
     await user.click(rebootButton);
     expect(mockFinishInstallation).toHaveBeenCalled();
+    screen.getByText("Your system has restarted");
+    screen.getByText("You can close this page now.");
+    expect(screen.queryByRole("button", { name: "Reboot" })).toBeNull();
   });
 
   describe("when running storage config in raw mode", () => {

--- a/web/src/components/core/InstallationFinished.test.tsx
+++ b/web/src/components/core/InstallationFinished.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2025] SUSE LLC
+ * Copyright (c) [2022-2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -119,9 +119,6 @@ describe("InstallationFinished", () => {
     const rebootButton = screen.getByRole("button", { name: "Reboot" });
     await user.click(rebootButton);
     expect(mockFinishInstallation).toHaveBeenCalled();
-    screen.getByText("Your system has restarted");
-    screen.getByText("You can close this page now.");
-    expect(screen.queryByRole("button", { name: "Reboot" })).toBeNull();
   });
 
   describe("when running storage config in raw mode", () => {

--- a/web/src/components/core/index.ts
+++ b/web/src/components/core/index.ts
@@ -26,6 +26,7 @@ export { default as FormValidationError } from "./FormValidationError";
 export { default as EmailInput } from "./EmailInput";
 export { default as InstallationFinished } from "./InstallationFinished";
 export { default as InstallationProgress } from "./InstallationProgress";
+export { default as InstallationExit } from "./InstallationExit";
 export { default as InstallButton } from "./InstallButton";
 export { default as IssuesAlert } from "./IssuesAlert";
 export { default as ListSearch } from "./ListSearch";

--- a/web/src/components/layout/Header.test.tsx
+++ b/web/src/components/layout/Header.test.tsx
@@ -81,7 +81,7 @@ describe("Header", () => {
     expect(screen.queryByRole("link", { name: "Skip to content" })).toBeNull();
   });
 
-  it("renders an options dropdown", async () => {
+  it("renders an options dropdown by default", async () => {
     const { user } = installerRender(<Header />);
     expect(screen.queryByRole("menu")).toBeNull();
     const toggler = screen.getByRole("button", { name: "Options toggle" });
@@ -89,6 +89,11 @@ describe("Header", () => {
     const menu = screen.getByRole("menu");
     within(menu).getByRole("menuitem", { name: "Change product" });
     within(menu).getByRole("menuitem", { name: "Download logs" });
+  });
+
+  it("does not render an options dropdown when showInstallerOptions is false", async () => {
+    installerRender(<Header showInstallerOptions={false} />);
+    expect(screen.queryByRole("button", { name: "Options toggle" })).toBeNull();
   });
 
   it.todo("allows downloading the logs");

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -106,6 +106,7 @@ export default function Header({
   showSidebarToggle = true,
   showProductName = true,
   showSkipToContent = true,
+  showInstallerOptions = true,
   toggleIssuesDrawer,
   isSidebarOpen,
   toggleSidebar,
@@ -149,9 +150,11 @@ export default function Header({
               <ToolbarItem>
                 <InstallButton onClickWithIssues={toggleIssuesDrawer} />
               </ToolbarItem>
-              <ToolbarItem>
-                <OptionsDropdown />
-              </ToolbarItem>
+              {showInstallerOptions && (
+                <ToolbarItem>
+                  <OptionsDropdown />
+                </ToolbarItem>
+              )}
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -25,7 +25,12 @@ import { createHashRouter, Outlet } from "react-router-dom";
 import App from "~/App";
 import Protected from "~/Protected";
 import { FullLayout, PlainLayout } from "~/components/layout";
-import { InstallationFinished, InstallationProgress, LoginPage } from "~/components/core";
+import {
+  InstallationExit,
+  InstallationFinished,
+  InstallationProgress,
+  LoginPage,
+} from "~/components/core";
 import { OverviewPage } from "~/components/overview";
 import l10nRoutes from "~/routes/l10n";
 import networkRoutes from "~/routes/network";
@@ -92,6 +97,19 @@ const protectedRoutes = () => [
       {
         path: PATHS.installationFinished,
         element: <InstallationFinished />,
+      },
+    ],
+  },
+  {
+    element: (
+      <PlainLayout mountHeader={false} mountSkipToContent={false}>
+        <Outlet />
+      </PlainLayout>
+    ),
+    children: [
+      {
+        path: PATHS.installationExit,
+        element: <InstallationExit />,
       },
     ],
   },

--- a/web/src/routes/paths.ts
+++ b/web/src/routes/paths.ts
@@ -51,6 +51,7 @@ const ROOT = {
   installation: "/installation",
   installationProgress: "/installation/progress",
   installationFinished: "/installation/finished",
+  installationExit: "/installation/exit",
   logs: "/api/manager/logs/store",
 };
 
@@ -114,6 +115,7 @@ const SIDE_PATHS = [
   PRODUCT.progress,
   ROOT.installationProgress,
   ROOT.installationFinished,
+  ROOT.installationExit,
 ];
 
 export {


### PR DESCRIPTION
## Problem

Currently, users receive no visual feedback after clicking either "Reboot" or "Finish" on the installation completion page. This lack of confirmation can lead to uncertainty about whether the intended action has taken effect.

Reported in: https://bugzilla.suse.com/show_bug.cgi?id=1237410 (protected link)

## Solution

Display proper feedback to provide clear confirmation that the system has either restarted or powered off. It also explicitly informs users that installer is not longer available and the page can be safely closed.

## Implementation notes

* The new path (`/installation/exit`) does not take Iguana into account, as it has been agreed that Agama will no longer support it.

* Agama assumes the system reboot has been triggered successfully without waiting for a response. Although it’s unlikely, there could be a chance the response might not be received if the system begins rebooting before the server sends it. This edge case still requires testing, but for now, assuming the reboot will take effect is considered sufficient.

* Although initially considered, the reboot action does not explicitly trigger a WebSocket disconnection. The connection will drop automatically after the maximum number of reconnection attempts. Importantly, it won’t fall back to either the `Loading` or `ServerError` screens, since the post-installation views are not under the scope of [internal `App.tsx` routing](https://github.com/agama-project/agama/blob/abd8552989bccbdaaed639c15e74df12ad04dfd8/web/src/App.tsx#L55-L90).

* Unfortunately, it’s not possible to fully clear the browser history stack to prevent users from navigating back to earlier installation steps. Users are encouraged to close the installer upon completion. If they do navigate back, they will likely encounter a `ServerError` screen.

## Testing

* Added small unit tests
* Tested manually by ~~using live image from https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:improve-reboot-feedback (https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/improve-reboot-feedback/images/iso/agama-installer.x86_64-openSUSE.iso)~~ generating the `/web` production build and copying it to `/user/share/agama/web_ui` in a running installation image using the latest openSUSE-based version since the custom image was not working because of 

  > "Agama service error: D-Bus service error: org.freedesktop.DBus.Error.UnknownMethod: Method "ListUserRepositories" on interface "org.opensuse.Agama.Software1

  possibly related to the rubygem not being up-to-date


## Screenshots

![localhost_8080_ (8)](https://github.com/user-attachments/assets/b812e967-5ffc-401f-937d-59e1da08df9b)



---

Related to https://trello.com/c/OJhG0Ovr/ (protected link)