### PR TITLE
Do not commit the products.pot file when only the timestamps are changed

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -131,6 +131,7 @@ jobs:
           else
             echo "POT file unchanged"
             echo "pot_updated=false" >> $GITHUB_OUTPUT
+            git -C agama-weblate reset --hard
           fi
 
       - name: Push updated products POT file


### PR DESCRIPTION
## Problem

- Weblate quite often reports a conflict in translations.
- It turned out that there are some unnecessary commits in the product POT file [like this one](https://github.com/agama-project/agama-weblate/commit/27163d7bfbfee44a2d5c46a6881c392eca76d7d2) which only change the timestamp in the file and nothing else. We should avoid such commits to decrease chance of conflicts.
- There is already a check if only timestamps are changed but there is a missing reset so the change is committed later anyway.

## Solution

- Reset the changes, we do the same for the other translation parts, for some reason it was missing here.

