### PR TITLE
fix: improve the logging information

### DIFF
--- a/rust/agama-server/src/l10n/model/locale.rs
+++ b/rust/agama-server/src/l10n/model/locale.rs
@@ -128,11 +128,10 @@ impl LocalesDatabase {
                 consolefont,
             };
 
-            tracing::info!("Using locale data {:?}", entry);
-
             result.push(entry)
         }
 
+        tracing::info!("Read {} locales", result.len());
         Ok(result)
     }
 

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -189,7 +189,10 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
     tokio::pin!(stream);
     let e = events.clone();
     while let Some((_, event)) = stream.next().await {
-        tracing::info!("event: {:?}", &event);
+        match serde_json::to_string(&event) {
+            Ok(json) => tracing::info!("event: {json}"),
+            Err(_) => tracing::info!("event (not serialized): {:?}", &event),
+        }
         _ = e.send(event);
     }
     Ok(())

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jul 17 10:35:10 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Adjust the information included in the logs (gh#agama-project/agama#2575).
+
+-------------------------------------------------------------------
 Wed Jul 16 14:55:00 UTC 2025 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>
 
 - Fix deletion of controller connections (gh#agama-project/agama#2564)

--- a/service/lib/agama/software/callbacks/media.rb
+++ b/service/lib/agama/software/callbacks/media.rb
@@ -59,7 +59,7 @@ module Agama
         #   false for local packages
         def start_provide(name, size, _remote)
           self.attempt = 1
-          logger.info("Downloading #{name}, size: #{size}")
+          logger.debug("Downloading #{name}, size: #{size}")
         end
 
         # Media change callback
@@ -91,7 +91,7 @@ module Agama
           # in other cases automatic retry usually does not make much sense
           if ["IO", "IO_SOFT"].include?(error_code) && attempt <= Repository::RETRY_COUNT
             self.attempt += 1
-            logger.info("Retry in #{Repository::RETRY_DELAY} seconds, attempt #{attempt}...")
+            logger.debug("Retry in #{Repository::RETRY_DELAY} seconds, attempt #{attempt}...")
             sleep(Repository::RETRY_DELAY)
 
             # retry

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jul 17 10:34:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Adjust the information included in the logs (gh#agama-project/agama#2575).
+
+-------------------------------------------------------------------
 Wed Jul 16 07:29:03 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Add AutoYaST conversion for DASD and zFCP sections


### PR DESCRIPTION
Agama logs are growing on every release. That's perfectly fine, but sometimes we are:

- Logging too much (locales),
- Logging with the wrong (or not consistent) level.
- Just dumping Rust structs. This is fine, but sometimes it might be better to use a JSON representation (like when dealing with events).

