### PR TITLE
feat(live): use kernel modules from driver updates

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -12,9 +12,9 @@ DUD_RPM_REPOSITORY="$NEWROOT/var/lib/agama/dud/repo"
 
 shopt -s nullglob
 
-# Apply all the updates.
+# Applies all the updates
 #
-# Read the URL of the updates from $AGAMA_DUD_INFO and process each one.
+# Reads the URL of the updates from $AGAMA_DUD_INFO and process each one.
 apply_updates() {
   local file
   local dud_url
@@ -81,6 +81,7 @@ apply_dud_update() {
   dud_root=$(echo "${dir}/linux/suse/${arch}"-*)
   install_update "${dud_root}/inst-sys"
   copy_packages "$dud_root" "$DUD_RPM_REPOSITORY"
+  update_kernel_modules "$dud_root"
 }
 
 # Extracts an RPM file
@@ -98,7 +99,7 @@ unpack_rpm() {
   popd || exit 1
 }
 
-# Applies an update to the installation system.
+# Applies an update to the installation system
 #
 # Updates are applied by copying files instead of installing packages. For that
 # reason, it might be needed to do some adjustments "manually", like settings
@@ -114,7 +115,7 @@ install_update() {
   set_alternative "$dud_dir" "agama-proxy-setup"
 }
 
-# Sets the alternative links.
+# Sets the alternative links
 set_alternative() {
   dud_instsys=$1
   name=$2
@@ -154,6 +155,94 @@ create_repo() {
   repo_dir=$1
 
   "$NEWROOT/usr/bin/chroot" "$NEWROOT" createrepo_c "${repo_dir##"$NEWROOT"}"
+}
+
+# Finds the kernel modules to update
+#
+# It searches for the modules in the modules/ directory of the update.
+find_kernel_modules() {
+  local directory=$1
+  local -n modules=$2
+  local module_name
+  local files
+
+  modules=()
+  files=("${directory}"/*.ko*)
+  for module in "${files[@]}"; do
+    module_name=${module#"${directory}/"}
+    module_name=${module_name%.ko*}
+
+    if [[ ! " ${modules[*]} " =~ \ ${module_name}\  ]]; then
+      modules+=("$module_name")
+    fi
+  done
+
+  echo "Found ${#files[@]} kernel modules"
+}
+
+# Copies a kernel module
+#
+# It searches for a module with the same name. If found, it replaces it.
+# Otherwise, it copies the module to the top-level modules directory.
+copy_kernel_module() {
+  local source_dir=$1
+  local module=$2
+  local target_dir=$3
+  local source_file
+
+  echo "Copying ${module}..."
+
+  # expect a single file with $module.ko* name
+  source_file=("${source_dir}/${module}".ko*)
+
+  echo old "${target_dir}/**/*/${module}.ko*"
+  old_module=("${target_dir}"/**/*/"${module}".ko*)
+  if [ "${#old_module[@]}" -eq "1" ]; then
+    info "  Replacing the module ${old_module[0]}"
+    cp "${source_file[0]}" "${old_module[0]}"
+  elif [ "${#old_module[@]}" -eq "0" ]; then
+    info "  Not found the module to replace, so copying to kernel/ directory."
+    cp "${source_file[0]}" "${target_dir}"
+  else
+    info "  Skipping the module because several modules with the same name were found."
+  fi
+}
+
+# Updates kernel modules
+#
+# It copies the kernel modules from the Driver Update Disk to the system under
+# /sysroot. If it finds a `module.order` file, it unloads the modules included
+# in the list and them to /etc/modules-load.d/99-agama.conf file so they will be
+# loaded by systemd after pivoting.
+update_kernel_modules() {
+  local dud_dir=$1
+  local kernel_modules_dir
+  kernel_modules_dir="${NEWROOT}/lib/modules/$(uname -r)"
+  local dud_modules_dir="${dud_dir}/modules"
+
+  local dud_modules
+  find_kernel_modules "$dud_modules_dir" dud_modules
+
+  for module in "${dud_modules[@]}"; do
+    echo "Processing ${module} module"
+    copy_kernel_module "$dud_modules_dir" "$module" "${kernel_modules_dir}/kernel"
+    rmmod "${module}" 2>&1
+  done
+
+  if [ -f "${dud_modules_dir}/module.order" ]; then
+    module_order=$(<"${dud_modules_dir}/module.order")
+    # unload the modules in reverse order
+    local idx
+    idx=("${!module_order[@]}")
+    for ((i = ${#idx[@]} - 1; i >= 0; i--)); do
+      rmmod "${module_order[$i]}" 2>&1
+    done
+
+    cp "${dud_modules_dir}/module.order" "${NEWROOT}/etc/modules-load.d/99-agama.conf"
+  fi
+
+  info "Updating modules dependencies..."
+  depmod -a -b "$NEWROOT"
 }
 
 if [ -f "$AGAMA_DUD_INFO" ]; then

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -222,13 +222,6 @@ update_kernel_modules() {
   kernel_modules_dir="${NEWROOT}/lib/modules/$(uname -r)"
   local dud_modules_dir="${dud_dir}/modules"
 
-  # copy hardware information
-  local hardware_ids="${dud_modules_dir}/hd.ids"
-  if [ -f "$hardware_ids" ]; then
-    mkdir -p "${NEWROOT}/var/lib/hardware"
-    cat "$hardware_ids" >>"${NEWROOT}/var/lib/hardware"
-  fi
-
   # find and copy kernel modules
   local dud_modules
   find_kernel_modules "$dud_modules_dir" dud_modules

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -210,6 +210,8 @@ copy_kernel_module() {
 
 # Updates kernel modules
 #
+# It copies the kernel modules and the hardware information for hwinfo.
+#
 # It copies the kernel modules from the Driver Update Disk to the system under
 # /sysroot. If it finds a `module.order` file, it unloads the modules included
 # in the list and them to /etc/modules-load.d/99-agama.conf file so they will be
@@ -227,15 +229,16 @@ update_kernel_modules() {
     cat "$hardware_ids" >>"${NEWROOT}/var/lib/hardware"
   fi
 
+  # find and copy kernel modules
   local dud_modules
   find_kernel_modules "$dud_modules_dir" dud_modules
-
   for module in "${dud_modules[@]}"; do
     echo "Processing ${module} module"
     copy_kernel_module "$dud_modules_dir" "$module" "${kernel_modules_dir}/kernel"
     rmmod "${module}" 2>&1
   done
 
+  # unload modules in the module.order file and make sure they will be loaded
   if [ -f "${dud_modules_dir}/module.order" ]; then
     module_order=$(<"${dud_modules_dir}/module.order")
     # unload the modules in reverse order
@@ -248,6 +251,7 @@ update_kernel_modules() {
     cp "${dud_modules_dir}/module.order" "${NEWROOT}/etc/modules-load.d/99-agama.conf"
   fi
 
+  # update modules dependencies on the live medium
   info "Updating modules dependencies..."
   depmod -a -b "$NEWROOT"
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -209,12 +209,10 @@ copy_kernel_module() {
 
 # Updates kernel modules
 #
-# It copies the kernel modules and the hardware information for hwinfo.
-#
 # It copies the kernel modules from the Driver Update Disk to the system under
 # /sysroot. If it finds a `module.order` file, it unloads the modules included
-# in the list and them to /etc/modules-load.d/99-agama.conf file so they will be
-# loaded by systemd after pivoting.
+# in the list and add them to /etc/modules-load.d/99-agama.conf file so they
+# will be loaded by systemd after pivoting.
 update_kernel_modules() {
   local dud_dir=$1
   local kernel_modules_dir

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -220,6 +220,13 @@ update_kernel_modules() {
   kernel_modules_dir="${NEWROOT}/lib/modules/$(uname -r)"
   local dud_modules_dir="${dud_dir}/modules"
 
+  # copy hardware information
+  local hardware_ids="${dud_modules_dir}/hd.ids"
+  if [ -f "$hardware_ids" ]; then
+    mkdir -p "${NEWROOT}/var/lib/hardware"
+    cat "$hardware_ids" >>"${NEWROOT}/var/lib/hardware"
+  fi
+
   local dud_modules
   find_kernel_modules "$dud_modules_dir" dud_modules
 

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -172,7 +172,7 @@ find_kernel_modules() {
     module_name=${module#"${directory}/"}
     module_name=${module_name%.ko*}
 
-    if [[ ! " ${modules[*]} " =~ \ ${module_name}\  ]]; then
+    if [[ ! " ${modules[*]} " =~ " ${module_name} " ]]; then
       modules+=("$module_name")
     fi
   done
@@ -195,7 +195,6 @@ copy_kernel_module() {
   # expect a single file with $module.ko* name
   source_file=("${source_dir}/${module}".ko*)
 
-  echo old "${target_dir}/**/*/${module}.ko*"
   old_module=("${target_dir}"/**/*/"${module}".ko*)
   if [ "${#old_module[@]}" -eq "1" ]; then
     info "  Replacing the module ${old_module[0]}"

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 10 13:09:26 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support to update kernel modules from a Driver Update Disk
+  (jsc#AGM-158, jsc#PED-3670, gh#agama-project/agama#2548).
+
+-------------------------------------------------------------------
 Wed Jul  9 12:07:21 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add the tpm2.0-tools package (jsc#PED-13114).


### PR DESCRIPTION
## Problem

The current Driver Update Disk mechanism does not handle kernel modules (drivers) updates.

- [PED-3670](https://jira.suse.com/browse/PED-3670)
- [AGM-158](https://jira.suse.com/browse/AGM-158)

## Solution

Add a new mechanism to update the kernel modules of the live media.

When you include kernel modules in a driver update, you can optionally add a `module.order` file that determines in which order the modules should be loaded. Check [mkdud howto](https://github.com/openSUSE/mkdud/blob/master/HOWTO.md) for further information.

The DUD mechanism will work in the following way:

- Copy the modules to the live medium (under `/sysroot/lib/modules/KERNEL-RELEASE/kernel`), unloading if possible to old ones.
- Unload all the kernel modules listed in the `module.order` file (if it exist).
- Copies the `module.order` file to (`/sysroot/etc/modules-load.d/99-agama.conf`) to make sure they are loaded first when pivoting.

## Testing

- *Tested manually*

# Documentation

- https://confluence.suse.com/display/YAST/Driver+Update+Disks+support
- A public document in our website is still pending.
