### PR TITLE
fix(rust): consider hashedPassword as "false" if not given

### DIFF
--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -184,7 +184,7 @@ impl ProfileEvaluator {
     pub fn evaluate_string(&self, profile: &str) -> anyhow::Result<String> {
         let dir = tempdir()?;
         let working_path = dir.path().join("profile.jsonnet");
-        fs::write(working_path, dbg!(profile))?;
+        fs::write(working_path, profile)?;
         self.evaluate_profile_jsonnet(&dir)
     }
 

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -98,6 +98,7 @@ pub struct UserPassword {
     /// User password
     pub password: String,
     /// Whether the password is hashed or is plain text
+    #[serde(default)]
     pub hashed_password: bool,
 }
 

--- a/rust/agama-lib/src/users/settings.rs
+++ b/rust/agama-lib/src/users/settings.rs
@@ -142,7 +142,7 @@ impl From<RootUser> for RootUserSettings {
 
 #[cfg(test)]
 mod test {
-    use crate::users::{FirstUser, RootUser};
+    use crate::users::{settings::UserPassword, FirstUser, RootUser};
 
     use super::{FirstUserSettings, RootUserSettings};
 
@@ -201,5 +201,18 @@ mod test {
         };
         let settings: RootUserSettings = with_ssh_public_key.into();
         assert_eq!(settings.ssh_public_key, Some("ssh-rsa ...".to_string()));
+    }
+
+    #[test]
+    fn test_parse_user_password() {
+        let password_str = r#"{ "password": "$a$b123", "hashedPassword": true }"#;
+        let password: UserPassword = serde_json::from_str(&password_str).unwrap();
+        assert_eq!(&password.password, "$a$b123");
+        assert_eq!(password.hashed_password, true);
+
+        let password_str = r#"{ "password": "$a$b123" }"#;
+        let password: UserPassword = serde_json::from_str(&password_str).unwrap();
+        assert_eq!(&password.password, "$a$b123");
+        assert_eq!(password.hashed_password, false);
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 11 13:12:12 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider `hashedPassword` as `false` when it is not specified
+  (gh#agama-project/agama#2464).
+
+-------------------------------------------------------------------
 Tue Jun 10 13:33:09 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Expose the user and the root password when exporting the configuration


### PR DESCRIPTION
## Problem

When deserializing a password, Agama expected both the `password` and the `hashedPassword` attributes to be set.

Found by @mvidner during [this review](https://github.com/agama-project/agama-project.github.io/pull/81/files#r2139859193). Thanks!

## Solution

Consider `hashedPassword` is `false` if not given.

Addionally, avoid writing the profile to the logs.

## Testing

- The first change was manually tested.
