### PR TITLE
fix: better handling of missing license translations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
 name = "agama-lib"
 version = "1.0.0"
 dependencies = [
+ "agama-locale-data",
  "agama-network",
  "agama-utils",
  "anyhow",

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0"
 agama-utils = { path = "../agama-utils" }
 agama-network = { path = "../agama-network" }
+agama-locale-data = { path = "../agama-locale-data" }
 async-trait = "0.1.83"
 futures-util = "0.3.30"
 jsonschema = { version = "0.30.0", default-features = false, features = [

--- a/rust/agama-lib/src/software/model/license.rs
+++ b/rust/agama-lib/src/software/model/license.rs
@@ -205,27 +205,21 @@ impl LicensesRepo {
     /// not the case, it searches for a "compatible" language (the main language
     /// on the same territory, if given).
     fn find_language(&self, license: &License, candidate: &LanguageTag) -> Option<LanguageTag> {
-        if license.languages.contains(&candidate) {
-            return Some(candidate.clone());
-        }
-
-        if let Some(language) = license
-            .languages
-            .iter()
-            .find(|l| l.language == candidate.language)
-        {
-            return Some(language.clone());
-        }
+        let mut candidates: Vec<LanguageTag> = vec![candidate.clone()];
+        candidates.push(LanguageTag {
+            language: candidate.language.clone(),
+            territory: None,
+        });
 
         if let Some(territory) = &candidate.territory {
             if let Some(fallback) = self.fallback.get(territory) {
-                if license.languages.contains(&fallback) {
-                    return Some(fallback.clone());
-                }
+                candidates.push(fallback.clone());
             }
         }
 
-        None
+        candidates
+            .into_iter()
+            .find(|c| license.languages.contains(&c))
     }
 }
 

--- a/rust/agama-lib/src/software/model/license.rs
+++ b/rust/agama-lib/src/software/model/license.rs
@@ -133,8 +133,7 @@ impl LicensesRepo {
     ///
     /// If a translation is not found for the given language, it returns the default text.
     pub fn find(&self, id: &str, language: &LanguageTag) -> Option<LicenseContent> {
-        let license = self.licenses.iter().find(|l| l.id.as_str() == id).unwrap();
-
+        let license = self.licenses.iter().find(|l| l.id.as_str() == id)?;
         let license_language = self.find_language(&license, &language).unwrap_or_default();
         self.read_license_content(id, &license_language).ok()
     }

--- a/rust/agama-lib/src/software/model/license.rs
+++ b/rust/agama-lib/src/software/model/license.rs
@@ -176,6 +176,7 @@ impl LicensesRepo {
         code.try_into().ok()
     }
 
+    /// Read a license content for a given language.
     fn read_license_content(
         &self,
         id: &str,
@@ -204,25 +205,23 @@ impl LicensesRepo {
     /// not the case, it searches for a "compatible" language (the main language
     /// on the same territory, if given).
     fn find_language(&self, license: &License, candidate: &LanguageTag) -> Option<LanguageTag> {
-        let found = license
+        if license.languages.contains(&candidate) {
+            return Some(candidate.clone());
+        }
+
+        if let Some(language) = license
             .languages
             .iter()
-            .find(|l| *l == candidate)
-            .or_else(|| {
-                license
-                    .languages
-                    .iter()
-                    .find(|l| l.language == candidate.language)
-            });
-
-        if found.is_some() {
-            return found.cloned();
+            .find(|l| l.language == candidate.language)
+        {
+            return Some(language.clone());
         }
 
         if let Some(territory) = &candidate.territory {
-            let fallback = self.fallback.get(territory);
-            if fallback.is_some() {
-                return fallback.cloned();
+            if let Some(fallback) = self.fallback.get(territory) {
+                if license.languages.contains(&fallback) {
+                    return Some(fallback.clone());
+                }
             }
         }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 16 15:37:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- When searching for a translation of a license, use the first
+  language in the same territory as fallback (bsc#1238364,
+  gh#agama-project/agama#2571).
+- Add the language tag to the /licences/:id endpoint.
+
+-------------------------------------------------------------------
 Wed Jul 16 14:55:00 UTC 2025 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
 
 - Fix deletion of controller connections (gh#agama-project/agama#2564)

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 16 15:39:14 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Display a message when the license is not available in the
+  selected language (bsc#1238364, gh#agama-project/agama#2571).
+
+-------------------------------------------------------------------
 Mon Jul 14 16:02:55 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Allow specifying the registration server (jsc#AGM-156).

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -21,71 +21,52 @@
  */
 
 import React, { useEffect, useState } from "react";
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownList,
-  MenuToggle,
-  ModalProps,
-  Stack,
-} from "@patternfly/react-core";
+import { Alert, ModalProps, Stack } from "@patternfly/react-core";
 import { Popup } from "~/components/core";
 import { Product } from "~/types/software";
 import { fetchLicense } from "~/api/software";
 import { useInstallerL10n } from "~/context/installerL10n";
+import { sprintf } from "sprintf-js";
 import supportedLanguages from "~/languages.json";
 import { _ } from "~/i18n";
 
-function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; product: Product }) {
-  const { language: uiLanguage } = useInstallerL10n();
-  const [language, setLanguage] = useState<string>(uiLanguage);
-  const [license, setLicense] = useState<string>();
-  const [languageSelectorOpen, setLanguageSelectorOpen] = useState(false);
-  const localesToggler = (toggleRef) => (
-    <MenuToggle
-      aria-label={_("License language")}
-      ref={toggleRef}
-      onClick={() => setLanguageSelectorOpen(!languageSelectorOpen)}
-      isExpanded={languageSelectorOpen}
-    >
-      {supportedLanguages[language]}
-    </MenuToggle>
-  );
-
-  useEffect(() => {
-    language && fetchLicense(product.license, language).then(({ body }) => setLicense(body));
-  }, [language, product.license]);
-
-  const onLocaleSelection = (_, lang: string) => {
-    setLanguage(lang);
-    setLanguageSelectorOpen(false);
-  };
+const MissingTranslation = ({ missing }) => {
+  const missingLanguage = supportedLanguages[missing];
 
   return (
-    <Popup
-      isOpen
-      title={product.name}
-      titleAddon={
-        <Dropdown
-          isOpen={languageSelectorOpen}
-          selected={language}
-          onSelect={onLocaleSelection}
-          onOpenChange={(isOpen) => setLanguageSelectorOpen(!isOpen)}
-          toggle={localesToggler}
-          isScrollable
-          popperProps={{ position: "right" }}
-        >
-          <DropdownList>
-            {Object.entries(supportedLanguages).map(([id, name]) => (
-              <DropdownItem key={id} value={id}>
-                {name}
-              </DropdownItem>
-            ))}
-          </DropdownList>
-        </Dropdown>
-      }
-      width="auto"
-    >
+    <Alert title={sprintf(_("Not available in %s"), missingLanguage)}>
+      {sprintf(_("This license is not translated to %s."), missingLanguage)}
+    </Alert>
+  );
+};
+
+const languagesMatches = (language1: string, language2: string) => {
+  const [lang1] = language1.split("-");
+  const [lang2] = language2.split("-");
+  return lang1 === lang2;
+};
+
+function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; product: Product }) {
+  const { language: uiLanguage } = useInstallerL10n();
+  const [language] = useState<string>(uiLanguage);
+  const [licenseLanguage, setLicenseLanguage] = useState<string | null>(undefined);
+  const [license, setLicense] = useState<string>();
+
+  useEffect(() => {
+    language &&
+      fetchLicense(product.license, language).then(({ body, language: foundLanguage }) => {
+        setLicense(body);
+        setLicenseLanguage(foundLanguage);
+      });
+  }, [language, product.license]);
+
+  return (
+    <Popup isOpen title={product.name} width="auto">
+      {licenseLanguage && !languagesMatches(uiLanguage, licenseLanguage) && (
+        <Stack hasGutter>
+          <MissingTranslation missing={uiLanguage} />
+        </Stack>
+      )}
       <Stack hasGutter>
         <pre>{license}</pre>
       </Stack>

--- a/web/src/components/product/LicenseDialog.tsx
+++ b/web/src/components/product/LicenseDialog.tsx
@@ -34,9 +34,11 @@ const MissingTranslation = ({ missing }) => {
   const missingLanguage = supportedLanguages[missing];
 
   return (
-    <Alert title={sprintf(_("Not available in %s"), missingLanguage)}>
-      {sprintf(_("This license is not translated to %s."), missingLanguage)}
-    </Alert>
+    <Alert
+      isPlain
+      variant="info"
+      title={sprintf(_("This license is not available in %s."), missingLanguage)}
+    />
   );
 };
 
@@ -62,12 +64,10 @@ function LicenseDialog({ onClose, product }: { onClose: ModalProps["onClose"]; p
 
   return (
     <Popup isOpen title={product.name} width="auto">
-      {licenseLanguage && !languagesMatches(uiLanguage, licenseLanguage) && (
-        <Stack hasGutter>
-          <MissingTranslation missing={uiLanguage} />
-        </Stack>
-      )}
       <Stack hasGutter>
+        {licenseLanguage && !languagesMatches(uiLanguage, licenseLanguage) && (
+          <MissingTranslation missing={uiLanguage} />
+        )}
         <pre>{license}</pre>
       </Stack>
       <Popup.Actions>

--- a/web/src/types/software.ts
+++ b/web/src/types/software.ts
@@ -59,6 +59,8 @@ type LicenseContent = {
   id: string;
   /** License body */
   body: string;
+  /** License language (e.g., "en-US") */
+  language: string;
 };
 
 type PatternsSelection = { [key: string]: SelectedBy };


### PR DESCRIPTION
## Problem

* [bsc#1238364](https://bugzilla.suse.com/show_bug.cgi?id=1238364)

When displaying a product license, Agama allows to select the language to display the license. In general, it offers the same list of languages Agama is translated to. This has a few problems:

* In some cases, the license is no translated to that language. The Agama falls back to English without informing the user.
* It is just another language selector, which is kind of confusing.

## Solution

Now the license is directly shown in the same language that Agama is using. No additional language selector. If the translation is missing:

* It tries to find an alternative language (e.g., "Spanish" for "Catalan".
* If there is no alternative, it falls back to English.

## Alternative language

To search for an alternative language, Agama choses the first language in the same "territory". For instance, if you pick "Catalan" ("ca-ES"), Agama uses the [langtable data](https://pypi.org/project/langtable/) to search for the first language in the same territory, which in this case it is "Spanish" (es).

## Testing

- Added a new unit test
- Tested manually

## Screenshots

<details>
<summary>The license is translated. No warning and no selector.</summary>

<img width="1335" height="1009" alt="license-found-license" src="https://github.com/user-attachments/assets/795ef340-cc38-4cf9-9841-3151c76f8b94" />
</details>

<details>
<summary>The license is not translated to Catalan, but to Spanish. Warn the user.</summary>

<img width="1335" height="1009" alt="license-missing-translation" src="https://github.com/user-attachments/assets/7bfbbd81-a05f-45d0-baaa-52f03cce856b" />
</details>

<details>
<summary>Fall back to English. Warn the user.</summary>

<img width="1335" height="1009" alt="license-fallback-english" src="https://github.com/user-attachments/assets/8dcc931f-1ba3-4020-b3fa-c4f261221d9c" />
</details>

## Known problems

* It takes a moment to refresh the page when you change the language. It may confuse QA but it is a known problem, not related to this PR.