### PR TITLE
fix broken build on SLE where is all opensuse products as rm is applied only on opensuse

### DIFF
--- a/products.d/agama-products.spec
+++ b/products.d/agama-products.spec
@@ -66,13 +66,14 @@ Definition of openSUSE products (Tumbleweed, Leap, MicroOS and Slowroll) for the
 %license LICENSE
 %dir %{_datadir}/agama
 %dir %{_datadir}/agama/products.d
-%if 0%{?is_opensuse} && 0%{?suse_version} > 1600
+# if building on SLES add all opensuse products
+%if !%{?is_opensuse} || 0%{?suse_version} > 1600
 %{_datadir}/agama/products.d/microos.yaml
 %{_datadir}/agama/products.d/tumbleweed.yaml
 %{_datadir}/agama/products.d/slowroll.yaml
 %{_datadir}/agama/products.d/kalpa.yaml
 %endif
-%if 0%{?is_opensuse} && 0%{?suse_version} == 1600
+%if !0%{?is_opensuse} || 0%{?suse_version} == 1600
 %{_datadir}/agama/products.d/leap_160.yaml
 %{_datadir}/agama/products.d/leap_micro_62.yaml
 %endif


### PR DESCRIPTION

## Problem

the build on SLE is broken after https://github.com/agama-project/agama/pull/2562


## Solution

Adapt spec file to not filter out any opensuse products on SLES as also filtering is not applied there.


## Testing

- run build with modified sources