### PR TITLE
Ipmi support for the Agama installer

### DIFF
--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -161,6 +161,9 @@
         <!-- it can be used by users in AutoYaST pre-scripts -->
         <package name="perl-XML-Simple"/>
         <archive name="live-root.tar.xz"/>
+        <!-- IPMI support -->
+        <package name="ipmitool" />
+        <package name="OpenIPMI"/>
     </packages>
 
     <!-- packages for local installation (desktop, browser, etc.) -->

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -163,7 +163,6 @@
         <archive name="live-root.tar.xz"/>
         <!-- IPMI support -->
         <package name="ipmitool" />
-        <package name="OpenIPMI"/>
     </packages>
 
     <!-- packages for local installation (desktop, browser, etc.) -->

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022-2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "agama/config"
+require 'tempfile'
+
+module Agama
+  # Class for very basic IPMI support
+  #
+  # Use for reporting current installer state to IPMI.
+  #
+  # Implemented:
+  #
+  # TBD:
+  # * STARTED
+  # * WAITING (?)
+  # * ABORTED
+  # * FAILED
+  # * FINISHED
+  class Ipmi
+    class << self
+      def setup(logger)
+        @current ||= Ipmi.new(logger)
+      end
+    end
+
+    # @return [Logger]
+    attr_reader :logger
+
+    def initialize(logger)
+      @logger = logger
+
+      logger.info("IPMI is available") if available?
+    end
+
+    def started
+      command(IPMI_STARTED)
+    end
+
+    def finished
+      command(IPMI_FINISHED)
+    end
+
+    def aborted
+      command(IPMI_ABORTED)
+    end
+
+    def failed
+      command(IPMI_FAILED)
+    end
+
+    private:
+
+    IPMI_STARTED = 0x7
+    IPMI_FINISHED = 0x8
+    IPMI_ABORTED = 0x9
+    IPMI_FAILED = 0xA
+
+    def available?
+      # Check whether we have a ipmi device and tool to use it.
+      # ipmi0 is used as a default in ipmitool
+      File.exist?("/dev/ipmi0") && File.exist?("/usr/bin/ipmitool")
+    end
+
+    # Sends an event to IPMI
+    #
+    # Events are 7B long but differs only in the command code
+    def command(code)
+      return if !available?
+      # ipmitool wants to read events from a file, not possible to
+      # pass it directly as an argument
+      file = Tempfile.new("agama-ipmi")
+
+      file.write("0x4 0x1F 0x0 0x6f %#{code} 0x0 0x0\n")
+      file.close
+
+      system("ipmitool event file #{file.path}")
+
+      file.unlink
+    end
+  end
+end

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -21,7 +21,7 @@
 
 require "yast"
 require "agama/config"
-require 'tempfile'
+require "tempfile"
 
 module Agama
   # Class for very basic IPMI support
@@ -29,19 +29,19 @@ module Agama
   # Use for reporting current installer state to IPMI.
   #
   # Implemented:
-  #
-  # TBD:
   # * STARTED
-  # * WAITING (?)
-  # * ABORTED
   # * FAILED
   # * FINISHED
+  # * ABORTED
+  #
+  # TBD:
+  # * WAITING (?)
   class Ipmi
     class << self
       attr_reader :current
 
       def setup(logger)
-        @current ||= Ipmi.new(logger)
+        @current = Ipmi.new(logger)
       end
     end
 
@@ -70,7 +70,7 @@ module Agama
       command(IPMI_FAILED)
     end
 
-    private
+  private
 
     IPMI_STARTED = 0x7
     IPMI_FINISHED = 0x8
@@ -88,6 +88,7 @@ module Agama
     # Events are 7B long but differs only in the command code
     def command(code)
       return if !available?
+
       # ipmitool wants to read events from a file, not possible to
       # pass it directly as an argument
       file = Tempfile.new("agama-ipmi")

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -37,14 +37,6 @@ module Agama
   # TBD:
   # * WAITING (?)
   class Ipmi
