### PR TITLE
feat(web): warn the user about weak encryption passwords

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 30 11:30:40 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Warn the user about using a weak encryption password
+  (gh#agama-project/agama#2524).
+
+-------------------------------------------------------------------
 Fri Jun 27 15:14:35 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Invalidate all software queries when the selected product changes

--- a/web/src/components/storage/EncryptionSection.test.tsx
+++ b/web/src/components/storage/EncryptionSection.test.tsx
@@ -32,6 +32,8 @@ jest.mock("~/queries/storage/config-model", () => ({
   useEncryption: () => mockUseEncryption(),
 }));
 
+jest.mock("~/components/users/PasswordCheck", () => () => <div>PasswordCheck Mock</div>);
+
 describe("EncryptionSection", () => {
   describe("if encryption is enabled", () => {
     beforeEach(() => {

--- a/web/src/components/storage/EncryptionSection.tsx
+++ b/web/src/components/storage/EncryptionSection.tsx
@@ -27,6 +27,7 @@ import { useEncryption } from "~/queries/storage/config-model";
 import { apiModel } from "~/api/storage/types";
 import { STORAGE } from "~/routes/paths";
 import { _ } from "~/i18n";
+import PasswordCheck from "~/components/users/PasswordCheck";
 
 function encryptionLabel(method?: apiModel.EncryptionMethod) {
   if (!method) return _("Encryption is disabled");
@@ -38,6 +39,7 @@ function encryptionLabel(method?: apiModel.EncryptionMethod) {
 export default function EncryptionSection() {
   const { encryption } = useEncryption();
   const method = encryption?.method;
+  const password = encryption?.password;
 
   return (
     <Page.Section
@@ -52,6 +54,7 @@ the new file systems, including data, programs, and system files.",
       <Card isCompact isPlain>
         <CardBody>
           <Content component="p">{encryptionLabel(method)}</Content>
+          {password && <PasswordCheck password={password} />}
         </CardBody>
       </Card>
     </Page.Section>

--- a/web/src/components/storage/EncryptionSettingsPage.test.tsx
+++ b/web/src/components/storage/EncryptionSettingsPage.test.tsx
@@ -26,6 +26,8 @@ import { installerRender } from "~/test-utils";
 import EncryptionSettingsPage from "./EncryptionSettingsPage";
 import { EncryptionHook } from "~/queries/storage/config-model";
 
+jest.mock("~/components/users/PasswordCheck", () => () => <div>PasswordCheck Mock</div>);
+
 const mockLuks2Encryption: EncryptionHook = {
   encryption: {
     method: "luks2",

--- a/web/src/components/storage/EncryptionSettingsPage.tsx
+++ b/web/src/components/storage/EncryptionSettingsPage.tsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { ActionGroup, Alert, Checkbox, Content, Form } from "@patternfly/react-core";
 import { NestedContent, Page, PasswordAndConfirmationInput } from "~/components/core";
+import PasswordCheck from "~/components/users/PasswordCheck";
 import { useEncryptionMethods } from "~/queries/storage";
 import { useEncryption } from "~/queries/storage/config-model";
 import { apiModel } from "~/api/storage/types";
@@ -132,6 +133,7 @@ at the new file systems, including data, programs, and system files.",
                 isDisabled={!isEnabled}
                 showErrors={false}
               />
+              <PasswordCheck password={password} />
               {isTpmAvailable && (
                 <Checkbox
                   id="tpmEncryptionMethod"

--- a/web/src/components/users/FirstUserForm.test.tsx
+++ b/web/src/components/users/FirstUserForm.test.tsx
@@ -35,7 +35,7 @@ jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
   <div>ProductRegistrationAlert Mock</div>
 ));
 
-jest.mock("~/components/users/PasswordCheck", () => () => <div>PasswordStrength Mock</div>);
+jest.mock("~/components/users/PasswordCheck", () => () => <div>PasswordCheck Mock</div>);
 
 jest.mock("~/queries/users", () => ({
   ...jest.requireActual("~/queries/users"),

--- a/web/src/components/users/RootUserForm.test.tsx
+++ b/web/src/components/users/RootUserForm.test.tsx
@@ -34,7 +34,7 @@ jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
   <div>ProductRegistrationAlert Mock</div>
 ));
 
-jest.mock("~/components/users/PasswordCheck", () => () => <div>PasswordStrength Mock</div>);
+jest.mock("~/components/users/PasswordCheck", () => () => <div>PasswordCheck Mock</div>);
 
 jest.mock("~/queries/users", () => ({
   ...jest.requireActual("~/queries/users"),


### PR DESCRIPTION
#2513 introduced a warning when using a weak password for the root or the first user. However, Agama days nothing if the encryption password for your disk is weak. This PR introduces the same behavior for the encryption password.
