### PR TITLE
feat(dud): Added "inst.dud_insecure" boot option

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jul 17 08:08:40 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Added "inst.dud_insecure" boot option for ignoring SSL
+  certificate problems when downloading DUD from an HTTPS server
+  (related to bsc#1245393)
+- Skip updating kernel module dependencies if the DUD image does
+  not provide any kernel module
+
+-------------------------------------------------------------------
 Tue Jul 15 16:19:21 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed downloading DUD files from HTTPS URL


### PR DESCRIPTION
## Problem

- DUD cannot be downloaded from an HTTPS server using a self-signed certificate

## Solution

- Add the `inst.dud_insecure` boot option for ignoring SSL certificate problems 

## Additional fix

- Skip updating kernel module dependencies if the DUD image does not provide any kernel module
- Originally the `depmod` command was called unconditionally. But that is pointless if no kernel module has been updated, it just causes a delay and takes space (RAM) for the regenerated files.

## Testing

- Tested manually

### Insecure DUD

By default the DUD download fails if a self-signed certificate is used:

```
dracut-pre-pivot[1157]: Fetching a Driver Update Disk from https://192.168.1.8:4443/dud.cpio.gz to /sysroot/run/agama/dud/dud.cpio.gz
dracut-pre-pivot[1168]: Could not retrieve https://192.168.1.8:4443/dud.cpio.gz
dracut-pre-pivot[1168]: Caused by:
dracut-pre-pivot[1168]:     [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: self-signed certificate)
dracut-pre-pivot[1157]: Warning: Failed to fetch the Driver Update Disk
```

With the `inst.dud_insecure=1` boot option is used the download succeeds:

```
dracut-pre-pivot[1158]: WARNING: Disabling SSL checks in DUD downloads
dracut-pre-pivot[1158]: Fetching a Driver Update Disk from https://192.168.1.8:4443/dud.cpio.gz to /sysroot/run/agama/dud/dud.cpio.gz
dracut-pre-pivot[1169]: File saved to /sysroot/run/agama/dud/dud.cpio.gz
dracut-pre-pivot[1158]: Apply update from a Driver Update Disk archive
```

### Kernel module improvement

Originally the `depmod` tool was called even when the DUD did not contain any kernel module. It took quite a lot of time (5 seconds on my fast machine):

```
Jul 16 21:27:26 localhost.localdomain dracut-pre-pivot[1151]: Found 0 kernel modules
Jul 16 21:27:26 localhost.localdomain dracut-pre-pivot[1151]: Updating modules dependencies...
Jul 16 21:27:31 localhost.localdomain rpc.idmapd[594]: exiting on signal 15
```

With the shortcut it is not called and it boots faster:

```
Jul 17 10:01:11 localhost.localdomain dracut-pre-pivot[1158]: Found 0 kernel modules
Jul 17 10:01:11 localhost.localdomain dracut-pre-pivot[1158]: Skipping kernel modules update
Jul 17 10:01:11 localhost.localdomain rpc.idmapd[594]: exiting on signal 15
```