### PR TITLE
fix(live): Include the "libopenssl-3-fips-provider" package (bsc#1246857)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 22 10:05:30 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Include the "libopenssl-3-fips-provider" package in the installer
+  image to work properly with the "fips=1" boot parameter
+  (bsc#1246857)
+
+-------------------------------------------------------------------
 Mon Jul 21 15:07:42 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 17

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -157,6 +157,8 @@
         <package name="qrencode"/>
         <package name="qemu-guest-agent" />
         <package name="aaa_base-extras"/>
+        <!-- to work correctly with the fips=1 boot parameter -->
+        <package name="libopenssl-3-fips-provider"/>
         <!-- it can be used by users in AutoYaST pre-scripts -->
         <package name="perl-XML-Simple"/>
         <archive name="live-root.tar.xz"/>


### PR DESCRIPTION
## Problem

- The installer crashes when using the `fips=1` boot parameter
- https://bugzilla.suse.com/show_bug.cgi?id=1246857

<img width="1280" height="800" alt="agama-fips-broken" src="https://github.com/user-attachments/assets/c18cdb22-d010-477e-9b5c-e9270c025946" />


## Solution

- include the `libopenssl-3-fips-provider` package in the Live ISO

## Testing

- Tested manually, with the additional package the installer starts also with the `fips=1` boot option as expected
<img width="1280" height="800" alt="agama-fips-fixed" src="https://github.com/user-attachments/assets/b891b7d5-a4e5-4d67-8666-d18aca08171b" />
