### PR TITLE
Add dns priority to network model

### DIFF
--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -879,6 +879,8 @@ pub struct IpConfig {
     pub dhcp4_settings: Option<Dhcp4Settings>,
     pub dhcp6_settings: Option<Dhcp6Settings>,
     pub ip6_privacy: Option<i32>,
+    pub dns_priority4: Option<i32>,
+    pub dns_priority6: Option<i32>,
 }
 
 #[skip_serializing_none]

--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -423,6 +423,10 @@ fn ip_config_to_ipv4_dbus<'a>(
         ipv4_dbus.insert("gateway", gateway.to_string().into());
     }
 
+    if let Some(dns_priority4) = &ip_config.dns_priority4 {
+        ipv4_dbus.insert("dns-priority", dns_priority4.into());
+    }
+
     if let Some(dhcp4_settings) = &ip_config.dhcp4_settings {
         if VersionReq::parse(">=1.52.0").unwrap().matches(nm_version) {
             let dhcp_send_hostname = match dhcp4_settings.send_hostname {
@@ -521,6 +525,10 @@ fn ip_config_to_ipv6_dbus<'a>(
 
     if let Some(ip6_privacy) = &ip_config.ip6_privacy {
         ipv6_dbus.insert("ip6-privacy", ip6_privacy.into());
+    }
+
+    if let Some(dns_priority6) = &ip_config.dns_priority6 {
+        ipv6_dbus.insert("dns-priority", dns_priority6.into());
     }
 
     if let Some(dhcp6_settings) = &ip_config.dhcp6_settings {
@@ -965,6 +973,10 @@ fn ip_config_from_dbus(conn: &OwnedNestedHash) -> Result<IpConfig, NmError> {
             ip_config.gateway4 = gateway.parse().ok();
         }
 
+        if let Some(dns_priority4) = get_optional_property(ipv4, "dns-priority")? {
+            ip_config.dns_priority4 = Some(dns_priority4);
+        }
+
         let mut dhcp4_settings = Dhcp4Settings::default();
         if let Some(dhcp_send_hostname) = get_optional_property(ipv4, "dhcp-send-hostname-v2")? {
             dhcp4_settings.send_hostname = match dhcp_send_hostname {
@@ -1033,6 +1045,10 @@ fn ip_config_from_dbus(conn: &OwnedNestedHash) -> Result<IpConfig, NmError> {
 
         if let Some(ip6_privacy) = get_optional_property(ipv6, "ip6-privacy")? {
             ip_config.ip6_privacy = Some(ip6_privacy);
+        }
+
+        if let Some(dns_priority6) = get_optional_property(ipv6, "dns-priority")? {
+            ip_config.dns_priority6 = Some(dns_priority6);
         }
 
         let mut dhcp6_settings = Dhcp6Settings::default();

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul 15 13:17:22 UTC 2025 - Jorik Cronenberg <jorik.cronenberg@suse.com>
+
+- Add dns priority to network model (gh#agama-project/agama#2533).
+
+-------------------------------------------------------------------
 Tue Jul 15 09:00:00 UTC 2025 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
 
 - Fix autoconnect setting for port interfaces (bsc#1246070).


### PR DESCRIPTION
## Problem

Missing dns priority value required for the `wicked2nm` migration.

## Solution

Add dns priority to network model.

## Testing

- *Tested manually*
- *Tested with https://github.com/openSUSE/wicked2nm/pull/31*