### PR TITLE
chore(rust): do not complain about 'cfg(ci)'

### DIFF
--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -66,3 +66,6 @@ path = "src/agama-web-server.rs"
 [dev-dependencies]
 http-body-util = "0.1.2"
 tokio-test = "0.4.4"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }


### PR DESCRIPTION
## Problem

After introducing 'cfg(ci)' to disable some tests on CI, we are getting the following error:

```
unexpected cfg condition name: ci
expected names are: docsrs, feature, and test and 31 more
consider using a Cargo feature instead
or consider adding in Cargo.toml the check-cfg lint config for the lint:
[lints.rust]
unexpected_cfgs = { level = “warn”, check-cfg = [‘cfg(ci)’] }
or consider adding println!("cargo::rustc-check-cfg=cfg(ci)"); to the top of the build.rs
see https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html for more information about checking conditional configuration
#[warn(unexpected_cfgs)] on by default (rustc unexpected_cfgs)
```

## Solution

Disable this check to reduce noise. Anyway, those lines are marked with a FIXME.

## Testing

- *Tested manually*
