### PR TITLE
Only required

### DIFF
--- a/doc/dbus/bus/org.opensuse.Agama.Software1.bus.xml
+++ b/doc/dbus/bus/org.opensuse.Agama.Software1.bus.xml
@@ -83,6 +83,7 @@
     </method>
     <property type="a{sy}" name="SelectedPatterns" access="read"/>
     <property type="a(ussa(uss))" name="Conflicts" access="read"/>
+    <property type="u" name="OnlyRequired" access="readwrite"/>
   </interface>
   <interface name="org.opensuse.Agama1.Issues">
     <property type="a(ssuu)" name="All" access="read"/>

--- a/doc/dbus/org.opensuse.Agama.Software1.doc.xml
+++ b/doc/dbus/org.opensuse.Agama.Software1.doc.xml
@@ -126,5 +126,12 @@
     </method>
     <property type="a{sy}" name="SelectedPatterns" access="read"/>
     <property type="a(ussa(uss))" name="Conflicts" access="read"/>
+    <!--
+      flag for only required packages
+      0 not set
+      1 false
+      2 true
+    -->
+    <property type="u" name="OnlyRequired" access="readwrite"/>
   </interface>
 </node>

--- a/rust/agama-lib/share/examples/only_required.json
+++ b/rust/agama-lib/share/examples/only_required.json
@@ -1,0 +1,15 @@
+{
+  "software": {
+    "patterns": ["gnome"],
+    "packages": ["helix"],
+    "onlyRequired": true
+  },
+  "product": {
+    "id": "Tumbleweed"
+  },
+  "user": {
+    "fullName": "Monsignore Tux",
+    "password": "linux",
+    "userName": "tux"
+  }
+}

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -182,6 +182,10 @@
             "examples": ["vim"]
           }
         },
+        "onlyRequired": {
+          "title": "Flag if only minimal hard dependecies should be used in solver",
+          "type": "boolean"
+        },
         "extraRepositories": {
           "title": "List of user specified repositories that will be used on top of default ones",
           "type": "array",

--- a/rust/agama-lib/src/product/http_client.rs
+++ b/rust/agama-lib/src/product/http_client.rs
@@ -70,6 +70,7 @@ impl ProductHTTPClient {
             patterns: None,
             packages: None,
             extra_repositories: None,
+            only_required: None,
         };
         self.set_software(&config).await
     }

--- a/rust/agama-lib/src/software/client.rs
+++ b/rust/agama-lib/src/software/client.rs
@@ -338,4 +338,25 @@ impl<'a> SoftwareClient<'a> {
             .await?;
         Ok(packages)
     }
+
+    /// Sets onlyRequired flag for proposal.
+    ///
+    /// * `value`: if flag is enabled or not.
+    pub async fn set_only_required(&self, value: bool) -> Result<(), ServiceError> {
+        let dbus_value = if value { 2 } else { 1 };
+        self.software_proxy.set_only_required(dbus_value).await?;
+        Ok(())
+    }
+
+    /// Gets onlyRequired flag for proposal.
+    pub async fn get_only_required(&self) -> Result<Option<bool>, ServiceError> {
+        let dbus_value = self.software_proxy.only_required().await?;
+        let res = match dbus_value {
+            0 => None,
+            1 => Some(false),
+            2 => Some(true),
+            _ => None, // should not happen
+        };
+        Ok(res)
+    }
 }

--- a/rust/agama-lib/src/software/http_client.rs
+++ b/rust/agama-lib/src/software/http_client.rs
@@ -83,6 +83,7 @@ impl SoftwareHTTPClient {
             patterns: Some(patterns),
             packages: None,
             extra_repositories: None,
+            only_required: None,
         };
         self.set_config(&config).await
     }

--- a/rust/agama-lib/src/software/model/packages.rs
+++ b/rust/agama-lib/src/software/model/packages.rs
@@ -33,6 +33,8 @@ pub struct SoftwareConfig {
     pub product: Option<String>,
     /// Extra repositories defined by user.
     pub extra_repositories: Option<Vec<RepositoryParams>>,
+    /// Flag if solver should use only hard dependencies.
+    pub only_required: Option<bool>,
 }
 
 /// Software resolvable type (package or pattern).

