### PR TITLE
(backend): Set connection method4 and method6 as auto in case of absense in the profile (bsc#1245798)

### DIFF
--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -1074,8 +1074,8 @@ pub struct UnknownIpMethod(String);
 #[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Ipv4Method {
-    #[default]
     Disabled = 0,
+    #[default]
     Auto = 1,
     Manual = 2,
     LinkLocal = 3,
@@ -1110,8 +1110,8 @@ impl FromStr for Ipv4Method {
 #[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Ipv6Method {
-    #[default]
     Disabled = 0,
+    #[default]
     Auto = 1,
     Manual = 2,
     LinkLocal = 3,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 16 09:21:30 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Make the method4 and method6 default to be "auto" in case of
+ absense (bsc#1246194).
+
+-------------------------------------------------------------------
 Wed Jul 16 07:30:02 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Add support for activating zFCP disks to Agama unattended profile


### PR DESCRIPTION
## Problem

The default for **IPv4** method and **IPv6** method is to have it disabled. But the defaults for NetworkManager and what most users would expect is to set it to auto.

- https://bugzilla.suse.com/show_bug.cgi?id=1245798

## Solution

Set the default to auto for IPv6 and IPv4 methods.

## Testing

- *Tested manually*

## Example

**profile.jsonnet**
```jsonnet
{
  "network": {
    "connections": [
      {
        "id": "Bridge0",
        "interface": "br0",
        "bridge": {
          "ports": ["enp5s0f4u1u1c2"],
          "stp": false
        }
      }
    ]
  }
}
```

```bash
agama config load < profile.jsonnet
agama config show 
{
  ...
  "network": {
    "connections": [
      {
        "id": "Bridge0",
        "method4": "auto",
        "method6": "auto",
        "ignoreAutoDns": false,
        "interface": "br0",
        "bridge": {
          "stp": false,
          "ports": [
            "enp5s0f4u1u1c2"
          ]
        },
        "status": "up",
        "autoconnect": true,
        "persistent": true
      }
    ]
  }
  ...
}
✓ The profile is valid.

```