### PR TITLE
fix relative URL resolution for /files

### DIFF
--- a/service/test/integration/profile_itest.rb
+++ b/service/test/integration/profile_itest.rb
@@ -127,14 +127,12 @@ describe "agama config" do
       let(:profile_body) do
         json = <<~JSON
           {
-            "scripts": {
-              "postPartitioning": [
+            "files": [
                 {
                   "name": "foo",
                   "url": "my-script.sh"
                 }
               ]
-            }
           }
         JSON
         json


### PR DESCRIPTION
## Problem

1. reported by Leo Manfredi: When using a relative reference in `files`, `agama config generate` does not resolve them
```
  files: [{
     destination: '/usr/local/share/dummy.xml',
     url: 'dummy.xml',
     chroot: false,
  }],
```

- openQA link: https://progress.opensuse.org/issues/184001#note-17

2. it is because the config fails schema validation (differently in Leo's case and my test case)
3. Agama outputs a validation failure message, and the invalid config, without resolving references. (Outputting the invalid config is intentional to make debugging easy)
4. It also does not stop processing at that point. That is IMHO the real bug


## Solution

*Short description of the fix.*


## Testing

- for now just modify a test to show the bug

## Screenshots

*If the fix affects the UI attach some screenshots here.*

## Documentation

*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
*other times they need advertisement and explanation.*

*Look for relevant sections and adjust:*
- The description parts of the [JSON schema][profile.schema.json]
- Is the CLI affected? See [cli.md][] for a complete overview,
  change the `///` comments (rust doc)
  and update the .md with `cargo xtask markdown`
- <https://agama-project.github.io/> ([source][gh.io])
- Run: `git ls-files '*.md'`

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md
[profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
[gh.io]: https://github.com/agama-project/agama-project.github.io/
