### PR TITLE
fix(web): use exact size for partition

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 27 11:23:29 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Improve usability for defining the size of a partition or logical
+  volume (gh#agama-project/agama#2496).
+
+-------------------------------------------------------------------
 Fri Jun 27 06:30:11 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Warn the user when using a weak user password (bsc#1237480).

--- a/web/src/components/storage/AutoSizeText.tsx
+++ b/web/src/components/storage/AutoSizeText.tsx
@@ -164,7 +164,7 @@ function AutoSizeTextDynamic({
         return sprintf(
           // TRANSLATORS: %1$s is a mount point (eg. /) and %2$s is another one (eg. /home)
           _(
-            "The size range for %1$s will be dynamically adjusted based on the amount of RAM in the system, the usage of Btrfs snapshots and the presence of a separate file system for %2$s.",
+            "The size for %1$s will be dynamically adjusted based on the amount of RAM in the system, the usage of Btrfs snapshots and the presence of a separate file system for %2$s.",
           ),
           path,
           otherPaths[0],
@@ -175,7 +175,7 @@ function AutoSizeTextDynamic({
         // TRANSLATORS: %1$s is a mount point and %2$s is a list of other paths
         return sprintf(
           _(
-            "The size range for %1$s will be dynamically adjusted based on the amount of RAM in the system, the usage of Btrfs snapshots and the presence of separate file systems for %2$s.",
+            "The size for %1$s will be dynamically adjusted based on the amount of RAM in the system, the usage of Btrfs snapshots and the presence of separate file systems for %2$s.",
           ),
           path,
           formatList(otherPaths),
@@ -185,7 +185,7 @@ function AutoSizeTextDynamic({
       return sprintf(
         // TRANSLATORS: %s is a mount point (eg. /)
         _(
-          "The size range for %s will be dynamically adjusted based on the amount of RAM in the system and the usage of Btrfs snapshots.",
+          "The size for %s will be dynamically adjusted based on the amount of RAM in the system and the usage of Btrfs snapshots.",
         ),
         path,
       );
@@ -196,7 +196,7 @@ function AutoSizeTextDynamic({
         return sprintf(
           // TRANSLATORS: %1$s is a mount point (eg. /) and %2$s is another one (eg. /home)
           _(
-            "The size range for %1$s will be dynamically adjusted based on the amount of RAM in the system and the presence of a separate file system for %2$s.",
+            "The size for %1$s will be dynamically adjusted based on the amount of RAM in the system and the presence of a separate file system for %2$s.",
           ),
           path,
           otherPaths[0],
@@ -206,7 +206,7 @@ function AutoSizeTextDynamic({
       return sprintf(
         // TRANSLATORS: %1$s is a mount point and %2$s is a list of other paths
         _(
-          "The size range for %1$s will be dynamically adjusted based on the amount of RAM in the system and the presence of separate file systems for %2$s.",
+          "The size for %1$s will be dynamically adjusted based on the amount of RAM in the system and the presence of separate file systems for %2$s.",
         ),
         path,
         formatList(otherPaths),
@@ -218,7 +218,7 @@ function AutoSizeTextDynamic({
         return sprintf(
           // TRANSLATORS: %1$s is a mount point (eg. /) and %2$s is another one (eg. /home)
           _(
-            "The size range for %1$s will be dynamically adjusted based on the usage of Btrfs snapshots and the presence of a separate file system for %2$s.",
+            "The size for %1$s will be dynamically adjusted based on the usage of Btrfs snapshots and the presence of a separate file system for %2$s.",
           ),
           path,
           otherPaths[0],
@@ -229,7 +229,7 @@ function AutoSizeTextDynamic({
         // TRANSLATORS: %1$s is a mount point and %2$s is a list of other paths
         return sprintf(
           _(
-            "The size range for %1$s will be dynamically adjusted based on the usage of Btrfs snapshots and the presence of separate file systems for %2$s.",
+            "The size for %1$s will be dynamically adjusted based on the usage of Btrfs snapshots and the presence of separate file systems for %2$s.",
           ),
           path,
           formatList(otherPaths),
@@ -238,9 +238,7 @@ function AutoSizeTextDynamic({
 
       return sprintf(
         // TRANSLATORS: %s is a mount point (eg. /)
-        _(
-          "The size range for %s will be dynamically adjusted based on the usage of Btrfs snapshots.",
-        ),
+        _("The size for %s will be dynamically adjusted based on the usage of Btrfs snapshots."),
         path,
       );
     }
@@ -249,7 +247,7 @@ function AutoSizeTextDynamic({
       return sprintf(
         // TRANSLATORS: %1$s is a mount point (eg. /) and %2$s is another one (eg. /home)
         _(
-          "The size range for %1$s will be dynamically adjusted based on the presence of a separate file system for %2$s.",
+          "The size for %1$s will be dynamically adjusted based on the presence of a separate file system for %2$s.",
         ),
         path,
         otherPaths[0],
@@ -259,7 +257,7 @@ function AutoSizeTextDynamic({
     return sprintf(
       // TRANSLATORS: %1$s is a mount point and %2$s is a list of other paths
       _(
-        "The size range for %1$s will be dynamically adjusted based on the presence of separate file systems for %2$s.",
+        "The size for %1$s will be dynamically adjusted based on the presence of separate file systems for %2$s.",
       ),
       path,
       formatList(otherPaths),

--- a/web/src/components/storage/LogicalVolumePage.tsx
+++ b/web/src/components/storage/LogicalVolumePage.tsx
@@ -42,12 +42,11 @@ import {
   SelectList,
   SelectOption,
   SelectOptionProps,
-  Split,
   Stack,
   StackItem,
   TextInput,
 } from "@patternfly/react-core";
-import { NestedContent, Page, SelectWrapper as Select, SubtleContent } from "~/components/core/";
+import { Page, SelectWrapper as Select, SubtleContent } from "~/components/core/";
 import { SelectWrapperProps as SelectProps } from "~/components/core/SelectWrapper";
 import SelectTypeaheadCreatable from "~/components/core/SelectTypeaheadCreatable";
 import AutoSizeText from "~/components/storage/AutoSizeText";
@@ -66,12 +65,12 @@ import { unique } from "radashi";
 import { compact } from "~/utils";
 import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
+import SizeModeSelect, { SizeMode, SizeRange } from "~/components/storage/SizeModeSelect";
 
 const NO_VALUE = "";
 const BTRFS_SNAPSHOTS = "btrfsSnapshots";
 
-type SizeOptionValue = "" | "auto" | "custom";
-type CustomSizeValue = "fixed" | "unlimited" | "range";
+type SizeOptionValue = "" | SizeMode;
 type FormValue = {
   mountPoint: string;
   name: string;
@@ -80,10 +79,6 @@ type FormValue = {
   sizeOption: SizeOptionValue;
   minSize: string;
   maxSize: string;
-};
-type SizeRange = {
-  min: string;
-  max: string;
 };
 type Error = {
   id: string;
@@ -162,7 +157,8 @@ function toFormValue(logicalVolume: apiModel.LogicalVolume): FormValue {
     return "custom";
   };
 
-  const size = (value: number | undefined): string => (value ? deviceSize(value) : NO_VALUE);
+  const size = (value: number | undefined): string =>
+    value ? deviceSize(value, { exact: true }) : NO_VALUE;
 
   return {
     mountPoint: mountPoint(),
@@ -555,48 +551,6 @@ function FilesystemLabel({ id, value, onChange }: FilesystemLabelProps): React.R
   );
 }
 
-type SizeOptionLabelProps = {
-  value: SizeOptionValue;
-  mountPoint: string;
-};
-
-function SizeOptionLabel({ value, mountPoint }: SizeOptionLabelProps): React.ReactNode {
-  if (mountPoint === NO_VALUE) return _("Waiting for a mount point");
-  if (value === "auto") return _("Calculated automatically");
-  if (value === "custom") return _("Custom");
-
-  return value;
-}
-
-type SizeOptionsProps = {
-  mountPoint: string;
-};
-
-function SizeOptions({ mountPoint }: SizeOptionsProps): React.ReactNode {
-  return (
-    <SelectList aria-label={_("Size options")}>
-      {mountPoint === NO_VALUE && (
-        <SelectOption value={NO_VALUE}>
-          <SizeOptionLabel value={NO_VALUE} mountPoint={mountPoint} />
-        </SelectOption>
-      )}
-      {mountPoint !== NO_VALUE && (
-        <>
-          <SelectOption
-            value="auto"
-            description={_("Let the installer propose a sensible range of sizes")}
-          >
-            <SizeOptionLabel value="auto" mountPoint={mountPoint} />
-          </SelectOption>
-          <SelectOption value="custom" description={_("Define a custom size or a range")}>
-            <SizeOptionLabel value="custom" mountPoint={mountPoint} />
-          </SelectOption>
-        </>
-      )}
-    </SelectList>
-  );
-}
-
 type AutoSizeInfoProps = {
   value: FormValue;
 };
@@ -612,146 +566,6 @@ function AutoSizeInfo({ value }: AutoSizeInfoProps): React.ReactNode {
     <SubtleContent>
       <AutoSizeText volume={volume} size={size} deviceType="logicalVolume" />
     </SubtleContent>
-  );
-}
-
-type CustomSizeOptionLabelProps = {
-  value: CustomSizeValue;
-};
-
-function CustomSizeOptionLabel({ value }: CustomSizeOptionLabelProps): React.ReactNode {
-  const labels = {
-    fixed: _("Same as minimum"),
-    unlimited: _("None"),
-    range: _("Limited"),
-  };
-
-  return labels[value];
-}
-
-function CustomSizeOptions(): React.ReactNode {
-  return (
-    <SelectList aria-label={_("Maximum size options")}>
-      <SelectOption
-        value="fixed"
-        description={_("The logical volume is created exactly with the given size")}
-      >
-        <CustomSizeOptionLabel value="fixed" />
-      </SelectOption>
-      <SelectOption
-        value="range"
-        description={_("The logical volume can grow until a given limit size")}
-      >
-        <CustomSizeOptionLabel value="range" />
-      </SelectOption>
-      <SelectOption
-        value="unlimited"
-        description={_("The logical volume can grow to use all the contiguous free space")}
-      >
-        <CustomSizeOptionLabel value="unlimited" />
-      </SelectOption>
-    </SelectList>
-  );
-}
-
-type CustomSizeProps = {
-  value: FormValue;
-  onChange: (size: SizeRange) => void;
-};
-
-function CustomSize({ value, onChange }: CustomSizeProps) {
-  const initialOption = (): CustomSizeValue => {
-    if (value.minSize === NO_VALUE) return "fixed";
-    if (value.minSize === value.maxSize) return "fixed";
-    if (value.maxSize === NO_VALUE) return "unlimited";
-    return "range";
-  };
-
-  const [option, setOption] = React.useState<CustomSizeValue>(initialOption());
-  const { max: solvedMaxSize } = useSolvedSizes(value);
-  const { getVisibleError } = useErrors(value);
-
-  const error = getVisibleError("customSize");
-
-  const changeMinSize = (min: string) => {
-    const max = option === "fixed" ? min : value.maxSize;
-    onChange({ min, max });
-  };
-
-  const changeMaxSize = (max: string) => {
-    onChange({ min: value.minSize, max });
-  };
-
-  const changeOption = (v: CustomSizeValue) => {
-    setOption(v);
-
-    const min = value.minSize;
-    if (v === "fixed") onChange({ min, max: min });
-    if (v === "unlimited") onChange({ min, max: NO_VALUE });
-    if (v === "range") {
-      const max = solvedMaxSize || NO_VALUE;
-      onChange({ min, max });
-    }
-  };
-
-  return (
-    <Stack hasGutter>
-      <Stack>
-        <SubtleContent>
-          {_("Sizes must be entered as a numbers optionally followed by a unit.")}
-        </SubtleContent>
-        <SubtleContent>
-          {_(
-            "If the unit is omitted, bytes (B) will be used. Greater units can be of \
-              the form GiB (power of 2) or GB (power of 10).",
-          )}
-        </SubtleContent>
-      </Stack>
-      <FormGroup>
-        <Flex>
-          <FlexItem>
-            <FormGroup fieldId="minSizeValue" label={_("Minimum")}>
-              <TextInput
-                id="minSizeValue"
-                className="w-14ch"
-                value={value.minSize}
-                aria-label={_("Minimum size value")}
-                onChange={(_, v) => changeMinSize(v)}
-              />
-            </FormGroup>
-          </FlexItem>
-          <FlexItem>
-            <FormGroup fieldId="maxSize" label={_("Maximum")}>
-              <Split hasGutter>
-                <Select
-                  id="maxSize"
-                  value={option}
-                  label={<CustomSizeOptionLabel value={option} />}
-                  onChange={changeOption}
-                  toggleName={_("Maximum size mode")}
-                >
-                  <CustomSizeOptions />
-                </Select>
-                {option === "range" && (
-                  <TextInput
-                    id="maxSizeValue"
-                    className="w-14ch"
-                    value={value.maxSize}
-                    aria-label={_("Maximum size value")}
-                    onChange={(_, v) => changeMaxSize(v)}
-                  />
-                )}
-              </Split>
-            </FormGroup>
-          </FlexItem>
-        </Flex>
-        <FormHelperText>
-          <HelperText>
-            {error && <HelperTextItem variant="error">{error.message}</HelperTextItem>}
-          </HelperText>
-        </FormHelperText>
-      </FormGroup>
-    </Stack>
   );
 }
 
@@ -834,9 +648,10 @@ export default function LogicalVolumePage() {
     setFilesystem(value);
   };
 
-  const changeSize = ({ min, max }) => {
-    if (min !== undefined) setMinSize(min);
-    if (max !== undefined) setMaxSize(max);
+  const changeSizeMode = (mode: SizeMode, size: SizeRange) => {
+    setSizeOption(mode);
+    if (size.min !== undefined) setMinSize(size.min);
+    if (size.max !== undefined) setMaxSize(size.max);
   };
 
   const onSubmit = () => {
@@ -852,6 +667,8 @@ export default function LogicalVolumePage() {
   const mountPointError = getVisibleError("mountPoint");
   const usedMountPt = mountPointError ? NO_VALUE : mountPoint;
   const showLabel = filesystem !== NO_VALUE && usedMountPt !== NO_VALUE;
+  const sizeMode: SizeMode = sizeOption === "" ? "auto" : sizeOption;
+  const sizeRange: SizeRange = { min: minSize, max: maxSize };
 
   return (
     <Page id="logicalVolumePage">
@@ -930,27 +747,27 @@ export default function LogicalVolumePage() {
                 </Flex>
               </FormGroup>
             </StackItem>
-            <FormGroup fieldId="size" label={_("Size")}>
-              <Flex
-                direction={{ default: "column" }}
-                alignItems={{ default: "alignItemsFlexStart" }}
-                gap={{ default: "gapMd" }}
-              >
-                <Select
-                  id="size"
-                  value={sizeOption}
-                  label={<SizeOptionLabel value={sizeOption} mountPoint={usedMountPt} />}
-                  onChange={(v: SizeOptionValue) => setSizeOption(v)}
-                  isDisabled={usedMountPt === NO_VALUE}
-                >
-                  <SizeOptions mountPoint={usedMountPt} />
-                </Select>
-                <NestedContent margin="mxMd" aria-live="polite">
-                  {sizeOption === "auto" && <AutoSizeInfo value={value} />}
-                  {sizeOption === "custom" && <CustomSize value={value} onChange={changeSize} />}
-                </NestedContent>
-              </Flex>
-            </FormGroup>
+            <StackItem>
+              <FormGroup fieldId="sizeMode" label={_("Size mode")}>
+                {usedMountPt === NO_VALUE && (
+                  <Select
+                    id="sizeMode"
+                    value={NO_VALUE}
+                    label={_("Waiting for a mount point")}
+                    isDisabled
+                  />
+                )}
+                {usedMountPt !== NO_VALUE && (
+                  <SizeModeSelect
+                    id="sizeMode"
+                    value={sizeMode}
+                    size={sizeRange}
+                    onChange={changeSizeMode}
+                    automaticHelp={<AutoSizeInfo value={value} />}
+                  />
+                )}
+              </FormGroup>
+            </StackItem>
             <ActionGroup>
               <Page.Submit isDisabled={!isFormValid} form="logicalVolumeForm" />
               <Page.Cancel />

--- a/web/src/components/storage/PartitionPage.test.tsx
+++ b/web/src/components/storage/PartitionPage.test.tsx
@@ -189,16 +189,17 @@ describe("PartitionPage", () => {
     const mountPoint = screen.getByRole("button", { name: "Mount point toggle" });
     const mountPointMode = screen.getByRole("button", { name: "Mount point mode" });
     const filesystem = screen.getByRole("button", { name: "File system" });
-    const size = screen.getByRole("button", { name: "Size" });
+    const waitingSize = screen.getByRole("button", { name: "Size mode" });
     // File system and size fields disabled until valid mount point selected
     expect(filesystem).toBeDisabled();
     expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
-    expect(size).toBeDisabled();
+    expect(waitingSize).toBeDisabled();
 
     await user.click(mountPoint);
     const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
     const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
     await user.click(homeMountPoint);
+    const size = screen.getByRole("button", { name: "Size mode" });
     // Valid mount point selected, enable file system and size fields
     expect(filesystem).toBeEnabled();
     expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
@@ -209,21 +210,14 @@ describe("PartitionPage", () => {
     // Display available file systems
     await user.click(filesystem);
     screen.getByRole("listbox", { name: "Available file systems" });
-    // Display available size options
+    // Display size modes
     await user.click(size);
-    const sizeOptions = screen.getByRole("listbox", { name: "Size options" });
+    const sizeModes = screen.getByRole("listbox", { name: "Size modes" });
     // Display custom size
-    const customSize = within(sizeOptions).getByRole("option", { name: /Custom/ });
+    const customSize = within(sizeModes).getByRole("option", { name: /Custom/ });
     await user.click(customSize);
-    screen.getByRole("textbox", { name: "Minimum size value" });
-    const maxSizeModeToggle = screen.getByRole("button", { name: "Maximum size mode" });
-    // Do not display input for a maximum size value by default
-    expect(screen.queryByRole("textbox", { name: "Maximum size value" })).toBeNull();
-    await user.click(maxSizeModeToggle);
-    const maxSizeOptions = screen.getByRole("listbox", { name: "Maximum size options" });
-    const limitedMaxSizeOption = within(maxSizeOptions).getByRole("option", { name: /Limited/ });
-    await user.click(limitedMaxSizeOption);
-    screen.getByRole("textbox", { name: "Maximum size value" });
+    screen.getByRole("textbox", { name: "Size" });
+    screen.getByRole("checkbox", { name: "Allow growing" });
   });
 
   it("allows reseting the chosen mount point", async () => {
@@ -231,7 +225,7 @@ describe("PartitionPage", () => {
     // Note that the underline PF component gives the role combobox to the input
     const mountPoint = screen.getByRole("combobox", { name: "Mount point" });
     const filesystem = screen.getByRole("button", { name: "File system" });
-    const size = screen.getByRole("button", { name: "Size" });
+    let size = screen.getByRole("button", { name: "Size mode" });
     expect(mountPoint).toHaveValue("");
     // File system and size fields disabled until valid mount point selected
     expect(filesystem).toBeDisabled();
@@ -244,6 +238,7 @@ describe("PartitionPage", () => {
     expect(mountPoint).toHaveValue("/home");
     expect(filesystem).toBeEnabled();
     expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    size = screen.getByRole("button", { name: "Size mode" });
     expect(size).toBeEnabled();
     const clearMountPointButton = screen.getByRole("button", {
       name: "Clear selected mount point",
@@ -253,6 +248,7 @@ describe("PartitionPage", () => {
     // File system and size fields disabled until valid mount point selected
     expect(filesystem).toBeDisabled();
     expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+    size = screen.getByRole("button", { name: "Size mode" });
     expect(size).toBeDisabled();
   });
 
@@ -260,37 +256,27 @@ describe("PartitionPage", () => {
     const { user } = installerRender(<PartitionPage />);
     screen.getByRole("form", { name: "Configure partition at /dev/sda" });
     const mountPoint = screen.getByRole("button", { name: "Mount point toggle" });
-    const size = screen.getByRole("button", { name: "Size" });
     const acceptButton = screen.getByRole("button", { name: "Accept" });
 
     await user.click(mountPoint);
     const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
     const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
     await user.click(homeMountPoint);
-    // Display available size options
-    await user.click(size);
-    const sizeOptions = screen.getByRole("listbox", { name: "Size options" });
-    // Display custom size
-    const customSize = within(sizeOptions).getByRole("option", { name: /Custom/ });
-    await user.click(customSize);
-    const minSizeInput = screen.getByRole("textbox", { name: "Minimum size value" });
-    const maxSizeModeToggle = screen.getByRole("button", { name: "Maximum size mode" });
-    await user.click(maxSizeModeToggle);
-    const maxSizeOptions = screen.getByRole("listbox", { name: "Maximum size options" });
-    const limitedMaxSizeOption = within(maxSizeOptions).getByRole("option", { name: /Limited/ });
-    await user.click(limitedMaxSizeOption);
-    const maxSizeInput = screen.getByRole("textbox", { name: "Maximum size value" });
+    expect(acceptButton).toBeEnabled();
 
-    await user.clear(minSizeInput);
-    await user.type(minSizeInput, "1");
-    screen.getByText(/The minimum must be.*followed by a unit/);
-    await user.clear(maxSizeInput);
-    await user.type(maxSizeInput, "3");
-    screen.getByText(/Size limits must be.*followed by a unit/);
-    await user.type(minSizeInput, " GiB");
-    await user.type(maxSizeInput, " TiB");
-    expect(screen.queryByText(/The minimum must be.*followed by a unit/)).toBeNull();
-    expect(screen.queryByText(/Size limits must be.*followed by a unit/)).toBeNull();
+    // Display size modes
+    const sizeMode = screen.getByRole("button", { name: "Size mode" });
+    await user.click(sizeMode);
+    const sizeModes = screen.getByRole("listbox", { name: "Size modes" });
+    // Display custom size
+    const customSize = within(sizeModes).getByRole("option", { name: /Custom/ });
+    await user.click(customSize);
+    const size = screen.getByRole("textbox", { name: "Size" });
+
+    await user.clear(size);
+    await user.type(size, "1");
+    expect(acceptButton).toBeDisabled();
+    await user.type(size, " GiB");
     expect(acceptButton).toBeEnabled();
   });
 
@@ -302,7 +288,7 @@ describe("PartitionPage", () => {
         size: {
           default: false,
           min: gib(5),
-          max: gib(15),
+          max: gib(5),
         },
         filesystem: {
           default: false,
@@ -322,14 +308,63 @@ describe("PartitionPage", () => {
       within(filesystemButton).getByText("XFS");
       const label = screen.getByRole("textbox", { name: "File system label" });
       expect(label).toHaveValue("HOME");
-      const sizeOptionButton = screen.getByRole("button", { name: "Size" });
-      within(sizeOptionButton).getByText("Custom");
-      const minSizeInput = screen.getByRole("textbox", { name: "Minimum size value" });
-      expect(minSizeInput).toHaveValue("5 GiB");
-      const maximumButton = screen.getByRole("button", { name: "Maximum size mode" });
-      within(maximumButton).getByText("Limited");
-      const maxSizeInput = screen.getByRole("textbox", { name: "Maximum size value" });
-      expect(maxSizeInput).toHaveValue("15 GiB");
+      const sizeModeButton = screen.getByRole("button", { name: "Size mode" });
+      within(sizeModeButton).getByText("Custom");
+      const sizeInput = screen.getByRole("textbox", { name: "Size" });
+      expect(sizeInput).toHaveValue("5 GiB");
+      const growCheck = screen.getByRole("checkbox", { name: "Allow growing" });
+      expect(growCheck).not.toBeChecked();
+    });
+
+    describe("if the max size is unlimited", () => {
+      beforeEach(() => {
+        mockParams({ list: "drives", listIndex: "0", partitionId: "/home" });
+        mockGetPartition.mockReturnValue({
+          mountPath: "/home",
+          size: {
+            default: false,
+            min: gib(5),
+          },
+          filesystem: {
+            default: false,
+            type: "xfs",
+          },
+        });
+      });
+
+      it("checks allow growing", async () => {
+        installerRender(<PartitionPage />);
+        const growCheck = screen.getByRole("checkbox", { name: "Allow growing" });
+        expect(growCheck).toBeChecked();
+      });
+    });
+
+    describe("if the max size has a value", () => {
+      beforeEach(() => {
+        mockParams({ list: "drives", listIndex: "0", partitionId: "/home" });
+        mockGetPartition.mockReturnValue({
+          mountPath: "/home",
+          size: {
+            default: false,
+            min: gib(5),
+            max: gib(10),
+          },
+          filesystem: {
+            default: false,
+            type: "xfs",
+          },
+        });
+      });
+
+      it("allows switching to a fixed size", async () => {
+        const { user } = installerRender(<PartitionPage />);
+        const switchButton = screen.getByRole("button", { name: /use a supported size\?/ });
+        await user.click(switchButton);
+        const sizeInput = screen.getByRole("textbox", { name: "Size" });
+        expect(sizeInput).toHaveValue("5 GiB");
+        const growCheck = screen.getByRole("checkbox", { name: "Allow growing" });
+        expect(growCheck).not.toBeChecked();
+      });
     });
   });
 });

--- a/web/src/components/storage/PartitionPage.tsx
+++ b/web/src/components/storage/PartitionPage.tsx
@@ -43,7 +43,7 @@ import {
   Stack,
   TextInput,
 } from "@patternfly/react-core";
-import { NestedContent, Page, SelectWrapper as Select, SubtleContent } from "~/components/core/";
+import { Page, SelectWrapper as Select, SubtleContent } from "~/components/core/";
 import { SelectWrapperProps as SelectProps } from "~/components/core/SelectWrapper";
 import SelectTypeaheadCreatable from "~/components/core/SelectTypeaheadCreatable";
 import AutoSizeText from "~/components/storage/AutoSizeText";
@@ -58,27 +58,21 @@ import { useDevices, useVolume } from "~/queries/storage";
 import { useConfigModel, useSolvedConfigModel } from "~/queries/storage/config-model";
 import { findDevice } from "~/helpers/storage/api-model";
 import { StorageDevice } from "~/types/storage";
-import {
-  baseName,
-  deviceSize,
-  deviceLabel,
-  filesystemLabel,
-  parseToBytes,
-} from "~/components/storage/utils";
+import { deviceSize, deviceLabel, filesystemLabel, parseToBytes } from "~/components/storage/utils";
 import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import { apiModel } from "~/api/storage/types";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { unique } from "radashi";
 import { compact } from "~/utils";
+import SizeModeSelect, { SizeMode, SizeRange } from "~/components/storage/SizeModeSelect";
 
 const NO_VALUE = "";
 const NEW_PARTITION = "new";
 const BTRFS_SNAPSHOTS = "btrfsSnapshots";
 const REUSE_FILESYSTEM = "reuse";
 
-type SizeOptionValue = "" | "auto" | "custom";
-type CustomSizeValue = "fixed" | "unlimited" | "range";
+type SizeOptionValue = "" | SizeMode;
 type FormValue = {
   mountPoint: string;
   target: string;
@@ -87,10 +81,6 @@ type FormValue = {
   sizeOption: SizeOptionValue;
   minSize: string;
   maxSize: string;
-};
-type SizeRange = {
-  min: string;
-  max: string;
 };
 type Error = {
   id: string;
@@ -183,7 +173,8 @@ function toFormValue(partitionConfig: apiModel.Partition): FormValue {
     return "custom";
   };
 
-  const size = (value: number | undefined): string => (value ? deviceSize(value) : NO_VALUE);
+  const size = (value: number | undefined): string =>
+    value ? deviceSize(value, { exact: true }) : NO_VALUE;
 
   return {
     mountPoint: mountPoint(),
@@ -498,12 +489,13 @@ type TargetOptionLabelProps = {
 
 function TargetOptionLabel({ value }: TargetOptionLabelProps): React.ReactNode {
   const device = useDevice();
+  const partition = usePartition(value);
 
   if (value === NEW_PARTITION) {
     // TRANSLATORS: %s is a disk name with its size (eg. "sda, 10 GiB"
     return sprintf(_("As a new partition on %s"), deviceLabel(device, true));
   } else {
-    return sprintf(_("Using partition %s"), baseName(value, true));
+    return sprintf(_("Using partition %s"), deviceLabel(partition, true));
   }
 }
 
@@ -674,58 +666,6 @@ function FilesystemLabel({ id, value, onChange }: FilesystemLabelProps): React.R
   );
 }
 
-type SizeOptionLabelProps = {
-  value: SizeOptionValue;
-  mountPoint: string;
-  target: string;
-};
-
-function SizeOptionLabel({ value, mountPoint, target }: SizeOptionLabelProps): React.ReactNode {
-  const partition = usePartition(target);
-  if (mountPoint === NO_VALUE) return _("Waiting for a mount point");
-  if (value === NO_VALUE && target !== NEW_PARTITION) return deviceSize(partition.size);
-  if (value === "auto") return _("Calculated automatically");
-  if (value === "custom") return _("Custom");
-
-  return value;
-}
-
-type SizeOptionsProps = {
-  mountPoint: string;
-  target: string;
-};
-
-function SizeOptions({ mountPoint, target }: SizeOptionsProps): React.ReactNode {
-  return (
-    <SelectList aria-label={_("Size options")}>
-      {mountPoint === NO_VALUE && (
-        <SelectOption value={NO_VALUE}>
-          <SizeOptionLabel value={NO_VALUE} mountPoint={mountPoint} target={target} />
-        </SelectOption>
-      )}
-      {mountPoint !== NO_VALUE && target !== NEW_PARTITION && (
-        // TRANSLATORS: %s is a partition name like /dev/vda2
-        <SelectOption value={NO_VALUE} description={sprintf(_("Keep size of %s"), target)}>
-          <SizeOptionLabel value={NO_VALUE} mountPoint={mountPoint} target={target} />
-        </SelectOption>
-      )}
-      {mountPoint !== NO_VALUE && target === NEW_PARTITION && (
-        <>
-          <SelectOption
-            value="auto"
-            description={_("Let the installer propose a sensible range of sizes")}
-          >
-            <SizeOptionLabel value="auto" mountPoint={mountPoint} target={target} />
-          </SelectOption>
-          <SelectOption value="custom" description={_("Define a custom size or a range")}>
-            <SizeOptionLabel value="custom" mountPoint={mountPoint} target={target} />
-          </SelectOption>
-        </>
-      )}
-    </SelectList>
-  );
-}
-
 type AutoSizeInfoProps = {
   value: FormValue;
 };
@@ -741,143 +681,6 @@ function AutoSizeInfo({ value }: AutoSizeInfoProps): React.ReactNode {
     <SubtleContent>
       <AutoSizeText volume={volume} size={size} deviceType={"partition"} />
     </SubtleContent>
-  );
-}
-
-type CustomSizeOptionLabelProps = {
-  value: CustomSizeValue;
-};
-
-function CustomSizeOptionLabel({ value }: CustomSizeOptionLabelProps): React.ReactNode {
-  const labels = {
-    fixed: _("Same as minimum"),
-    unlimited: _("None"),
-    range: _("Limited"),
-  };
-
-  return labels[value];
-}
-
-function CustomSizeOptions(): React.ReactNode {
-  return (
-    <SelectList aria-label={_("Maximum size options")}>
-      <SelectOption
-        value="fixed"
-        description={_("The partition is created exactly with the given size")}
-      >
-        <CustomSizeOptionLabel value="fixed" />
-      </SelectOption>
-      <SelectOption
-        value="range"
-        description={_("The partition can grow until a given limit size")}
-      >
-        <CustomSizeOptionLabel value="range" />
-      </SelectOption>
-      <SelectOption
-        value="unlimited"
-        description={_("The partition can grow to use all the contiguous free space")}
-      >
-        <CustomSizeOptionLabel value="unlimited" />
-      </SelectOption>
-    </SelectList>
-  );
-}
-
-type CustomSizeProps = {
-  value: FormValue;
-  onChange: (size: SizeRange) => void;
-};
-
-function CustomSize({ value, onChange }: CustomSizeProps) {
-  const initialOption = (): CustomSizeValue => {
-    if (value.minSize === NO_VALUE) return "fixed";
-    if (value.minSize === value.maxSize) return "fixed";
-    if (value.maxSize === NO_VALUE) return "unlimited";
-    return "range";
-  };
-
-  const [option, setOption] = React.useState<CustomSizeValue>(initialOption());
-  const { max: solvedMaxSize } = useSolvedSizes(value);
-  const { getVisibleError } = useErrors(value);
-
-  const error = getVisibleError("customSize");
-
-  const changeMinSize = (min: string) => {
-    const max = option === "fixed" ? min : value.maxSize;
-    onChange({ min, max });
-  };
-
-  const changeMaxSize = (max: string) => {
-    onChange({ min: value.minSize, max });
-  };
-
-  const changeOption = (v: CustomSizeValue) => {
-    setOption(v);
-
-    const min = value.minSize;
-    if (v === "fixed") onChange({ min, max: min });
-    if (v === "unlimited") onChange({ min, max: NO_VALUE });
-    if (v === "range") {
-      const max = solvedMaxSize || NO_VALUE;
-      onChange({ min, max });
-    }
-  };
-
-  return (
-    <Stack hasGutter>
-      <Stack>
-        <SubtleContent>
-          {_(
-            "Sizes must be entered as a numbers followed by a unit of \
-              the form GiB (power of 2) or GB (power of 10).",
-          )}
-        </SubtleContent>
-      </Stack>
-      <FormGroup>
-        <Flex>
-          <FlexItem>
-            <FormGroup fieldId="minSizeValue" label={_("Minimum")}>
-              <TextInput
-                id="minSizeValue"
-                className="w-14ch"
-                value={value.minSize}
-                aria-label={_("Minimum size value")}
-                onChange={(_, v) => changeMinSize(v)}
-              />
-            </FormGroup>
-          </FlexItem>
-          <FlexItem>
-            <FormGroup fieldId="maxSize" label={_("Maximum")}>
-              <Split hasGutter>
-                <Select
-                  id="maxSize"
-                  value={option}
-                  label={<CustomSizeOptionLabel value={option} />}
-                  onChange={changeOption}
-                  toggleName={_("Maximum size mode")}
-                >
-                  <CustomSizeOptions />
-                </Select>
-                {option === "range" && (
-                  <TextInput
-                    id="maxSizeValue"
-                    className="w-14ch"
-                    value={value.maxSize}
-                    aria-label={_("Maximum size value")}
-                    onChange={(_, v) => changeMaxSize(v)}
-                  />
-                )}
-              </Split>
-            </FormGroup>
-          </FlexItem>
-        </Flex>
-        <FormHelperText>
-          <HelperText>
-            {error && <HelperTextItem variant="error">{error.message}</HelperTextItem>}
-          </HelperText>
-        </FormHelperText>
-      </FormGroup>
-    </Stack>
   );
 }
 
@@ -972,9 +775,10 @@ export default function PartitionPage() {
     setFilesystem(value);
   };
 
-  const changeSize = ({ min, max }) => {
-    if (min !== undefined) setMinSize(min);
-    if (max !== undefined) setMaxSize(max);
+  const changeSizeMode = (mode: SizeMode, size: SizeRange) => {
+    setSizeOption(mode);
+    if (size.min !== undefined) setMinSize(size.min);
+    if (size.max !== undefined) setMaxSize(size.max);
   };
 
   const onSubmit = () => {
@@ -991,6 +795,8 @@ export default function PartitionPage() {
   const mountPointError = getVisibleError("mountPoint");
   const usedMountPt = mountPointError ? NO_VALUE : mountPoint;
   const showLabel = filesystem !== NO_VALUE && filesystem !== REUSE_FILESYSTEM;
+  const sizeMode: SizeMode = sizeOption === "" ? "auto" : sizeOption;
+  const sizeRange: SizeRange = { min: minSize, max: maxSize };
 
   return (
     <Page id="partitionPage">
@@ -1064,33 +870,27 @@ export default function PartitionPage() {
                 )}
               </Flex>
             </FormGroup>
-            <FormGroup fieldId="size" label={_("Size")}>
-              <Flex
-                direction={{ default: "column" }}
-                alignItems={{ default: "alignItemsFlexStart" }}
-                gap={{ default: "gapMd" }}
-              >
-                <Select
-                  id="size"
-                  value={sizeOption}
-                  label={
-                    <SizeOptionLabel value={sizeOption} mountPoint={usedMountPt} target={target} />
-                  }
-                  onChange={(v: SizeOptionValue) => setSizeOption(v)}
-                  isDisabled={usedMountPt === NO_VALUE}
-                >
-                  <SizeOptions mountPoint={usedMountPt} target={target} />
-                </Select>
-                <NestedContent margin="mxMd" aria-live="polite">
-                  {target === NEW_PARTITION && sizeOption === "auto" && (
-                    <AutoSizeInfo value={value} />
-                  )}
-                  {target === NEW_PARTITION && sizeOption === "custom" && (
-                    <CustomSize value={value} onChange={changeSize} />
-                  )}
-                </NestedContent>
-              </Flex>
-            </FormGroup>
+            {target === NEW_PARTITION && (
+              <FormGroup fieldId="sizeMode" label={_("Size mode")}>
+                {usedMountPt === NO_VALUE && (
+                  <Select
+                    id="sizeMode"
+                    value={NO_VALUE}
+                    label={_("Waiting for a mount point")}
+                    isDisabled
+                  />
+                )}
+                {usedMountPt !== NO_VALUE && (
+                  <SizeModeSelect
+                    id="sizeMode"
+                    value={sizeMode}
+                    size={sizeRange}
+                    onChange={changeSizeMode}
+                    automaticHelp={<AutoSizeInfo value={value} />}
+                  />
+                )}
+              </FormGroup>
+            )}
             <ActionGroup>
               <Page.Submit isDisabled={!isFormValid} form="partitionForm" />
               <Page.Cancel />

--- a/web/src/components/storage/SizeModeSelect.tsx
+++ b/web/src/components/storage/SizeModeSelect.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import {
+  Button,
+  Checkbox,
+  Flex,
+  FlexItem,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  SelectList,
+  SelectOption,
+  TextInput,
+} from "@patternfly/react-core";
+import { NestedContent, SubtleContent, SelectWrapper as Select } from "~/components/core/";
+import { deviceSize, parseToBytes } from "~/components/storage/utils";
+import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+
+const NO_VALUE = "";
+
+export type SizeMode = "auto" | "custom";
+
+export type SizeRange = {
+  min: string;
+  max: string;
+};
+
+function approxSize(size: string): string | null {
+  const minify = (size: string): string => size.replaceAll(" ", "");
+  const approx = deviceSize(parseToBytes(size));
+
+  if (minify(approx) === minify(size)) return null;
+  if (parseToBytes(approx) === parseToBytes(size)) return null;
+
+  return approx;
+}
+
+type UnsupportedSizeProps = {
+  value: SizeRange;
+  onClick: () => void;
+};
+
+function UnsupportedSize({ value, onClick }: UnsupportedSizeProps): React.ReactNode {
+  return (
+    <SubtleContent>
+      <Stack hasGutter>
+        <StackItem>
+          {sprintf(
+            _(
+              "The size is configured as a range between %s and %s, but defining a range of sizes is not supported by the UI.",
+            ),
+            value.min,
+            value.max,
+          )}
+        </StackItem>
+        <StackItem>
+          <Button variant="link" isInline onClick={onClick}>
+            {_("Do you want to use a supported size?")}
+          </Button>
+        </StackItem>
+      </Stack>
+    </SubtleContent>
+  );
+}
+
+type CustomSizeProps = {
+  value: SizeRange;
+  onChange: (size: SizeRange) => void;
+};
+
+function CustomSize({ value, onChange }: CustomSizeProps) {
+  const [grow, setGrow] = useState(value.max === NO_VALUE);
+
+  const changeSize = (min: string) => {
+    const max = grow ? NO_VALUE : min;
+    onChange({ min, max });
+  };
+
+  const toggleGrow = () => {
+    const newGrow = !grow;
+    const max = newGrow ? NO_VALUE : value.min;
+    setGrow(newGrow);
+    onChange({ min: value.min, max });
+  };
+
+  const regexp = /^[0-9]+(\.[0-9]+)?(\s*([KkMmGgTtPpEeZzYy][iI]?)?[Bb])$/;
+  const error = value.min && !regexp.test(value.min);
+  const approxMin = error ? null : approxSize(value.min);
+  const help = _(
+    "The size must be a number followed by a unit of the form GiB (power of 2) or GB (power of 10).",
+  );
+
+  if (value.max !== NO_VALUE && value.min !== value.max) {
+    return <UnsupportedSize value={value} onClick={() => changeSize(value.min)} />;
+  }
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup fieldId="minSizeValue" label={_("Size")}>
+          <Flex>
+            <FlexItem>
+              <TextInput
+                id="minSizeValue"
+                className="w-14ch"
+                value={value.min}
+                onChange={(_, v) => changeSize(v)}
+              />
+            </FlexItem>
+            {!error && approxMin && (
+              <FlexItem>
+                <SubtleContent>
+                  {
+                    // TRANSLATORS: %s is a disk size (e.g., "10 GiB").
+                    sprintf(_("approx. %s"), approxMin)
+                  }
+                </SubtleContent>
+              </FlexItem>
+            )}
+          </Flex>
+          {!error && <SubtleContent>{help}</SubtleContent>}
+          {error && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">{help}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <Checkbox id="setGrow" label={_("Allow growing")} isChecked={grow} onChange={toggleGrow} />
+        <SubtleContent>
+          {_("The final size can be bigger in order to fill the contiguous free space.")}
+        </SubtleContent>
+      </StackItem>
+    </Stack>
+  );
+}
+
+export type SizeModeSelectProps = {
+  id?: string;
+  value: SizeMode;
+  size: SizeRange;
+  automaticHelp?: React.ReactNode;
+  onChange: (value: SizeMode, size: SizeRange) => void;
+};
+
+export default function SizeModeSelect({
+  id,
+  value,
+  size,
+  onChange,
+  automaticHelp,
+}: SizeModeSelectProps): React.ReactNode {
+  const changeSize = (size: SizeRange) => onChange(value, size);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Select
+          id={id || "sizeMode"}
+          value={value}
+          label={value === "auto" ? _("Automatic") : _("Custom")}
+          onChange={(v: SizeMode) => onChange(v, size)}
+        >
+          <SelectList aria-label={_("Size modes")}>
+            <SelectOption value="auto" description={_("Let the installer propose a sensible size")}>
+              {_("Automatic")}
+            </SelectOption>
+            <SelectOption value="custom" description={_("Define a custom size")}>
+              {_("Custom")}
+            </SelectOption>
+          </SelectList>
+        </Select>
+      </StackItem>
+      <StackItem>
+        <NestedContent margin="mxMd" aria-live="polite">
+          {value === "auto" && automaticHelp}
+          {value === "custom" && <CustomSize value={size} onChange={changeSize} />}
+        </NestedContent>
+      </StackItem>
+    </Stack>
+  );
+}

--- a/web/src/components/storage/utils.test.ts
+++ b/web/src/components/storage/utils.test.ts
@@ -155,9 +155,20 @@ const lvmLv1: StorageDevice = {
 lvmVg.logicalVolumes = [lvmLv1];
 
 describe("deviceSize", () => {
-  it("returns the size with units", () => {
-    const result = deviceSize(1024);
-    expect(result).toEqual("1 KiB");
+  it("returns the approx size with units", () => {
+    expect(deviceSize(1028)).toEqual("1 KiB");
+    expect(deviceSize(5 * 1024 ** 2 - 1024)).toEqual("5 MiB");
+    expect(deviceSize(5 * 1024 ** 2 - 1000)).toEqual("5 MiB");
+    expect(deviceSize(5 * 1024 ** 2 - 7)).toEqual("5 MiB");
+  });
+
+  describe("with exact option", () => {
+    it("returns the exact size with units", () => {
+      expect(deviceSize(1028, { exact: true })).toEqual("1028 B");
+      expect(deviceSize(5 * 1024 ** 2 - 1024, { exact: true })).toEqual("5119 KiB");
+      expect(deviceSize(5 * 1024 ** 2 - 1000, { exact: true })).toEqual("5241.88 KB");
+      expect(deviceSize(5 * 1024 ** 2 - 7, { exact: true })).toEqual("5242873 B");
+    });
   });
 });
 

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -115,46 +115,6 @@ const SPACE_POLICIES: SpacePolicy[] = [
 ];
 
 /**
- * Convenience method for generating a size object based on given input
- *
- * It split given input when a string is given or the result of converting the
- * input otherwise. Note, however, that -1 number will treated as empty string
- * since it means nothing for Agama UI although it represents the "unlimited"
- * size in the backend.
- */
-const splitSize = (size: number | string | undefined): SizeObject => {
-  // From D-Bus, maxSize comes as undefined when set as "unlimited", but for Agama UI
-  // it means "leave it empty"
-  const sanitizedSize = size === undefined ? "" : size;
-  const parsedSize =
-    typeof sanitizedSize === "string" ? sanitizedSize : xbytes(sanitizedSize, { iec: true });
-  const [qty, unit] = parsedSize.split(" ");
-  // `Number` will remove trailing zeroes;
-  // parseFloat ensures Number does not transform "" into 0.
-  const sanitizedQty = Number(parseFloat(qty));
-
-  return {
-    unit,
-    size: isNaN(sanitizedQty) ? undefined : sanitizedQty,
-  };
-};
-
-/**
- * Generates a disk size representation
- *
- * @example
- * deviceSize(1024)
- * // returns "1 KiB"
- */
-const deviceSize = (size: number): string => {
-  // Sadly, we cannot returns directly the xbytes(size, { iec: true }) because
-  // it does not have an option for dropping/ignoring trailing zeroes and we do
-  // not want to render them.
-  const result = splitSize(size);
-  return `${Number(result.size)} ${result.unit}`;
-};
-
-/**
  * Returns the equivalent in bytes resulting from parsing given input
  *
  * @example
@@ -175,6 +135,77 @@ const parseToBytes = (size: string | number): number => {
 
   // Avoid decimals resulting from the conversion. D-Bus iface only accepts integer
   return Math.trunc(value);
+};
+
+type ExactSizeOptions = Pick<xbytes.MainOpts, "iec" | "prefixIndex">;
+
+/**
+ * Converts bytes to an exact size representation.
+ *
+ * An exact representation means that the same number of bytes is obtained when transforming the
+ * size string back to bytes. The feasible bigger size unit is used.
+ */
+function exactSize(bytes: number, options?: ExactSizeOptions): string {
+  options = { iec: true, ...options };
+
+  const size = xbytes(bytes, options);
+  const bytesFromSize = parseToBytes(size);
+
+  // The size represents the given amount of bytes.
+  if (bytes === bytesFromSize) return size;
+
+  if (options.iec) {
+    // Try without IEC unit
+    options = { ...options, iec: false };
+  } else {
+    // Try with smaller unit
+    const prefixIndex = xbytes.parseString(size).prefixIndex - 1;
+    options = { iec: true, prefixIndex };
+  }
+
+  return exactSize(bytes, options);
+}
+
+type SizeOptions = { exact: boolean };
+
+/**
+ * Convenience method for generating a size object based on given input
+ *
+ * It split given input when a string is given or the result of converting the
+ * input otherwise. Note, however, that -1 number will treated as empty string
+ * since it means nothing for Agama UI although it represents the "unlimited"
+ * size in the backend.
+ */
+const splitSize = (size: number | string | undefined, options?: SizeOptions): SizeObject => {
+  const strSize = (size) => (options?.exact ? exactSize(size) : xbytes(size, { iec: true }));
+  // From D-Bus, maxSize comes as undefined when set as "unlimited", but for Agama UI
+  // it means "leave it empty"
+  const sanitizedSize = size === undefined ? "" : size;
+  const parsedSize = typeof sanitizedSize === "string" ? sanitizedSize : strSize(size);
+  const [qty, unit] = parsedSize.split(" ");
+  // `Number` will remove trailing zeroes;
+  // parseFloat ensures Number does not transform "" into 0.
+  const sanitizedQty = Number(parseFloat(qty));
+
+  return {
+    unit,
+    size: isNaN(sanitizedQty) ? undefined : sanitizedQty,
+  };
+};
+
+/**
+ * Generates a disk size representation
+ *
+ * @example
+ * deviceSize(1024)
+ * // returns "1 KiB"
+ */
+const deviceSize = (size: number, options?: SizeOptions): string => {
+  // Sadly, we cannot returns directly the xbytes(size, { iec: true }) because
+  // it does not have an option for dropping/ignoring trailing zeroes and we do
+  // not want to render them.
+  const result = splitSize(size, options);
+  return `${Number(result.size)} ${result.unit}`;
 };
 
 const TRUNCATE_MAX_LENGTH = 17;


### PR DESCRIPTION
## Problem

The size displayed in the partition/lv form sometimes does not correspond exactly with the number of bytes from the config. Just editing and saving withouth touching any value might slightly change the number of bytes.

## Solution

The size field is always filled with an exact size, using until 2 decimals and the bigger unit possible. If the size presented by the UI is an approximate size, then the size field shows a hint with the approx. size (see screenshot).

Moreover, the concept of max size was hidden in the UI. Now, only a fixed size can be entered, with an option for growing if possible. If the size from the config has a max, then the UI allows to switch to a fixed size.

## Screenshots

![localhost_8080_ (24)](https://github.com/user-attachments/assets/72dcf279-8098-419b-8997-5d4b29a0963d)
