### PR TITLE
fix: preserve AutoYaST pre-scripts

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun 18 07:17:30 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Preserve AutoYaST pre-scripts artifacts (bsc#1243776, gh#agama-project/agama#2344).
+
+-------------------------------------------------------------------
 Tue Jun 17 12:21:43 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improve logging of WebSocket events (gh#agama-project/agama#2479).

--- a/service/lib/agama/autoyast/pre_script.rb
+++ b/service/lib/agama/autoyast/pre_script.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "autoinstall/script"
+require "fileutils"
 
 module Agama
   module AutoYaST
@@ -29,7 +30,14 @@ module Agama
     # This class wraps around an AutoYaST pre-script and redefines
     # some of its methods to adapt it to Agama.
     class PreScript < Y2Autoinstallation::PreScript
-      SCRIPTS_DIR = "/run/agama/scripts"
+      SCRIPTS_DIR = "/run/agama/scripts/autoyast"
+
+      class << self
+        # Clean the existing pre-scripts.
+        def clean_all
+          Dir[File.join(SCRIPTS_DIR, "*")]
+        end
+      end
 
       # Overrides the logs directory.
       def logs_dir

--- a/service/lib/agama/autoyast/pre_script.rb
+++ b/service/lib/agama/autoyast/pre_script.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "autoinstall/script"
+
+module Agama
+  module AutoYaST
+    # Wrapper around an AutoYaST pre-script
+    #
+    # This class wraps around an AutoYaST pre-script and redefines
+    # some of its methods to adapt it to Agama.
+    class PreScript < Y2Autoinstallation::PreScript
+      SCRIPTS_DIR = "/run/agama/scripts"
+
+      # Overrides the logs directory.
+      def logs_dir
+        SCRIPTS_DIR
+      end
+
+      # Overrides the path of the file to write th logs.
+      def log_path
+        File.join(SCRIPTS_DIR, "#{script_name}.log")
+      end
+
+      # Overrides the path to save the script to.
+      def script_path
+        File.join(SCRIPTS_DIR, script_name)
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/profile_fetcher.rb
+++ b/service/lib/agama/autoyast/profile_fetcher.rb
@@ -75,6 +75,7 @@ module Agama
       end
 
       def run_pre_scripts
+        PreScript.clean_all
         pre_scripts = Yast::Profile.current.fetch_as_hash("scripts")
           .fetch_as_array("pre-scripts")
           .map { |h| PreScript.new(h) }

--- a/service/lib/agama/autoyast/profile_fetcher.rb
+++ b/service/lib/agama/autoyast/profile_fetcher.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "agama/autoyast/pre_script"
 
 # :nodoc:
 module Agama
@@ -76,7 +77,7 @@ module Agama
       def run_pre_scripts
         pre_scripts = Yast::Profile.current.fetch_as_hash("scripts")
           .fetch_as_array("pre-scripts")
-          .map { |h| Y2Autoinstallation::PreScript.new(h) }
+          .map { |h| PreScript.new(h) }
         script_runner = Y2Autoinstall::ScriptRunner.new
 
         pre_scripts.each do |script|

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun 18 07:17:23 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Preserve AutoYaST pre-scripts artifacts (bsc#1243776, gh#agama-project/agama#2344).
+
+-------------------------------------------------------------------
 Mon Jun 16 14:26:06 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Initial support for sorting storage devices when searching them

--- a/service/test/agama/autoyast/profile_fetcher_test.rb
+++ b/service/test/agama/autoyast/profile_fetcher_test.rb
@@ -57,6 +57,7 @@ describe Agama::AutoYaST::ProfileFetcher do
 
   before do
     stub_const("Y2Autoinstallation::XmlChecks::ERRORS_PATH", File.join(tmpdir, "errors"))
+    stub_const("Agama::AutoYaST::PreScript::SCRIPTS_DIR", File.join(tmpdir, "scripts"))
     Yast.import "Installation"
     allow(Yast::Installation).to receive(:sourcedir).and_return(File.join(tmpdir, "mount"))
     allow(Yast::AutoinstConfig).to receive(:scripts_dir)


### PR DESCRIPTION
## Problem

When using an AutoYaST profile, the pre-scripts are executed as part of the initial profile validation (`agama config generate`). The problem is that those scripts, and its logs, are missing from the `/run/agama/scripts` directory and hence not copied to the final system.

## Solution

The fix consists on copying those files to `/run/agama/scripts/autoyast`. We are not using the regular `/run/agama/scripts/pre` because they are executed at a different point.

## Testing

- [x] Added a new unit test
- [x] Tested manually