### PR TITLE
feat(storage): directly format devices

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 16 14:46:32 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Allow to use a whole disk or MD RAID without a partition table
+  (gh#agama-project/agama#2559).
+
+-------------------------------------------------------------------
 Mon Jul 14 16:02:55 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Allow specifying the registration server (jsc#AGM-156).

--- a/web/src/components/storage/BootSelection.test.tsx
+++ b/web/src/components/storage/BootSelection.test.tsx
@@ -141,6 +141,8 @@ describe("BootSelection", () => {
         isDefault: true,
         getDevice: () => null,
       },
+      drives: [],
+      mdRaids: [],
     });
   });
 
@@ -183,6 +185,8 @@ describe("BootSelection", () => {
           isDefault: false,
           getDevice: () => sda,
         },
+        drives: [],
+        mdRaids: [],
       });
     });
 
@@ -203,6 +207,8 @@ describe("BootSelection", () => {
           isDefault: false,
           getDevice: () => null,
         },
+        drives: [],
+        mdRaids: [],
       });
     });
 
@@ -224,6 +230,8 @@ describe("BootSelection", () => {
           isDefault: false,
           getDevice: () => sda,
         },
+        drives: [],
+        mdRaids: [],
       });
     });
 

--- a/web/src/components/storage/BootSelection.tsx
+++ b/web/src/components/storage/BootSelection.tsx
@@ -39,6 +39,14 @@ import {
   useDisableBootConfig,
 } from "~/hooks/storage/boot";
 
+const filteredCandidates = (candidates, model): StorageDevice[] => {
+  return candidates.filter((candidate) => {
+    const collection = candidate.isDrive ? model.drives : model.mdRaids;
+    const device = collection.find((d) => d.name === candidate.name);
+    return !device || !device.filesystem;
+  });
+};
+
 // FIXME: improve classNames
 // FIXME: improve and rename to BootSelectionDialog
 
