### PR TITLE
feat(live): add the tpm2.0-tools package

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul  9 12:07:21 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the tpm2.0-tools package (jsc#PED-13114).
+
+-------------------------------------------------------------------
 Wed Jul  2 13:28:46 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - live: fix_bootconfig.s390x: strip CDLABEL from the kiwi-generated

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -163,6 +163,8 @@
         <archive name="live-root.tar.xz"/>
         <!-- IPMI support -->
         <package name="ipmitool" />
+        <!-- jsc#PED-13114 -->
+        <package name="tpm2.0-tools" />
     </packages>
 
     <!-- packages for local installation (desktop, browser, etc.) -->


### PR DESCRIPTION
We received a request to add the `tpm2.0-tools` package to the live media.

- [PED-13114](https://jira.suse.com/browse/PED-13114) (internal link)
