### PR TITLE
fix(rust): do not export l10n, hostname and product null settings

### DIFF
--- a/rust/agama-lib/src/hostname/model.rs
+++ b/rust/agama-lib/src/hostname/model.rs
@@ -26,9 +26,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize, Default, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HostnameSettings {
-    #[serde(rename = "transient")]
+    #[serde(rename = "transient", skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
     // empty string means removing the static hostname
-    #[serde(rename = "static")]
+    #[serde(rename = "static", skip_serializing_if = "Option::is_none")]
     pub static_hostname: Option<String>,
 }

--- a/rust/agama-lib/src/localization/settings.rs
+++ b/rust/agama-lib/src/localization/settings.rs
@@ -28,9 +28,12 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct LocalizationSettings {
     /// like "en_US.UTF-8"
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     /// like "cz(qwerty)"
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub keyboard: Option<String>,
     /// like "Europe/Berlin"
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
 }

--- a/rust/agama-lib/src/product/settings.rs
+++ b/rust/agama-lib/src/product/settings.rs
@@ -41,6 +41,7 @@ pub struct AddonSettings {
 #[serde(rename_all = "camelCase")]
 pub struct ProductSettings {
     /// ID of the product to install (e.g., "ALP", "Tumbleweed", etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registration_code: Option<String>,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 11 06:56:29 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not exported null values for localization, hostname
+  and product settings (gh#agama-project/agama#2543).
+
+-------------------------------------------------------------------
 Wed Jul  9 12:25:08 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - unattended installation: allow registration to RMT when


### PR DESCRIPTION
## Problem

As described in #2539, `agama generate` exports missing hostname and localization settings as as `null`.

## Solution

Stop exporting those options as they are optional.

## Testing

- Tested manually
