### PR TITLE
Send the current language to the registration server (SCC/RMT)

### DIFF
--- a/service/lib/agama/registration.rb
+++ b/service/lib/agama/registration.rb
@@ -295,9 +295,25 @@ module Agama
     # @return [Hash]
     def connect_params(params = {})
       default_params = {}
+      default_params[:language] = http_language if http_language
       default_params[:url] = registration_url if registration_url
       default_params[:verify_callback] = verify_callback
       default_params.merge(params)
+    end
+
+    def http_language
+      lang = Yast::WFM.GetLanguage
+      return nil if ["POSIX", "C"].include?(lang)
+
+      # remove the encoding suffix (e.g. ".UTF-8")
+      lang = lang.sub(/\..*$/, "")
+
+      # replace Linux locale separator "_" by the HTTP separator "-", downcase the country name
+      # see https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-language
+      lang.tr!("_", "-")
+      lang.downcase!
+
+      lang
     end
 
     # returns SSL verify callback

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 13 15:11:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Send the current language to the registration server (SCC/RMT)
+  to display localized error messages (gh#agama-project/agama#2477)
+
+-------------------------------------------------------------------
 Fri Jun 13 08:23:46 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Split registration key and registered status to support RMT with

--- a/service/test/agama/registration_test.rb
+++ b/service/test/agama/registration_test.rb
@@ -95,9 +95,22 @@ describe Agama::Registration do
       context "and the product is not registered yet" do
         it "announces the system" do
           expect(SUSE::Connect::YaST).to receive(:announce_system).with(
-            { token: "11112222", email: "test@test.com", verify_callback: anything },
+            { language: anything, token: "11112222", email: "test@test.com",
+              verify_callback: anything },
             "test-5-x86_64"
           )
+
+          subject.register("11112222", email: "test@test.com")
+        end
+
+        it "sets the current language in the request" do
+          expect(SUSE::Connect::YaST).to receive(:announce_system).with(
+            { language: "de-de", token: "11112222", email: "test@test.com",
+              verify_callback: anything },
+            "test-5-x86_64"
+          )
+
+          allow(Yast::WFM).to receive(:GetLanguage).and_return("de_DE")
 
           subject.register("11112222", email: "test@test.com")
         end
@@ -110,7 +123,7 @@ describe Agama::Registration do
           it "registers using the given URL" do
             expect(SUSE::Connect::YaST).to receive(:announce_system).with(
               { token: "11112222", email: "test@test.com", url: "http://scc.example.net",
-                verify_callback: anything },
+                verify_callback: anything, language: anything },
               "test-5-x86_64"
             )
 
@@ -424,7 +437,8 @@ describe Agama::Registration do
 
         it "deactivates the system" do
           expect(SUSE::Connect::YaST).to receive(:deactivate_system).with(
-            { token: "11112222", email: "test@test.com", verify_callback: anything }
+            { token: "11112222", email: "test@test.com", verify_callback: anything,
+              language: anything }
           )
 
           subject.deregister


### PR DESCRIPTION
## Problem

- The error messages from SCC are not translated
- https://github.com/agama-project/agama/issues/2477
- When using an invalid registration code, the error message from SCC "Unknown Registration Code" is not translated to the currently selected language.

![Image](https://github.com/user-attachments/assets/f4cd4f95-cd25-43ac-aaa6-37e53771a4d8) 

## Solution

- Send the current language in the request

## Testing

- Added a new unit test
- Tested manually, "Unbekannter Registrierungscode" is displayed when using German language

![agama-registration-translated-scc-error](https://github.com/user-attachments/assets/2a0b2e59-a722-4e41-a6d2-1801d77b852f)

