### PR TITLE
(backend bug): Added missed VLAN device type conversion from NetworkManager

### DIFF
--- a/rust/agama-network/src/nm/model.rs
+++ b/rust/agama-network/src/nm/model.rs
@@ -103,6 +103,7 @@ impl TryFrom<NmDeviceType> for DeviceType {
             NmDeviceType(1) => Ok(DeviceType::Ethernet),
             NmDeviceType(2) => Ok(DeviceType::Wireless),
             NmDeviceType(10) => Ok(DeviceType::Bond),
+            NmDeviceType(11) => Ok(DeviceType::Vlan),
             NmDeviceType(13) => Ok(DeviceType::Bridge),
             NmDeviceType(22) => Ok(DeviceType::Dummy),
             NmDeviceType(32) => Ok(DeviceType::Loopback),

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 21 10:56:54 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix device type detection when reading a VLAN connection
+  (gh#agama-project/agama#2586). 
+
+-------------------------------------------------------------------
 Fri Jul 18 06:54:08 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Add support to configure VLANs through the CLI or HTTP API


### PR DESCRIPTION
## Problem

VLAN connections are skipped from reading because the DeviceType is not identified properly.

- Related to https://trello.com/c/U3TS6jy3/5099-vlan-unattended

## Solution

Added the proper conversion from NmDeviceType to DeviceType missed by (https://github.com/agama-project/agama/pull/918 & https://github.com/agama-project/agama/pull/2580).


## Test

Tested manually checking the the configuration is read and the connection details is displayed properly in the UI.

<img width="849" height="551" alt="image" src="https://github.com/user-attachments/assets/000390c0-0b9f-48a1-a574-b21122fc2fac" />
