### PR TITLE
fix(live): Use the new way for starting the display manager

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 20 14:57:08 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Install "gdm-systemd" and enable "gdm.service" to start the
+  graphical desktop, this is a new way for starting display managers
+
+-------------------------------------------------------------------
 Thu Jun 19 09:06:50 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Add hyper-v on x86_64 and aarch64 only (related to bsc#1236961).

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -171,7 +171,7 @@
         <package name="fonts-config"/>
         <package name="xauth"/>
         <package name="MozillaFirefox"/>
-        <package name="gdm"/>
+        <package name="gdm-systemd"/>
         <package name="gnome-shell"/>
         <package name="gnome-session-wayland"/>
         <package name="gnome-kiosk"/>

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -71,6 +71,7 @@ systemctl enable live-root-shell.service
 systemctl enable checkmedia.service
 systemctl enable qemu-guest-agent.service
 systemctl enable setup-systemd-proxy-env.path
+systemctl enable gdm.service
 test -f  /usr/lib/systemd/system/spice-vdagentd.service && systemctl enable spice-vdagentd.service
 systemctl enable zramswap
 


### PR DESCRIPTION
## Problem

- The graphical UI does not start in the SLES builds

## Solution

- Install the `gdm-systemd` package and enable the `gdm.service`
- That's a new way for starting display managers, see links
  - https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/5S6DQE2NB6DZQ7DSY2NVXH3XHJPXSUBP/
  - https://en.opensuse.org/openSUSE:DisplayManagerRework

## Testing

- Tested manually in both openSUSE Tumbleweed and SLE16 builds, the graphical UI starts in both cases.