### PR TITLE
initialize InstallationPhase (bsc#1245760)

### DIFF
--- a/service/lib/agama/installation_phase.rb
+++ b/service/lib/agama/installation_phase.rb
@@ -30,6 +30,7 @@ module Agama
     FINISH = "finish"
 
     def initialize
+      @value = STARTUP
       @on_change_callbacks = []
     end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  9 14:04:23 UTC 2025 - Martin Vidner <mvidner@suse.com>
+
+- Fix error at /api/manager/installer: initialize the backend value
+  for org.opensuse.Agama1.Manager.CurrentInstallationPhase (bsc#1245760)
+
+-------------------------------------------------------------------
 Wed Jul  9 12:21:55 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Add AutoYaST conversion for RMT registration (gh#agama-project/agama#2545).


### PR DESCRIPTION
## Problem

A race condition, an unattended installation sometimes stalls and this is in the log:

> agama-web-server[3392]: Server return error Agama service error: D-Bus service error: 
> org.freedesktop.DBus.Error.Failed: nil is not a member of 0..4294967295; caused by 
> 1 sender=:1.2 -> dest=org.opensuse.Agama.Manager1 serial=104 reply_serial=
> path=/org/opensuse/Agama/Manager1; interface=org.freedesktop.DBus.Properties; member=Get error_name=

The message does not mention the offending property, but from the context of the request we find it is `CurrentInstallationPhase`.

- https://bugzilla.suse.com/show_bug.cgi?id=1245760


## Solution

It turns out that `InstallationPhase` is not initializing itself properly, exposing an uninitialized `nil` value for some short(?) time. So initialize it.

## Testing

No, but I dare say the fix is simple enough


## Screenshots

No

## Documentation

This fix does not need docs