### PR TITLE
Disable local installation repositories (bsc#1243064)

### DIFF
--- a/service/lib/agama/software/repositories_manager.rb
+++ b/service/lib/agama/software/repositories_manager.rb
@@ -45,8 +45,13 @@ module Agama
       # Adds a new repository
       #
       # @param url [String] Repository URL
-      def add(url)
-        repositories << Repository.create(name: url, url: url)
+      # @param name [String] Repository name, if not specified the URL is used
+      # @param repo_alias [String] Repository alias, must be unique,
+      #   if not specified a random one is generated
+      # @param autorefresh [Boolean] Whether the repository should be autorefreshed
+      def add(url, name: nil, repo_alias: "", autorefresh: true)
+        repositories << Repository.create(name: name || url, url: url, repo_alias: repo_alias,
+          autorefresh: autorefresh)
       end
 
       # returns user repositories as it was previously specified

--- a/service/lib/agama/software/repository.rb
+++ b/service/lib/agama/software/repository.rb
@@ -31,10 +31,33 @@ module Agama
     #
     # @see RepositoriesManager
     class Repository < Y2Packager::Repository
+      Yast.import "Pkg"
+
       # delay before retrying (in seconds)
       RETRY_DELAY = 5
       # number of automatic retries
       RETRY_COUNT = 1
+
+      class << self
+        # Add a repository
+        # Override the Y2Packager::Repository.create which does not accept the alias option
+        #
+        # @param name        [String]       Name
+        # @param repo_alias  [String]       Unique alias, if missing some ugly name is generated
+        # @param url         [URI::Generic, ZyppUrl] Repository URL
+        # @param product_dir [String]       Product directory
+        # @param enabled     [Boolean]      Is the repository enabled?
+        # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
+        # @return [Y2Packager::Repository,nil] New repository or nil if creation failed
+        def create(name:, url:, repo_alias: "", product_dir: "", enabled: true, autorefresh: true)
+          repo_id = Yast::Pkg.RepositoryAdd(
+            "name" => name, "base_urls" => [url.to_s], "enabled" => enabled,
+            "autorefresh" => autorefresh, "prod_dir" => product_dir, "alias" => repo_alias
+          )
+
+          repo_id ? find(repo_id) : nil
+        end
+      end
 
       # Probes a repository
       #

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 18 12:28:14 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Disable local installation repositories instead of removing them
+  (bsc#1243064)
+
+-------------------------------------------------------------------
 Wed Jun 18 07:17:23 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Preserve AutoYaST pre-scripts artifacts (bsc#1243776, gh#agama-project/agama#2344).

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -461,22 +461,21 @@ describe Agama::Software::Manager do
           [
             Agama::Software::Repository.new(
               repo_id: repo_id, repo_alias: "alias", name: "name",
-              url: "dir:///run/initramfs/live/install", enabled: true, autorefresh: false
+              url: "dvd:/install?devices=/dev/sr0", enabled: true, autorefresh: false
             )
-          ],
-          # for the second and further calls return empty list, the repo has been removed
-          []
-        )
+          ]
+        ).twice
       end
 
-      it "removes the local repository" do
-        expect(Yast::Pkg).to receive(:SourceDelete).with(repo_id)
+      it "disables the local repository" do
+        allow(subject).to receive(:copy_zypp_to_target)
+        expect(Yast::Pkg).to receive(:SourceSetEnabled).with(repo_id, false)
 
         subject.finish
       end
 
-      it "does not copy the libzypp cache" do
-        expect(subject).to_not receive(:copy_zypp_to_target)
+      it "copies the libzypp cache" do
+        expect(subject).to receive(:copy_zypp_to_target)
 
         subject.finish
       end

--- a/service/test/agama/software/repositories_manager_test.rb
+++ b/service/test/agama/software/repositories_manager_test.rb
@@ -55,7 +55,7 @@ describe Agama::Software::RepositoriesManager do
     it "registers the repository in the packaging system" do
       url = "https://example.net"
       expect(Agama::Software::Repository).to receive(:create)
-        .with(name: url, url: url)
+        .with(autorefresh: true, name: url, repo_alias: "", url: url)
         .and_return(repo)
       subject.add(url)
       expect(subject.repositories).to include(repo)


### PR DESCRIPTION
## Problem

- When using a local installation repository (e.g. Full DVD) then this repository is removed from the system
- It should behave like in SLE15 which keeps the installation repository, just disables it. After enabling it manually it can be used for installing additional packages.

## Solution

- Disable local repositories instead of removing them

## Notes

- Because we keep the Full installation repository in the system it should have some meaningful name and alias. And because the packages are fixed the autorefresh should be disabled.
- This required extending the API to allow specifying required data.

## DVD

- For DVDs during installation the device name is included in the URL to ensure the correct repository is used. (In theory there might be multiple DVD drives in the system and the other drive might contain a different version of the product or a completely different product. This ensures libzypp uses the correct drive.
- After installation the device is removed from URL, this allows inserting the installation medium into a different drive without a failure. Libzypp verifies that the correct medium is inserted by checking the `/media.1/media` content with the file saved in the  cache.

## Hard disk or USB flash disk

- For these media it uses the `/dev/disk/by-id` device name. That should be more specific and should avoid problems with using incorrect media. It is important  for USB flash disk for which the device name might change in the installed system. (The installation flash disk might become `/dev/sdc` instead of `/dev/sdb` if you attach some different USB flash disk before it.

## Testing

- Updated unit test
- Tested manually

## Screenshots

- In all cases after enabling the repository manually it was possible to install additional package from the original installation medium.

### Installation from DVD

- When installing from the DVD the repository URL is modified
- Notice the descriptive repository name and alias

![agama-installed-dvd-repos](https://github.com/user-attachments/assets/5d5b5563-cb0f-4d2c-8f6b-d8af0f3cead8)

### Installation from second hard disk

- The installation ISO was dumped to a second disk and the system was booted from it (actually I converted the ISO file to QCOW image format using `qemu-img convert` command and used the QCOW image for the second disk).
- The system was installed on the first disk.

![agama-installed-sata-repos](https://github.com/user-attachments/assets/b115fedf-4061-45bd-9f9a-eddbd27238f2)

### Installation from USB flash disk

- Because VirtualBox cannot boot from USB I used Qemu for testing installation from USB
- To use a virtual flash disk use these additional Qemu parameters: `-drive if=none,id=stick,format=raw,file=full.iso -device nec-usb-xhci,id=xhci -device usb-storage,bus=xhci.0,drive=stick,removable=on -boot menu=on`, at boot press `Esc` and select the second option (the USB disk) in the boot menu.

![agama-installed-usb-repos](https://github.com/user-attachments/assets/a554b612-f139-444d-bdf3-504a3b62e992)
