### PR TITLE
branch2obs.sh - remove obsolete OBS projects

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -107,6 +107,17 @@ project for submitting.
   GitHub variable. Just to avoid accidentally updating the packages with the old
   code when a commit is added to the old branch.
 
+## Cleanup
+
+After deleting a branch in Git (either explicitly or automatically after merging a pull request) the
+respective OBS project should be deleted.
+
+That can be done by running `branch2obs.sh -c`, it scans the OBS subprojects and deletes the ones
+which do not have a matching Git branch. It also removes the brach from the mapping stored in the
+OBS_PROJECTS GitHub Action variable.
+
+To just print the obsolete projects without deleting them run command `branch2obs.sh -o`.
+
 ## Implementation details
 
 The mapping between the Git branch and the target OBS project is stored in the

--- a/devel/branch2obs.sh
+++ b/devel/branch2obs.sh
@@ -11,17 +11,27 @@ usage () {
   echo "  -b <branch|tag> - source git branch or tag (default: current git branch)"
   echo "  -p <project>    - target OBS project (based on the git branch)"
   echo "  -t              - keep all original build targets (default: disable Leap 16.0)"
+  echo "  -c              - cleanup (delete) all obsolete projects, exclusive option,"
+  echo "                    all other options are ignored"
+  echo "  -o              - print obsolete projects, similar to -c but only print"
+  echo "                    the projects instead of deleting them"
   echo "  -h              - print this help"
 }
 
 # process command line arguments
-while getopts ":ab:hp:t" opt; do
+while getopts ":ab:chop:t" opt; do
   case ${opt} in
     a)
       ALL_ARCHS=true
       ;;
     b)
       branch="${OPTARG}"
+      ;;
+    c)
+      CLEANUP=true
+      ;;
+    o)
+      OBSOLETE=true
       ;;
     p)
       PROJECT="${OPTARG}"
@@ -71,11 +81,56 @@ if ! gh auth status --active > /dev/null 2>&1; then
   exit 1
 fi
 
+repo_slug=$(gh repo view --json nameWithOwner -q ".nameWithOwner")
+
+if [ -n "$CLEANUP" ] || [ -n "$OBSOLETE" ]; then
+  if [ "$repo_slug" = "agama-project/agama" ]; then
+    # the upstream repository
+    prefix="systemsmanagement:Agama:branches"
+  else
+    # a fork
+    prefix="home:${osc_user}:Agama:branches"
+  fi
+
+  echo "Scanning obsolete projects..."
+
+  # find the matching projects
+  mapfile -t obs_projects < <(osc search --substring --project "$prefix" | grep "$prefix" | grep -v "^matches for")
+
+  # count the obsolete projects for the final summary
+  counter=0
+
+  for project in "${obs_projects[@]}"; do
+    # remove the prefix to get the related Git branch
+    branch_name=$(echo -n "$project" | sed -e "s/^$prefix://")
+    if ! git ls-remote --exit-code --heads origin "$branch_name" > /dev/null; then
+      if [ -n "$CLEANUP" ]; then
+        echo "Deleting obsolete project $project..."
+        # recursive remote delete (allows deleting a non-empty project)
+        osc rdelete --recursive --force --message "Deleting obsolete project" "$project"
+
+        config=$(gh -R "$repo_slug" variable get OBS_PROJECTS 2> /dev/null)
+        if [ -n "$config" ]; then
+          # remove the mapping for the deleted project
+          echo "$config" | jq "del(.[\"$project\"])" | gh -R "$repo_slug" variable set OBS_PROJECTS
+        fi
+      else
+        echo "Found obsolete project: $project"
+      fi
+      ((counter++))
+    fi
+  done
+
+  # print a summary
+  echo "Found $counter obsolete projects"
+
+  # cleanup and check are exclusive options, finish the script
+  exit 0
+fi
+
 # git branch from the command line or the current git branch
 BRANCH=${branch-$(git rev-parse --abbrev-ref HEAD)}
 echo "Git branch: $BRANCH"
-
-repo_slug=$(gh repo view --json nameWithOwner -q ".nameWithOwner")
 
 # is this repository a GitHub fork?
 if [ "$repo_slug" = "agama-project/agama" ]; then


### PR DESCRIPTION
## Problem

- Using the `branch2obs.sh` script is easy for creating new OBS projects which build the Live ISO from a Git branch.
- Unfortunately developers quite often forget to delete the project when it is not needed anymore. And because the Live ISO build needs quite a lot resources and takes a lot of time this wastes lot of OBS power which could be used for building other projects/packages.

## Solution

- Add new options to the `branch2obs.sh` script which can automatically report or delete the obsolete projects.
- Scan the OBS subprojects and checks if there is a respective Git branch for it, if not then delete it or report as obsolete.

## Details 

- The `-o` option prints the obsolete projects (suggested to be as a dry-run before real deleting)
- The `-c` option deletes them
- When using one of these options the other options are ignored, you can either run the cleanup or create a new project
- It does not matter whether the project was created by you or someone else, it can delete all subprojects (you just need to have the appropriate OBS access rights)
- It also removes the branch mapping from the GitHub Actions `OBS_PROJECTS` variable to keep it short.

## Testing

- Tested manually

Listing obsolete projects:
```console
> ./branch2obs.sh -o
Scanning obsolete projects...
Found obsolete project: systemsmanagement:Agama:branches:add-noto-sans-for-cyrillic-script
Found obsolete project: systemsmanagement:Agama:branches:add_hyper-v_package
Found obsolete project: systemsmanagement:Agama:branches:better-agama-auto
Found obsolete project: systemsmanagement:Agama:branches:bind_interface
Found obsolete project: systemsmanagement:Agama:branches:clemens_feature
Found obsolete project: systemsmanagement:Agama:branches:dud-kernel
Found obsolete project: systemsmanagement:Agama:branches:dud_repository
Found obsolete project: systemsmanagement:Agama:branches:fix-iscsi
Found obsolete project: systemsmanagement:Agama:branches:fix-product-cache
Found obsolete project: systemsmanagement:Agama:branches:network-persistent-connections-handling
Found obsolete project: systemsmanagement:Agama:branches:rmt_registration
Found obsolete project: systemsmanagement:Agama:branches:storage_reprobe_fix
Found obsolete project: systemsmanagement:Agama:branches:systemd_link
Found obsolete project: systemsmanagement:Agama:branches:test_branch2obs
Found obsolete project: systemsmanagement:Agama:branches:user-pw-check
Found 15 obsolete projects
```

Deleting them:
```console
> ./branch2obs.sh -c
Scanning obsolete projects...
Deleting obsolete project systemsmanagement:Agama:branches:add-noto-sans-for-cyrillic-script...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:add_hyper-v_package...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:better-agama-auto...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:bind_interface...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:clemens_feature...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:dud-kernel...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:dud_repository...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:fix-iscsi...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:fix-product-cache...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:network-persistent-connections-handling...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:rmt_registration...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:storage_reprobe_fix...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:systemd_link...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:test_branch2obs...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Deleting obsolete project systemsmanagement:Agama:branches:user-pw-check...
✓ Updated variable OBS_PROJECTS for agama-project/agama
Found 15 obsolete projects
```

As you can check the [current project list](https://build.opensuse.org/project/subprojects/systemsmanagement:Agama) these projects are gone.

