### PR TITLE
fix(live): avoid duplicated iSCSI initiator name

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul 23 14:18:38 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Ensure iSCSI initiator name is unique (bsc#1246280).
+
+-------------------------------------------------------------------
 Wed Jul 23 08:08:23 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - In Firefox disable downloading the binary H.264 codec from

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -147,6 +147,9 @@ fi
 # Remove nvme hostid and hostnqn (bsc#1238038)
 rm -f /etc/nvme/host*
 
+# Remove default iSCSI initiator name (bsc#1246280)
+rm -f /etc/iscsi/initiatorname.iscsi
+
 # replace the @@LIVE_MEDIUM_LABEL@@ with the real Live partition label name from KIWI
 sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/live-password
 sed -i -e "s/@@LIVE_MEDIUM_LABEL@@/$label/g" /usr/bin/checkmedia-service


### PR DESCRIPTION
### Problem

The live media always includes the same iSCSI initiator name (/etc/iscsi/initiatorname.iscsi) which is copied to the target system. This implies all the installed systems would have the same initiator name, but it must be unique. 

https://bugzilla.suse.com/show_bug.cgi?id=1246280

### Solution

Remove /etc/iscsi/initiatorname.iscsi from the live media, so a new one is always generated when iscsi.service starts on each boot.
