### PR TITLE
fix: make sure queries are sync

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 17 12:21:43 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve logging of WebSocket events (gh#agama-project/agama#2479).
+
+-------------------------------------------------------------------
 Fri Jun 13 12:45:49 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Configure the console font so the non-ASCII characters are

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -23,7 +23,7 @@ module.exports = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ["src/**/*.{js,jsx}", "!src/lib/*.js"],
+  collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}"],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jun 17 12:22:46 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Make sure queries data is in sync with the WebSocket messages
+  (bsc#1243276, gh#agama-project/agama#2479).
+- Properly jump to the progress page when the product is selected
+  by a third party (e.g., "agama config load").
+- Log WebSocket messages in the console with "debug" log level.
+
+-------------------------------------------------------------------
 
 Fri Jun 13 08:24:59 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -90,7 +90,7 @@ describe("App", () => {
     // setting the language through a cookie
     document.cookie = "agamaLang=en-US; path=/;";
     (createClient as jest.Mock).mockImplementation(() => {
-      return {};
+      return { isConnected: () => true };
     });
 
     mockProducts = [tumbleweed, microos];

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -30,15 +30,6 @@ import { Product } from "./types/software";
 
 jest.mock("~/client");
 
-jest.mock("~/api/l10n", () => ({
-  ...jest.requireActual("~/api/l10n"),
-  fetchConfig: jest.fn().mockResolvedValue({
-    uiKeymap: "en",
-    uiLocale: "en_US",
-  }),
-  updateConfig: jest.fn(),
-}));
-
 const tumbleweed: Product = { id: "openSUSE", name: "openSUSE Tumbleweed", registration: false };
 const microos: Product = { id: "Leap Micro", name: "openSUSE Micro", registration: false };
 
@@ -116,7 +107,7 @@ describe("App", () => {
     });
 
     it("renders the Loading screen", async () => {
-      installerRender(<App />, { withL10n: true });
+      installerRender(<App />);
       await screen.findByText("Loading Mock");
     });
   });
@@ -128,7 +119,7 @@ describe("App", () => {
     });
 
     it("renders the Loading screen", async () => {
-      installerRender(<App />, { withL10n: true });
+      installerRender(<App />);
       await screen.findByText("Loading Mock");
     });
   });
@@ -145,7 +136,7 @@ describe("App", () => {
       });
 
       it("redirects to product selection progress", async () => {
-        installerRender(<App />, { withL10n: true });
+        installerRender(<App />);
         await screen.findByText("Navigating to /products/progress");
       });
     });
@@ -156,7 +147,7 @@ describe("App", () => {
       });
 
       it("renders the application content", async () => {
-        installerRender(<App />, { withL10n: true });
+        installerRender(<App />);
         await screen.findByText(/Outlet Content/);
       });
     });
@@ -169,7 +160,7 @@ describe("App", () => {
     });
 
     it("navigates to installation progress", async () => {
-      installerRender(<App />, { withL10n: true });
+      installerRender(<App />);
       await screen.findByText("Navigating to /installation/progress");
     });
   });
@@ -181,7 +172,7 @@ describe("App", () => {
     });
 
     it("navigates to installation finished", async () => {
-      installerRender(<App />, { withL10n: true });
+      installerRender(<App />);
       await screen.findByText("Navigating to /installation/finished");
     });
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,6 @@
 
 import React, { useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
-import { ServerError } from "~/components/core";
 import { Loading } from "~/components/layout";
 import { useProduct, useProductChanges } from "~/queries/software";
 import { useL10nConfigChanges } from "~/queries/l10n";

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,14 @@ function App() {
     };
   }, [queryClient]);
 
