### PR TITLE
use more generic fix to disable lvm auto assembly

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -96,9 +96,9 @@ systemctl disable snapper-timeline.timer
 systemctl disable YaST2-Firstboot.service
 systemctl disable YaST2-Second-Stage.service
 
-# mask storage services (bsc#1246133)
+# mask storage services and disable lvm auto assembly (bsc#1246133)
 systemctl mask lvm2-monitor.service
-systemctl mask lvm-activate-system.service
+sed -i 's:# udev_rules = 1:udev_rules = 0:' /etc/lvm/lvm.conf
 
 # the "eurlatgr" is the default font for the English locale
 echo -e "\nFONT=eurlatgr.psfu" >> /etc/vconsole.conf

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -99,6 +99,7 @@ systemctl disable YaST2-Second-Stage.service
 # mask storage services and disable lvm auto assembly (bsc#1246133)
 systemctl mask lvm2-monitor.service
 sed -i 's:# udev_rules = 1:udev_rules = 0:' /etc/lvm/lvm.conf
+sed -i 's:# event_activation = 1:event_activation = 0:' /etc/lvm/lvm.conf
 
 # the "eurlatgr" is the default font for the English locale
 echo -e "\nFONT=eurlatgr.psfu" >> /etc/vconsole.conf

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -98,7 +98,6 @@ systemctl disable YaST2-Second-Stage.service
 
 # mask storage services and disable lvm auto assembly (bsc#1246133)
 systemctl mask lvm2-monitor.service
-sed -i 's:# udev_rules = 1:udev_rules = 0:' /etc/lvm/lvm.conf
 sed -i 's:# event_activation = 1:event_activation = 0:' /etc/lvm/lvm.conf
 
 # the "eurlatgr" is the default font for the English locale

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -148,15 +148,12 @@ module Agama
 
         raise ArgumentError unless new_product
 
-        # order is important here as we want to first set internally new product to ensure that cache read will read it properly
-        @product = new_product
-
-        update_repositories(new_product)
-
-        # here it will reset config cache, so do it last to have all stuff in place
         proposal.set_resolvables(
           PROPOSAL_ID, :pattern, new_product.preselected_patterns
         )
+        update_repositories(new_product)
+
+        @product = new_product
 
         update_issues
         true

--- a/service/lib/agama/software/manager.rb
+++ b/service/lib/agama/software/manager.rb
@@ -148,12 +148,15 @@ module Agama
 
         raise ArgumentError unless new_product
 
+        # order is important here as we want to first set internally new product to ensure that cache read will read it properly
+        @product = new_product
+
+        update_repositories(new_product)
+
+        # here it will reset config cache, so do it last to have all stuff in place
         proposal.set_resolvables(
           PROPOSAL_ID, :pattern, new_product.preselected_patterns
         )
-        update_repositories(new_product)
-
-        @product = new_product
 
         update_issues
         true


### PR DESCRIPTION
## Problem

LVM with name different to system is still assembled and blocking  libstorage-ng actions.

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1246133#c38


## Solution

Try to disable udev lvm assembly in `/etc/lvm/lvm.conf`.


## Testing

- *Added a new unit test*
- *Tested manually*

Tested manually and current devel iso contain some issues with products so hard to test, but still I see some EBusy errors in journalctl. But lvm-activate systemd unit is not generated.