### PR TITLE
live: fix_bootconfig.s390x: strip CDLABEL from the kiwi-generated grub config (bsc#1245453)

### DIFF
--- a/live/config-cdroot/fix_bootconfig.s390x
+++ b/live/config-cdroot/fix_bootconfig.s390x
@@ -62,6 +62,7 @@ fi
 #
 
 boot_dir=$dst/boot/s390x
+grub_dir=$dst/boot/grub2
 
 # if files are in a 'loader' subdir, move them out
 if [ -d $boot_dir/loader ] ; then
@@ -149,6 +150,12 @@ SAY 'LOADING SLES FILES INTO READER...'
 'PUNCH SLES INITRD A (NOH'                                                      
 'IPL 00C'                                                                       
 XXX
+
+# Strip CDLABEL from the kiwi-generated grub configuration
+# We are specifying the correct one in /etc/cmdline.d (see config.sh)
+# and having it here might be confusing to repackers such as
+# mksusecd (bsc#1245453)
+sed -i -E 's|root=live:CDLABEL=[^ ]+||g' $grub_dir/grub.cfg
 
 # Note:
 #

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  2 13:28:46 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- live: fix_bootconfig.s390x: strip CDLABEL from the kiwi-generated
+  grub config (bsc#1245453)
+
+-------------------------------------------------------------------
 Mon Jun 30 15:51:37 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 16


### PR DESCRIPTION
## Problem

We are determining the Volume ID ourselves, and actually setting it in /etc/cmdline.d during image creation phase.

During image build, having the entry in the cmdline is not an issue, as the volid is passed directly to xorriso by the main fix_bootconfig script.

However, when repacking the image with some tools such as mksusecd, they might (correctly!) default to the specified label name in the grub configuration, which in our case is not what we want.

Only s390x is affected as the other architectures's fix_bootconfig scripts replace the whole grub configuration.

- https://bugzilla.suse.com/show_bug.cgi?id=1245453

## Solution

Ensure we strip the root=live:CDLABEL cmdline entry added in the kiwi-generated grub2 configuration.

## Testing

- *Tested manually*