### PR TITLE
fix(live): Fixed building mini PXE images

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -71,8 +71,8 @@ systemctl enable live-root-shell.service
 systemctl enable checkmedia.service
 systemctl enable qemu-guest-agent.service
 systemctl enable setup-systemd-proxy-env.path
-systemctl enable gdm.service
-test -f  /usr/lib/systemd/system/spice-vdagentd.service && systemctl enable spice-vdagentd.service
+test -f /usr/lib/systemd/system/gdm.service && systemctl enable gdm.service
+test -f /usr/lib/systemd/system/spice-vdagentd.service && systemctl enable spice-vdagentd.service
 systemctl enable zramswap
 
 # set the default target


### PR DESCRIPTION
## Problem

- The mini PXE images do not build
- The GDM service is not installed so the service activation fails

## Solution

- Activate the service only if it is present
