### PR TITLE
Initial support for sorting storage devices during the search

### DIFF
--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -369,6 +369,10 @@
       "minimum": 1,
       "maximum": 128
     },
+    "searchSortCriterionOrder": {
+      "description": "Direction of sorting at the search results",
+      "enum": ["asc", "desc"]
+    },
     "driveSearch": {
       "anyOf": [
         { "$ref": "#/$defs/searchAll" },
@@ -381,6 +385,7 @@
       "additionalProperties": false,
       "properties": {
         "condition": { "$ref": "#/$defs/driveSearchCondition" },
+        "sort": { "$ref": "#/$defs/driveSearchSort" },
         "max": { "$ref": "#/$defs/searchMax" },
         "ifNotFound": { "$ref": "#/$defs/searchActions" }
       }
@@ -390,6 +395,34 @@
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" }
       ]
+    },
+    "driveSearchSort": {
+      "anyOf": [
+        { "$ref": "#/$defs/driveSearchSortCriterion" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/driveSearchSortCriterion" }
+        }
+      ]
+    },
+    "driveSearchSortCriterion": {
+      "anyOf": [
+        { "$ref": "#/$defs/driveSearchSortCriterionShort" },
+        { "$ref": "#/$defs/driveSearchSortCriterionFull" }
+      ]
+    },
+    "driveSearchSortCriterionShort": {
+      "enum": ["name", "size"]
+    },
+    "driveSearchSortCriterionFull": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/searchSortCriterionOrder" },
+        "size": { "$ref": "#/$defs/searchSortCriterionOrder" }
+      },
+      "minProperties": 1,
+      "maxProperties": 1
     },
     "mdRaidSearch": {
       "anyOf": [
@@ -403,6 +436,7 @@
       "additionalProperties": false,
       "properties": {
         "condition": { "$ref": "#/$defs/mdRaidSearchCondition" },
+        "sort": { "$ref": "#/$defs/mdRaidSearchSort" },
         "max": { "$ref": "#/$defs/searchMax" },
         "ifNotFound": { "$ref": "#/$defs/searchCreatableActions" }
       }
@@ -412,6 +446,34 @@
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" }
       ]
+    },
+    "mdRaidSearchSort": {
+      "anyOf": [
+        { "$ref": "#/$defs/mdRaidSearchSortCriterion" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/mdRaidSearchSortCriterion" }
+        }
+      ]
+    },
+    "mdRaidSearchSortCriterion": {
+      "anyOf": [
+        { "$ref": "#/$defs/mdRaidSearchSortCriterionShort" },
+        { "$ref": "#/$defs/mdRaidSearchSortCriterionFull" }
+      ]
+    },
+    "mdRaidSearchSortCriterionShort": {
+      "enum": ["name", "size"]
+    },
+    "mdRaidSearchSortCriterionFull": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/searchSortCriterionOrder" },
+        "size": { "$ref": "#/$defs/searchSortCriterionOrder" }
+      },
+      "minProperties": 1,
+      "maxProperties": 1
     },
     "partitionSearch": {
       "anyOf": [
@@ -425,6 +487,7 @@
       "additionalProperties": false,
       "properties": {
         "condition": { "$ref": "#/$defs/partitionSearchCondition" },
+        "sort": { "$ref": "#/$defs/partitionSearchSort" },
         "max": { "$ref": "#/$defs/searchMax" },
         "ifNotFound": { "$ref": "#/$defs/searchCreatableActions" }
       }
@@ -441,6 +504,7 @@
       "additionalProperties": false,
       "properties": {
         "condition": { "$ref": "#/$defs/partitionSearchCondition" },
+        "sort": { "$ref": "#/$defs/partitionSearchSort" },
         "max": { "$ref": "#/$defs/searchMax" },
         "ifNotFound": { "$ref": "#/$defs/searchActions" }
       }
@@ -511,6 +575,35 @@
         }
       }
     },
