### PR TITLE
Encode connection ID for the URL path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "log",
+ "percent-encoding",
  "regex",
  "reqwest",
  "serde",

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -44,6 +44,7 @@ regex = "1.11.1"
 fluent-uri = { version = "0.3.2", features = ["serde"] }
 tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 tokio-native-tls = "0.3.1"
+percent-encoding = "2.3.1"
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -20,7 +20,7 @@
 
 use super::{settings::NetworkConnection, types::Device};
 use crate::http::{BaseHTTPClient, BaseHTTPClientError};
-use crate::utils::url::encoded;
+use crate::utils::url::encode;
 
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkClientError {
@@ -57,7 +57,7 @@ impl NetworkClient {
 
     /// Returns an array of network connections
     pub async fn connection(&self, id: &str) -> Result<NetworkConnection, NetworkClientError> {
-        let encoded_id = encoded(id.to_string());
+        let encoded_id = encode(id);
         let json = self
             .client
             .get::<NetworkConnection>(format!("/network/connections/{encoded_id}").as_str())
@@ -72,7 +72,7 @@ impl NetworkClient {
         connection: NetworkConnection,
     ) -> Result<(), NetworkClientError> {
         let id = connection.id.clone();
-        let encoded_id = encoded(id.to_string());
+        let encoded_id = encode(id.as_str());
         let response = self.connection(id.as_str()).await;
 
         if response.is_ok() {

--- a/rust/agama-lib/src/network/client.rs
+++ b/rust/agama-lib/src/network/client.rs
@@ -20,6 +20,7 @@
 
 use super::{settings::NetworkConnection, types::Device};
 use crate::http::{BaseHTTPClient, BaseHTTPClientError};
+use crate::utils::url::encoded;
 
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkClientError {
@@ -56,9 +57,10 @@ impl NetworkClient {
 
     /// Returns an array of network connections
     pub async fn connection(&self, id: &str) -> Result<NetworkConnection, NetworkClientError> {
+        let encoded_id = encoded(id.to_string());
         let json = self
             .client
-            .get::<NetworkConnection>(format!("/network/connections/{id}").as_str())
+            .get::<NetworkConnection>(format!("/network/connections/{encoded_id}").as_str())
             .await?;
 
         Ok(json)
@@ -70,10 +72,11 @@ impl NetworkClient {
         connection: NetworkConnection,
     ) -> Result<(), NetworkClientError> {
         let id = connection.id.clone();
+        let encoded_id = encoded(id.to_string());
         let response = self.connection(id.as_str()).await;
 
         if response.is_ok() {
-            let path = format!("/network/connections/{id}");
+            let path = format!("/network/connections/{encoded_id}");
             self.client.put_void(path.as_str(), &connection).await?
         } else {
             self.client

--- a/rust/agama-lib/src/utils/url.rs
+++ b/rust/agama-lib/src/utils/url.rs
@@ -18,10 +18,10 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use url::form_urlencoded::byte_serialize;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
-pub fn encoded(value: String) -> String {
-    let serialized_value: String = byte_serialize(value.as_bytes()).collect();
+pub fn encode(value: &str) -> String {
+    let serialized_value: String = utf8_percent_encode(value, NON_ALPHANUMERIC).to_string();
     // Encode space to '%20' as per url standard
     // Should be fixed by https://github.com/servo/rust-url/pull/1028
     serialized_value.replace("+", "%20")
@@ -30,12 +30,12 @@ pub fn encoded(value: String) -> String {
 #[cfg(test)]
 mod tests {
 
-    use super::encoded;
+    use super::encode;
 
     #[test]
     fn test_encode_value() {
         let id = "Wired #1";
-        let encoded_id = encoded(id.to_string());
+        let encoded_id = encode(id);
         assert_eq!(encoded_id, "Wired%20%231");
     }
 }

--- a/rust/agama-lib/src/utils/url.rs
+++ b/rust/agama-lib/src/utils/url.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2025] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -18,11 +18,24 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-//! Utility module for Agama.
+use url::form_urlencoded::byte_serialize;
 
-mod file_format;
-mod transfer;
-pub mod url;
+pub fn encoded(value: String) -> String {
+    let serialized_value: String = byte_serialize(value.as_bytes()).collect();
+    // Encode space to '%20' as per url standard
+    // Should be fixed by https://github.com/servo/rust-url/pull/1028
+    serialized_value.replace("+", "%20")
+}
 
-pub use file_format::*;
-pub use transfer::*;
+#[cfg(test)]
+mod tests {
+
+    use super::encoded;
+
+    #[test]
+    fn test_encode_value() {
+        let id = "Wired #1";
+        let encoded_id = encoded(id.to_string());
+        assert_eq!(encoded_id, "Wired%20%231");
+    }
+}

--- a/rust/agama-lib/src/utils/url.rs
+++ b/rust/agama-lib/src/utils/url.rs
@@ -21,10 +21,7 @@
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 pub fn encode(value: &str) -> String {
-    let serialized_value: String = utf8_percent_encode(value, NON_ALPHANUMERIC).to_string();
-    // Encode space to '%20' as per url standard
-    // Should be fixed by https://github.com/servo/rust-url/pull/1028
-    serialized_value.replace("+", "%20")
+    utf8_percent_encode(value, NON_ALPHANUMERIC).to_string()
 }
 
 #[cfg(test)]

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 23 11:37:04 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix CLI connection update when using an special character in
+  the connection ID (bsc#1246930, gh#agama-project/agama#2605).
+
+-------------------------------------------------------------------
 Tue Jul 22 07:53:34 UTC 2025 - Martin Vidner <mvidner@suse.com>
 
 - fix .changes errors reported by obs-service-source_validator


### PR DESCRIPTION
## Problem

The CLI needs to encode the connection Id in order to use it in the URL for adding or updating it.

- https://bugzilla.suse.com/show_bug.cgi?id=1246930
- https://trello.com/c/H8mxZJxy/5185-2-agama-loading-a-profile-tries-to-create-an-existing-network-

## Solution

Encode the connection id in order to use it in the URL path for adding or updating a connection


## Testing

- *Tested manually*
**Example profile net.json**
```
suse@vikingo:~$ cat net.json 
{
  "product": {
    "id": "Tumbleweed"
  },
  "network": {
    "connections": [
      {
        "id": "Wired #1",
        "status": "up"
      }
    ]
  }
}

suse@vikingo:~$ agama config load < net.json 
✓ The profile is valid.

suse@vikingo:~$ agama config load < net.json 
✓ The profile is valid.

## REMOVED IRRELEVANT DATA
suse@vikingo:~$ agama config show 
{
  "network": {
    "connections": [
      {
        "id": "Wired #1",
        "method4": "auto",
        "method6": "auto",
        "ignoreAutoDns": false,
        "status": "up",
        "autoconnect": true,
        "persistent": true
      }
    ]
  }
}
```
