### PR TITLE
fix(web): do not scroll to top when selecting sofware

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jul  4 14:51:14 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Avoid scroll to top on software selection (bsc#1245732).
+
+-------------------------------------------------------------------
 Tue Jul  1 12:57:50 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
 
 - Add LeapMicro.svg

--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -170,6 +170,7 @@ const useConfigMutation = () => {
       queryClient.invalidateQueries({ queryKey: ["software", "config"] });
       queryClient.invalidateQueries({ queryKey: ["software", "proposal"] });
       if (config.product) {
+        queryClient.invalidateQueries({ queryKey: ["software", "selectedProduct"] });
         await systemProbe();
         queryClient.invalidateQueries({ queryKey: ["storage"] });
       }

--- a/web/src/queries/software.ts
+++ b/web/src/queries/software.ts
@@ -81,6 +81,15 @@ const proposalQuery = () => ({
 });
 
 /**
+ * Query to retrieve selected product
+ */
+const selectedProductQuery = () => ({
+  queryKey: ["software", "selectedProduct"],
+  queryFn: () => fetchConfig().then(({ product }) => product),
+  staleTime: Infinity,
+});
+
+/**
  * Query to retrieve available products
  */
 const productsQuery = () => ({
@@ -158,7 +167,8 @@ const useConfigMutation = () => {
   const query = {
     mutationFn: updateConfig,
     onSuccess: async (_, config: SoftwareConfig) => {
-      queryClient.invalidateQueries({ queryKey: ["software"] });
+      queryClient.invalidateQueries({ queryKey: ["software", "config"] });
+      queryClient.invalidateQueries({ queryKey: ["software", "proposal"] });
       if (config.product) {
         await systemProbe();
         queryClient.invalidateQueries({ queryKey: ["storage"] });
@@ -228,20 +238,20 @@ const useProduct = (
 ): { products?: Product[]; selectedProduct?: Product } => {
   const func = options?.suspense ? useSuspenseQueries : useQueries;
   const [
-    { data: config, isPending: isConfigPending },
+    { data: product, isPending: isSelectedProductPending },
     { data: products, isPending: isProductsPending },
   ] = func({
-    queries: [configQuery(), productsQuery()],
+    queries: [selectedProductQuery(), productsQuery()],
   }) as [{ data: SoftwareConfig; isPending: boolean }, { data: Product[]; isPending: boolean }];
 
-  if (isConfigPending || isProductsPending) {
+  if (isSelectedProductPending || isProductsPending) {
     return {
       products: [],
       selectedProduct: undefined,
     };
   }
 
-  const selectedProduct = products.find((p: Product) => p.id === config.product);
+  const selectedProduct = products.find((p: Product) => p.id === product);
   return {
     products,
     selectedProduct,


### PR DESCRIPTION
## Problem

Recent changes to cache handling in the web interface caused the software selection page to scroll to the top whenever the user changes their selection. This behavior degrades the user experience.

* https://bugzilla.suse.com/show_bug.cgi?id=1245732 (protected link)

## Solution

Partially revert https://github.com/agama-project/agama/commit/dc5ea33c1f8294d629704de3ddddbe12a21ae969 to separate the selected product's cache from the software/config cache. This prevents the src/App wrapper component from being re-rendered when the configuration updates due to software changes, preserving the scroll position.

## Testing

Manually tested: used the generated ISO at https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/ (link may no longer work) to verify that changing the software selection no longer causes the page to scroll to the top.
