### PR TITLE
Use new libzypp callbacks

### DIFF
--- a/service/lib/agama/progress.rb
+++ b/service/lib/agama/progress.rb
@@ -60,6 +60,8 @@ module Agama
   #   progress.step("Installing packages") { installing } # overwrite the description
   #   progress.current_step.description                   # "Installing packages"
   class Progress
+    include Yast::I18n
+
     # Step of the progress
     class Step
       # Id of the step
@@ -184,7 +186,8 @@ module Agama
     #
     # @return [String]
     def to_s
-      return "Finished" if finished?
+      # TRANSLATORS: progress message, the task has been finished
+      return _("Finished") if finished?
 
       "#{current_step.description} (#{@counter}/#{total_steps})"
     end

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -201,7 +201,8 @@ module Agama
         Yast::Pkg.TargetInitialize(Yast::Installation.destdir)
         Yast::Pkg.TargetLoad
 
-        steps = proposal.packages_count
+        # TODO: FIXME: distinguish between the download and install steps
+        steps = proposal.packages_count + proposal.packages_download_count
         start_progress_with_size(steps)
         Callbacks::Progress.setup(steps, progress, logger)
 

--- a/service/share/agama.service
+++ b/service/share/agama.service
@@ -5,6 +5,9 @@ After=network-online.target
 [Service]
 Type=forking
 ExecStart=/usr/bin/agamactl --daemon
+# FIXME: for testing temporarily change the libzypp default,
+# can be removed when this is the default libzypp behavior
+Environment=ZYPP_SINGLE_RPMTRANS=1
 EnvironmentFile=-/run/agama/environment.conf
 PIDFile=/run/agama/bus.pid
 User=root


### PR DESCRIPTION
## Problem

- No installation progress with new libzypp
- https://bugzilla.suse.com/show_bug.cgi?id=1244319

## Solution

- Use the new install callbacks
- Use also the download callbacks, now the default download mode is "downloadInAdvance" (first download all needed packages, the install them at once) so we need to show the progress for the download stage otherwise there would be no progress for quite some time as reported in the bug.


## Testing

- Tested manually
- A testing installation ISO is built in the [systemsmanagement:Agama:branches:new_libzypp_callbacks](https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:new_libzypp_callbacks) OBS project, the ISO can downloaded [here](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/new_libzypp_callbacks/images/iso/)

## Screenshots

Note: The total number (1504 in this case) is not a number of packages to install but the total number of download and install steps. The remote packages are counted twice, the local packages only once. (But see the note below.)

That's just for simplification, I didn't have time to fix it.

![agama-download-progress](https://github.com/user-attachments/assets/5fd30121-0934-4f23-af80-51153a63cfe6)

## Notes

- Currently it is not possible to abort a running package installation and if there is a problem during installation there is no retry (limitation of the current libzypp).

## TODO

- [ ] Fix the failing unit tests
- [ ] Add a dependency to the [new version of the pkg-bindings](https://github.com/yast/yast-pkg-bindings/pull/192)
- [ ] Test with offline (Full) medium, I'm not sure if the packages are also copied from the DVD and if the download callbacks are also used for that. In that case we would need to count the download also for the local packages. (Or ask the libzypp maintainers.)
- [ ] Count the downloads and installs separately to provide better progress
- [ ] Changes :smiley: 

