### PR TITLE
feat(cli): Added -i/--insecure optional argument to the "agama download" command

### DIFF
--- a/rust/agama-cli/src/cli_input.rs
+++ b/rust/agama-cli/src/cli_input.rs
@@ -131,7 +131,7 @@ impl CliInput {
             }
             Self::Url(url_string) => {
                 let mut bytebuf = Vec::new();
-                Transfer::get(&url_string, &mut bytebuf)
+                Transfer::get(&url_string, &mut bytebuf, false)
                     .context(format!("Retrieving data from URL {}", url_string))?;
                 let s = String::from_utf8(bytebuf)
                     .context(format!("Invalid UTF-8 data at URL {}", url_string))?;

--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -104,6 +104,9 @@ pub enum Commands {
         url: String,
         /// File name
         destination: PathBuf,
+        /// Disables SSL verification for HTTPS downloads
+        #[arg(short, long)]
+        insecure: bool,
     },
     /// Finish the installation.
     Finish {

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -169,7 +169,7 @@ async fn wait_until_idle(monitor: MonitorClient) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn download_file(url: &str, path: &PathBuf) -> anyhow::Result<()> {
+pub fn download_file(url: &str, path: &PathBuf, insecure: bool) -> anyhow::Result<()> {
     let mut file = fs::OpenOptions::new()
         .create(true)
         .write(true)
@@ -186,7 +186,7 @@ pub fn download_file(url: &str, path: &PathBuf) -> anyhow::Result<()> {
         uri.resolve_against(&context.source)?.to_string()
     };
 
-    Transfer::get(&absolute_url, &mut file)?;
+    Transfer::get(&absolute_url, &mut file, insecure)?;
     println!("File saved to {}", path.display());
     Ok(())
 }
@@ -322,7 +322,11 @@ pub async fn run_command(cli: Cli) -> anyhow::Result<()> {
             let client = build_http_client(api_url, cli.opts.insecure, true).await?;
             run_logs_cmd(client, subcommand).await?
         }
-        Commands::Download { url, destination } => download_file(&url, &destination)?,
+        Commands::Download {
+            url,
+            destination,
+            insecure,
+        } => download_file(&url, &destination, insecure)?,
         Commands::Auth(subcommand) => {
             let client = build_http_client(api_url, cli.opts.insecure, false).await?;
             run_auth_cmd(client, subcommand).await?;

--- a/rust/agama-lib/src/file_source.rs
+++ b/rust/agama-lib/src/file_source.rs
@@ -85,7 +85,7 @@ impl FileSource {
         match &self {
             FileSource::Text { content } => file.write_all(content.as_bytes())?,
             // Transfer::get will fail if the URL is relative.
-            FileSource::Remote { url } => Transfer::get(&url.to_string(), &mut file)?,
+            FileSource::Remote { url } => Transfer::get(&url.to_string(), &mut file, false)?,
         }
 
         file.flush()?;

--- a/rust/agama-lib/src/utils/transfer.rs
+++ b/rust/agama-lib/src/utils/transfer.rs
@@ -40,7 +40,7 @@
 //!
 //! ```no_run
 //! use agama_lib::utils::Transfer;
-//! Transfer::get("label://OEMDRV/autoinst.xml", &mut std::io::stdout()).unwrap();
+//! Transfer::get("label://OEMDRV/autoinst.xml", &mut std::io::stdout(), false).unwrap();
 //! ````
 
 use std::io::Write;
@@ -85,13 +85,14 @@ impl Transfer {
     ///
     /// * `url`: URL to get the data from.
     /// * `out_fd`: where to write the data.
-    pub fn get(url: &str, out_fd: &mut impl Write) -> TransferResult<()> {
+    /// * `insecure`: ignore SSL problems in HTTPS downloads.
+    pub fn get(url: &str, out_fd: &mut impl Write, insecure: bool) -> TransferResult<()> {
         let url = Url::parse(url)?;
         match url.scheme() {
             "device" | "usb" => DeviceHandler::default().get(url, out_fd),
             "label" => LabelHandler::default().get(url, out_fd),
             "cd" | "dvd" | "hd" => HdHandler::default().get(url, out_fd),
-            _ => GenericHandler::default().get(url, out_fd),
+            _ => GenericHandler::default().get(url, out_fd, insecure),
         }
     }
 }

--- a/rust/agama-lib/src/utils/transfer/handlers/generic.rs
+++ b/rust/agama-lib/src/utils/transfer/handlers/generic.rs
@@ -32,11 +32,18 @@ use crate::utils::{TransferError, TransferResult};
 pub struct GenericHandler {}
 
 impl GenericHandler {
-    pub fn get(&self, url: Url, out_fd: &mut impl Write) -> TransferResult<()> {
+    pub fn get(&self, url: Url, out_fd: &mut impl Write, insecure: bool) -> TransferResult<()> {
         let mut handle = Easy::new();
         handle.follow_location(true)?;
         handle.fail_on_error(true)?;
         handle.url(url.as_ref())?;
+
+        if insecure {
+            // allow self-signed certificate, ignore verification failures
+            handle.ssl_verify_peer(false)?;
+            // allow not matching hostname
+            handle.ssl_verify_host(false)?;
+        }
 
         let mut transfer = handle.transfer();
         transfer.write_function(|buf| Ok(out_fd.write(buf).unwrap()))?;

--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -124,7 +124,7 @@ impl ProfileQuery {
     fn retrieve_profile(&self) -> Result<Option<String>, ProfileServiceError> {
         if let Some(url_string) = &self.url {
             let mut bytebuf = Vec::new();
-            Transfer::get(url_string, &mut bytebuf)
+            Transfer::get(url_string, &mut bytebuf, false)
                 .context(format!("Retrieving data from URL {}", url_string))?;
             let s = String::from_utf8(bytebuf)
                 .context(format!("Invalid UTF-8 data at URL {}", url_string))?;

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 16 08:42:59 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Added -i/--insecure optional argument to the "agama download"
+  command to ignore SSL problems in HTTPS downloads (self-signed
+  certificate, non-matching host, unknown CA...)
+  (related to bsc#1245393)
+
+-------------------------------------------------------------------
 Wed Jul 16 07:30:02 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Add support for activating zFCP disks to Agama unattended profile


### PR DESCRIPTION
## Problem

- The `agama download` command fails when downloading from HTTPS with a self-signed certificate
- It should be possible to ignore the problem and download the file anyway (only on explicit user request)
- Useful for testing, might be used by customers in local networks
- https://bugzilla.suse.com/show_bug.cgi?id=1245393

## Solution

- Ignore SSL problems in HTTPS downloads (self-signed certificate, non-matching host, unknown CA...)

## Testing

- Tested manually

### Fails by default 

Downloading from HTTPS server using a self-signed certificate fails:

```console
> ./agama download https://localhost:9000 index.html
Could not retrieve https://localhost:9000/

Caused by:
    [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: self-signed certificate)
```

### Using the `--insecure` option

When using the `--insecure` option the problem is ignored and the download succeeds:

```console
> ./agama download --insecure https://localhost:9000 index.html
File saved to index.html
```

### Help

The option is described in the help output:

```console
> ./agama download --help
Download file from a given (AutoYaST) URL

The purpose of this command is to download files using AutoYaST supported schemas (e.g. device://).
It can be used to download additional scripts, configuration files and so on. You can use it for
downloading Agama autoinstallation profiles. If you want to convert an AutoYaST profile, use "agama
config generate".

Usage: agama download [OPTIONS] <URL> <DESTINATION>

Arguments:
  <URL>
          URL reference pointing to file for download. If a relative URL is provided, it will be
          resolved against the current working directory

  <DESTINATION>
          File name

Options:
  -i, --insecure
          Disables SSL verification for HTTPS downloads

  -h, --help
          Print help (see a summary with '-h')
```