--- a/rust/agama-lib/src/software/proxies/software.rs
+++ b/rust/agama-lib/src/software/proxies/software.rs
@@ -123,6 +123,12 @@ pub trait Software1 {
     #[allow(clippy::type_complexity)]
     fn conflicts(&self) -> zbus::Result<Vec<(u32, String, String, Vec<(u32, String, String)>)>>;
 
+    /// OnlyRequired property
+    #[zbus(property)]
+    fn only_required(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn set_only_required(&self, value: u32) -> zbus::Result<()>;
+
     /// SelectedPatterns property
     #[zbus(property)]
     fn selected_patterns(&self) -> zbus::Result<std::collections::HashMap<String, u8>>;

--- a/rust/agama-lib/src/software/settings.rs
+++ b/rust/agama-lib/src/software/settings.rs
@@ -37,11 +37,18 @@ pub struct SoftwareSettings {
     /// List of user specified repositories to use on top of default ones.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_repositories: Option<Vec<RepositoryParams>>,
+    /// List of user specified repositories to use on top of default ones.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub only_required: Option<bool>,
 }
 
 impl SoftwareSettings {
     pub fn to_option(self) -> Option<Self> {
-        if self.patterns.is_none() && self.packages.is_none() && self.extra_repositories.is_none() {
+        if self.patterns.is_none()
+            && self.packages.is_none()
+            && self.extra_repositories.is_none()
+            && self.only_required.is_none()
+        {
             None
         } else {
             Some(self)

--- a/rust/agama-lib/src/software/store.rs
+++ b/rust/agama-lib/src/software/store.rs
@@ -58,6 +58,7 @@ impl SoftwareStore {
             },
             packages: config.packages,
             extra_repositories: config.extra_repositories,
+            only_required: config.only_required,
         })
     }
 
@@ -73,6 +74,7 @@ impl SoftwareStore {
             patterns,
             packages: settings.packages.clone(),
             extra_repositories: settings.extra_repositories.clone(),
+            only_required: settings.only_required,
         };
         self.software_client.set_config(&config).await?;
 
@@ -120,6 +122,7 @@ mod test {
             patterns: Some(vec!["xfce".to_owned()]),
             packages: Some(vec!["vim".to_owned()]),
             extra_repositories: None,
+            only_required: None,
         };
         // main assertion
         assert_eq!(settings, expected);
@@ -147,6 +150,7 @@ mod test {
             patterns: Some(vec!["xfce".to_owned()]),
             packages: Some(vec!["vim".to_owned()]),
             extra_repositories: None,
+            only_required: None,
         };
 
         let result = store.store(&settings).await;
@@ -177,6 +181,7 @@ mod test {
             patterns: Some(vec!["no_such_pattern".to_owned()]),
             packages: Some(vec!["vim".to_owned()]),
             extra_repositories: None,
+            only_required: None,
         };
 
         let result = store.store(&settings).await;

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -603,6 +603,11 @@ async fn set_config(
     State(state): State<SoftwareState<'_>>,
     Json(config): Json<SoftwareConfig>,
 ) -> Result<(), Error> {
+    // first set only require flag to ensure that it is used for later computing of solver
+    if let Some(only_required) = config.only_required {
+        state.software.set_only_required(only_required).await?;
+    }
+
     if let Some(product) = config.product {
         state.product.select_product(&product).await?;
     }
@@ -682,6 +687,7 @@ async fn read_config(state: &SoftwareState<'_>) -> Result<SoftwareConfig, Error>
         packages: Some(packages),
         product,
         extra_repositories: if repos.is_empty() { None } else { Some(repos) },
+        only_required: state.software.get_only_required().await?,
     })
 }
 

--- a/service/lib/agama/dbus/software/manager.rb
+++ b/service/lib/agama/dbus/software/manager.rb
@@ -70,6 +70,11 @@ module Agama
         private_constant :SOFTWARE_INTERFACE
 
         dbus_interface SOFTWARE_INTERFACE do
+          # Flag for proposing required only dependencies
+          # Do not forget to call Propose method after changing flag
+          # value mapping 0 for not set, 1 for false and 2 for true
+          dbus_accessor :only_required, "u"
+
           # array of repository properties: pkg-bindings ID, alias, name, URL, product dir, enabled
           # and loaded flag
           dbus_method :ListRepositories, "out Result:a(issssbb)" do
@@ -182,6 +187,30 @@ module Agama
           busy_while do
             backend.locale = locale
           end
+        end
+
+        def only_required
+          case backend.proposal.only_required
+          when nil then 0
+          when false then 1
+          when true then 2
+          else
+            @logger.warn(
+              "Unexpected value in only_required #{backend.proposal.only_required.inspect}"
+            )
+            0
+          end
+        end
+
+        def only_required=(flag)
+          value = case flag
+          when 0 then nil
+          when 1 then false
+          when 2 then true
+          else
+            @logger.warn "Unexpected value in only_required #{flag.inspect}"
+          end
+          backend.proposal.only_required = value
         end
 
         def ssl_fingerprints

--- a/service/lib/agama/software/proposal.rb
+++ b/service/lib/agama/software/proposal.rb
@@ -65,6 +65,10 @@ module Agama
       # @return [Array<Hash<string, Object>>>] List of conflicts from the last solver run
       attr_reader :conflicts
 
+      # @return [boolean, nil] flag to indicate that solver should add only required packages
+      #   and not recommended. Nil means not set
+      attr_accessor :only_required
+
       # Constructor
       #
       # @param logger [Logger]
@@ -76,6 +80,7 @@ module Agama
         @addon_products = []
         @conflicts = []
         @conflicts_change_callbacks = []
+        @only_required = false
       end
 
       # Adds the given list of resolvables to the proposal
@@ -195,7 +200,8 @@ module Agama
         Yast::Pkg.SetPackageLocale(preferred || "")
         Yast::Pkg.SetAdditionalLocales(additional)
 
-        Yast::Pkg.SetSolverFlags("ignoreAlreadyRecommended" => false, "onlyRequires" => false)
+        Yast::Pkg.SetSolverFlags("ignoreAlreadyRecommended" => false,
+          "onlyRequires" => @only_required)
       end
 
       # Selects the base product


### PR DESCRIPTION
## Problem

Agama is missing option to specify that only mandatory dependencies should be installed.

- trello: https://trello.com/c/czY7e3c0/4898-3-agm-154-rc2-gehc-would-like-to-choose-not-to-install-recommended-packages-auto
- jira: https://jira.suse.com/browse/AGM-154


## Solution

Implement support for unattended installation to specify if only required dependencies should be used.


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

## Documentation

*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
*other times they need advertisement and explanation.*

*Look for relevant sections and adjust:*
- The description parts of the [JSON schema][profile.schema.json]
- Is the CLI affected? See [cli.md][] for a complete overview,
  change the `///` comments (rust doc)
  and update the .md with `cargo xtask markdown`
- <https://agama-project.github.io/> ([source][gh.io])
- Run: `git ls-files '*.md'`

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md
[profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
[gh.io]: https://github.com/agama-project/agama-project.github.io/