@@ -62,8 +70,8 @@ export default function BootSelectionDialog() {
   const [state, setState] = useState<BootSelectionState>({ load: false });
   const navigate = useNavigate();
   const devices = useDevices("system");
-  const candidateDevices = useCandidateDevices();
   const model = useModel({ suspense: true });
+  const candidateDevices = filteredCandidates(useCandidateDevices(), model);
   const setBootDevice = useSetBootDevice();
   const setDefaultBootDevice = useSetDefaultBootDevice();
   const disableBootConfig = useDisableBootConfig();

--- a/web/src/components/storage/ConfigureDeviceMenu.test.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.test.tsx
@@ -72,7 +72,7 @@ const mockUseModel = jest.fn();
 
 jest.mock("~/hooks/storage/system", () => ({
   ...jest.requireActual("~/hooks/storage/system"),
-  useCandidateDevices: () => [vda, vdb],
+  useAvailableDevices: () => [vda, vdb],
 }));
 
 jest.mock("~/hooks/storage/model", () => ({

--- a/web/src/components/storage/ConfigureDeviceMenu.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.tsx
@@ -24,7 +24,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import MenuButton, { MenuButtonItem } from "~/components/core/MenuButton";
 import { Divider, MenuItemProps } from "@patternfly/react-core";
-import { useCandidateDevices } from "~/hooks/storage/system";
+import { useAvailableDevices } from "~/hooks/storage/system";
 import { useModel } from "~/hooks/storage/model";
 import { useAddDrive } from "~/hooks/storage/drive";
 import { useAddReusedMdRaid } from "~/hooks/storage/md-raid";
@@ -104,7 +104,7 @@ export default function ConfigureDeviceMenu(): React.ReactNode {
   const model = useModel({ suspense: true });
   const addDrive = useAddDrive();
   const addReusedMdRaid = useAddReusedMdRaid();
-  const allDevices = useCandidateDevices();
+  const allDevices = useAvailableDevices();
 
   const usedDevicesNames = model.drives.concat(model.mdRaids).map((d) => d.name);
   const usedDevicesCount = usedDevicesNames.length;

--- a/web/src/components/storage/ConfigureDeviceMenu.tsx
+++ b/web/src/components/storage/ConfigureDeviceMenu.tsx
@@ -35,36 +35,59 @@ import { StorageDevice } from "~/types/storage";
 import DeviceSelectorModal from "./DeviceSelectorModal";
 
 type AddDeviceMenuItemProps = {
+  /** Whether some of the available devices is an MD RAID */
+  withRaids: boolean;
   /** Available devices to be chosen */
   devices: StorageDevice[];
   /** The total amount of drives and RAIDs already configured */
   usedCount: number;
 } & MenuItemProps;
 
-const AddDeviceTitle = ({ usedCount }) =>
-  usedCount
-    ? _("Select another disk to define partitions")
-    : _("Select a disk to define partitions");
+const AddDeviceTitle = ({ withRaids, usedCount }) => {
+  if (withRaids) {
+    if (usedCount === 0) return _("Select a device to define partitions or to mount");
+    return _("Select another device to define partitions or to mount");
+  }
 
-const AddDeviceDescription = ({ usedCount, isDisabled = false }) => {
-  if (isDisabled) return _("Already using all available disks");
+  if (usedCount === 0) return _("Select a disk to define partitions or to mount");
+  return _("Select another disk to define partitions or to mount");
+};
 
-  return usedCount
-    ? sprintf(
+const AddDeviceDescription = ({ withRaids, usedCount, isDisabled = false }) => {
+  if (isDisabled) {
+    if (withRaids) return _("Already using all available devices");
+    return _("Already using all available disks");
+  }
+
+  if (usedCount) {
+    if (withRaids)
+      return sprintf(
         n_(
-          "Extend the installation beyond the currently selected disk",
-          "Extend the installation beyond the current %d disks",
+          "Extend the installation beyond the currently selected device",
+          "Extend the installation beyond the current %d devices",
           usedCount,
         ),
         usedCount,
-      )
-    : _("Start configuring a basic installation");
+      );
+
+    return sprintf(
+      n_(
+        "Extend the installation beyond the currently selected disk",
+        "Extend the installation beyond the current %d disks",
+        usedCount,
+      ),
+      usedCount,
+    );
+  }
+
+  return _("Start configuring a basic installation");
 };
 
 /**
  * Internal component holding the logic for rendering the disks drilldown menu
  */
 const AddDeviceMenuItem = ({
+  withRaids,
   usedCount,
   devices,
   onClick,
@@ -75,10 +98,16 @@ const AddDeviceMenuItem = ({
       <MenuButtonItem
         aria-label={_("Add device menu")}
         isDisabled={isDisabled}
-        description={<AddDeviceDescription usedCount={usedCount} isDisabled={isDisabled} />}
+        description={
+          <AddDeviceDescription
+            withRaids={withRaids}
+            usedCount={usedCount}
+            isDisabled={isDisabled}
+          />
+        }
         onClick={onClick}
       >
-        <AddDeviceTitle usedCount={usedCount} />
+        <AddDeviceTitle withRaids={withRaids} usedCount={usedCount} />
       </MenuButtonItem>
     </>
   );
@@ -87,12 +116,6 @@ const AddDeviceMenuItem = ({
 /**
  * Menu that provides options for users to configure storage drives
  *
- * It uses a drilled-down menu approach for disks, making the available options less
- * overwhelming by presenting them in a more organized manner.
- *
- * TODO: Refactor and test the component after extracting a basic DrillDown menu to
- * share the internal logic with other potential menus that could benefit from a similar
- * approach.
  */
 export default function ConfigureDeviceMenu(): React.ReactNode {
   const [deviceSelectorOpen, setDeviceSelectorOpen] = useState(false);
@@ -109,6 +132,7 @@ export default function ConfigureDeviceMenu(): React.ReactNode {
   const usedDevicesNames = model.drives.concat(model.mdRaids).map((d) => d.name);
   const usedDevicesCount = usedDevicesNames.length;
   const devices = allDevices.filter((d) => !usedDevicesNames.includes(d.name));
+  const withRaids = !!allDevices.filter((d) => !d.isDrive).length;
 
   const addDevice = (device: StorageDevice) => {
     const hook = device.isDrive ? addDrive : addReusedMdRaid;
@@ -130,6 +154,7 @@ export default function ConfigureDeviceMenu(): React.ReactNode {
             key="select-disk-option"
             usedCount={usedDevicesCount}
             devices={devices}
+            withRaids={withRaids}
             onClick={openDeviceSelector}
           />,
           <Divider key="divider-option" />,
@@ -147,8 +172,8 @@ export default function ConfigureDeviceMenu(): React.ReactNode {
       {deviceSelectorOpen && (
         <DeviceSelectorModal
           devices={devices}
-          title={<AddDeviceTitle usedCount={usedDevicesCount} />}
-          description={<AddDeviceDescription usedCount={usedDevicesCount} />}
+          title={<AddDeviceTitle withRaids={withRaids} usedCount={usedDevicesCount} />}
+          description={<AddDeviceDescription withRaids={withRaids} usedCount={usedDevicesCount} />}
           onCancel={closeDeviceSelector}
           onConfirm={([device]) => {
             addDevice(device);

--- a/web/src/components/storage/DeviceEditorContent.tsx
+++ b/web/src/components/storage/DeviceEditorContent.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Stack, Flex, StackItem } from "@patternfly/react-core";
+import { generatePath } from "react-router-dom";
+import Link from "~/components/core/Link";
+import { STORAGE as PATHS } from "~/routes/paths";
+import FilesystemMenu from "~/components/storage/FilesystemMenu";
+import PartitionsMenu from "~/components/storage/PartitionsMenu";
+import SpacePolicyMenu from "~/components/storage/SpacePolicyMenu";
+import { model, StorageDevice } from "~/types/storage";
+import { _ } from "~/i18n";
+
+type DeviceEmptyStateProps = Pick<DeviceEditorContentProps, "deviceModel">;
+
+function DeviceEmptyState({ deviceModel }: DeviceEmptyStateProps): React.ReactNode {
+  const { list, listIndex } = deviceModel;
+  const newPartitionPath = generatePath(PATHS.addPartition, { list, listIndex });
+  const formatDevicePath = generatePath(PATHS.formatDevice, { list, listIndex });
+
+  return (
+    <Flex gap={{ default: "gapXs" }}>
+      <Stack>
+        <StackItem>
+          <Link variant="link" isInline to={newPartitionPath}>
+            {_("Add a new partition or mount an existing one")}
+          </Link>
+        </StackItem>
+        <StackItem>
+          <Link variant="link" isInline to={formatDevicePath}>
+            {_("Mount the device")}
+          </Link>
+        </StackItem>
+      </Stack>
+    </Flex>
+  );
+}
+
+type DeviceEditorContentProps = { deviceModel: model.Drive | model.MdRaid; device: StorageDevice };
+
+export default function DeviceEditorContent({
+  deviceModel,
+  device,
+}: DeviceEditorContentProps): React.ReactNode {
+  if (!deviceModel.isUsed) return <DeviceEmptyState deviceModel={deviceModel} />;
+
+  return (
+    <>
+      {deviceModel.filesystem && <FilesystemMenu deviceModel={deviceModel} />}
+      {!deviceModel.filesystem && <PartitionsMenu device={deviceModel} />}
+      {!deviceModel.filesystem && <SpacePolicyMenu modelDevice={deviceModel} device={device} />}
+    </>
+  );
+}

--- a/web/src/components/storage/DeviceEditorContent.tsx
+++ b/web/src/components/storage/DeviceEditorContent.tsx
@@ -21,40 +21,11 @@
  */
 
 import React from "react";
-import { Stack, Flex, StackItem } from "@patternfly/react-core";
-import { generatePath } from "react-router-dom";
-import Link from "~/components/core/Link";
-import { STORAGE as PATHS } from "~/routes/paths";
+import UnusedMenu from "~/components/storage/UnusedMenu";
 import FilesystemMenu from "~/components/storage/FilesystemMenu";
 import PartitionsMenu from "~/components/storage/PartitionsMenu";
 import SpacePolicyMenu from "~/components/storage/SpacePolicyMenu";
 import { model, StorageDevice } from "~/types/storage";
-import { _ } from "~/i18n";
-
-type DeviceEmptyStateProps = Pick<DeviceEditorContentProps, "deviceModel">;
-
-function DeviceEmptyState({ deviceModel }: DeviceEmptyStateProps): React.ReactNode {
-  const { list, listIndex } = deviceModel;
-  const newPartitionPath = generatePath(PATHS.addPartition, { list, listIndex });
-  const formatDevicePath = generatePath(PATHS.formatDevice, { list, listIndex });
-
-  return (
-    <Flex gap={{ default: "gapXs" }}>
-      <Stack>
-        <StackItem>
-          <Link variant="link" isInline to={newPartitionPath}>
-            {_("Add a new partition or mount an existing one")}
-          </Link>
-        </StackItem>
-        <StackItem>
-          <Link variant="link" isInline to={formatDevicePath}>
-            {_("Mount the device")}
-          </Link>
-        </StackItem>
-      </Stack>
-    </Flex>
-  );
-}
 
 type DeviceEditorContentProps = { deviceModel: model.Drive | model.MdRaid; device: StorageDevice };
 
@@ -62,7 +33,7 @@ export default function DeviceEditorContent({
   deviceModel,
   device,
 }: DeviceEditorContentProps): React.ReactNode {
-  if (!deviceModel.isUsed) return <DeviceEmptyState deviceModel={deviceModel} />;
+  if (!deviceModel.isUsed) return <UnusedMenu deviceModel={deviceModel} />;
 
   return (
     <>

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -23,8 +23,7 @@
 import React from "react";
 import ConfigEditorItem from "~/components/storage/ConfigEditorItem";
 import DriveHeader from "~/components/storage/DriveHeader";
-import PartitionsMenu from "~/components/storage/PartitionsMenu";
-import SpacePolicyMenu from "~/components/storage/SpacePolicyMenu";
+import DeviceEditorContent from "~/components/storage/DeviceEditorContent";
 import SearchedDeviceMenu from "~/components/storage/SearchedDeviceMenu";
 import { Drive } from "~/types/storage/model";
 import { model, StorageDevice } from "~/types/storage";
@@ -55,12 +54,7 @@ export default function DriveEditor({ drive, driveDevice }: DriveEditorProps) {
   return (
     <ConfigEditorItem
       header={<DriveHeader drive={drive} device={driveDevice} />}
-      content={
-        <>
-          <PartitionsMenu device={drive} />
-          <SpacePolicyMenu modelDevice={drive} device={driveDevice} />
-        </>
-      }
+      content={<DeviceEditorContent deviceModel={drive} device={driveDevice} />}
       actions={<DriveDeviceMenu drive={drive} selected={driveDevice} />}
     />
   );

--- a/web/src/components/storage/DriveHeader.tsx
+++ b/web/src/components/storage/DriveHeader.tsx
@@ -28,6 +28,13 @@ import { _ } from "~/i18n";
 export type DriveHeaderProps = { drive: model.Drive; device: StorageDevice };
 
 const text = (drive: model.Drive): string => {
+  if (drive.filesystem) {
+    // TRANSLATORS: %s will be replaced by a disk name and its size - "sda (20 GiB)"
+    if (drive.filesystem.reuse) return _("Mount disk %s");
+    // TRANSLATORS: %s will be replaced by a disk name and its size - "sda (20 GiB)"
+    return _("Format disk %s");
+  }
+
   const { isBoot, isTargetDevice: hasPv } = drive;
   const isRoot = !!drive.getPartition("/");
   const hasFs = !!drive.getMountPaths().length;

--- a/web/src/components/storage/FilesystemMenu.tsx
+++ b/web/src/components/storage/FilesystemMenu.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useId } from "react";
+import { Divider, Flex } from "@patternfly/react-core";
+import { useNavigate, generatePath } from "react-router-dom";
+import Text from "~/components/core/Text";
+import MenuHeader from "~/components/core/MenuHeader";
+import MenuButton from "~/components/core/MenuButton";
+import { useDeleteFilesystem } from "~/hooks/storage/filesystem";
+import { STORAGE as PATHS } from "~/routes/paths";
+import { model } from "~/types/storage";
+import * as driveUtils from "~/components/storage/utils/drive";
+import { sprintf } from "sprintf-js";
+import { _ } from "~/i18n";
+import { filesystemType } from "~/components/storage/utils";
+
+function deviceDescription(deviceModel: FilesystemMenuProps["deviceModel"]): string {
+  const fs = filesystemType(deviceModel.filesystem);
+  const mountPath = deviceModel.mountPath;
+  const reuse = deviceModel.filesystem.reuse;
+  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs), %2$s is a mount point (eg. /home).
+  if (reuse && fs && mountPath) return sprintf(_("Mount current %1$s at %2$s"), fs, mountPath);
+  // TRANSLATORS: %1$s is a mount point (eg. /home).
+  if (reuse && mountPath) return sprintf(_("Mount at %1$s"), mountPath);
+  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs).
+  if (reuse && fs) return sprintf(_("Reuse current %1$s"), fs);
+  if (reuse) return _("Reuse current file system");
+  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs), %2$s is a mount point (eg. /home).
+  if (mountPath) return sprintf(_("Format as %1$s for %2$s"), fs, mountPath);
+
+  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs).
+  return sprintf(_("Format as %1$s"), fs);
+}
+
+type FilesystemMenuProps = { deviceModel: model.Drive | model.MdRaid };
+
+export default function FilesystemMenu({ deviceModel }: FilesystemMenuProps): React.ReactNode {
+  const navigate = useNavigate();
+  const ariaLabelId = useId();
+  const toggleTextId = useId();
+  const deleteFilesystem = useDeleteFilesystem();
+  const { list, listIndex } = deviceModel;
+  const editFilesystemPath = generatePath(PATHS.formatDevice, { list, listIndex });
+
+  // TRANSLATORS: %s is the name of device, like '/dev/sda'.
+  const detailsAriaLabel = sprintf(_("Details for %s"), deviceModel.name);
+
+  return (
+    <Flex gap={{ default: "gapXs" }}>
+      <Text id={ariaLabelId} srOnly>
+        {detailsAriaLabel}
+      </Text>
+      <Text isBold aria-hidden>
+        {_("Details")}
+      </Text>
+      <MenuButton
+        menuProps={{
+          "aria-label": detailsAriaLabel,
+        }}
+        toggleProps={{
+          variant: "plainText",
+          "aria-labelledby": `${ariaLabelId} ${toggleTextId}`,
+        }}
+        items={[
+          <MenuHeader key="header-filesystem" description={deviceDescription(deviceModel)} />,
+          <Divider key="divider-filesystem" component="li" />,
+          <MenuButton.Item
+            key="edit-filesystem"
+            itemId="edit-filesystem"
+            description={_("Change the file system or mount point")}
+            onClick={() => navigate(editFilesystemPath)}
+          >
+            {_("Edit")}
+          </MenuButton.Item>,
+          <MenuButton.Item
+            key="delete-filesystem"
+            itemId="delete-filesystem"
+            description={_("Neither format nor mount the device")}
+            onClick={() => deleteFilesystem(list, listIndex)}
+          >
+            {_("Do not configure")}
+          </MenuButton.Item>,
+        ]}
+      >
+        <Text id={toggleTextId}>{driveUtils.contentDescription(deviceModel)}</Text>
+      </MenuButton>
+    </Flex>
+  );
+}

--- a/web/src/components/storage/FilesystemMenu.tsx
+++ b/web/src/components/storage/FilesystemMenu.tsx
@@ -26,7 +26,6 @@ import { useNavigate, generatePath } from "react-router-dom";
 import Text from "~/components/core/Text";
 import MenuHeader from "~/components/core/MenuHeader";
 import MenuButton from "~/components/core/MenuButton";
-import { useDeleteFilesystem } from "~/hooks/storage/filesystem";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { model } from "~/types/storage";
 import * as driveUtils from "~/components/storage/utils/drive";
@@ -58,7 +57,6 @@ export default function FilesystemMenu({ deviceModel }: FilesystemMenuProps): Re
   const navigate = useNavigate();
   const ariaLabelId = useId();
   const toggleTextId = useId();
-  const deleteFilesystem = useDeleteFilesystem();
   const { list, listIndex } = deviceModel;
   const editFilesystemPath = generatePath(PATHS.formatDevice, { list, listIndex });
 
@@ -91,14 +89,6 @@ export default function FilesystemMenu({ deviceModel }: FilesystemMenuProps): Re
             onClick={() => navigate(editFilesystemPath)}
           >
             {_("Edit")}
-          </MenuButton.Item>,
-          <MenuButton.Item
-            key="delete-filesystem"
-            itemId="delete-filesystem"
-            description={_("Neither format nor mount the device")}
-            onClick={() => deleteFilesystem(list, listIndex)}
-          >
-            {_("Do not configure")}
           </MenuButton.Item>,
         ]}
       >

--- a/web/src/components/storage/FilesystemMenu.tsx
+++ b/web/src/components/storage/FilesystemMenu.tsx
@@ -31,24 +31,26 @@ import { model } from "~/types/storage";
 import * as driveUtils from "~/components/storage/utils/drive";
 import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
-import { filesystemType } from "~/components/storage/utils";
+import { filesystemType, formattedPath } from "~/components/storage/utils";
 
 function deviceDescription(deviceModel: FilesystemMenuProps["deviceModel"]): string {
   const fs = filesystemType(deviceModel.filesystem);
   const mountPath = deviceModel.mountPath;
   const reuse = deviceModel.filesystem.reuse;
-  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs), %2$s is a mount point (eg. /home).
-  if (reuse && fs && mountPath) return sprintf(_("Mount current %1$s at %2$s"), fs, mountPath);
-  // TRANSLATORS: %1$s is a mount point (eg. /home).
-  if (reuse && mountPath) return sprintf(_("Mount at %1$s"), mountPath);
-  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs).
-  if (reuse && fs) return sprintf(_("Reuse current %1$s"), fs);
-  if (reuse) return _("Reuse current file system");
-  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs), %2$s is a mount point (eg. /home).
-  if (mountPath) return sprintf(_("Format as %1$s for %2$s"), fs, mountPath);
 
-  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs).
-  return sprintf(_("Format as %1$s"), fs);
+  // I don't think this can happen, maybe when loading a configuration not created with the UI
+  if (!mountPath) {
+    if (reuse) return _("The device will be mounted");
+    return _("The device will be formatted");
+  }
+
+  const path = formattedPath(mountPath);
+
+  // TRANSLATORS: %s is a formatted mount point (eg. '"/home'").
+  if (reuse) return sprintf(_("The current file system will be mounted at %s"), path);
+
+  // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs), %2$s is a mount point (eg. '"/home"').
+  return sprintf(_("The device will be formatted as %1$s and mounted at %2$s"), fs, path);
 }
 
 type FilesystemMenuProps = { deviceModel: model.Drive | model.MdRaid };

--- a/web/src/components/storage/FormattableDevicePage.test.tsx
+++ b/web/src/components/storage/FormattableDevicePage.test.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, within } from "@testing-library/react";
+import { installerRender, mockParams } from "~/test-utils";
+import FormattableDevicePage from "~/components/storage/FormattableDevicePage";
+import { StorageDevice, model } from "~/types/storage";
+import { Volume } from "~/api/storage/types";
+import { gib } from "./utils";
+
+const sda: StorageDevice = {
+  sid: 59,
+  isDrive: true,
+  type: "disk",
+  name: "/dev/sda",
+  size: gib(10),
+  description: "",
+};
+
+const sdaModel: model.Drive = {
+  name: "/dev/sda",
+  spacePolicy: "keep",
+  partitions: [],
+  list: "drives",
+  listIndex: 0,
+  isExplicitBoot: false,
+  isUsed: true,
+  isAddingPartitions: true,
+  isReusingPartitions: true,
+  isTargetDevice: false,
+  isBoot: true,
+  getMountPaths: jest.fn(),
+  getVolumeGroups: jest.fn(),
+  getPartition: jest.fn(),
+  getConfiguredExistingPartitions: jest.fn(),
+};
+
+const homeVolume: Volume = {
+  mountPath: "/home",
+  mountOptions: [],
+  target: "default",
+  fsType: "btrfs",
+  minSize: gib(1),
+  maxSize: gib(5),
+  autoSize: false,
+  snapshots: false,
+  transactional: false,
+  outline: {
+    required: false,
+    fsTypes: ["btrfs", "xfs"],
+    supportAutoSize: false,
+    snapshotsConfigurable: false,
+    snapshotsAffectSizes: false,
+    sizeRelevantVolumes: [],
+    adjustByRam: false,
+  },
+};
+
+jest.mock("~/queries/issues", () => ({
+  ...jest.requireActual("~/queries/issues"),
+  useIssues: () => [],
+}));
+
+jest.mock("~/queries/storage", () => ({
+  ...jest.requireActual("~/queries/storage"),
+  useDevices: () => [sda],
+}));
+
+const mockModel = jest.fn();
+jest.mock("~/hooks/storage/model", () => ({
+  ...jest.requireActual("~/hooks/storage/model"),
+  useModel: () => mockModel(),
+}));
+
+jest.mock("~/hooks/storage/product", () => ({
+  ...jest.requireActual("~/hooks/storage/product"),
+  useMissingMountPaths: () => ["/home", "swap"],
+  useVolume: () => homeVolume,
+}));
+
+const mockAddFilesystem = jest.fn();
+jest.mock("~/hooks/storage/filesystem", () => ({
+  ...jest.requireActual("~/hooks/storage/filesystem"),
+  useAddFilesystem: () => mockAddFilesystem,
+}));
+
+beforeEach(() => {
+  mockParams({ list: "drives", listIndex: "0" });
+  mockModel.mockReturnValue({
+    drives: [sdaModel],
+    getMountPaths: () => [],
+  });
+});
+
+describe("FormattableDevicePage", () => {
+  it("renders a form for formatting the device", async () => {
+    const { user } = installerRender(<FormattableDevicePage />);
+    screen.getByRole("form", { name: "Configure device /dev/sda" });
+    const mountPoint = screen.getByRole("button", { name: "Mount point toggle" });
+    const filesystem = screen.getByRole("button", { name: "File system" });
+    // File system and size fields disabled until valid mount point selected
+    expect(filesystem).toBeDisabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+
+    await user.click(mountPoint);
+    const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
+    const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
+    await user.click(homeMountPoint);
+    // Valid mount point selected, enable file system field
+    expect(filesystem).toBeEnabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    // Display available file systems
+    await user.click(filesystem);
+    screen.getByRole("listbox", { name: "Available file systems" });
+  });
+
+  it("allows reseting the chosen mount point", async () => {
+    const { user } = installerRender(<FormattableDevicePage />);
+    // Note that the underline PF component gives the role combobox to the input
+    const mountPoint = screen.getByRole("combobox", { name: "Mount point" });
+    const filesystem = screen.getByRole("button", { name: "File system" });
+    expect(mountPoint).toHaveValue("");
+    // File system field is disabled until a valid mount point selected
+    expect(filesystem).toBeDisabled();
+    const mountPointToggle = screen.getByRole("button", { name: "Mount point toggle" });
+    await user.click(mountPointToggle);
+    const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
+    const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
+    await user.click(homeMountPoint);
+    expect(mountPoint).toHaveValue("/home");
+    expect(filesystem).toBeEnabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    const clearMountPointButton = screen.getByRole("button", {
+      name: "Clear selected mount point",
+    });
+    await user.click(clearMountPointButton);
+    expect(mountPoint).toHaveValue("");
+    // File system field is disabled until a valid mount point selected
+    expect(filesystem).toBeDisabled();
+    expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+  });
+
+  describe("if the device has already a filesystem config", () => {
+    const formattedSdaModel: model.Drive = {
+      ...sdaModel,
+      mountPath: "/home",
+      filesystem: {
+        default: false,
+        type: "xfs",
+        label: "HOME",
+      },
+    };
+
+    beforeEach(() => {
+      mockModel.mockReturnValue({
+        drives: [formattedSdaModel],
+        getMountPaths: () => [],
+      });
+    });
+
+    it("initializes the form with the current values", async () => {
+      installerRender(<FormattableDevicePage />);
+      const mountPointSelector = screen.getByRole("combobox", { name: "Mount point" });
+      expect(mountPointSelector).toHaveValue("/home");
+      const filesystemButton = screen.getByRole("button", { name: "File system" });
+      within(filesystemButton).getByText("XFS");
+      const label = screen.getByRole("textbox", { name: "File system label" });
+      expect(label).toHaveValue("HOME");
+    });
+  });
+
+  describe("if the form is accepted", () => {
+    it("changes the device config", async () => {
+      const { user } = installerRender(<FormattableDevicePage />);
+      const mountPointToggle = screen.getByRole("button", { name: "Mount point toggle" });
+      await user.click(mountPointToggle);
+      const mountPointOptions = screen.getByRole("listbox", { name: "Suggested mount points" });
+      const homeMountPoint = within(mountPointOptions).getByRole("option", { name: "/home" });
+      await user.click(homeMountPoint);
+      const filesystemButton = screen.getByRole("button", { name: "File system" });
+      await user.click(filesystemButton);
+      const filesystemOptions = screen.getByRole("listbox", { name: "Available file systems" });
+      const xfs = within(filesystemOptions).getByRole("option", { name: "XFS" });
+      await user.click(xfs);
+      const labelInput = screen.getByRole("textbox", { name: "File system label" });
+      await user.type(labelInput, "TEST");
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+      expect(mockAddFilesystem).toHaveBeenCalledWith("drives", 0, {
+        mountPath: "/home",
+        filesystem: {
+          type: "xfs",
+          snapshots: false,
+          label: "TEST",
+        },
+      });
+    });
+  });
+});

--- a/web/src/components/storage/FormattableDevicePage.tsx
+++ b/web/src/components/storage/FormattableDevicePage.tsx
@@ -48,7 +48,7 @@ import { useAddFilesystem } from "~/hooks/storage/filesystem";
 import { useModel } from "~/hooks/storage/model";
 import { useDevices } from "~/queries/storage";
 import { data, model, StorageDevice } from "~/types/storage";
-import { filesystemLabel } from "~/components/storage/utils";
+import { deviceBaseName, filesystemLabel } from "~/components/storage/utils";
 import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import { apiModel } from "~/api/storage/types";
@@ -310,8 +310,10 @@ function FilesystemOptions({ mountPoint }: FilesystemOptionsProps): React.ReactN
       {mountPoint !== NO_VALUE && canReuse && (
         <SelectOption
           value={REUSE_FILESYSTEM}
-          // TRANSLATORS: %s is the name of a device, like /dev/vda
-          description={sprintf(_("Do not format %s and keep the current data"), device.name)}
+          description={
+            // TRANSLATORS: %s is the name of a device, like vda
+            sprintf(_("Do not format %s and keep the current data"), deviceBaseName(device, true))
+          }
         >
           <FilesystemOptionLabel value={REUSE_FILESYSTEM} />
         </SelectOption>

--- a/web/src/components/storage/FormattableDevicePage.tsx
+++ b/web/src/components/storage/FormattableDevicePage.tsx
@@ -1,0 +1,516 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useId } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  ActionGroup,
+  Content,
+  Divider,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  SelectGroup,
+  SelectList,
+  SelectOption,
+  SelectOptionProps,
+  Stack,
+  TextInput,
+} from "@patternfly/react-core";
+import { Page, SelectWrapper as Select } from "~/components/core/";
+import { SelectWrapperProps as SelectProps } from "~/components/core/SelectWrapper";
+import SelectTypeaheadCreatable from "~/components/core/SelectTypeaheadCreatable";
+import { useMissingMountPaths, useVolume } from "~/hooks/storage/product";
+import { useAddFilesystem } from "~/hooks/storage/filesystem";
+import { useModel } from "~/hooks/storage/model";
+import { useDevices } from "~/queries/storage";
+import { data, model, StorageDevice } from "~/types/storage";
+import { filesystemLabel } from "~/components/storage/utils";
+import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+import { apiModel } from "~/api/storage/types";
+import { STORAGE as PATHS } from "~/routes/paths";
+import { unique } from "radashi";
+import { compact } from "~/utils";
+
+const NO_VALUE = "";
+const BTRFS_SNAPSHOTS = "btrfsSnapshots";
+const REUSE_FILESYSTEM = "reuse";
+
+type DeviceModel = model.Drive | model.MdRaid;
+type FormValue = {
+  mountPoint: string;
+  filesystem: string;
+  filesystemLabel: string;
+};
+type Error = {
+  id: string;
+  message?: string;
+  isVisible: boolean;
+};
+type ErrorsHandler = {
+  errors: Error[];
+  getError: (id: string) => Error | undefined;
+  getVisibleError: (id: string) => Error | undefined;
+};
+
+function toData(value: FormValue): data.Formattable {
+  const filesystemType = (): apiModel.FilesystemType | undefined => {
+    if (value.filesystem === NO_VALUE) return undefined;
+    if (value.filesystem === BTRFS_SNAPSHOTS) return "btrfs";
+
+    /**
+     * @note This type cast is needed because the list of filesystems coming from a volume is not
+     *  enumerated (the volume simply contains a list of strings). This implies we have to rely on
+     *  whatever value coming from such a list as a filesystem type accepted by the config model.
+     *  This will be fixed in the future by directly exporting the volumes as a JSON, similar to the
+     *  config model. The schema for the volumes will define the explicit list of filesystem types.
+     */
+    return value.filesystem as apiModel.FilesystemType;
+  };
+
+  const filesystem = (): data.Filesystem | undefined => {
+    if (value.filesystem === REUSE_FILESYSTEM) return { reuse: true };
+
+    const type = filesystemType();
+    if (type === undefined) return undefined;
+
+    return {
+      type,
+      snapshots: value.filesystem === BTRFS_SNAPSHOTS,
+      label: value.filesystemLabel,
+    };
+  };
+
+  return {
+    mountPath: value.mountPoint,
+    filesystem: filesystem(),
+  };
+}
+
+function toFormValue(deviceModel: DeviceModel): FormValue {
+  const mountPoint = (): string => deviceModel.mountPath || NO_VALUE;
+
+  const filesystem = (): string => {
+    const fsConfig = deviceModel.filesystem;
+    if (!fsConfig) return NO_VALUE;
+    if (fsConfig.reuse) return REUSE_FILESYSTEM;
+    if (!fsConfig.type) return NO_VALUE;
+    if (fsConfig.type === "btrfs" && fsConfig.snapshots) return BTRFS_SNAPSHOTS;
+
+    return fsConfig.type;
+  };
+
+  const filesystemLabel = (): string => deviceModel.filesystem?.label || NO_VALUE;
+
+  return {
+    mountPoint: mountPoint(),
+    filesystem: filesystem(),
+    filesystemLabel: filesystemLabel(),
+  };
+}
+
+function useDeviceModel(): DeviceModel {
+  const { list, listIndex } = useParams();
+  const model = useModel({ suspense: true });
+  return model[list].at(listIndex);
+}
+
+function useDevice(): StorageDevice {
+  const deviceModel = useDeviceModel();
+  const devices = useDevices("system", { suspense: true });
+  return devices.find((d) => d.name === deviceModel.name);
+}
+
+function useCurrentFilesystem(): string | null {
+  const device = useDevice();
+  return device?.filesystem?.type || null;
+}
+
+function useDefaultFilesystem(mountPoint: string): string {
+  const volume = useVolume(mountPoint, { suspense: true });
+  return volume.mountPath === "/" && volume.snapshots ? BTRFS_SNAPSHOTS : volume.fsType;
+}
+
+function useInitialFormValue(): FormValue | null {
+  const deviceModel = useDeviceModel();
+  return React.useMemo(() => (deviceModel ? toFormValue(deviceModel) : null), [deviceModel]);
+}
+
+/** Unused predefined mount points. Includes the currently used mount point when editing. */
+function useUnusedMountPoints(): string[] {
+  const unusedMountPaths = useMissingMountPaths();
+  const deviceModel = useDeviceModel();
+  return compact([deviceModel?.mountPath, ...unusedMountPaths]);
+}
+
+function useUsableFilesystems(mountPoint: string): string[] {
+  const volume = useVolume(mountPoint);
+  const defaultFilesystem = useDefaultFilesystem(mountPoint);
+
+  const usableFilesystems = React.useMemo(() => {
+    const volumeFilesystems = (): string[] => {
+      const allValues = volume.outline.fsTypes;
+
+      if (volume.mountPath !== "/") return allValues;
+
+      // Btrfs without snapshots is not an option.
+      if (!volume.outline.snapshotsConfigurable && volume.snapshots) {
+        return [BTRFS_SNAPSHOTS, ...allValues].filter((v) => v !== "btrfs");
+      }
+
+      // Btrfs with snapshots is not an option
+      if (!volume.outline.snapshotsConfigurable && !volume.snapshots) {
+        return allValues;
+      }
+
+      return [BTRFS_SNAPSHOTS, ...allValues];
+    };
+
+    return unique([defaultFilesystem, ...volumeFilesystems()]);
+  }, [volume, defaultFilesystem]);
+
+  return usableFilesystems;
+}
+
+function useMountPointError(value: FormValue): Error | undefined {
+  const model = useModel({ suspense: true });
+  const mountPoints = model?.getMountPaths() || [];
+  const deviceModel = useDeviceModel();
+  const mountPoint = value.mountPoint;
+
+  if (mountPoint === NO_VALUE) {
+    return {
+      id: "mountPoint",
+      isVisible: false,
+    };
+  }
+
+  const regex = /^swap$|^\/$|^(\/[^/\s]+)+$/;
+  if (!regex.test(mountPoint)) {
+    return {
+      id: "mountPoint",
+      message: _("Select or enter a valid mount point"),
+      isVisible: true,
+    };
+  }
+
+  // Exclude itself when editing
+  const initialMountPoint = deviceModel?.mountPath;
+  if (mountPoint !== initialMountPoint && mountPoints.includes(mountPoint)) {
+    return {
+      id: "mountPoint",
+      message: _("Select or enter a mount point that is not already assigned to another device"),
+      isVisible: true,
+    };
+  }
+}
+
+function useErrors(value: FormValue): ErrorsHandler {
+  const mountPointError = useMountPointError(value);
+  const errors = compact([mountPointError]);
+
+  const getError = (id: string): Error | undefined => errors.find((e) => e.id === id);
+
+  const getVisibleError = (id: string): Error | undefined => {
+    const error = getError(id);
+    return error?.isVisible ? error : undefined;
+  };
+
+  return { errors, getError, getVisibleError };
+}
+
+function useAutoRefreshFilesystem(handler, value: FormValue) {
+  const { mountPoint } = value;
+  const defaultFilesystem = useDefaultFilesystem(mountPoint);
+  const usableFilesystems = useUsableFilesystems(mountPoint);
+  const currentFilesystem = useCurrentFilesystem();
+
+  React.useEffect(() => {
+    // Reset filesystem if there is no mount point yet.
+    if (mountPoint === NO_VALUE) handler(NO_VALUE);
+    // Select default filesystem for the mount point if the device has no filesystem.
+    if (mountPoint !== NO_VALUE && !currentFilesystem) handler(defaultFilesystem);
+    // Reuse the filesystem from the device if possible.
+    if (mountPoint !== NO_VALUE && currentFilesystem) {
+      const reuse = usableFilesystems.includes(currentFilesystem);
+      handler(reuse ? REUSE_FILESYSTEM : defaultFilesystem);
+    }
+  }, [handler, mountPoint, defaultFilesystem, usableFilesystems, currentFilesystem]);
+}
+
+function mountPointSelectOptions(mountPoints: string[]): SelectOptionProps[] {
+  return mountPoints.map((p) => ({ value: p, children: p }));
+}
+
+type FilesystemOptionLabelProps = {
+  value: string;
+};
+
+function FilesystemOptionLabel({ value }: FilesystemOptionLabelProps): React.ReactNode {
+  const filesystem = useCurrentFilesystem();
+  if (value === NO_VALUE) return _("Waiting for a mount point");
+  // TRANSLATORS: %s is a filesystem type, like Btrfs
+  if (value === REUSE_FILESYSTEM && filesystem)
+    return sprintf(_("Current %s"), filesystemLabel(filesystem));
+  if (value === BTRFS_SNAPSHOTS) return _("Btrfs with snapshots");
+
+  return filesystemLabel(value);
+}
+
+type FilesystemOptionsProps = {
+  mountPoint: string;
+};
+
+function FilesystemOptions({ mountPoint }: FilesystemOptionsProps): React.ReactNode {
+  const device = useDevice();
+  const volume = useVolume(mountPoint);
+  const defaultFilesystem = useDefaultFilesystem(mountPoint);
+  const usableFilesystems = useUsableFilesystems(mountPoint);
+  const currentFilesystem = useCurrentFilesystem();
+  const canReuse = currentFilesystem && usableFilesystems.includes(currentFilesystem);
+
+  const defaultOptText = volume.mountPath
+    ? sprintf(_("Default file system for %s"), mountPoint)
+    : _("Default file system");
+  const formatText = currentFilesystem
+    ? _("Destroy current data and format device as")
+    : _("Format device as");
+
+  return (
+    <SelectList aria-label="Available file systems">
+      {mountPoint === NO_VALUE && (
+        <SelectOption value={NO_VALUE}>
+          <FilesystemOptionLabel value={NO_VALUE} />
+        </SelectOption>
+      )}
+      {mountPoint !== NO_VALUE && canReuse && (
+        <SelectOption
+          value={REUSE_FILESYSTEM}
+          // TRANSLATORS: %s is the name of a device, like /dev/vda
+          description={sprintf(_("Do not format %s and keep the current data"), device.name)}
+        >
+          <FilesystemOptionLabel value={REUSE_FILESYSTEM} />
+        </SelectOption>
+      )}
+      {mountPoint !== NO_VALUE && canReuse && usableFilesystems.length && <Divider />}
+      {mountPoint !== NO_VALUE && (
+        <SelectGroup label={formatText}>
+          {usableFilesystems.map((fsType, index) => (
+            <SelectOption
+              key={index}
+              value={fsType}
+              description={fsType === defaultFilesystem && defaultOptText}
+            >
+              <FilesystemOptionLabel value={fsType} />
+            </SelectOption>
+          ))}
+        </SelectGroup>
+      )}
+    </SelectList>
+  );
+}
+
+type FilesystemSelectProps = {
+  id?: string;
+  value: string;
+  mountPoint: string;
+  onChange: SelectProps["onChange"];
+};
+
+function FilesystemSelect({
+  id,
+  value,
+  mountPoint,
+  onChange,
+}: FilesystemSelectProps): React.ReactNode {
+  const usedValue = mountPoint === NO_VALUE ? NO_VALUE : value;
+
+  return (
+    <Select
+      id={id}
+      value={usedValue}
+      label={<FilesystemOptionLabel value={usedValue} />}
+      onChange={onChange}
+      isDisabled={mountPoint === NO_VALUE}
+    >
+      <FilesystemOptions mountPoint={mountPoint} />
+    </Select>
+  );
+}
+
+type FilesystemLabelProps = {
+  id?: string;
+  value: string;
+  onChange: (v: string) => void;
+};
+
+function FilesystemLabel({ id, value, onChange }: FilesystemLabelProps): React.ReactNode {
+  const isValid = (v: string) => /^[\w-_.]*$/.test(v);
+
+  return (
+    <TextInput
+      id={id}
+      aria-label={_("File system label")}
+      value={value}
+      onChange={(_, v) => isValid(v) && onChange(v)}
+    />
+  );
+}
+
+/**
+ * @fixme This component has to be adapted to use the new hooks from ~/hooks/storage/ instead of the
+ * deprecated hooks from ~/queries/storage/config-model.
+ */
+export default function FormattableDevicePage() {
+  const navigate = useNavigate();
+  const headingId = useId();
+  const [mountPoint, setMountPoint] = React.useState(NO_VALUE);
+  const [filesystem, setFilesystem] = React.useState(NO_VALUE);
+  const [filesystemLabel, setFilesystemLabel] = React.useState(NO_VALUE);
+  // Filesystem and size selectors should not be auto refreshed before the user interacts with other
+  // selectors like the mount point or the target selectors.
+  const [autoRefreshFilesystem, setAutoRefreshFilesystem] = React.useState(false);
+
+  const initialValue = useInitialFormValue();
+  const value = { mountPoint, filesystem, filesystemLabel };
+  const { errors, getVisibleError } = useErrors(value);
+
+  const device = useDeviceModel();
+  const unusedMountPoints = useUnusedMountPoints();
+  const addFilesystem = useAddFilesystem();
+
+  // Initializes the form values.
+  React.useEffect(() => {
+    if (initialValue) {
+      setMountPoint(initialValue.mountPoint);
+      setFilesystem(initialValue.filesystem);
+      setFilesystemLabel(initialValue.filesystemLabel);
+    }
+  }, [initialValue]);
+
+  const refreshFilesystemHandler = React.useCallback(
+    (filesystem: string) => autoRefreshFilesystem && setFilesystem(filesystem),
+    [autoRefreshFilesystem, setFilesystem],
+  );
+
+  useAutoRefreshFilesystem(refreshFilesystemHandler, value);
+
+  const changeMountPoint = (value: string) => {
+    if (value !== mountPoint) {
+      setAutoRefreshFilesystem(true);
+      setMountPoint(value);
+    }
+  };
+
+  const changeFilesystem = (value: string) => {
+    setAutoRefreshFilesystem(false);
+    setFilesystem(value);
+  };
+
+  const onSubmit = () => {
+    const data = toData(value);
+    const { list, listIndex } = device;
+    addFilesystem(list, listIndex, data);
+    navigate(PATHS.root);
+  };
+
+  const isFormValid = errors.length === 0;
+  const mountPointError = getVisibleError("mountPoint");
+  const usedMountPt = mountPointError ? NO_VALUE : mountPoint;
+  const showLabel = filesystem !== NO_VALUE && filesystem !== REUSE_FILESYSTEM;
+
+  return (
+    <Page id="formattablePage">
+      <Page.Header>
+        <Content component="h2" id={headingId}>
+          {sprintf(_("Configure device %s"), device.name)}
+        </Content>
+      </Page.Header>
+
+      <Page.Content>
+        <Form id="formattableForm" aria-labelledby={headingId} onSubmit={onSubmit}>
+          <Stack hasGutter>
+            <FormGroup fieldId="mountPoint" label={_("Mount point")}>
+              <Flex>
+                <FlexItem>
+                  <SelectTypeaheadCreatable
+                    id="mountPoint"
+                    toggleName={_("Mount point toggle")}
+                    listName={_("Suggested mount points")}
+                    inputName={_("Mount point")}
+                    clearButtonName={_("Clear selected mount point")}
+                    value={mountPoint}
+                    options={mountPointSelectOptions(unusedMountPoints)}
+                    createText={_("Use")}
+                    onChange={changeMountPoint}
+                  />
+                </FlexItem>
+              </Flex>
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant={mountPointError ? "error" : "default"}>
+                    {!mountPointError && _("Select or enter a mount point")}
+                    {mountPointError?.message}
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+            <FormGroup>
+              <Flex>
+                <FlexItem>
+                  <FormGroup fieldId="fileSystem" label={_("File system")}>
+                    <FilesystemSelect
+                      id="fileSystem"
+                      value={filesystem}
+                      mountPoint={usedMountPt}
+                      onChange={changeFilesystem}
+                    />
+                  </FormGroup>
+                </FlexItem>
+                {showLabel && (
+                  <FlexItem>
+                    <FormGroup fieldId="fileSystemLabel" label={_("Label")}>
+                      <FilesystemLabel
+                        id="fileSystemLabel"
+                        value={filesystemLabel}
+                        onChange={setFilesystemLabel}
+                      />
+                    </FormGroup>
+                  </FlexItem>
+                )}
+              </Flex>
+            </FormGroup>
+            <ActionGroup>
+              <Page.Submit isDisabled={!isFormValid} form="formattableForm" />
+              <Page.Cancel />
+            </ActionGroup>
+          </Stack>
+        </Form>
+      </Page.Content>
+    </Page>
+  );
+}

--- a/web/src/components/storage/FormattableDevicePage.tsx
+++ b/web/src/components/storage/FormattableDevicePage.tsx
@@ -300,7 +300,7 @@ function FilesystemOptions({ mountPoint }: FilesystemOptionsProps): React.ReactN
 
   const defaultOptText = volume.mountPath
     ? sprintf(_("Default file system for %s"), mountPoint)
-    : _("Default file system");
+    : _("Default file system for generic mount paths");
   const formatText = currentFilesystem
     ? _("Destroy current data and format device as")
     : _("Format device as");
@@ -317,7 +317,7 @@ function FilesystemOptions({ mountPoint }: FilesystemOptionsProps): React.ReactN
           value={REUSE_FILESYSTEM}
           description={
             // TRANSLATORS: %s is the name of a device, like vda
-            sprintf(_("Do not format %s and keep the current data"), deviceBaseName(device, true))
+            sprintf(_("Do not format %s and keep the data"), deviceBaseName(device, true))
           }
         >
           <FilesystemOptionLabel value={REUSE_FILESYSTEM} />

--- a/web/src/components/storage/FormattableDevicePage.tsx
+++ b/web/src/components/storage/FormattableDevicePage.tsx
@@ -20,6 +20,11 @@
  * find current contact information at www.suse.com.
  */
 
+/**
+ * @fixme This file, PartitionPage and LogicalVolumePage need to be refactored in order to avoid
+ *  code duplication.
+ */
+
 import React, { useId } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
@@ -383,18 +388,14 @@ function FilesystemLabel({ id, value, onChange }: FilesystemLabelProps): React.R
   );
 }
 
-/**
- * @fixme This component has to be adapted to use the new hooks from ~/hooks/storage/ instead of the
- * deprecated hooks from ~/queries/storage/config-model.
- */
 export default function FormattableDevicePage() {
   const navigate = useNavigate();
   const headingId = useId();
   const [mountPoint, setMountPoint] = React.useState(NO_VALUE);
   const [filesystem, setFilesystem] = React.useState(NO_VALUE);
   const [filesystemLabel, setFilesystemLabel] = React.useState(NO_VALUE);
-  // Filesystem and size selectors should not be auto refreshed before the user interacts with other
-  // selectors like the mount point or the target selectors.
+  // Filesystem selectors should not be auto refreshed before the user interacts with the mount
+  // point selector.
   const [autoRefreshFilesystem, setAutoRefreshFilesystem] = React.useState(false);
 
   const initialValue = useInitialFormValue();

--- a/web/src/components/storage/LogicalVolumePage.tsx
+++ b/web/src/components/storage/LogicalVolumePage.tsx
@@ -472,9 +472,10 @@ type FilesystemOptionsProps = {
 function FilesystemOptions({ mountPoint }: FilesystemOptionsProps): React.ReactNode {
   const defaultFilesystem = useDefaultFilesystem(mountPoint);
   const usableFilesystems = useUsableFilesystems(mountPoint);
+  const volume = useVolume(mountPoint);
 
   const defaultOptText =
-    mountPoint !== NO_VALUE
+    mountPoint !== NO_VALUE && volume.mountPath
       ? sprintf(_("Default file system for %s"), mountPoint)
       : _("Default file system for generic logical volumes");
 

--- a/web/src/components/storage/LvmPage.test.tsx
+++ b/web/src/components/storage/LvmPage.test.tsx
@@ -161,7 +161,7 @@ jest.mock("~/queries/storage", () => ({
 
 jest.mock("~/hooks/storage/system", () => ({
   ...jest.requireActual("~/hooks/storage/system"),
-  useCandidateDevices: () => mockUseAllDevices,
+  useAvailableDevices: () => mockUseAllDevices,
 }));
 
 jest.mock("~/hooks/storage/model", () => ({

--- a/web/src/components/storage/LvmPage.tsx
+++ b/web/src/components/storage/LvmPage.tsx
@@ -35,8 +35,7 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 import { Page, SubtleContent } from "~/components/core";
-import { useCandidateDevices } from "~/hooks/storage/system";
-import { useDevices } from "~/queries/storage";
+import { useAvailableDevices } from "~/hooks/storage/system";
 import { StorageDevice, model, data } from "~/types/storage";
 import { useModel } from "~/hooks/storage/model";
 import {
@@ -53,24 +52,19 @@ import { _ } from "~/i18n";
 /**
  * Hook that returns the devices that can be selected as target to automatically create LVM PVs.
  *
- * FIXME: temporary and weak implementation that relies on the current model to offer only the
- * candidate RAIDs and those non-candidate RAIDs that are already present at the current
- * configuration. In the future we plan to add all available RAIDs to this form and then this whole
- * function should disappear.
+ * Filters out devices that are going to be directly formatted.
  */
 function useLvmTargetDevices(): StorageDevice[] {
-  const candidateDevices = useCandidateDevices();
-  const systemDevices = useDevices("system", { suspense: true });
+  const availableDevices = useAvailableDevices();
   const model = useModel({ suspense: true });
 
   const targetDevices = useMemo(() => {
-    const sids = candidateDevices.map((d) => d.sid);
-    const raids = model.mdRaids
-      .map((r) => systemDevices.find((d) => d.name === r.name))
-      .filter((r) => !sids.includes(r.sid));
-
-    return [...candidateDevices, ...raids];
-  }, [candidateDevices, systemDevices, model]);
+    return availableDevices.filter((candidate) => {
+      const collection = candidate.isDrive ? model.drives : model.mdRaids;
+      const device = collection.find((d) => d.name === candidate.name);
+      return !device || !device.filesystem;
+    });
+  }, [availableDevices, model]);
 
   return targetDevices;
 }

--- a/web/src/components/storage/MdRaidEditor.tsx
+++ b/web/src/components/storage/MdRaidEditor.tsx
@@ -23,8 +23,7 @@
 import React from "react";
 import ConfigEditorItem from "~/components/storage/ConfigEditorItem";
 import MdRaidHeader from "~/components/storage/MdRaidHeader";
-import PartitionsMenu from "~/components/storage/PartitionsMenu";
-import SpacePolicyMenu from "~/components/storage/SpacePolicyMenu";
+import DeviceEditorContent from "~/components/storage/DeviceEditorContent";
 import SearchedDeviceMenu from "~/components/storage/SearchedDeviceMenu";
 import { model, StorageDevice } from "~/types/storage";
 import { MdRaid } from "~/types/storage/model";
@@ -55,12 +54,7 @@ export default function MdRaidEditor({ raid, raidDevice }: MdRaidEditorProps) {
   return (
     <ConfigEditorItem
       header={<MdRaidHeader raid={raid} device={raidDevice} />}
-      content={
-        <>
-          <PartitionsMenu device={raid} />
-          <SpacePolicyMenu modelDevice={raid} device={raidDevice} />
-        </>
-      }
+      content={<DeviceEditorContent deviceModel={raid} device={raidDevice} />}
       actions={<MdRaidDeviceMenu raid={raid} selected={raidDevice} />}
     />
   );

--- a/web/src/components/storage/MdRaidHeader.tsx
+++ b/web/src/components/storage/MdRaidHeader.tsx
@@ -28,6 +28,13 @@ import { _ } from "~/i18n";
 export type MdRaidHeaderProps = { raid: model.MdRaid; device: StorageDevice };
 
 const text = (raid: model.MdRaid): string => {
+  if (raid.filesystem) {
+    // TRANSLATORS: %s will be replaced by a RAID name and its size - "md0 (20 GiB)"
+    if (raid.filesystem.reuse) return _("Mount RAID %s");
+    // TRANSLATORS: %s will be replaced by a RAID name and its size - "md0 (20 GiB)"
+    return _("Format RAID %s");
+  }
+
   const { isBoot, isTargetDevice: hasPv } = raid;
   const isRoot = !!raid.getPartition("/");
   const hasFs = !!raid.getMountPaths().length;

--- a/web/src/components/storage/NewVgMenuOption.tsx
+++ b/web/src/components/storage/NewVgMenuOption.tsx
@@ -33,6 +33,9 @@ export type NewVgMenuOptionProps = { device: model.Drive | model.MdRaid };
 
 export default function NewVgMenuOption({ device }: NewVgMenuOptionProps): React.ReactNode {
   const convertToVg = useConvertToVolumeGroup();
+
+  if (device.filesystem) return;
+
   const vgs = device.getVolumeGroups();
   const paths = device.partitions.filter((p) => !p.name).map((p) => formattedPath(p.mountPath));
   const displayName = deviceBaseName(device, true);

--- a/web/src/components/storage/PartitionsMenu.test.tsx
+++ b/web/src/components/storage/PartitionsMenu.test.tsx
@@ -89,14 +89,12 @@ jest.mock("~/hooks/storage/partition", () => ({
   useDeletePartition: () => mockDeletePartition,
 }));
 
-// FIXME: enable it back once wording is adapted in both, the component and the
-// test.
-xdescribe("PartitionMenuItem", () => {
+describe("PartitionMenuItem", () => {
   it("allows users to delete a not required partition", async () => {
     const { user } = plainRender(<PartitionsMenu device={drive1} />);
 
-    const partitionsButton = screen.getByRole("button", { name: "Partitions" });
-    await user.click(partitionsButton);
+    const detailsButton = screen.getByRole("button", { name: /Details for .*sda/ });
+    await user.click(detailsButton);
     const partitionsMenu = screen.getByRole("menu");
     const deleteSwapButton = within(partitionsMenu).getByRole("menuitem", {
       name: "Delete swap",
@@ -108,8 +106,8 @@ xdescribe("PartitionMenuItem", () => {
   it("allows users to delete a required partition", async () => {
     const { user } = plainRender(<PartitionsMenu device={drive1} />);
 
-    const partitionsButton = screen.getByRole("button", { name: "Partitions" });
-    await user.click(partitionsButton);
+    const detailsButton = screen.getByRole("button", { name: /Details for .*sda/ });
+    await user.click(detailsButton);
     const partitionsMenu = screen.getByRole("menu");
     const deleteRootButton = within(partitionsMenu).getByRole("menuitem", {
       name: "Delete /",
@@ -121,8 +119,8 @@ xdescribe("PartitionMenuItem", () => {
   it("allows users to edit a partition", async () => {
     const { user } = plainRender(<PartitionsMenu device={drive1} />);
 
-    const partitionsButton = screen.getByRole("button", { name: "Partitions" });
-    await user.click(partitionsButton);
+    const detailsButton = screen.getByRole("button", { name: /Details for .*sda/ });
+    await user.click(detailsButton);
     const partitionsMenu = screen.getByRole("menu");
     const editSwapButton = within(partitionsMenu).getByRole("menuitem", {
       name: "Edit swap",

--- a/web/src/components/storage/PartitionsMenu.tsx
+++ b/web/src/components/storage/PartitionsMenu.tsx
@@ -24,7 +24,6 @@ import React, { useId } from "react";
 import { Divider, Stack, Flex } from "@patternfly/react-core";
 import { useNavigate, generatePath } from "react-router-dom";
 import Text from "~/components/core/Text";
-import Link from "~/components/core/Link";
 import MenuButton from "~/components/core/MenuButton";
 import MenuHeader from "~/components/core/MenuHeader";
 import MountPathMenuItem from "~/components/storage/MountPathMenuItem";
@@ -136,22 +135,11 @@ export default function PartitionsMenu({ device }) {
   const navigate = useNavigate();
   const ariaLabelId = useId();
   const toggleTextId = useId();
-  const { isBoot, isTargetDevice, list, listIndex } = device;
+  const { list, listIndex } = device;
   const newPartitionPath = generatePath(PATHS.addPartition, { list, listIndex });
   // TRANSLATORS: %s is the name of device, like '/dev/sda'.
   const detailsAriaLabel = sprintf(_("Details for %s"), device.name);
-
   const hasPartitions = device.partitions.some((p: Partition) => p.mountPath);
-
-  if (!isBoot && !isTargetDevice && !hasPartitions) {
-    return (
-      <Flex gap={{ default: "gapXs" }}>
-        <Link variant="link" isInline to={newPartitionPath}>
-          {_("Add a new partition or mount an existing one")}
-        </Link>
-      </Flex>
-    );
-  }
 
   // FIXME: All strings and widgets are now calculated and assembled here. But we are actually
   // aiming for a different organization of the widgets (eg. using a MenuGroup with a label to

--- a/web/src/components/storage/SearchedDeviceMenu.tsx
+++ b/web/src/components/storage/SearchedDeviceMenu.tsx
@@ -209,10 +209,6 @@ const RemoveEntryOption = ({ device, onClick }: RemoveEntryOptionProps): React.R
     return !onlyToBoot;
   };
 
-  // If the target device cannot be changed, this button will always be disabled and would only
-  // provide redundant information.
-  if (UseOnlyOneOption(device)) return;
-
   // When no additional drives has been added, the "Do not use" button can be confusing so it is
   // omitted for all drives.
   if (!hasAdditionalDrives(model)) return;
@@ -221,6 +217,10 @@ const RemoveEntryOption = ({ device, onClick }: RemoveEntryOptionProps): React.R
   const isExplicitBoot = device.isExplicitBoot;
   const hasPv = device.isTargetDevice;
   const isDisabled = isExplicitBoot || hasPv;
+
+  // If these cases, the target device cannot be changed and this disabled button would only provide
+  // information that is redundant to the one already displayed at the disabled "change device" one.
+  if (!device.getMountPaths().length && (hasPv || isExplicitBoot)) return;
 
   if (isExplicitBoot) {
     if (hasPv) {

--- a/web/src/components/storage/SpacePolicyMenu.tsx
+++ b/web/src/components/storage/SpacePolicyMenu.tsx
@@ -27,7 +27,6 @@ import { useNavigate, generatePath } from "react-router-dom";
 import { useSetSpacePolicy } from "~/hooks/storage/space-policy";
 import { SPACE_POLICIES } from "~/components/storage/utils";
 import { apiModel } from "~/api/storage/types";
-import { Partition } from "~/api/storage/types/model";
 import { STORAGE as PATHS } from "~/routes/paths";
 import * as driveUtils from "~/components/storage/utils/drive";
 import { isEmpty } from "radashi";
@@ -50,12 +49,10 @@ const PolicyItem = ({ policy, modelDevice, isSelected, onClick }) => {
 export default function SpacePolicyMenu({ modelDevice, device }) {
   const navigate = useNavigate();
   const setSpacePolicy = useSetSpacePolicy();
-  const { isBoot, isTargetDevice, list, listIndex } = modelDevice;
+  const { list, listIndex } = modelDevice;
   const existingPartitions = device.partitionTable?.partitions.length;
-  const hasPartitions = modelDevice.partitions.some((p: Partition) => p.mountPath);
 
   if (isEmpty(existingPartitions)) return;
-  if (!isBoot && !isTargetDevice && !hasPartitions) return;
 
   const onSpacePolicyChange = (spacePolicy: apiModel.SpacePolicy) => {
     if (spacePolicy === "custom") {

--- a/web/src/components/storage/UnusedMenu.tsx
+++ b/web/src/components/storage/UnusedMenu.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useId } from "react";
+import { Flex } from "@patternfly/react-core";
+import { useNavigate, generatePath } from "react-router-dom";
+import Text from "~/components/core/Text";
+import MenuButton from "~/components/core/MenuButton";
+import { STORAGE as PATHS } from "~/routes/paths";
+import { model } from "~/types/storage";
+import { sprintf } from "sprintf-js";
+import { _ } from "~/i18n";
+
+type UnusedMenuProps = { deviceModel: model.Drive | model.MdRaid };
+
+export default function UnusedMenu({ deviceModel }: UnusedMenuProps): React.ReactNode {
+  const navigate = useNavigate();
+  const ariaLabelId = useId();
+  const toggleTextId = useId();
+  const { list, listIndex } = deviceModel;
+  const newPartitionPath = generatePath(PATHS.addPartition, { list, listIndex });
+  const formatDevicePath = generatePath(PATHS.formatDevice, { list, listIndex });
+
+  // TRANSLATORS: %s is the name of device, like '/dev/sda'.
+  const detailsAriaLabel = sprintf(_("Details for %s"), deviceModel.name);
+  const description = _("Not configured yet");
+  const filesystemLabel =
+    list === "drives" ? _("Use the disk without partitions") : _("Use the RAID without partitions");
+
+  return (
+    <Flex gap={{ default: "gapXs" }}>
+      <Text id={ariaLabelId} srOnly>
+        {detailsAriaLabel}
+      </Text>
+      <Text isBold aria-hidden>
+        {_("Details")}
+      </Text>
+      <MenuButton
+        menuProps={{
+          "aria-label": detailsAriaLabel,
+        }}
+        toggleProps={{
+          variant: "plainText",
+          "aria-labelledby": `${ariaLabelId} ${toggleTextId}`,
+        }}
+        items={[
+          <MenuButton.Item
+            key="add-partition"
+            itemId="add-partition"
+            description={_("Add a partition or mount an existing one")}
+            onClick={() => navigate(newPartitionPath)}
+          >
+            {_("Add or use partition")}
+          </MenuButton.Item>,
+          <MenuButton.Item
+            key="filesystem"
+            itemId="filesystem"
+            description={_("Format the whole device or mount an existing file system")}
+            onClick={() => navigate(formatDevicePath)}
+          >
+            {filesystemLabel}
+          </MenuButton.Item>,
+        ]}
+      >
+        <Text id={toggleTextId}>{description}</Text>
+      </MenuButton>
+    </Flex>
+  );
+}

--- a/web/src/components/storage/utils/drive.tsx
+++ b/web/src/components/storage/utils/drive.tsx
@@ -23,7 +23,13 @@
 import { _, n_, formatList } from "~/i18n";
 import { apiModel } from "~/api/storage/types";
 import { Drive } from "~/types/storage/model";
-import { SpacePolicy, SPACE_POLICIES, baseName, formattedPath } from "~/components/storage/utils";
+import {
+  SpacePolicy,
+  SPACE_POLICIES,
+  baseName,
+  formattedPath,
+  filesystemType,
+} from "~/components/storage/utils";
 import { sprintf } from "sprintf-js";
 
 /**
@@ -146,6 +152,14 @@ const contentActionsDescription = (drive: Drive, policyId: string | undefined): 
 const contentDescription = (drive: apiModel.Drive): string => {
   const newPartitions = drive.partitions.filter((p) => !p.name);
   const reusedPartitions = drive.partitions.filter((p) => p.name && p.mountPath);
+
+  if (drive.filesystem) {
+    if (drive.mountPath) {
+      return sprintf(_("The device will be used for %s"), drive.mountPath);
+    } else {
+      return sprintf(_("The device will formatted as %s"), filesystemType(drive.filesystem));
+    }
+  }
 
   if (newPartitions.length === 0) {
     if (reusedPartitions.length === 0) {

--- a/web/src/components/storage/utils/drive.tsx
+++ b/web/src/components/storage/utils/drive.tsx
@@ -23,13 +23,7 @@
 import { _, n_, formatList } from "~/i18n";
 import { apiModel } from "~/api/storage/types";
 import { Drive } from "~/types/storage/model";
-import {
-  SpacePolicy,
-  SPACE_POLICIES,
-  baseName,
-  formattedPath,
-  filesystemType,
-} from "~/components/storage/utils";
+import { SpacePolicy, SPACE_POLICIES, baseName, formattedPath } from "~/components/storage/utils";
 import { sprintf } from "sprintf-js";
 
 /**
@@ -155,10 +149,11 @@ const contentDescription = (drive: apiModel.Drive): string => {
 
   if (drive.filesystem) {
     if (drive.mountPath) {
-      return sprintf(_("The device will be used for %s"), drive.mountPath);
-    } else {
-      return sprintf(_("The device will formatted as %s"), filesystemType(drive.filesystem));
+      return sprintf(_("The whole device will be used for %s"), formattedPath(drive.mountPath));
     }
+
+    // I don't think this can happen, maybe when loading a configuration not created with the UI
+    return _("A file system will be used for the whole device");
   }
 
   if (newPartitions.length === 0) {

--- a/web/src/helpers/storage/filesystem.ts
+++ b/web/src/helpers/storage/filesystem.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { apiModel } from "~/api/storage/types";
+import { data } from "~/types/storage";
+import { copyApiModel } from "~/helpers/storage/api-model";
+
+function findDevice(
+  apiModel: apiModel.Config,
+  list: string,
+  index: number | string,
+): apiModel.Drive | apiModel.MdRaid | null {
+  return (apiModel[list] || []).at(index) || null;
+}
+
+function configureFilesystem(
+  apiModel: apiModel.Config,
+  list: string,
+  index: number | string,
+  data: data.Formattable,
+): apiModel.Config {
+  apiModel = copyApiModel(apiModel);
+
+  const device = findDevice(apiModel, list, index);
+  if (!device) return apiModel;
+
+  device.mountPath = data.mountPath;
+
+  if (data.filesystem) {
+    device.filesystem = {
+      default: false,
+      ...data.filesystem,
+    };
+  } else {
+    device.filesystem = undefined;
+  }
+
+  return apiModel;
+}
+
+export { configureFilesystem };

--- a/web/src/helpers/storage/search.ts
+++ b/web/src/helpers/storage/search.ts
@@ -79,6 +79,26 @@ function switchSearched(
 
   const device = findDevice(apiModel, oldList, index);
   const deviceModel = buildModelDevice(apiModel, oldList, index);
+  const targetIndex = findDeviceIndex(apiModel, list, name);
+  const target = targetIndex === -1 ? null : findDevice(apiModel, list, targetIndex);
+
+  if (deviceModel.filesystem) {
+    if (target) {
+      target.mountPath = device.mountPath;
+      target.filesystem = device.filesystem;
+      target.spacePolicy = "keep";
+    } else {
+      apiModel[list].push({
+        name,
+        mountPath: device.mountPath,
+        filesystem: device.filesystem,
+        spacePolicy: "keep",
+      });
+    }
+
+    apiModel[oldList].splice(index, 1);
+    return apiModel;
+  }
 
   const [newPartitions, existingPartitions] = fork(deviceModel.partitions, (p) => p.isNew);
   const reusedPartitions = existingPartitions.filter((p) => p.isReused);
@@ -90,9 +110,7 @@ function switchSearched(
     apiModel[oldList].splice(index, 1);
   }
 
-  const targetIndex = findDeviceIndex(apiModel, list, name);
-  if (targetIndex !== -1) {
-    const target = findDevice(apiModel, list, targetIndex);
+  if (target) {
     target.partitions ||= [];
     target.partitions = [...target.partitions, ...newPartitions];
   } else {

--- a/web/src/hooks/storage/filesystem.ts
+++ b/web/src/hooks/storage/filesystem.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { useApiModel, useUpdateApiModel } from "~/hooks/storage/api-model";
+import { configureFilesystem } from "~/helpers/storage/filesystem";
+import { QueryHookOptions } from "~/types/queries";
+import { data } from "~/types/storage";
+
+type AddFilesystemFn = (list: string, index: number, data: data.Formattable) => void;
+
+function useAddFilesystem(options?: QueryHookOptions): AddFilesystemFn {
+  const apiModel = useApiModel(options);
+  const updateApiModel = useUpdateApiModel();
+  return (list: string, index: number, data: data.Formattable) => {
+    updateApiModel(configureFilesystem(apiModel, list, index, data));
+  };
+}
+
+type DeleteFilesystemFn = (list: string, index: number) => void;
+
+function useDeleteFilesystem(options?: QueryHookOptions): DeleteFilesystemFn {
+  const apiModel = useApiModel(options);
+  const updateApiModel = useUpdateApiModel();
+  return (list: string, index: number) => {
+    updateApiModel(configureFilesystem(apiModel, list, index, {}));
+  };
+}
+
+export { useAddFilesystem, useDeleteFilesystem };
+export type { AddFilesystemFn, DeleteFilesystemFn };

--- a/web/src/hooks/storage/product.ts
+++ b/web/src/hooks/storage/product.ts
@@ -47,6 +47,12 @@ function useMissingMountPaths(options?: QueryHookOptions): string[] {
 
 function useVolume(mountPath: string, options?: QueryHookOptions): Volume {
   const func = options?.suspense ? useSuspenseQuery : useQuery;
+  const { mountPoints } = useProductParams(options);
+
+  // The query returns a volume with the given mount path, but we need the "generic" volume without
+  // mount path for an arbitrary mount path. Take it into account while refactoring the backend side
+  // in order to report all the volumes in a single call (e.g., as part of the product params).
+  if (!mountPoints.includes(mountPath)) mountPath = "";
   const { data } = func(volumeQuery(mountPath));
   return data;
 }

--- a/web/src/routes/paths.ts
+++ b/web/src/routes/paths.ts
@@ -78,6 +78,7 @@ const STORAGE = {
   editBootDevice: "/storage/boot-device/edit",
   editEncryption: "/storage/encryption/edit",
   editSpacePolicy: "/storage/:list/:listIndex/space-policy/edit",
+  formatDevice: "/storage/:list/:listIndex/format",
   addPartition: "/storage/:list/:listIndex/partitions/add",
   editPartition: "/storage/:list/:listIndex/partitions/:partitionId/edit",
   selectDevice: "/storage/devices/select",

--- a/web/src/routes/storage.tsx
+++ b/web/src/routes/storage.tsx
@@ -29,6 +29,7 @@ import EncryptionSettingsPage from "~/components/storage/EncryptionSettingsPage"
 import SpacePolicySelection from "~/components/storage/SpacePolicySelection";
 import ProposalPage from "~/components/storage/ProposalPage";
 import ISCSIPage from "~/components/storage/ISCSIPage";
+import FormattableDevicePage from "~/components/storage/FormattableDevicePage";
 import PartitionPage from "~/components/storage/PartitionPage";
 import LvmPage from "~/components/storage/LvmPage";
 import LogicalVolumePage from "~/components/storage/LogicalVolumePage";
@@ -63,6 +64,10 @@ const routes = (): Route => ({
     {
       path: PATHS.editSpacePolicy,
       element: <SpacePolicySelection />,
+    },
+    {
+      path: PATHS.formatDevice,
+      element: <FormattableDevicePage />,
     },
     {
       path: PATHS.addPartition,

--- a/web/src/types/storage/data.ts
+++ b/web/src/types/storage/data.ts
@@ -55,6 +55,11 @@ type SpacePolicy = {
   actions?: SpacePolicyAction[];
 };
 
+type Formattable = {
+  mountPath?: string;
+  filesystem?: Filesystem;
+};
+
 // So far this type is used only for adding a pre-existing RAID searched by name. So we are starting
 // with this simplistic definition. Such a definition will likely grow in the future if the same
 // type is used for more operations.
@@ -72,12 +77,13 @@ type Drive = {
 
 export type {
   Drive,
+  Filesystem,
+  Formattable,
+  LogicalVolume,
   MdRaid,
   Partition,
-  VolumeGroup,
-  LogicalVolume,
-  Filesystem,
   Size,
   SpacePolicy,
   SpacePolicyAction,
+  VolumeGroup,
 };

--- a/web/src/types/storage/model.ts
+++ b/web/src/types/storage/model.ts
@@ -95,4 +95,6 @@ interface VolumeGroup extends Omit<apiModel.VolumeGroup, "targetDevices" | "logi
 
 type LogicalVolume = apiModel.LogicalVolume;
 
-export type { Model, Boot, Drive, MdRaid, Partition, VolumeGroup, LogicalVolume };
+type Formattable = Drive | MdRaid | Partition | LogicalVolume;
+
+export type { Model, Boot, Drive, MdRaid, Partition, VolumeGroup, LogicalVolume, Formattable };


### PR DESCRIPTION
## Goal

This pull request enables users of the UI to indicate they want to directly mount a whole disk or a software-defined MD RAID without a partition table. Possibly formatting it in the process.

It can work with software-defined MD RAIDs that are already present in the system, this does not include the ability to create new MD RAIDs using the web UI.

## Screenshots

This is how the whole process looks, step by step.

<img width="1059" height="620" alt="uno" src="https://github.com/user-attachments/assets/8bdf57b7-1819-453b-8b39-3624d727b5a9" />

<img width="1060" height="619" alt="dos" src="https://github.com/user-attachments/assets/e91049b0-0b39-4449-b2ab-3472ec8d874d" />

<img width="1057" height="622" alt="tres" src="https://github.com/user-attachments/assets/bd14fea0-4705-467e-b8bd-ce3fd7bfa7eb" />

<img width="1058" height="623" alt="cuatro" src="https://github.com/user-attachments/assets/11f0f849-3661-4a0f-b024-ba2da97f3461" />
