### PR TITLE
Use the DUD repository for installing packages

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -49,8 +49,6 @@ apply_updates() {
 
     ((index++))
   done <$AGAMA_DUD_INFO
-
-  create_repo "$DUD_RPM_REPOSITORY"
 }
 
 # Applies an update from an RPM package
@@ -136,7 +134,7 @@ set_alternative() {
 # This function is mainly a PoC.
 #
 # This is a simplistic version that just copies all the RPMs to the new repository.
-# In the future, it might need to put each package under a different respository depending
+# In the future, it might need to put each package under a different repository depending
 # on the distribution (e.g., "/run/agama/dud/repo/tw" for "x86_64-tw").
 copy_packages() {
   dud_dir=$1
@@ -147,13 +145,6 @@ copy_packages() {
     mkdir -p "$repo_dir"
     cp "$rpm" "$repo_dir"
   done
-}
-
-# Creates the repository metadata.
-create_repo() {
-  repo_dir=$1
-
-  "$NEWROOT/usr/bin/chroot" "$NEWROOT" createrepo_c "${repo_dir##"$NEWROOT"}"
 }
 
 if [ -f "$AGAMA_DUD_INFO" ]; then

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -157,7 +157,6 @@
         <package name="qrencode"/>
         <package name="qemu-guest-agent" />
         <package name="aaa_base-extras"/>
-        <package name="createrepo_c" />
         <!-- it can be used by users in AutoYaST pre-scripts -->
         <package name="perl-XML-Simple"/>
         <archive name="live-root.tar.xz"/>

--- a/service/.rubocop.yml
+++ b/service/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - agama-yast.gemspec
     - package/*.spec
 
-# a D-Bus method definition may take up more line lenght than usual
+# a D-Bus method definition may take up more line length than usual
 Layout/LineLength:
   IgnoredPatterns:
     - dbus_method
@@ -31,6 +31,8 @@ Metrics/AbcSize:
 
 Metrics/ParameterLists:
   Max: 6
+  Exclude:
+    - lib/agama/software/repository.rb
 
 Metrics/ClassLength:
   Max: 300

--- a/service/lib/agama/software/repositories_manager.rb
+++ b/service/lib/agama/software/repositories_manager.rb
@@ -49,9 +49,11 @@ module Agama
       # @param repo_alias [String] Repository alias, must be unique,
       #   if not specified a random one is generated
       # @param autorefresh [Boolean] Whether the repository should be autorefreshed
-      def add(url, name: nil, repo_alias: "", autorefresh: true)
+      # @param priority    [Integer] Repository priority, the lower number the higher (!)
+      #                              priority, the default libzypp priority is 99
+      def add(url, name: nil, repo_alias: "", autorefresh: true, priority: 99)
         repositories << Repository.create(name: name || url, url: url, repo_alias: repo_alias,
-          autorefresh: autorefresh)
+          autorefresh: autorefresh, priority: priority)
       end
 
       # returns user repositories as it was previously specified

--- a/service/lib/agama/software/repository.rb
+++ b/service/lib/agama/software/repository.rb
@@ -48,11 +48,16 @@ module Agama
         # @param product_dir [String]       Product directory
         # @param enabled     [Boolean]      Is the repository enabled?
         # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
+        # @param priority    [Integer]      Repository priority, the lower number the higher (!)
+        #                                   priority, the default libzypp priority is 99
         # @return [Y2Packager::Repository,nil] New repository or nil if creation failed
-        def create(name:, url:, repo_alias: "", product_dir: "", enabled: true, autorefresh: true)
+        def create(name:, url:, repo_alias: "", product_dir: "", enabled: true, autorefresh: true,
+          priority: 99)
+
           repo_id = Yast::Pkg.RepositoryAdd(
             "name" => name, "base_urls" => [url.to_s], "enabled" => enabled,
-            "autorefresh" => autorefresh, "prod_dir" => product_dir, "alias" => repo_alias
+            "autorefresh" => autorefresh, "prod_dir" => product_dir, "alias" => repo_alias,
+            "priority" => priority
           )
 
           repo_id ? find(repo_id) : nil

--- a/service/test/agama/software/manager_test.rb
+++ b/service/test/agama/software/manager_test.rb
@@ -458,14 +458,14 @@ describe Agama::Software::Manager do
     context "only a local repository is used" do
       let(:repo_id) { 42 }
       before do
-        expect(Agama::Software::Repository).to receive(:all).and_return(
+        allow(Agama::Software::Repository).to receive(:all).and_return(
           [
             Agama::Software::Repository.new(
               repo_id: repo_id, repo_alias: "alias", name: "name",
               url: "dvd:/install?devices=/dev/sr0", enabled: true, autorefresh: false
             )
           ]
-        ).twice
+        )
       end
 
       it "disables the local repository" do

--- a/service/test/agama/software/repositories_manager_test.rb
+++ b/service/test/agama/software/repositories_manager_test.rb
@@ -55,7 +55,7 @@ describe Agama::Software::RepositoriesManager do
     it "registers the repository in the packaging system" do
       url = "https://example.net"
       expect(Agama::Software::Repository).to receive(:create)
-        .with(autorefresh: true, name: url, repo_alias: "", url: url)
+        .with(autorefresh: true, name: url, repo_alias: "", url: url, priority: 99)
         .and_return(repo)
       subject.add(url)
       expect(subject.repositories).to include(repo)


### PR DESCRIPTION
## Problem

- The DUD repository is not used for installing packages into the target system

## Solution

- Add the local DUD repository into the list of used repositories, use a higher priority so the provided packages are preferred (even when they have a lower version than in the other repositories). 

## Notes

- Libzypp supports "plaindir" repository type, that is basically a local directory with RPM files without any metadata. When no metadata is found in a `dir:/` repository then libzypp automatically switches to the "plaindir" type and scans the available RPMs there.
- That is easier to handle (no need to create metadata) and it saves some RAMdisk space (not creating the metadata files). The most important feature is that the "plaindir" repositories are by definition not GPG signed so libzypp does not complain about using an unsigned repository.
- So we can remove the `createrepo_c` package from the Live medium and do not call it.

## TODO

- [ ] Add an option for ignoring the GPG problems for the DUD packages

## Testing

- Tested manually with a DUD with trivial [hello-world](https://build.opensuse.org/package/show/home:lslezak:dud-test2/hello-world) package
- Note: The testing package uses the `Supplements: aaa_base` dependency to select the package to install, otherwise the package would need to be selected to install by using CLI.

## Screenshots

The testing package is signed by an unknown GPG key, an error is reported during installation:

![agama-install-unsigned-package](https://github.com/user-attachments/assets/fa52256b-4dbf-4802-9795-f78a9d3b4054)

But after pressing "Continue Anyway" it is installed into the system and works as expected and the temporary DUD repository is not included in the installed system:

![agama-dud-package-installed](https://github.com/user-attachments/assets/8e6bf14a-43fb-4a3a-87d0-c7f40de73023)