-    class << self
-      attr_reader :current
-
-      def setup(logger)
-        @current = Ipmi.new(logger)
-      end
-    end
-
     # @return [Logger]
     attr_reader :logger
 
@@ -83,7 +75,7 @@ module Agama
       File.exist?("/dev/ipmi0") && File.exist?("/usr/bin/ipmitool")
     end
 
-    # Sends an event to IPMI
+    # Sends an event to IPMI when /dev/ipmi0 device is available
     #
     # Events are 7B long but differs only in the command code.
     #

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -85,7 +85,9 @@ module Agama
 
     # Sends an event to IPMI
     #
-    # Events are 7B long but differs only in the command code
+    # Events are 7B long but differs only in the command code.
+    #
+    # @param code [Byte] one byte in hex
     def command(code)
       return if !available?
 

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -51,7 +51,7 @@ module Agama
     def initialize(logger)
       @logger = logger
 
-      logger.info("IPMI is available") if available?
+      logger.info("IPMI available: #{available?}")
     end
 
     def started
@@ -70,7 +70,7 @@ module Agama
       command(IPMI_FAILED)
     end
 
-    private:
+    private
 
     IPMI_STARTED = 0x7
     IPMI_FINISHED = 0x8

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -33,9 +33,6 @@ module Agama
   # * FAILED
   # * FINISHED
   # * ABORTED
-  #
-  # TBD:
-  # * WAITING (?)
   class Ipmi
     # @return [Logger]
     attr_reader :logger

--- a/service/lib/agama/ipmi.rb
+++ b/service/lib/agama/ipmi.rb
@@ -38,6 +38,8 @@ module Agama
   # * FINISHED
   class Ipmi
     class << self
+      attr_reader :current
+
       def setup(logger)
         @current ||= Ipmi.new(logger)
       end

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -72,9 +72,9 @@ module Agama
       @installation_phase = InstallationPhase.new
       @service_status_recorder = ServiceStatusRecorder.new
       @service_status = DBus::ServiceStatus.new.busy
+      @ipmi = Ipmi.new(logger)
 
       on_progress_change { logger.info progress.to_s }
-      Ipmi.setup(logger)
     end
 
     # Runs the startup phase
@@ -117,7 +117,7 @@ module Agama
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def install_phase
       service_status.busy
-      Ipmi.current.started
+      @ipmi.started
 
       installation_phase.install
       start_progress_with_descriptions(
@@ -148,11 +148,11 @@ module Agama
         end
       end
 
-      Ipmi.current.finished
+      @ipmi.finished
 
       logger.info("Install phase done")
     rescue StandardError => e
-      Ipmi.current.failed
+      @ipmi.failed
       logger.error "Installation error: #{e.inspect}. Backtrace: #{e.backtrace}"
     ensure
       service_status.idle

--- a/service/lib/agama/manager.rb
+++ b/service/lib/agama/manager.rb
@@ -116,9 +116,9 @@ module Agama
     # Runs the install phase
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def install_phase
+      service_status.busy
       Ipmi.current.started
 
-      service_status.busy
       installation_phase.install
       start_progress_with_descriptions(
         _("Prepare disks"),

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 23 07:22:22 UTC 2025 - Michal Filka <mfilka@suse.com>
+
+- jsc#PED-12285
+  - initial implementation for installer state status report via
+    IPMI
+
+-------------------------------------------------------------------
 Thu Jun 19 10:21:13 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add missing steps for iSCSI installation


### PR DESCRIPTION
## Problem

https://jira.suse.com/browse/PED-12285
We were requested to signal Agama's status via IPMI

## Solution

Initial implementation for IPMI statuses. Works if ```/dev/ipmi0``` is found in the system.


## Testing

- *Tested manually* (manual installer run together with ipmi emulator)
