### PR TITLE
nm/dbus: fix autoconnect of port devices

### DIFF
--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -86,8 +86,6 @@ pub fn connection_to_dbus<'a>(
             .as_deref()
             .unwrap_or(controller.id.as_str());
         connection_dbus.insert("master", master.into());
-        connection_dbus.remove("autoconnect");
-        connection_dbus.insert("autoconnect", false.into());
     } else {
         if VersionReq::parse(">=1.46.0").unwrap().matches(&nm_version) {
             connection_dbus.insert("port-type", "".into());

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul 15 09:00:00 UTC 2025 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
+
+- Fix autoconnect setting for port interfaces (bsc#1246070).
+
+-------------------------------------------------------------------
 Fri Jul 11 06:56:29 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not exported null values for localization, hostname


### PR DESCRIPTION
## Problem

 * A port device should also inherit the `autoconnect` from it's corresponding agama connection, otherwise it happen that the interface isn't added as port to the controller.
 * This happen, because we always (which I think is correct) add/modify the controller connection first (see: [rust/agama-network/src/nm/adapter.rs#L187](https://github.com/cfconrad/agama//blob/9404de422d57da7f61dc1cdf5b7473f0b3d67d6e/rust/agama-network/src/nm/adapter.rs#L187) )
 * Later if we add a port, the `autoconnect-ports=1` isn't triggered anymore.
 * The (from my point of view) faulty behavior was introduced here https://github.com/agama-project/agama/commit/61cffffcee7d8c4bc77e861f306bf818eaae1950

Faulty example (this is how it looks like, if we keep the force of  `autoconnect=false` for the port device):
```bash
$ bridge=br1
$ port=en0
$ nmcli connection add type bridge con-name $bridge ifname $bridge \
      ipv4.method manual ipv4.addresses 192.0.2.1/24  \
      connection.autoconnect 1 connection.autoconnect-ports 1
Connection 'br1' (80038fbc-ed60-41e3-b994-9cbaa9d258a2) successfully added.
$ nmcli connection add type ethernet con-name en0 port-type bridge controller $bridge \
      connection.autoconnect 0
Connection 'en0' (324617a8-70cb-43e7-b121-64306229d3dc) successfully added.
$ brctl show
bridge name     bridge id               STP enabled     interfaces
br1             8000.c6c15414602b       yes
```

Compared to (where brctl show the interface as port):
```
$ bridge=br1
$ port=en0
$ nmcli connection add type bridge con-name $bridge ifname $bridge \
      ipv4.method manual ipv4.addresses 192.0.2.1/24 \
      connection.autoconnect 1 connection.autoconnect-ports 1
Connection 'br1' (e83dbff7-d67e-4d08-b799-cf320f46719e) successfully added.
$ nmcli connection add type ethernet con-name $port ifname $port port-type bridge controller $bridge \
      connection.autoconnect 1
Connection 'en0' (6173b81e-3eb0-41a4-b30c-884ab751d2df) successfully added.
$ brctl show
bridge name     bridge id               STP enabled     interfaces
br1             8000.c6c15414602b       yes             en0
``` 

## Solution

* Do not force `autoconnect=0` for port connections

## Testing

- *Tested manually*
