### PR TITLE
Fixed running Rust unit tests in CI

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -131,8 +131,8 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install libclang-18-dev libpam0g-dev python3-langtable
         # the langtable data location is different in SUSE/openSUSE, create a symlink
-        sudo mkdir -p /usr/share/langtable/data
-        sudo ln -s /usr/lib/python3/dist-packages/langtable/data/timezoneidparts.xml.gz /usr/share/langtable/data/timezoneidparts.xml.gz
+        sudo mkdir -p /usr/share/langtable
+        sudo ln -s /usr/lib/python3/dist-packages/langtable/data /usr/share/langtable/data
 
     - name: Installed packages
       run: apt list --installed
@@ -157,7 +157,7 @@ jobs:
       # flags, to avoid reusing the previous builds it always starts from scratch.
       # The --skip-clean skips the cleanup and allows using the cached results.
       # See https://github.com/xd009642/tarpaulin/discussions/772
-      run: cargo tarpaulin --all --doc --out xml --target-dir target-coverage --skip-clean -- --nocapture
+      run: cargo tarpaulin --workspace --all-targets --doc --out xml --target-dir target-coverage --skip-clean -- --nocapture
       env:
         # use the "stable" tool chain (installed by default) instead of the "nightly" default in tarpaulin
         RUSTC_BOOTSTRAP: 1


### PR DESCRIPTION
## Problem

- The CI tests actually do not run the Rust unit tests, only the documentation tests.

## Solution

- The `--doc` tarpaulin option means "Test only this library's documentation" so the unit tests were not executed
- Use also the `--all-targets` option which means "Test all targets (excluding doctests)"
- The `--all` option is deprecated alias for the `--workspace` option, use `--workspace` directly
- Symlink all langtable data files (the complete directory)

## Testing

- Tested manually, all unit tests are executed


## Notes

- The CI failure here is expected and shows that the unit tests are really executed
