### PR TITLE
fix(storage): keep storage config after registration

### DIFF
--- a/rust/agama-lib/src/manager.rs
+++ b/rust/agama-lib/src/manager.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -144,6 +144,12 @@ impl<'a> ManagerClient<'a> {
     pub async fn probe(&self) -> Result<(), ServiceError> {
         self.wait().await?;
         Ok(self.manager_proxy.probe().await?)
+    }
+
+    /// Starts the reprobing process.
+    pub async fn reprobe(&self) -> Result<(), ServiceError> {
+        self.wait().await?;
+        Ok(self.manager_proxy.reprobe().await?)
     }
 
     /// Starts the installation.

--- a/rust/agama-lib/src/manager/http_client.rs
+++ b/rust/agama-lib/src/manager/http_client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -50,6 +50,13 @@ impl ManagerHTTPClient {
         // BaseHTTPClient did not anticipate POST without request body
         // so we pass () which is rendered as `null`
         Ok(self.client.post_void("/manager/probe_sync", &()).await?)
+    }
+
+    /// Starts a "reprobing".
+    pub async fn reprobe(&self) -> Result<(), ManagerHTTPClientError> {
+        // BaseHTTPClient did not anticipate POST without request body
+        // so we pass () which is rendered as `null`
+        Ok(self.client.post_void("/manager/reprobe_sync", &()).await?)
     }
 
     /// Starts the installation.

--- a/rust/agama-lib/src/product/store.rs
+++ b/rust/agama-lib/src/product/store.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -78,6 +78,7 @@ impl ProductStore {
 
     pub async fn store(&self, settings: &ProductSettings) -> ProductStoreResult<()> {
         let mut probe = false;
+        let mut reprobe = false;
         if let Some(product) = &settings.id {
             let existing_product = self.product_client.product().await?;
             if *product != existing_product {
@@ -94,7 +95,7 @@ impl ProductStore {
 
             self.product_client.register(reg_code, email).await?;
             // TODO: avoid reprobing if the system has been already registered with the same code?
-            probe = true;
+            reprobe = true;
         }
         // register the addons in the order specified in the profile
         if let Some(addons) = &settings.addons {
@@ -105,6 +106,8 @@ impl ProductStore {
 
         if probe {
             self.manager_client.probe().await?;
+        } else if reprobe {
+            self.manager_client.reprobe().await?;
         }
 
         Ok(())

--- a/rust/agama-lib/src/proxies/manager1.rs
+++ b/rust/agama-lib/src/proxies/manager1.rs
@@ -41,6 +41,9 @@ pub trait Manager1 {
     /// Probe method
     fn probe(&self) -> zbus::Result<()>;
 
+    /// Reprobe method
+    fn reprobe(&self) -> zbus::Result<()>;
+
     /// BusyServices property
     #[zbus(property)]
     fn busy_services(&self) -> zbus::Result<Vec<String>>;

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -104,6 +104,7 @@ pub async fn manager_service(
     Ok(Router::new()
         .route("/probe", post(probe_action))
         .route("/probe_sync", post(probe_sync_action))
+        .route("/reprobe_sync", post(reprobe_sync_action))
         .route("/install", post(install_action))
         .route("/finish", post(finish_action))
         .route("/installer", get(installer_status))
@@ -159,6 +160,20 @@ async fn probe_action(State(state): State<ManagerState<'_>>) -> Result<(), Error
 )]
 async fn probe_sync_action(State(state): State<ManagerState<'_>>) -> Result<(), Error> {
     state.manager.probe().await?;
+    Ok(())
+}
+
+/// Starts the reprobing process and waits until it is done.
+#[utoipa::path(
+    post,
+    path = "/reprobe_sync",
+    context_path = "/api/manager",
+    responses(
+      (status = 200, description = "Re-probing done.")
+    )
+)]
+async fn reprobe_sync_action(State(state): State<ManagerState<'_>>) -> Result<(), Error> {
+    state.manager.reprobe().await?;
     Ok(())
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  4 11:33:44 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Reprobe the system after registering the product
+  (gh#agama-project/agama#2532, bsc#1245400).
+
+-------------------------------------------------------------------
 Wed Jul  2 16:02:07 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Cache the list of products during the startup (bsc#1241208).

--- a/service/lib/agama/dbus/clients/storage.rb
+++ b/service/lib/agama/dbus/clients/storage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2024] SUSE LLC
+# Copyright (c) [2022-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -51,6 +51,11 @@ module Agama
         # @param done [Proc] Block to execute once the probing is done
         def probe(&done)
           dbus_object[STORAGE_IFACE].Probe(&done)
+        end
+
+        # Reprobes (keeps the current settings).
+        def reprobe
+          dbus_object.Reprobe
         end
 
         # Performs the packages installation

--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -64,6 +64,7 @@ module Agama
 
       dbus_interface MANAGER_INTERFACE do
         dbus_method(:Probe, "") { config_phase }
+        dbus_method(:Reprobe, "") { config_phase(reprobe: true) }
         dbus_method(:Commit, "") { install_phase }
         dbus_method(:CanInstall, "out result:b") { can_install? }
         dbus_method(:CollectLogs, "out tarball_filesystem_path:s") { collect_logs }
@@ -75,9 +76,9 @@ module Agama
       end
 
       # Runs the config phase
-      def config_phase
+      def config_phase(reprobe: false)
         safe_run do
-          busy_while { backend.config_phase }
+          busy_while { backend.config_phase(reprobe: reprobe) }
         end
       end
 

--- a/service/lib/agama/dbus/manager_service.rb
+++ b/service/lib/agama/dbus/manager_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -69,8 +69,6 @@ module Agama
       # @note The service runs its startup phase
       def start
         export
-        # We need locale for data from users
-        locale_client = Clients::Locale.instance
         manager.on_progress_change { dispatch } # make single thread more responsive
         manager.startup_phase
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  4 11:31:21 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Extend D-Bus API to allow reprobing the system
+  (gh#agama-project/agama#2532, bsc#1245400).
+
+-------------------------------------------------------------------
 Wed Jul  2 10:50:56 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Add missing iSCSI discovery when importing the iSCSI config
@@ -19,7 +25,7 @@ Mon Jun 30 11:23:03 UTC 2025 - Martin Vidner <mvidner@suse.com>
 Fri Jun 27 14:02:57 UTC 2025 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-11193
-  - do not create the "after install" snapshot 
+  - do not create the "after install" snapshot
 
 -------------------------------------------------------------------
 Fri Jun 27 12:07:35 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/service/test/agama/manager_test.rb
+++ b/service/test/agama/manager_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -56,7 +56,7 @@ describe Agama::Manager do
   let(:network) { instance_double(Agama::Network, install: nil, startup: nil) }
   let(:storage) do
     instance_double(
-      Agama::DBus::Clients::Storage, probe: nil, install: nil, finish: nil,
+      Agama::DBus::Clients::Storage, probe: nil, reprobe: nil, install: nil, finish: nil,
       on_service_status_change: nil, errors?: false
     )
   end
@@ -123,6 +123,18 @@ describe Agama::Manager do
       expect(storage).to receive(:probe)
       expect(software).to receive(:probe)
       subject.config_phase
+    end
+
+    context "if reprobe is requested" do
+      it "calls #reprobe method of the storage module" do
+        expect(storage).to receive(:reprobe)
+        subject.config_phase(reprobe: true)
+      end
+
+      it "calls #probe method of the software module" do
+        expect(software).to receive(:probe)
+        subject.config_phase(reprobe: true)
+      end
     end
   end
 

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  4 11:34:59 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Reprobe the system after registering the product
+  (gh#agama-project/agama#2532, bsc#1245400).
+
+-------------------------------------------------------------------
 Tue Jul  1 12:57:50 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Add LeapMicro.svg

--- a/web/src/api/manager.ts
+++ b/web/src/api/manager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2024] SUSE LLC
+ * Copyright (c) [2024-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -33,6 +33,11 @@ const startProbing = () => post("/api/manager/probe");
 const probe = () => post("/api/manager/probe_sync");
 
 /**
+ * Triggers a synchronous reprobing process.
+ */
+const reprobe = () => post("/api/manager/reprobe_sync");
+
+/**
  * Starts the installation process.
  *
  * The progress of the installation process can be tracked through installer signals.
@@ -49,4 +54,4 @@ const finishInstallation = () => post("/api/manager/finish");
  */
 const fetchLogs = () => get("/api/manager/logs/store");
 
-export { startProbing, probe, startInstallation, finishInstallation, fetchLogs };
+export { startProbing, probe, reprobe, startInstallation, finishInstallation, fetchLogs };

--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2024] SUSE LLC
+ * Copyright (c) [2024-2025] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -62,7 +62,7 @@ import {
   updateConfig,
 } from "~/api/software";
 import { QueryHookOptions } from "~/types/queries";
-import { probe as systemProbe } from "~/api/manager";
+import { probe as systemProbe, reprobe as systemReprobe } from "~/api/manager";
 
 /**
  * Query to retrieve software configuration
@@ -180,7 +180,7 @@ const useRegisterMutation = () => {
   const query = {
     mutationFn: register,
     onSuccess: async () => {
-      await systemProbe();
+      await systemReprobe();
       queryClient.invalidateQueries({ queryKey: ["software", "registration"] });
       queryClient.invalidateQueries({ queryKey: ["storage"] });
     },


### PR DESCRIPTION
## Problem

The storage config is lost after registering a product. 

https://bugzilla.suse.com/show_bug.cgi?id=1245400

## Solution

Reprobe the system instead of a complete probing.

Note: in the future, a better solution will be implemented to avoid delegating the reprobing call to the clients, see https://gist.github.com/joseivanlopez/8d8103ffd4a8e5539046cb6e134be05f.
