### PR TITLE
Add hyper-v bootstrap package (bsc#1236961) #2486

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 17 08:47:46 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Add hyper-v bootstrap package (bsc#1236961).
+
+-------------------------------------------------------------------
 Fri Jun 13 10:41:15 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add initial support to apply updates from RPM packages and DUD archives

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -214,6 +214,7 @@
         <package name="udev"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>
+        <package name="hyper-v"/>
         <package name="ca-certificates"/>
         <package name="ca-certificates-mozilla"/>
     </packages>


### PR DESCRIPTION
## Problem

The hyper-v.rpm package includes a number of packages which interact with the host. One useful feature is the hv_kvp_daemon, which reports the active IP addresses to the host tooling. It would be nice to have it in Agama.

- https://bugzilla.suse.com/show_bug.cgi?id=1236961

## Solution

Added the package to the list of bootstrap packages.