### PR TITLE
Removed misleading 'diag' value from example (bsc#1245124)

### DIFF
--- a/rust/agama-lib/share/examples/dasd.json
+++ b/rust/agama-lib/share/examples/dasd.json
@@ -4,7 +4,6 @@
             {
                 "channel": "0.0.0200",
                 "format": true,
-                "diag": true,
                 "state": "active"
             },
             {


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1245124


## Problem

The public example for using a DASD contains the `diag` value, but that only works for _some_ systems. This needs more explanations, and it shouldn't be in an example which users may casually copy and paste; it might be counterproductive in their setup.