### PR TITLE
Rmt registration

### DIFF
--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -116,6 +116,11 @@ impl<'a> ProductClient<'a> {
         }
     }
 
+    /// flag if base product is registered
+    pub async fn registered(&self) -> Result<bool, ServiceError> {
+        Ok(self.registration_proxy.registered().await?)
+    }
+
     /// registration code used to register product
     pub async fn registration_code(&self) -> Result<String, ServiceError> {
         Ok(self.registration_proxy.reg_code().await?)

--- a/rust/agama-lib/src/product/proxies.rs
+++ b/rust/agama-lib/src/product/proxies.rs
@@ -72,6 +72,10 @@ pub trait Registration {
     #[zbus(property)]
     fn reg_code(&self) -> zbus::Result<String>;
 
+    /// Registered property
+    #[zbus(property)]
+    fn registered(&self) -> zbus::Result<bool>;
+
     /// Url property
     #[zbus(property)]
     fn url(&self) -> zbus::Result<String>;

--- a/rust/agama-lib/src/product/store.rs
+++ b/rust/agama-lib/src/product/store.rs
@@ -149,6 +149,7 @@ mod test {
                 .header("content-type", "application/json")
                 .body(
                     r#"{
+                    "registered": false,
                     "key": "",
                     "email": "",
                     "url": ""

--- a/rust/agama-lib/src/software/model/registration.rs
+++ b/rust/agama-lib/src/software/model/registration.rs
@@ -69,6 +69,8 @@ pub struct AddonProperties {
 #[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RegistrationInfo {
+    /// Registration status. True if base system is already registered.
+    pub registered: bool,
     /// Registration key. Empty value mean key not used or not registered.
     pub key: String,
     /// Registration email. Empty value mean email not used or not registered.

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -416,6 +416,7 @@ async fn get_registration(
     State(state): State<SoftwareState<'_>>,
 ) -> Result<Json<RegistrationInfo>, Error> {
     let result = RegistrationInfo {
+        registered: state.product.registered().await?,
         key: state.product.registration_code().await?,
         email: state.product.email().await?,
         url: state.product.registration_url().await?,

--- a/service/test/agama/dbus/software/product_test.rb
+++ b/service/test/agama/dbus/software/product_test.rb
@@ -93,7 +93,7 @@ describe Agama::DBus::Software::Product do
     context "if the current product is registered" do
       before do
         subject.select_product("MicroOS")
-        allow(backend.registration).to receive(:reg_code).and_return("123XX432")
+        allow(backend.registration).to receive(:registered).and_return(true)
       end
 
       it "returns result code 2 and description" do
@@ -107,6 +107,29 @@ describe Agama::DBus::Software::Product do
       end
     end
   end
+
+  describe "#registered" do
+    before do
+      allow(backend.registration).to receive(:registered).and_return(registered)
+    end
+
+    context "if there is no registered product yet" do
+      let(:registered) { false }
+
+      it "returns false" do
+        expect(subject.registered).to eq(false)
+      end
+    end
+
+    context "if there is a registered product" do
+      let(:registered) { true }
+
+      it "returns true" do
+        expect(subject.registered).to eq(true)
+      end
+    end
+  end
+
 
   describe "#reg_code" do
     before do
@@ -175,12 +198,13 @@ describe Agama::DBus::Software::Product do
 
       context "if the product is already registered" do
         it "returns result code 2 and description if the code is different" do
-          allow(backend.registration).to receive(:reg_code).and_return("123XX432YY")
+          allow(backend.registration).to receive(:registered).and_return(true)
           expect(subject.register("123XX432")).to contain_exactly(2, /product already registered/i)
         end
 
         it "returns result code 0 and empty error if the code is the same" do
           allow(backend.registration).to receive(:reg_code).and_return("123XX432")
+          allow(backend.registration).to receive(:registered).and_return(true)
           expect(subject.register("123XX432")).to contain_exactly(0, "")
         end
       end
@@ -283,7 +307,7 @@ describe Agama::DBus::Software::Product do
 
   describe "#deregister" do
     before do
-      allow(backend.registration).to receive(:reg_code).and_return("123XX432")
+      allow(backend.registration).to receive(:registered).and_return(true)
     end
 
     context "if there is no product selected yet" do
@@ -299,7 +323,7 @@ describe Agama::DBus::Software::Product do
 
       context "if the product is not registered yet" do
         before do
-          allow(backend.registration).to receive(:reg_code).and_return(nil)
+          allow(backend.registration).to receive(:registered).and_return(false)
         end
 
         it "returns result code 2 and description" do

--- a/service/test/agama/registration_test.rb
+++ b/service/test/agama/registration_test.rb
@@ -520,7 +520,7 @@ describe Agama::Registration do
   describe "#finish" do
     context "system is not registered" do
       before do
-        subject.instance_variable_set(:@reg_code, nil)
+        subject.instance_variable_set(:@registered, false)
       end
 
       it "do nothing" do
@@ -532,6 +532,7 @@ describe Agama::Registration do
 
     context "system is registered" do
       before do
+        subject.instance_variable_set(:@registered, true)
         subject.instance_variable_set(:@reg_code, "test")
         subject.instance_variable_set(:@credentials_files, ["test"])
         Yast::Installation.destdir = "/mnt"

--- a/web/src/components/product/ProductRegistrationPage.test.tsx
+++ b/web/src/components/product/ProductRegistrationPage.test.tsx
@@ -73,7 +73,7 @@ describe("ProductRegistrationPage", () => {
   describe("when selected product is not registrable", () => {
     beforeEach(() => {
       selectedProduct = tw;
-      registrationInfoMock = { key: "", email: "" };
+      registrationInfoMock = { registered: false, key: "", email: "", url: "" };
     });
 
     it("renders nothing", () => {
@@ -85,7 +85,7 @@ describe("ProductRegistrationPage", () => {
   describe("when selected product is registrable and registration code is not set", () => {
     beforeEach(() => {
       selectedProduct = sle;
-      registrationInfoMock = { key: "", email: "" };
+      registrationInfoMock = { registered: false, key: "", email: "", url: "" };
     });
 
     describe("and the static hostname is not set", () => {
@@ -156,52 +156,18 @@ describe("ProductRegistrationPage", () => {
       );
     });
 
-    it("renders error when a field is missing", async () => {
-      const { user } = installerRender(<ProductRegistrationPage />, { withL10n: true });
-      const registrationCodeInput = screen.getByLabelText("Registration code");
-      const submitButton = screen.getByRole("button", { name: "Register" });
-      await user.click(submitButton);
-
-      screen.getByText("Warning alert:");
-      screen.getByText("Some fields are missing. Please check and fill them.");
-      expect(registerMutationMock).not.toHaveBeenCalled();
-
-      await user.type(registrationCodeInput, "INTERNAL-USE-ONLY-1234-5678");
-
-      // email input is optional, user has to explicitely activate it
-      const provideEmailCheckbox = screen.getByRole("checkbox", { name: "Provide email address" });
-      expect(provideEmailCheckbox).not.toBeChecked();
-      await user.click(provideEmailCheckbox);
-      expect(provideEmailCheckbox).toBeChecked();
-      await user.click(submitButton);
-
-      screen.getByText("Warning alert:");
-      screen.getByText("Some fields are missing. Please check and fill them.");
-      expect(registerMutationMock).not.toHaveBeenCalled();
-
-      const emailInput = screen.getByRole("textbox", { name: /Email/ });
-      await user.type(emailInput, "example@company.test");
-
-      await user.click(submitButton);
-
-      expect(screen.queryByText("Warning alert:")).toBeNull();
-      expect(screen.queryByText("All fields are required")).toBeNull();
-      expect(registerMutationMock).toHaveBeenCalledWith(
-        {
-          email: "example@company.test",
-          key: "INTERNAL-USE-ONLY-1234-5678",
-        },
-        expect.anything(),
-      );
-    });
-
     it.todo("handles and renders errors from server, if any");
   });
 
   describe("when selected product is registrable and registration code is set", () => {
     beforeEach(() => {
       selectedProduct = sle;
-      registrationInfoMock = { key: "INTERNAL-USE-ONLY-1234-5678", email: "example@company.test" };
+      registrationInfoMock = {
+        registered: true,
+        key: "INTERNAL-USE-ONLY-1234-5678",
+        email: "example@company.test",
+        url: "",
+      };
       addonInfoMock = [
         {
           id: "sle-ha",

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -40,7 +40,7 @@ import {
 import { Link, Page } from "~/components/core";
 import RegistrationExtension from "./RegistrationExtension";
 import RegistrationCodeInput from "./RegistrationCodeInput";
-import { RegistrationInfo } from "~/types/software";
+import { RegistrationParams } from "~/types/software";
 import { HOSTNAME } from "~/routes/paths";
 import { useProduct, useRegistration, useRegisterMutation, useAddons } from "~/queries/software";
 import { useHostname } from "~/queries/system";
@@ -104,15 +104,8 @@ const RegistrationFormSection = () => {
     e.preventDefault();
     setError(null);
 
-    const data: RegistrationInfo = { key, email: provideEmail ? email : "" };
+    const data: RegistrationParams = { key, email: provideEmail ? email : "" };
 
-    // TODO: Replace with a more sophisticated mechanism to ensure all available
-    // fields are filled and validated. Ideally, this should be a reusable solution
-    // applicable to all Agama forms.
-    if (isEmpty(key) || (provideEmail && isEmpty(email))) {
-      setError("Some fields are missing. Please check and fill them.");
-      return;
-    }
     setLoading(true);
 
     // @ts-expect-error
@@ -200,9 +193,7 @@ const Extensions = () => {
 
 export default function ProductRegistrationPage() {
   const { selectedProduct: product } = useProduct();
-  const { key } = useRegistration();
-  // FIXME: this needs to be fixed for RMT which allows registering with empty key
-  const isRegistered = !isEmpty(key);
+  const { registered } = useRegistration();
 
   // TODO: render something meaningful instead? "Product not registrable"?
   if (!product.registration) return;
@@ -214,9 +205,9 @@ export default function ProductRegistrationPage() {
       </Page.Header>
 
       <Page.Content>
-        {!isRegistered && <HostnameAlert />}
-        {!isRegistered ? <RegistrationFormSection /> : <RegisteredProductSection />}
-        {isRegistered && <Extensions />}
+        {!registered && <HostnameAlert />}
+        {!registered ? <RegistrationFormSection /> : <RegisteredProductSection />}
+        {registered && <Extensions />}
       </Page.Content>
     </Page>
   );

--- a/web/src/types/software.ts
+++ b/web/src/types/software.ts
@@ -107,8 +107,17 @@ type Repository = {
 };
 
 type RegistrationInfo = {
+  registered: boolean;
+  key: string;
+  email: string;
+  url: string;
+};
+
+type RegistrationParams = {
+  registered?: boolean;
   key: string;
   email?: string;
+  url?: string;
 };
 
 type AddonInfo = {
@@ -160,6 +169,7 @@ export type {
   Product,
   RegisteredAddonInfo,
   RegistrationInfo,
+  RegistrationParams,
   Repository,
   SoftwareConfig,
   SoftwareProposal,


### PR DESCRIPTION
## Problem

The RMT can be configured to not require registration key. So sending empty one should be valid option, but it is not possible with current agama.

## Solution

Change registration API to distinguish between registered and registration key, that can be empty ( used in past as indication of not registered system ).


## Testing

- *Added a new unit test*
- *Tested manually*