+    "partitionSearchSort": {
+      "anyOf": [
+        { "$ref": "#/$defs/partitionSearchSortCriterion" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/partitionSearchSortCriterion" }
+        }
+      ]
+    },
+    "partitionSearchSortCriterion": {
+      "anyOf": [
+        { "$ref": "#/$defs/partitionSearchSortCriterionShort" },
+        { "$ref": "#/$defs/partitionSearchSortCriterionFull" }
+      ]
+    },
+    "partitionSearchSortCriterionShort": {
+      "enum": ["name", "size", "number"]
+    },
+    "partitionSearchSortCriterionFull": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/searchSortCriterionOrder" },
+        "size": { "$ref": "#/$defs/searchSortCriterionOrder" },
+        "number": { "$ref": "#/$defs/searchSortCriterionOrder" }
+      },
+      "minProperties": 1,
+      "maxProperties": 1
+    },
     "searchMax": {
       "description": "Maximum devices to match.",
       "type": "integer",
@@ -531,7 +624,7 @@
       "const": "*"
     },
     "searchName": {
-      "descrition": "Search by device name",
+      "description": "Search by device name",
       "type": "string",
       "examples": ["/dev/vda", "/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9"]
     },

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 16 14:28:22 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Extend the storage schema to allow sorting storage devices as
+  part of the search (gh#agama-project/agama#2474).
+
+-------------------------------------------------------------------
 Fri Jun 13 12:45:49 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Configure the console font so the non-ASCII characters are

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_conversions/to_json_conversions/base"
+require "agama/storage/configs/sort_criteria"
 
 module Agama
   module Storage
@@ -39,6 +40,7 @@ module Agama
           def conversions
             {
               condition:  convert_condition,
+              sort:       convert_sort,
               ifNotFound: config.if_not_found.to_s,
               max:        config.max
             }
@@ -75,6 +77,33 @@ module Agama
             {
               size: { size.operator => size.value.to_i }
             }
+          end
+
+          # @return [Hash, nil]
+          def convert_sort
+            criteria = config.sort_criteria
+            return if criteria.nil? || criteria.empty?
+
+            criteria.map do |criterion|
+              { criterion_name(criterion) => criterion_order(criterion) }
+            end
+          end
+
+          SORT_CRITERIA = {
+            Configs::SortCriteria::Name            => :name,
+            Configs::SortCriteria::Size            => :size,
+            Configs::SortCriteria::PartitionNumber => :number
+          }.freeze
+          private_constant :SORT_CRITERIA
+
+          # @see #convert_sort
+          def criterion_name(criterion)
+            SORT_CRITERIA[criterion.class]
+          end
+
+          # @see #convert_sort
+          def criterion_order(criterion)
+            criterion.asc? ? "asc" : "desc"
           end
         end
       end

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -62,10 +62,14 @@ module Agama
         #   matched
         attr_accessor :max
 
+        # return [Array<SortCriteria::Base>]
+        attr_accessor :sort_criteria
+
         # Constructor
         def initialize
           @solved = false
           @if_not_found = :error
+          @sort_criteria = []
         end
 
         # Whether the search was already solved.

--- a/service/lib/agama/storage/configs/sort_criteria.rb
+++ b/service/lib/agama/storage/configs/sort_criteria.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    module Configs
+      # Namespace for criteria used to sort the result when searching devices.
+      module SortCriteria
+        # Base class for all sorting criteria
+        class Base
+          # Constructor
+          def initialize
+            @asc = true
+          end
+
+          # @return [Boolean] Whether sorting must be in ascending order
+          attr_accessor :asc
+          alias_method :asc?, :asc
+
+          # @return [Boolean] Whether sorting must be in descending order
+          def desc
+            !@asc
+          end
+          alias_method :desc?, :desc
+
+          # @see #desc
+          def desc=(value)
+            @asc = !value
+          end
+
+          # Order for the two operators
+          #
+          # @param dev_a [Y2Storage#device]
+          # @param dev_b [Y2Storage#device]
+          # @return [Integer] less than 0 when b follows a, greater than 0 when a follows b, 0 when
+          #   both are equivalent
+          def compare(dev_a, dev_b)
+            asc? ? compare_asc(dev_a, dev_b) : compare_asc(dev_b, dev_a)
+          end
+
+          # @see #compare
+          def compare_asc(dev_a, dev_b)
+            raise NotImplementedError
+          end
+        end
+
+        # Compares by device name
+        class Name < Base
+          def compare_asc(dev_a, dev_b)
+            dev_a.name <=> dev_b.name
+          end
+        end
+
+        # Compares by device size
+        class Size < Base
+          def compare_asc(dev_a, dev_b)
+            dev_a.size <=> dev_b.size
+          end
+        end
+
+        # Compares by partition number
+        class PartitionNumber < Base
+          def compare_asc(dev_a, dev_b)
+            dev_a.number <=> dev_b.number
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/configs/sort_criteria.rb
+++ b/service/lib/agama/storage/configs/sort_criteria.rb
@@ -41,11 +41,6 @@ module Agama
           end
           alias_method :desc?, :desc
 
-          # @see #desc
-          def desc=(value)
-            @asc = !value
-          end
-
           # Order for the two operators
           #
           # @param dev_a [Y2Storage#device]

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 16 14:26:06 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Initial support for sorting storage devices when searching them
+  at the configuration (gh#agama-project/agama#2474).
+
+-------------------------------------------------------------------
 Fri Jun 13 20:51:10 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix copy of self-signed certificates for RMT

--- a/service/test/agama/storage/config_conversions/to_json_conversions/search_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/search_test.rb
@@ -39,6 +39,7 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Search do
   let(:config_json) do
     {
       condition:  condition,
+      sort:       sort,
       ifNotFound: if_not_found,
       max:        max
     }
@@ -47,6 +48,7 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Search do
   let(:condition) { nil }
   let(:if_not_found) { nil }
   let(:max) { nil }
+  let(:sort) { nil }
 
   shared_examples "with device" do
     context "and there is an assigned device" do
@@ -103,7 +105,6 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Search do
         config_json = subject.convert
         expect(config_json[:condition]).to eq({ name: "/dev/vda" })
       end
-
     end
 
     context "if #condition is configured to search by size" do
@@ -139,6 +140,24 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Search do
 
       it "generates the expected JSON" do
         expect(subject.convert[:ifNotFound]).to eq("skip")
+      end
+    end
+
+    context "if #sort is configured with a single criterion" do
+      let(:sort) { "name" }
+
+      it "generates a JSON with a fully defined list of sort criteria" do
+        config_json = subject.convert
+        expect(config_json[:sort]).to eq [{ name: "asc" }]
+      end
+    end
+
+    context "if #sort is configured with complex criteria" do
+      let(:sort) { ["size", { name: "desc" }] }
+
+      it "generates a JSON with a fully defined list of sort criteria" do
+        config_json = subject.convert
+        expect(config_json[:sort]).to eq [{ size: "asc" }, { name: "desc" }]
       end
     end
   end

--- a/service/test/agama/storage/config_solvers/partitions_search_test.rb
+++ b/service/test/agama/storage/config_solvers/partitions_search_test.rb
@@ -335,6 +335,45 @@ describe Agama::Storage::ConfigSolvers::PartitionsSearch do
           include_examples "do not find device"
         end
       end
+
+      context "if a partition config has a search with sorting" do
+        let(:scenario) { "sizes.yaml" }
+        let(:disk) { devicegraph.find_by_name("/dev/vdb") }
+
+        let(:partitions) do
+          [
+            {
+              search: {
+                sort: sort
+              }
+            }
+          ]
+        end
+
+        context "by size" do
+          let(:sort) { { size: "desc" } }
+
+          it "matches the partitions in the expected order" do
+            subject.solve(drive)
+            partitions = drive.partitions
+            expect(partitions.map(&:search).map(&:device).map(&:name)).to eq [
+              "/dev/vdb2", "/dev/vdb3", "/dev/vdb1"
+            ]
+          end
+        end
+
+        context "by size and partition number" do
+          let(:sort) { [{ size: "desc" }, { number: "desc" }] }
+
+          it "matches the partitions in the expected order" do
+            subject.solve(drive)
+            partitions = drive.partitions
+            expect(partitions.map(&:search).map(&:device).map(&:name)).to eq [
+              "/dev/vdb3", "/dev/vdb2", "/dev/vdb1"
+            ]
+          end
+        end
+      end
     end
   end
 end

--- a/service/test/fixtures/sizes.yaml
+++ b/service/test/fixtures/sizes.yaml
@@ -27,6 +27,15 @@
     - partition:
         size: 30 GiB
         name: /dev/vdb3
+- disk:
+    name: /dev/vdc
+    size: 150 GiB
+- disk:
+    name: /dev/vdd
+    size: 200 GiB
+- disk:
+    name: /dev/vde
+    size: 500 GiB
 - md:
     name: "/dev/md0"
     chunk_size: 16 KiB


### PR DESCRIPTION
## Problem

The results of the `search` section in the description of `drives`, `partitions` and `mdRaids` are always sorted by name. Making it very hard to specify something like "the two biggest disks".

## Solution

This implements support for implementing such searches with the syntax shown in the following examples:

```json
{
  "search": {
    "sort": { "size": "desc" },
    "max": 2
  }
}
```

Several criteria can be specified to resolve ties.

```json
{
  "search": {
    "sort": [
        { "size": "desc" },
        "name"
    ],
    "max": 2
  }
}
```

And, of course, all that can be combined with a condition to filter out devices before sorting.

```json
{
  "search": {
    "condition": { "size": { "less": "1TiB" } },
    "sort": { "size": "desc" },
    "max": 2
  }
}
```

## Testing

- Added unit tests for the new parts
- Tested manually
