### PR TITLE
fix(rust): cache products during the startup

### DIFF
--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -71,7 +71,7 @@ struct SoftwareState<'a> {
     licenses: LicensesRepo,
     // cache the software values, during installation the software service is
     // not responsive (blocked in a libzypp call)
-    products: Arc<RwLock<Option<Vec<Product>>>>,
+    products: Arc<RwLock<Vec<Product>>>,
     config: Arc<RwLock<Option<SoftwareConfig>>>,
 }
 
@@ -224,12 +224,17 @@ fn reason_to_selected_by(
 /// * `products`: list of products (shared behind a mutex).
 pub async fn receive_events(
     mut events: EventsReceiver,
-    products: Arc<RwLock<Option<Vec<Product>>>>,
+    products: Arc<RwLock<Vec<Product>>>,
+    client: ProductClient<'_>,
 ) {
     while let Ok(event) = events.recv().await {
         if let Event::LocaleChanged { locale: _ } = event {
             let mut cached_products = products.write().await;
-            *cached_products = None;
+            if let Ok(products) = client.products().await {
+                *cached_products = products;
+            } else {
+                tracing::error!("Could not update the products cached");
+            }
         }
     }
 }
@@ -266,16 +271,19 @@ pub async fn software_service(
 
     let product = ProductClient::new(dbus.clone()).await?;
     let software = SoftwareClient::new(dbus).await?;
+    let all_products = product.products().await?;
+
     let state = SoftwareState {
         product,
         software,
         licenses: licenses_repo,
-        products: Arc::new(RwLock::new(None)),
+        products: Arc::new(RwLock::new(all_products)),
         config: Arc::new(RwLock::new(None)),
     };
 
     let cached_products = Arc::clone(&state.products);
-    tokio::spawn(async move { receive_events(events, cached_products).await });
+    let products_client = state.product.clone();
+    tokio::spawn(async move { receive_events(events, cached_products, products_client).await });
 
     let router = Router::new()
         .route("/patterns", get(patterns))
@@ -320,18 +328,7 @@ pub async fn software_service(
     )
 )]
 async fn products(State(state): State<SoftwareState<'_>>) -> Result<Json<Vec<Product>>, Error> {
-    let cached_products = state.products.read().await.clone();
-
-    if let Some(products) = cached_products {
-        tracing::info!("Returning cached products");
-        return Ok(Json(products));
-    }
-
-    let products = state.product.products().await?;
-
-    let mut cached_products_write = state.products.write().await;
-    *cached_products_write = Some(products.clone());
-
+    let products = state.products.read().await.clone();
     Ok(Json(products))
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul  2 16:02:07 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Cache the list of products during the startup (bsc#1241208).
+
+-------------------------------------------------------------------
 Mon Jun 30 15:51:35 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 16


### PR DESCRIPTION
## Problem

Some time ago we, we introduced [a cache](https://github.com/agama-project/agama/pull/2364) to store the software data and avoid blocking the UI. The problem is that the list of products is cached only when a client asks for it. So in the case of an unattended installation, it might happen that the installation starts before the web UI asks for the list of products for the first time.

- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1241208

## Solution

Read the list of products during the web server initialization. It will be updated only when the locale changes.

## Testing

- *Tested manually*
