### PR TITLE
agama-installer.kiwi: Set OBS-Milestone.

### DIFF
--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- OBS-ExclusiveArch: aarch64 ppc64le x86_64 s390x -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
+<!-- OBS-Milestone: %current_milestone -->
 
 <image schemaversion="7.5" name="agama-installer">
     <description type="system">


### PR DESCRIPTION
The OBS-Milestone allows, after setting the `%current_milestone` in the OBS project configuration, to have correctly versioned artifacts.

Add the following (or equivalent code) to your project configuration:

```
%define current_milestone Snapshot-202506-1
Macros:
%current_milestone Snapshot-202506-1
:Macros
```

## Problem

SLES 16.0 Agama build artifacts don't have the correct milestone name and break OBS releases.

## Solution

Setting `OBS-Milestone` and the `%current_milestone` macro.