### PR TITLE
[rc3] fix(live): disable downloading the binary H.264 codec

### DIFF
--- a/live/live-root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/live-root/root/.mozilla/firefox/profile/user.js.template
@@ -21,6 +21,9 @@ user_pref("datareporting.healthreport.uploadEnabled", false);
 user_pref("datareporting.usage.uploadEnabled", false);
 user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
 
+// disable downloading the binary H.264 codec from ciscobinary.openh264.org
+user_pref("media.gmp-gmpopenh264.enabled", false);
+
 // globally disable extensions autoupdate,
 // the AutoFullscreen extension does not specify the update URL
 // but rather be on the safe side

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 23 08:08:23 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- In Firefox disable downloading the binary H.264 codec from
+  ciscobinary.openh264.org
+
+-------------------------------------------------------------------
 Tue Jul 22 10:05:30 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Include the "libopenssl-3-fips-provider" package in the installer


### PR DESCRIPTION
## Problem

- While testing the proxy functionality I found out in the proxy log that Firefox automatically downloads an H.264 binary codec from ciscobinary.openh264.org
- We do not need it and it wastes some resources (unpacked codec binary is about 1.6MB)
- This could be potentially a security risk

From proxy log:
```
1753202585.423    486 192.168.1.3 TCP_MISS/200 589485 GET http://ciscobinary.openh264.org/openh264-linux64-652bdb7719f30b52b08e506645a7322ff1b2cc6f.zip - HIER_DIRECT/23.55.161.185 application/zip
``` 

## Solution

- Disable H.264 support in Firefox, then it does not download the codec automatically

## Testing

- Tested manually with locally built ISO, the codec download is not present in the proxy log anymore.