+  console.log("App component", {
+    phase,
+    isBusy,
+    products,
+    selectedProduct,
+    location: location.pathname,
+  });
+
   const Content = () => {
     if (phase === InstallationPhase.Install) {
       console.log("Navigating to the installation progress page");
@@ -68,11 +76,6 @@ function App() {
     }
 
     if (!products || (selectedProduct === undefined && isBusy)) {
-      console.log("Loading screen: Initialization", {
-        products,
-        selectedProduct,
-        isBusy,
-      });
       return <Loading listenQuestions />;
     }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,18 +36,18 @@ import { useQueryClient } from "@tanstack/react-query";
  * Main application component.
  */
 function App() {
+  useL10nConfigChanges();
+  useProductChanges();
+  useIssuesChanges();
+  useInstallerStatusChanges();
+  useDeprecatedChanges();
+
   const location = useLocation();
   const { isBusy, phase } = useInstallerStatus({ suspense: true });
   const { selectedProduct, products } = useProduct({
     suspense: phase !== InstallationPhase.Install,
   });
   const queryClient = useQueryClient();
-
-  useL10nConfigChanges();
-  useProductChanges();
-  useIssuesChanges();
-  useInstallerStatusChanges();
-  useDeprecatedChanges();
 
   useEffect(() => {
     // Invalidate the queries when unmounting this component.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
       return <Navigate to={ROOT.installationFinished} />;
     }
 
-    if (!products || (selectedProduct === undefined && isBusy)) {
+    if (!products) {
       return <Loading listenQuestions />;
     }
 
@@ -84,7 +84,7 @@ function App() {
       return <Loading listenQuestions />;
     }
 
-    if (selectedProduct === undefined && location.pathname !== PRODUCT.root) {
+    if (selectedProduct === undefined && !isBusy && location.pathname !== PRODUCT.root) {
       console.log("Navigating to the product selection page");
       return <Navigate to={PRODUCT.root} />;
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,8 +24,6 @@ import React, { useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { ServerError } from "~/components/core";
 import { Loading } from "~/components/layout";
-import { useInstallerL10n } from "~/context/installerL10n";
-import { useInstallerClientStatus } from "~/context/installer";
 import { useProduct, useProductChanges } from "~/queries/software";
 import { useL10nConfigChanges } from "~/queries/l10n";
 import { useIssuesChanges } from "~/queries/issues";
@@ -41,11 +39,9 @@ import { useQueryClient } from "@tanstack/react-query";
 function App() {
   const location = useLocation();
   const { isBusy, phase } = useInstallerStatus({ suspense: true });
-  const { connected, error } = useInstallerClientStatus();
   const { selectedProduct, products } = useProduct({
     suspense: phase !== InstallationPhase.Install,
   });
-  const { language } = useInstallerL10n();
   const queryClient = useQueryClient();
 
   useL10nConfigChanges();
@@ -62,8 +58,6 @@ function App() {
   }, [queryClient]);
 
   const Content = () => {
-    if (error) return <ServerError />;
-
     if (phase === InstallationPhase.Install) {
       console.log("Navigating to the installation progress page");
       return <Navigate to={ROOT.installationProgress} />;
@@ -74,10 +68,9 @@ function App() {
       return <Navigate to={ROOT.installationFinished} />;
     }
 
-    if (!products || !connected || (selectedProduct === undefined && isBusy)) {
+    if (!products || (selectedProduct === undefined && isBusy)) {
       console.log("Loading screen: Initialization", {
         products,
-        connected,
         selectedProduct,
         isBusy,
       });
@@ -101,8 +94,6 @@ function App() {
 
     return <Outlet />;
   };
-
-  if (!language) return null;
 
   return <Content />;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { ServerError } from "~/components/core";
 import { Loading } from "~/components/layout";
@@ -33,6 +33,7 @@ import { useInstallerStatus, useInstallerStatusChanges } from "~/queries/status"
 import { useDeprecatedChanges } from "~/queries/storage";
 import { ROOT, PRODUCT } from "~/routes/paths";
 import { InstallationPhase } from "~/types/status";
+import { useQueryClient } from "@tanstack/react-query";
 
 /**
  * Main application component.
@@ -45,11 +46,20 @@ function App() {
     suspense: phase !== InstallationPhase.Install,
   });
   const { language } = useInstallerL10n();
+  const queryClient = useQueryClient();
+
   useL10nConfigChanges();
   useProductChanges();
   useIssuesChanges();
   useInstallerStatusChanges();
   useDeprecatedChanges();
+
+  useEffect(() => {
+    // Invalidate the queries when unmounting this component.
+    return () => {
+      queryClient.invalidateQueries();
+    };
+  }, [queryClient]);
 
   const Content = () => {
     if (error) return <ServerError />;

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { WSClient, EventHandlerFn, ErrorHandlerFn } from "./ws";
+import { WSClient, EventHandlerFn, ErrorHandlerFn, WSClientIface } from "./ws";
 
 type VoidFn = () => void;
 type BooleanFn = () => boolean;
@@ -57,11 +57,11 @@ export type InstallerClient = {
  *
  * @param url - URL of the HTTP API.
  */
-const createClient = (url: URL): InstallerClient => {
+const createClient = (url: URL, wsClient?: WSClientIface): InstallerClient => {
   url.hash = "";
   url.pathname = url.pathname.concat("api/ws");
   url.protocol = url.protocol === "http:" ? "ws" : "wss";
-  const ws = new WSClient(url);
+  const ws = wsClient || new WSClient(url);
 
   const isConnected = () => ws.isConnected() || false;
   const isRecoverable = () => !!ws.isRecoverable();

--- a/web/src/client/ws.ts
+++ b/web/src/client/ws.ts
@@ -20,6 +20,8 @@
  * find current contact information at www.suse.com.
  */
 
+import { noop } from "radashi";
+
 type RemoveFn = () => void;
 type BaseHandlerFn = () => void;
 export type EventHandlerFn = (event) => void;
@@ -39,6 +41,20 @@ const SocketStates = Object.freeze({
 const MAX_ATTEMPTS = 15;
 const ATTEMPT_INTERVAL = 1000;
 
+// WebSocket client interface
+//
+// It defines the interface a WebSocket client should adhere to.
+// The main point is to make it possible to replace the native
+// WebSocket implementation with something else in the tests.
+interface WSClientIface {
+  isConnected: () => boolean;
+  isRecoverable: () => boolean;
+  onOpen: (func: BaseHandlerFn) => RemoveFn;
+  onError: (func: ErrorHandlerFn) => RemoveFn;
+  onClose: (func: BaseHandlerFn) => RemoveFn;
+  onEvent: (func: EventHandlerFn) => RemoveFn;
+}
+
 /**
  * Agama WebSocket client.
  *
@@ -46,7 +62,7 @@ const ATTEMPT_INTERVAL = 1000;
  * This class is not expected to be used directly, but through the
  * HTTPClient API.
  */
-class WSClient {
+class WSClient implements WSClientIface {
   url: string;
 
   client: WebSocket;
@@ -229,4 +245,32 @@ class WSClient {
   }
 }
 
-export { WSClient };
+// WebSocket client to be used in the tests.
+class DummyWSClient implements WSClientIface {
+  isConnected() {
+    return true;
+  }
+
+  isRecoverable() {
+    return true;
+  }
+
+  onOpen(): RemoveFn {
+    return noop;
+  }
+
+  onError(): RemoveFn {
+    return noop;
+  }
+
+  onClose(): RemoveFn {
+    return noop;
+  }
+
+  onEvent(): RemoveFn {
+    return noop;
+  }
+}
+
+export { WSClient, DummyWSClient };
+export type { WSClientIface };

--- a/web/src/client/ws.ts
+++ b/web/src/client/ws.ts
@@ -122,6 +122,7 @@ class WSClient implements WSClientIface {
     };
 
     client.onmessage = (event) => {
+      console.debug("Event received", event);
       this.dispatchEvent(event);
     };
 

--- a/web/src/components/core/ServerError.test.tsx
+++ b/web/src/components/core/ServerError.test.tsx
@@ -23,9 +23,9 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
-import { ServerError } from "~/components/core";
 import { noop } from "radashi";
 import * as utils from "~/utils";
+import ServerError from "./ServerError";
 
 jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
   <div>ProductRegistrationAlert Mock</div>

--- a/web/src/components/core/index.ts
+++ b/web/src/components/core/index.ts
@@ -38,7 +38,6 @@ export { default as Popup } from "./Popup";
 export { default as ProgressReport } from "./ProgressReport";
 export { default as ProgressText } from "./ProgressText";
 export { default as PasswordInput } from "./PasswordInput";
-export { default as ServerError } from "./ServerError";
 export { default as TreeTable } from "./TreeTable";
 export { default as Link } from "./Link";
 export { default as EmptyState } from "./EmptyState";

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -168,7 +168,9 @@ const Layout = ({
       >
         <Suspense fallback={<Loading />}>{children || <Outlet />}</Suspense>
       </Page>
-      {location.pathname !== ROOT.login && <Questions />}
+      {location.pathname !== ROOT.login && location.pathname !== ROOT.installationExit && (
+        <Questions />
+      )}
     </>
   );
 };

--- a/web/src/components/overview/StorageSection.test.tsx
+++ b/web/src/components/overview/StorageSection.test.tsx
@@ -23,26 +23,79 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
-import { mockApi, addMockApi, ApiData } from "~/mocks/api";
-import * as deviceFactory from "~/factories/storage/device";
 import { StorageSection } from "~/components/overview";
 
-const defaultApiData: ApiData = {
-  "/api/storage/devices/available_drives": [],
-  "/api/storage/devices/available_md_raids": [],
-  "/api/storage/devices/system": [
-    deviceFactory.generate({ sid: 59, name: "/dev/sda", size: 536870912000 }),
-    deviceFactory.generate({ sid: 60, name: "/dev/sdb", size: 697932185600 }),
-  ],
+let mockModel = {
+  drives: [],
 };
 
+const sda = {
+  sid: 59,
+  name: "/dev/sda",
+  description: "",
+  isDrive: false,
+  type: "drive",
+  active: true,
+  encrypted: false,
+  shrinking: { unsuppored: [] },
+  size: 536870912000,
+  start: 0,
+  systems: [],
+  udevIds: [],
+  udevPaths: [],
+};
+
+const sdb = {
+  sid: 60,
+  name: "/dev/sdb",
+  description: "",
+  isDrive: false,
+  type: "drive",
+  active: true,
+  encrypted: false,
+  shrinking: { unsuppored: [] },
+  size: 697932185600,
+  start: 0,
+  systems: [],
+  udevIds: [],
+  udevPaths: [],
+};
+
+jest.mock("~/queries/storage/config-model", () => ({
+  ...jest.requireActual("~/queries/storage/config-model"),
+  useConfigModel: () => mockModel,
+}));
+
+const mockDevices = [sda, sdb];
+
+jest.mock("~/queries/storage", () => ({
+  ...jest.requireActual("~/queries/storage"),
+  useDevices: () => mockDevices,
+}));
+
+let mockAvailableDevices = [sda, sdb];
+
+jest.mock("~/hooks/storage/system", () => ({
+  ...jest.requireActual("~/hooks/storage/system"),
+  useAvailableDevices: () => mockAvailableDevices,
+}));
+
+let mockSystemErrors = [];
+
+jest.mock("~/queries/issues", () => ({
+  ...jest.requireActual("~/queries/issues"),
+  useSystemErrors: () => mockSystemErrors,
+}));
+
 beforeEach(() => {
-  mockApi(defaultApiData);
+  mockSystemErrors = [];
 });
 
 describe("when the configuration does not include any device", () => {
   beforeEach(() => {
-    addMockApi({ "/api/storage/config_model": { drives: [] } });
+    mockModel = {
+      drives: [],
+    };
   });
 
   it("indicates that a device is not selected", async () => {
@@ -54,11 +107,9 @@ describe("when the configuration does not include any device", () => {
 
 describe("when the configuration contains one drive", () => {
   beforeEach(() => {
-    addMockApi({
-      "/api/storage/config_model": {
-        drives: [{ name: "/dev/sda", spacePolicy: "delete" }],
-      },
-    });
+    mockModel = {
+      drives: [{ name: "/dev/sda", spacePolicy: "delete" }],
+    };
   });
 
   it("renders the proposal summary", async () => {
@@ -71,11 +122,9 @@ describe("when the configuration contains one drive", () => {
 
   describe("and the space policy is set to 'resize'", () => {
     beforeEach(() => {
-      addMockApi({
-        "/api/storage/config_model": {
-          drives: [{ name: "/dev/sda", spacePolicy: "resize" }],
-        },
-      });
+      mockModel = {
+        drives: [{ name: "/dev/sda", spacePolicy: "resize" }],
+      };
     });
 
     it("indicates that partitions may be shrunk", async () => {
@@ -87,11 +136,9 @@ describe("when the configuration contains one drive", () => {
 
   describe("and the space policy is set to 'keep'", () => {
     beforeEach(() => {
-      addMockApi({
-        "/api/storage/config_model": {
-          drives: [{ name: "/dev/sda", spacePolicy: "keep" }],
-        },
-      });
+      mockModel = {
+        drives: [{ name: "/dev/sda", spacePolicy: "keep" }],
+      };
     });
 
     it("indicates that partitions will be kept", async () => {
@@ -103,11 +150,9 @@ describe("when the configuration contains one drive", () => {
 
   describe("and the space policy is set to 'custom'", () => {
     beforeEach(() => {
-      addMockApi({
-        "/api/storage/config_model": {
-          drives: [{ name: "/dev/sda", spacePolicy: "custom" }],
-        },
-      });
+      mockModel = {
+        drives: [{ name: "/dev/sda", spacePolicy: "custom" }],
+      };
     });
 
     it("indicates that custom strategy for allocating space is set", async () => {
@@ -119,11 +164,9 @@ describe("when the configuration contains one drive", () => {
 
   describe("and the drive matches no disk", () => {
     beforeEach(() => {
-      addMockApi({
-        "/api/storage/config_model": {
-          drives: [{ name: undefined, spacePolicy: "delete" }],
-        },
-      });
+      mockModel = {
+        drives: [{ name: undefined, spacePolicy: "delete" }],
+      };
     });
 
     it("indicates that a device is not selected", async () => {
@@ -136,14 +179,12 @@ describe("when the configuration contains one drive", () => {
 
 describe("when the configuration contains several drives", () => {
   beforeEach(() => {
-    addMockApi({
-      "/api/storage/config_model": {
-        drives: [
-          { name: "/dev/sda", spacePolicy: "delete" },
-          { name: "/dev/sdb", spacePolicy: "delete" },
-        ],
-      },
-    });
+    mockModel = {
+      drives: [
+        { name: "/dev/sda", spacePolicy: "delete" },
+        { name: "/dev/sdb", spacePolicy: "delete" },
+      ],
+    };
   });
 
   it("renders the proposal summary", async () => {
@@ -155,14 +196,12 @@ describe("when the configuration contains several drives", () => {
 
   describe("but one of them has a different space policy", () => {
     beforeEach(() => {
-      addMockApi({
-        "/api/storage/config_model": {
-          drives: [
-            { name: "/dev/sda", spacePolicy: "delete" },
-            { name: "/dev/sdb", spacePolicy: "resize" },
-          ],
-        },
-      });
+      mockModel = {
+        drives: [
+          { name: "/dev/sda", spacePolicy: "delete" },
+          { name: "/dev/sdb", spacePolicy: "resize" },
+        ],
+      };
     });
 
     it("indicates that custom strategy for allocating space is set", async () => {
@@ -175,15 +214,15 @@ describe("when the configuration contains several drives", () => {
 
 describe("when there is no configuration model (unsupported features)", () => {
   beforeEach(() => {
-    addMockApi({ "/api/storage/config_model": null });
+    mockModel = null;
   });
 
   describe("if the storage proposal succeeded", () => {
-    beforeEach(() => {
-      addMockApi({ "/api/storage/issues": [] });
-    });
-
     describe("and there are no available devices", () => {
+      beforeEach(() => {
+        mockAvailableDevices = [];
+      });
+
       it("indicates that an unhandled configuration was used", async () => {
         plainRender(<StorageSection />);
         await screen.findByText(/advanced configuration/);
@@ -192,9 +231,7 @@ describe("when there is no configuration model (unsupported features)", () => {
 
     describe("and there are available disks", () => {
       beforeEach(() => {
-        addMockApi({
-          "/api/storage/devices/available_drives": [59],
-        });
+        mockAvailableDevices = [sda];
       });
 
       it("indicates that an unhandled configuration was used", async () => {
@@ -206,20 +243,22 @@ describe("when there is no configuration model (unsupported features)", () => {
 
   describe("if the storage proposal was not possible", () => {
     beforeEach(() => {
-      addMockApi({
-        "/api/storage/issues": [
-          {
-            description: "System error",
-            kind: "storage",
-            details: "",
-            source: 1,
-            severity: 1,
-          },
-        ],
-      });
+      mockSystemErrors = [
+        {
+          description: "System error",
+          kind: "storage",
+          details: "",
+          source: 1,
+          severity: 1,
+        },
+      ];
     });
 
     describe("and there are no available devices", () => {
+      beforeEach(() => {
+        mockAvailableDevices = [];
+      });
+
       it("indicates that there are no available disks", async () => {
         plainRender(<StorageSection />);
         await screen.findByText(/no disks available/);
@@ -228,7 +267,7 @@ describe("when there is no configuration model (unsupported features)", () => {
 
     describe("and there are available devices", () => {
       beforeEach(() => {
-        addMockApi({ "/api/storage/devices/available_drives": [59] });
+        mockAvailableDevices = [sda];
       });
 
       it("indicates that an unhandled configuration was used", async () => {

--- a/web/src/components/product/ProductSelectionProgress.tsx
+++ b/web/src/components/product/ProductSelectionProgress.tsx
@@ -41,7 +41,7 @@ function ProductSelectionProgress() {
     <Page>
       <ProgressReport
         title={_("Configuring the product, please wait ...")}
-        firstStep={selectedProduct.name}
+        firstStep={selectedProduct?.name}
       />
     </Page>
   );

--- a/web/src/context/installer.tsx
+++ b/web/src/context/installer.tsx
@@ -22,6 +22,7 @@
 
 import React, { useState, useEffect } from "react";
 import { createDefaultClient, InstallerClient } from "~/client";
+import Loading from "~/components/layout/Loading";
 
 type ClientStatus = {
   /** Whether the client is connected or not. */
@@ -108,10 +109,16 @@ function InstallerClientProvider({ children, client = null }: InstallerClientPro
     });
   }, [value]);
 
+  const Content = () => {
+    if (!connected) return <Loading />;
+
+    return children;
+  };
+
   return (
     <InstallerClientContext.Provider value={value}>
       <InstallerClientStatusContext.Provider value={{ connected, error }}>
-        {children}
+        <Content />
       </InstallerClientStatusContext.Provider>
     </InstallerClientContext.Provider>
   );

--- a/web/src/context/installer.tsx
+++ b/web/src/context/installer.tsx
@@ -71,7 +71,7 @@ function useInstallerClientStatus(): ClientStatus {
 
 function InstallerClientProvider({ children, client = null }: InstallerClientProviderProps) {
   const [value, setValue] = useState(client);
-  const [connected, setConnected] = useState(false);
+  const [connected, setConnected] = useState(!!client?.isConnected());
   const [error, setError] = useState(false);
 
   useEffect(() => {

--- a/web/src/context/installer.tsx
+++ b/web/src/context/installer.tsx
@@ -23,14 +23,7 @@
 import React, { useState, useEffect } from "react";
 import { createDefaultClient, InstallerClient } from "~/client";
 import Loading from "~/components/layout/Loading";
-import { ServerError } from "~/components/core";
-
-type ClientStatus = {
-  /** Whether the client is connected or not. */
-  connected: boolean;
-  /** Whether the client present an error and cannot reconnect. */
-  error: boolean;
-};
+import ServerError from "~/components/core/ServerError";
 
 type InstallerClientProviderProps = React.PropsWithChildren<{
   /** Client to connect to Agama service; if it is undefined, it instantiates a
@@ -39,12 +32,6 @@ type InstallerClientProviderProps = React.PropsWithChildren<{
 }>;
 
 const InstallerClientContext = React.createContext(null);
-// TODO: we use a separate context to avoid changing all the codes to
-// `useInstallerClient`. We should merge them in the future.
-const InstallerClientStatusContext = React.createContext({
-  connected: false,
-  error: false,
-});
 
 /**
  * Returns the D-Bus installer client
@@ -53,18 +40,6 @@ function useInstallerClient(): InstallerClient {
   const context = React.useContext(InstallerClientContext);
   if (context === undefined) {
     throw new Error("useInstallerClient must be used within a InstallerClientProvider");
-  }
-
-  return context;
-}
-
-/**
- * Returns the client status.
- */
-function useInstallerClientStatus(): ClientStatus {
-  const context = React.useContext(InstallerClientStatusContext);
-  if (!context) {
-    throw new Error("useInstallerClientStatus must be used within a InstallerClientProvider");
   }
 
   return context;
@@ -119,11 +94,9 @@ function InstallerClientProvider({ children, client = null }: InstallerClientPro
 
   return (
     <InstallerClientContext.Provider value={value}>
-      <InstallerClientStatusContext.Provider value={{ connected, error }}>
-        <Content />
-      </InstallerClientStatusContext.Provider>
+      <Content />
     </InstallerClientContext.Provider>
   );
 }
 
-export { InstallerClientProvider, useInstallerClient, useInstallerClientStatus };
+export { InstallerClientProvider, useInstallerClient };

--- a/web/src/context/installer.tsx
+++ b/web/src/context/installer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2021-2024] SUSE LLC
+ * Copyright (c) [2021-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -34,7 +34,7 @@ type InstallerClientProviderProps = React.PropsWithChildren<{
 const InstallerClientContext = React.createContext(null);
 
 /**
- * Returns the D-Bus installer client
+ * Returns the installer client
  */
 function useInstallerClient(): InstallerClient {
   const context = React.useContext(InstallerClientContext);

--- a/web/src/context/installer.tsx
+++ b/web/src/context/installer.tsx
@@ -23,6 +23,7 @@
 import React, { useState, useEffect } from "react";
 import { createDefaultClient, InstallerClient } from "~/client";
 import Loading from "~/components/layout/Loading";
+import { ServerError } from "~/components/core";
 
 type ClientStatus = {
   /** Whether the client is connected or not. */
@@ -110,6 +111,7 @@ function InstallerClientProvider({ children, client = null }: InstallerClientPro
   }, [value]);
 
   const Content = () => {
+    if (error) return <ServerError />;
     if (!connected) return <Loading />;
 
     return children;

--- a/web/src/context/installerL10n.tsx
+++ b/web/src/context/installerL10n.tsx
@@ -22,7 +22,6 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { locationReload, setLocationSearch } from "~/utils";
-import { useInstallerClientStatus } from "./installer";
 import agama from "~/agama";
 import supportedLanguages from "~/languages.json";
 import { fetchConfig as defaultFetchConfig, updateConfig } from "~/api/l10n";
@@ -243,7 +242,6 @@ function InstallerL10nProvider({
   children?: React.ReactNode;
 }) {
   const fetchConfig = fetchConfigFn || defaultFetchConfig;
-  const { connected } = useInstallerClientStatus();
   const [language, setLanguage] = useState(initialLanguage);
   const [keymap, setKeymap] = useState(undefined);
 
@@ -290,12 +288,10 @@ function InstallerL10nProvider({
 
   const changeKeymap = useCallback(
     async (id: string) => {
-      if (!connected) return;
-
       setKeymap(id);
       await updateConfig({ uiKeymap: id });
     },
-    [setKeymap, connected],
+    [setKeymap],
   );
 
   useEffect(() => {
@@ -303,10 +299,10 @@ function InstallerL10nProvider({
   }, [changeLanguage, language]);
 
   useEffect(() => {
-    if (!connected || !language) return;
+    if (!language) return;
 
     syncBackendLanguage();
-  }, [connected, language, syncBackendLanguage]);
+  }, [language, syncBackendLanguage]);
 
   useEffect(() => {
     fetchConfig().then((c) => setKeymap(c.uiKeymap));

--- a/web/src/context/installerL10n.tsx
+++ b/web/src/context/installerL10n.tsx
@@ -311,6 +311,8 @@ function InstallerL10nProvider({
 
   const value = { language, changeLanguage, keymap, changeKeymap };
 
+  if (!language) return null;
+
   return <L10nContext.Provider value={value}>{children}</L10nContext.Provider>;
 }
 

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -100,19 +100,6 @@ const protectedRoutes = () => [
       },
     ],
   },
-  {
-    element: (
-      <PlainLayout mountHeader={false} mountSkipToContent={false}>
-        <Outlet />
-      </PlainLayout>
-    ),
-    children: [
-      {
-        path: PATHS.installationExit,
-        element: <InstallationExit />,
-      },
-    ],
-  },
 ];
 
 const router = () =>
@@ -124,6 +111,19 @@ const router = () =>
           <LoginPage />
         </PlainLayout>
       ),
+    },
+    {
+      element: (
+        <PlainLayout mountHeader={false} mountSkipToContent={false}>
+          <Outlet />
+        </PlainLayout>
+      ),
+      children: [
+        {
+          path: PATHS.installationExit,
+          element: <InstallationExit />,
+        },
+      ],
     },
     {
       path: PATHS.root,

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -110,6 +110,9 @@ const Providers = ({ children, withL10n }) => {
     client.onClose = noop;
   }
 
+  // Pretend that we are always connected.
+  client.isConnected = () => true;
+
   if (withL10n) {
     return (
       <InstallerClientProvider client={client}>

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -113,9 +113,17 @@ const Providers = ({ children, withL10n }) => {
   }
 
   if (withL10n) {
+    const fetchConfig = async () => ({
+      keymap: "us",
+      timezone: "Europe/Berlin",
+      uiLocale: "en_US",
+      uiKeymap: "us",
+    });
     return (
       <InstallerClientProvider client={client}>
-        <InstallerL10nProvider initialLanguage="en-US">{children}</InstallerL10nProvider>
+        <InstallerL10nProvider initialLanguage="en-US" fetchConfigFn={fetchConfig}>
+          {children}
+        </InstallerL10nProvider>
       </InstallerClientProvider>
     );
   }

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -37,6 +37,7 @@ import { createClient } from "~/client/index";
 import { InstallerClientProvider } from "~/context/installer";
 import { InstallerL10nProvider } from "~/context/installerL10n";
 import { isObject, noop } from "radashi";
+import { DummyWSClient } from "./client/ws";
 
 /**
  * Internal mock for manipulating routes, using ["/"] by default
@@ -98,7 +99,8 @@ jest.mock("react-router-dom", () => ({
 }));
 
 const Providers = ({ children, withL10n }) => {
-  const client = createClient(new URL("https://localhost"));
+  const ws = new DummyWSClient();
+  const client = createClient(new URL("https://localhost"), ws);
 
   if (!client.onConnect) {
     client.onConnect = noop;
@@ -109,9 +111,6 @@ const Providers = ({ children, withL10n }) => {
   if (!client.onClose) {
     client.onClose = noop;
   }
-
-  // Pretend that we are always connected.
-  client.isConnected = () => true;
 
   if (withL10n) {
     return (


### PR DESCRIPTION
## Problem

Here is a proposal to solve [bsc#1243276](https://bugzilla.suse.com/show_bug.cgi?id=1243276) and other synchronization problems. It needs to be tested more extensively.

We have detected that the web UI can get into the following scenario:

1. The web UI tries to connect to the WebSocket.
2. The web UI asks for the selected product. It caches the response.
3. The product gets selected, for instance, loading a profile.
4. The server emits the signal `ProductSelected`.
5. **The WebSocket connection is finally established.**

As you can see, there is a chance that Agama misses the signal (step 4). If the WebSocket connections happens before (which is the normal case), everything should work.

## Solution

* Do not mount the `App` component until the `WebSocket` is ready.
* If the connection is lost, `App` is umounted and it has the chance to clean-up the queries.

## Tasks

- [x] Fix the tests.
- [x] Build an ISO to test the change. Testing images are [here](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/sync-queries/images/iso).