### PR TITLE
fix(live): Fixed downloading DUD files from HTTPS URL (bsc#1245393)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 15 16:19:21 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed downloading DUD files from HTTPS URL
+  (link the SSL certificates and config from the root image)
+  (bsc#1245393)
+
+-------------------------------------------------------------------
 Mon Jul 14 11:25:22 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Use "plaindir" repository type for the DUD package repository,


### PR DESCRIPTION
## Problem

- Downloading DUD from an HTTPS location fails with error "[60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: unable to get local issuer certificate)"
- https://bugzilla.suse.com/show_bug.cgi?id=1245393

## Solution

- Link the SSL certificates and config from the root image so the SSL verification works
- Debugged manually in dracut shell:
  <img width="640" height="480" alt="agama-download-ssl" src="https://github.com/user-attachments/assets/2f6bafdd-6d3d-472d-a02e-89e33907c98f" />


## Testing

- Tested manually, using the `inst.dud=https://download.opensuse.org/repositories/home:/lslezak:/dud-test/openSUSE_Tumbleweed/noarch/hello-world-0.1-1.1.noarch.rpm` boot parameter works as expected:
```
Jul 15 18:02:24 localhost.localdomain dracut-pre-pivot[1165]: Fetching a Driver Update Disk from https://download.opensuse.org/repositories/home:/lslezak:/dud-test/openSUSE_Tumbleweed/noarch/hello-world-0.1-1.1.noarch.rpm to /sysroot/run/agama/dud/hello-w
orld-0.1-1.1.noarch.rpm
Jul 15 18:02:24 localhost.localdomain dracut-pre-pivot[1173]: File saved to /sysroot/run/agama/dud/hello-world-0.1-1.1.noarch.rpm
Jul 15 18:02:25 localhost.localdomain dracut-pre-pivot[1165]: Apply update from an RPM package
Jul 15 18:02:25 localhost.localdomain dracut-pre-pivot[1165]: Unpacking RPM /sysroot/run/agama/dud/hello-world-0.1-1.1.noarch.rpm to /sysroot/run/agama/dud/dud_000
Jul 15 18:02:25 localhost.localdomain dracut-pre-pivot[1165]: /sysroot/run/agama/dud/dud_000 /
Jul 15 18:02:25 localhost.localdomain dracut-pre-pivot[1184]: 1 block
Jul 15 18:02:25 localhost.localdomain dracut-pre-pivot[1165]: /
Jul 15 18:02:25 localhost.localdomain dracut-pre-pivot[1165]: Apply inst-sys update from /sysroot/run/agama/dud/dud_000
```


