### PR TITLE
fix(devel): Fixed package branching in the branch2obs.sh script

### DIFF
--- a/.github/workflows/obs-staging-debug.yml
+++ b/.github/workflows/obs-staging-debug.yml
@@ -1,6 +1,8 @@
 # This is a helper action for debugging the conditions used for starting the
 # automatic OBS submission.
 
+# See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions
+
 name: Debug obs2branch
 
 permissions:

--- a/devel/branch2obs.sh
+++ b/devel/branch2obs.sh
@@ -123,7 +123,7 @@ else
   for pkg in "${packages[@]}"; do
     echo "Branching package $pkg"
     # branch the package
-    osc branch systemsmanagement:Agama:Devel "$pkg" "$PROJECT" > /dev/null
+    osc branch --nodevelproject systemsmanagement:Agama:Devel "$pkg" "$PROJECT" > /dev/null
     # detach branch so the package is not updated when the original package changes,
     # this also avoids possible conflicts
     osc detachbranch "$PROJECT" "$pkg"

--- a/live/live-root/root/.bash_history
+++ b/live/live-root/root/.bash_history
@@ -1,5 +1,5 @@
 mount | cut -f3 -d" " | grep /mnt | sort -r | xargs -r umount; swapon --show=NAME --noheadings | grep -v zram | xargs -r swapoff
-systemctl restart agama.service agama-web-server.service && sleep 2 && systemctl restart x11-autologin.service
+systemctl restart agama.service agama-web-server.service
 less /var/log/YaST2/y2log
 journalctl -u agama-web-server.service
 journalctl -u agama.service


### PR DESCRIPTION
## Problem

The OBS project created by the `branch2obs.sh` script could contain some obsolete package versions, not the latest ones from the `master` branch.

## Details

It turned out that the `osc branch systemsmanagement:Agama:Devel <package>` call actually does not branch from the systemsmanagement:Agama:Devel project as expected but from the systemsmanagement:Agama:Release (its development project) which contains older versions.

*That's quite unexpected behavior, if I would like to branch from the development project I would explicitly use it. Anyway...* :thinking: 

## Fix

The fix is to use the `--nodevelproject` option in the branching command to not follow the defined devel project.

## Testing

Tested manually, with that option the package is correctly branched from the systemsmanagement:Agama:Devel project.

## Additional fixes

- Added documentation link to the debug GitHub Action (it should have been part of the initial PR but I forgot to commit the change).
- The `x11-autologin.service` is not present anymore after switching to Wayland.
