### PR TITLE
fix(storage): add missing iSCSI discovery

### DIFF
--- a/service/lib/agama/storage/iscsi/adapter.rb
+++ b/service/lib/agama/storage/iscsi/adapter.rb
@@ -63,6 +63,14 @@ module Agama
           Yast::IscsiClientLib.discover(host, port, authentication(credentials), silent: true)
         end
 
+        # Discovers iSCSI targets from a portal.
+        #
+        # @param portal [String]
+        # @param interfaces [Array<String>]
+        def discover_from_portal(portal, interfaces: [])
+          Yast::IscsiClientLib.discover_from_portal(portal, interfaces)
+        end
+
         # Reads the iSCSI initiator config.
         # @return [Initiator]
         def read_initiator

--- a/service/lib/agama/storage/iscsi/config.rb
+++ b/service/lib/agama/storage/iscsi/config.rb
@@ -33,6 +33,27 @@ module Agama
         #
         # @return [Array<Configs::Target>, nil] If nil, then targets are not configured.
         attr_accessor :targets
+
+        # All portals.
+        #
+        # @return [Array<String>]
+        def portals
+          return [] unless targets
+
+          targets.map(&:portal).uniq
+        end
+
+        # All interfaces from a portal.
+        #
+        # @param portal [String]
+        # @return [Array<String>]
+        def interfaces(portal)
+          targets
+            .select { |t| t.portal?(portal) }
+            .map(&:interface)
+            .compact
+            .uniq
+        end
       end
     end
   end

--- a/service/lib/agama/storage/iscsi/configs/target.rb
+++ b/service/lib/agama/storage/iscsi/configs/target.rb
@@ -69,6 +69,23 @@ module Agama
           #
           # @return [String, nil]
           attr_accessor :initiator_password
+
+          # Target portal
+          #
+          # @return [String, nil]
+          def portal
+            return unless address && port
+
+            "#{address}:#{port}"
+          end
+
+          # Whether the target matches with the given portal.
+          #
+          # @param portal [String]
+          # @return [Boolean]
+          def portal?(portal)
+            self.portal == portal
+          end
         end
       end
     end

--- a/service/lib/agama/storage/iscsi/manager.rb
+++ b/service/lib/agama/storage/iscsi/manager.rb
@@ -296,9 +296,10 @@ module Agama
         def apply_targets_config(config)
           return unless config.targets
 
-          start_progress_with_size(2)
+          start_progress_with_size(3)
           progress.step(_("Logout iSCSI targets")) { logout_targets }
-          progress.step(_("Login iSCSI targets")) { login_targets(config.targets) }
+          progress.step(_("Discover iSCSI targets")) { discover_from_portals(config) }
+          progress.step(_("Login iSCSI targets")) { login_targets(config) }
         end
 
         # Tries to logout from all targets (nodes).
@@ -306,16 +307,26 @@ module Agama
           nodes.select(&:connected?).each { |n| adapter.logout(n) }
         end
 
-        # Tries to login to all given targets.
+        # Discovers iSCSI targets from all the portals.
+        #
+        # @param config [ISCSI::Config]
+        def discover_from_portals(config)
+          config.portals.each do |portal|
+            interfaces = config.interfaces(portal)
+            adapter.discover_from_portal(portal, interfaces: interfaces)
+          end
+        end
+
+        # Tries to login to all targets.
         #
         # @note If the login of a target fails, then an issue is generated. The process stops on
         #   the first failing login.
         #
-        # @param targets [Array<ISCSI::Config::Target>]
-        def login_targets(targets)
+        # @param config [ISCSI::Config]
+        def login_targets(config)
           issues = []
 
-          targets.each do |target|
+          config.targets.each do |target|
             success = apply_target_config(target)
             if !success
               issues << login_issue(target)

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -20,7 +20,7 @@
     Requires:       yast2-country
     Requires:       yast2-hardware-detection
     Requires:       yast2-installation
-    Requires:       yast2-iscsi-client >= 4.5.7
+    Requires:       yast2-iscsi-client >= 5.0.8
     Requires:       yast2-network
     Requires:       yast2-proxy
     Requires:       yast2-storage-ng >= 5.0.31

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  2 10:50:56 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Add missing iSCSI discovery when importing the iSCSI config
+  (bsc#1245171).
+
+-------------------------------------------------------------------
 Mon Jun 30 15:51:33 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 16

--- a/service/test/agama/storage/iscsi/manager_test.rb
+++ b/service/test/agama/storage/iscsi/manager_test.rb
@@ -50,6 +50,7 @@ describe Agama::Storage::ISCSI::Manager do
     allow(Yast::IscsiClientLib).to receive(:iBFT?)
     allow(Yast::IscsiClientLib).to receive(:find_session)
     allow(Yast::IscsiClientLib).to receive(:getStartupStatus)
+    allow(Yast::IscsiClientLib).to receive(:discover_from_portal)
     allow(Yast::Service).to receive(:start)
     allow(subject).to receive(:adapter).and_return(adapter)
     allow(subject).to receive(:sleep)
@@ -614,6 +615,16 @@ describe Agama::Storage::ISCSI::Manager do
 
         before do
           allow(adapter).to receive(:login).and_return(true)
+        end
+
+        it "performs a discovery for each portal" do
+          expect(adapter).to receive(:discover_from_portal)
+            .with("192.168.100.151:3260", interfaces: ["default"])
+
+          expect(adapter).to receive(:discover_from_portal)
+            .with("192.168.100.152:3260", interfaces: ["default"])
+
+          subject.apply_config_json(config_json)
         end
 
         it "tries to login to each target" do


### PR DESCRIPTION
## Problem

The iSCSI discovery is not done while importing an iSCSI config. Without that, the target login fails.

https://bugzilla.suse.com/show_bug.cgi?id=1245171

## Solution

Add the missing discovery step.

Requires https://github.com/yast/yast-iscsi-client/pull/146.
