### PR TITLE
fix(storage): inhibit storage subsystems

### DIFF
--- a/service/bin/agamactl
+++ b/service/bin/agamactl
@@ -61,7 +61,6 @@ def start_service(name)
 
   logger = logger_for(name)
   service_runner = Agama::DBus::ServiceRunner.new(name, logger: logger)
-  logger.info "Starting the service"
   service_runner.run
 end
 
@@ -100,9 +99,5 @@ elsif ["-d", "--daemon"].include?(ARGV[0])
 else
   dbus_server_manager.find_or_start_server
   name = ARGV[0]
-  Signal.trap("SIGINT") do
-    puts "Stopping #{name} service..."
-    exit
-  end
   start_service(name.to_sym)
 end

--- a/service/lib/agama/dbus/service_runner.rb
+++ b/service/lib/agama/dbus/service_runner.rb
@@ -46,8 +46,12 @@ module Agama
       #
       # This method listens for D-Bus calls.
       def run
+        logger.info "Starting service ..."
+
         initialize_yast
-        service = build_service(name, logger)
+        @service = build_service(name, logger)
+        Signal.trap("SIGINT") { stop }
+
         # TODO: implement a #start method in all services,
         # which is equivalent to #export in most cases.
         service.respond_to?(:start) ? service.start : service.export
@@ -62,6 +66,15 @@ module Agama
     private
 
       attr_reader :name, :logger
+
+      attr_reader :service
+
+      # Stops the service.
+      def stop
+        puts "Stopping #{name} service ..."
+        service.tear_down if service.respond_to?(:tear_down)
+        exit
+      end
 
       # Configuration
       def config

--- a/service/lib/agama/dbus/storage_service.rb
+++ b/service/lib/agama/dbus/storage_service.rb
@@ -26,6 +26,7 @@ require "agama/dbus/service_status"
 require "agama/dbus/storage/iscsi"
 require "agama/dbus/storage/manager"
 require "agama/storage"
+require "y2storage/inhibitors"
 
 module Agama
   module DBus
@@ -51,8 +52,11 @@ module Agama
         Bus.current
       end
 
-      # Starts storage service. It does more then just #export method.
+      # Starts storage service.
       def start
+        # Inhibits various storage subsystem (udisk, systemd mounts, raid auto-assembly) that
+        # interfere with the operation of yast-storage-ng and libstorage-ng.
+        Y2Storage::Inhibitors.new.inhibit
         export
       end
 
@@ -61,6 +65,11 @@ module Agama
         dbus_objects.each { |o| service.export(o) }
         paths = dbus_objects.map(&:path).join(", ")
         logger.info "Exported #{paths} objects"
+      end
+
+      # Actions before stopping the service.
+      def tear_down
+        Y2Storage::Inhibitors.new.uninhibit
       end
 
       # Call this from some main loop to dispatch the D-Bus messages

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -247,7 +247,6 @@ module Agama
       # Activates the devices, calling activation callbacks if needed
       def activate_devices
         callbacks = Callbacks::Activate.new(questions_client, logger)
-
         iscsi.activate
         Y2Storage::StorageManager.instance.activate(callbacks)
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jul 10 12:13:14 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Inhibit storage subsystems (bsc#1245159, bsc#1246133).
+
+-------------------------------------------------------------------
 Wed Jul  9 14:04:23 UTC 2025 - Martin Vidner <mvidner@suse.com>
 
 - Fix error at /api/manager/installer: initialize the backend value
@@ -12,7 +17,7 @@ Wed Jul  9 12:21:55 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 -------------------------------------------------------------------
 Wed Jul  9 08:32:37 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
-- Handle the LSM defined in the product definition as it was 
+- Handle the LSM defined in the product definition as it was
   selected by the user allowing to deselect it (bsc#1244431).
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Agama live media differs from the old YaST installation media. With the new live ISO, systemd is present and there are some storage subsystems that interfer with the libstorage-ng operation (e.g., udisk, systemd mounts, mdadm auto-assembly). 

https://bugzilla.suse.com/show_bug.cgi?id=1245159
https://bugzilla.suse.com/show_bug.cgi?id=1246133

## Solution

Call to the storage inhibitors while starting the storage service, similar to what the YaST Expert Partitioner client does in an installed system.
