### PR TITLE
fix(web): drop no longer needed CSS

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -494,11 +494,6 @@ label.pf-m-disabled + .pf-v6-c-check__description {
   }
 }
 
-// Nested alerts should kept no header margin
-:is(.pf-v6-c-content--h4, .pf-v6-c-content h4) {
-  margin-block-start: 0;
-}
-
 // Some utilities not found at PF
 .w-14ch {
   inline-size: 14ch;


### PR DESCRIPTION
Obsolete after change made at 265b9bd566f133b1d57fdff4601d81f3ab4614ed as part of https://github.com/agama-project/agama/pull/2459 and merged to master in 5eb8d52702e72d71652febe4b1c0439c99c11900

