### PR TITLE
Add hyper-v package only on x86_64 and aarch64

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Jun 19 09:06:50 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
-- Add hyper-v on x86_64 only (related to bsc#1236961).
+- Add hyper-v on x86_64 and aarch64 only (related to bsc#1236961).
 
 -------------------------------------------------------------------
 Wed Jun 18 11:29:08 UTC 2025 - David Diaz <dgonzalez@suse.com>

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -108,7 +108,7 @@
         <package name="systemd"/>
         <package name="procps"/>
         <package name="iputils"/>
-        <package name="hyper-v" arch="x86_64"/>
+        <package name="hyper-v" arch="aarch64,x86_64"/>
         <package name="vim"/>
         <package name="vim-data"/>
         <package name="grub2"/>


### PR DESCRIPTION
## Problem

The package is not available for s390x and ppc64le archs (it was added by #2487)

## Solution

Add the package only on x86_64 and aarch64.
