### PR TITLE
Fix base product names

### DIFF
--- a/products.d/kalpa.yaml
+++ b/products.d/kalpa.yaml
@@ -37,7 +37,7 @@ software:
     - NetworkManager
     - openSUSE-repos-MicroOS
   optional_packages: null
-  base_product: MicroOS
+  base_product: Kalpa
 
 security:
   lsm: selinux

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -71,7 +71,7 @@ software:
     - openSUSE-repos-Leap
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_packages: null
-  base_product: openSUSE
+  base_product: Leap
 
 security:
   lsm: selinux

--- a/products.d/leap_micro_62.yaml
+++ b/products.d/leap_micro_62.yaml
@@ -46,7 +46,7 @@ software:
     - NetworkManager
     - openSUSE-repos-LeapMicro
   optional_packages: null
-  base_product: openSUSE
+  base_product: Leap-Micro
 
 security:
   lsm: selinux


### PR DESCRIPTION
## Problem

- The product definitions contain some incorrect product names
  - The openSUSE Leap product has been renamed from `openSUSE` to `Leap` (since Leap 15.3)
  - Similarly for LeapMicro there is `Leap-Micro` product
  - And there actually is `Kalpa` product in the Tumbleweed OSS repository, so let's use it

## Solution

- Fixed the installed base product names for Kalpa, Leap 16.0 and Leap-Micro 6.2 distributions.
