### PR TITLE
Fix Rust changelog sequence

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -28,6 +28,11 @@ Fri Jul 18 06:54:08 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
   (gh#agama-project/agama#2580).
 
 -------------------------------------------------------------------
+Thu Jul 17 10:35:10 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Adjust the information included in the logs (gh#agama-project/agama#2575).
+
+-------------------------------------------------------------------
 Wed Jul 16 19:05:48 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix crash when an Agama profile contains only the zfcp section by
@@ -42,11 +47,6 @@ Wed Jul 16 15:37:34 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
   language in the same territory as fallback (bsc#1238364,
   gh#agama-project/agama#2571).
 - Add the language tag to the /licences/:id endpoint.
-
--------------------------------------------------------------------
-Thu Jul 17 10:35:10 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
-
-- Adjust the information included in the logs (gh#agama-project/agama#2575).
 
 -------------------------------------------------------------------
 Wed Jul 16 14:55:00 UTC 2025 - Clemens Famulla-Conrad <cfamullaconrad@suse.com>


### PR DESCRIPTION
## Problem

Automated validation tools detected that a changelog entry was not in the correct chronological order, resulting in validation failures.

## Solution

Reordered the changelog entries to ensure they follow the expected sequence, placing the problematic entry in its correct chronological position.


