### PR TITLE
Fixed crash when registering an extension without registration key

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 21 10:49:02 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed crash when registering an extension without registration
+  key (bsc#1246690)
+
+-------------------------------------------------------------------
 Thu Jul 17 19:26:17 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Replaced all usage of generatePath with generateEncodedPath to

--- a/web/src/components/product/RegistrationExtension.tsx
+++ b/web/src/components/product/RegistrationExtension.tsx
@@ -44,11 +44,16 @@ import RegistrationCodeInput from "./RegistrationCodeInput";
  * @param param0
  * @returns
  */
-const RegisteredExtensionStatus = ({ registrationCode }: { registrationCode: string }) => {
+const RegisteredExtensionStatus = ({ registrationCode }: { registrationCode: string | null }) => {
   const [showCode, setShowCode] = useState(false);
 
   // TRANSLATORS: %s will be replaced by the registration key.
   const [msg1, msg2] = _("The extension has been registered with key %s.").split("%s");
+
+  // free extension or registered via RMT
+  if (registrationCode === null) {
+    return <span>{_("The extension was registered without any registration code.")}</span>;
+  }
 
   return (
     <span>


### PR DESCRIPTION
## Problem

- Registering the HA extension from an RMT server crashes the web UI
- https://bugzilla.suse.com/show_bug.cgi?id=1246690

<img width="2154" height="1626" alt="agama-rmt-ha-broken" src="https://github.com/user-attachments/assets/5847183a-4a55-41b3-8cc4-90214744c1ef" />


## Solution

- When registering the HA extension via an RMT server no registration key is required. In that case it set to `null` which was not handled in the code properly.

## Testing

- Tested manually

<img width="2154" height="1626" alt="agama-rmt-ha-fixed" src="https://github.com/user-attachments/assets/aa7e8171-afc1-4883-a62f-6ea58b637f73" />
