### PR TITLE
Added "make sles" to easily build the SLES Live ISO sources

### DIFF
--- a/live/Makefile
+++ b/live/Makefile
@@ -21,10 +21,19 @@ OBS_API = "https://api.opensuse.org"
 OBS_TARGET = "images"
 ARCH = $(shell uname -m)
 
-# files to copy from src/
-COPY_FILES = $(patsubst $(SRCDIR)/%,$(DESTDIR)/%,$(wildcard $(SRCDIR)/*))
+# list of target files, ignore the SLES specific files (matching *_sles pattern)
+COPY_FILES = $(patsubst $(SRCDIR)/%,$(DESTDIR)/%, $(filter-out ./src/%_sles,$(wildcard $(SRCDIR)/*)))
+# only the SLES specific target files (matching *_sles pattern)
+COPY_FILES_SLES = $(patsubst $(SRCDIR)/%,$(DESTDIR)/%, $(filter ./src/%_sles,$(wildcard $(SRCDIR)/*)))
 
+# the default target, build the sources for openSUSE image
 all: $(DESTDIR) $(COPY_FILES) $(DESTDIR)/config-cdroot.tar.xz $(DESTDIR)/live-root.tar.xz $(DESTDIR)/live-root-PXE.tar.xz
+
+# build the sources for SLES image, builds the openSUSE sources and then modifies them for SLES
+# (use the SLES specific _multibuild file, add "SLES" into the changes and the Kiwi file name)
+sles: all $(COPY_FILES_SLES)
+	rename _sles "" $(DESTDIR)/*_sles
+	rename . -- -SLES. $(DESTDIR)/*-installer.changes $(DESTDIR)/*-installer.kiwi
 
 # clean the destination directory (but keep the .osc directory if it is present)
 clean:
@@ -80,4 +89,4 @@ shellcheck:
 	@find config-cdroot root src -type f -exec grep -l -E "^#! *(/usr/|)/bin/(ba|)sh" \{\} \; \
 	  | xargs -I% bash -c "echo 'Checking warnings in %...' && shellcheck %" || true
 
-.PHONY: build all clean shellcheck
+.PHONY: build all sles clean shellcheck

--- a/live/README.md
+++ b/live/README.md
@@ -60,6 +60,15 @@ make clean
 
 or just simply delete the `dist` subdirectory.
 
+By default it builds the sources for openSUSE, if you want to build the sources for SLES run
+
+```shell
+make sles
+```
+
+It is recommended to run `make clean` before changing the target product to ensure there are no
+leftovers from the previous product.
+
 ## Building the ISO image
 
 To build the ISO locally run the

--- a/live/src/_multibuild_sles
+++ b/live/src/_multibuild_sles
@@ -1,0 +1,5 @@
+<multibuild>
+  <flavor>SUSE_SLE_16</flavor>
+  <flavor>SUSE_SLE_16_PXE</flavor>
+  <flavor>SUSE_SLE_16_PXE_MINI</flavor>
+</multibuild>


### PR DESCRIPTION
## Problem

- Building the SLES Live ISO sources is not trivial, it needs some manual modifications
- See the exact steps in https://trello.com/c/9sl2EdSl

## Solution

- Added `make sles` target to automate building the sources
  - It uses a special `_multibuild` file for SLES
  - Renames the changes and the Kiwi file to `agama-installer-SLES.changes` and `agama-installer-SLES.kiwi`

## Testing

- Tested manually, both openSUSE and SLES sources are built correctly

## TODO

- [ ] Update the Trello card to use the new `make sles` command