### PR TITLE
branch2obs.sh: disable building the agama-installer-Leap image in Tumbleweed

### DIFF
--- a/devel/branch2obs.sh
+++ b/devel/branch2obs.sh
@@ -145,6 +145,11 @@ else
       osc meta prj -F - "$PROJECT"
   fi
 
+  # disable building the agama-installer-Leap image for Tumbleweed, that does not work
+  osc meta pkg "$PROJECT" agama-installer-Leap | \
+    sed 's#</package>#<build><disable repository="images"/></build></package>##' | \
+    osc meta pkg -F - "$PROJECT" agama-installer-Leap
+
   # enable publishing of the built packages and images (delete the disabled publish section)
   echo "Enable publishing of the build results"
   osc meta prj "$PROJECT" | sed "/^\s*<publish>\s*$/,/^\s*<\/publish>\s*$/d" | \


### PR DESCRIPTION
## Problem

- After running the `branch2obs.sh` script the `agama-installer-Leap` image is enabled to build for Tumbleweed.
- But that cannot work, that image is designed for Leap 16.0.
- It is quite strange, in the original systemsmanagement:Agama:Devel project the build for TW is disabled, no idea why that's not inherited during branching.

## Solution

- Explicitly disable build in `images`

## Testing

- Tested manually in [systemsmanagement:Agama:branches:new_libzypp_callbacks](https://build.opensuse.org/package/show/systemsmanagement:Agama:branches:new_libzypp_callbacks/agama-installer-Leap) project, works as expected.