### PR TITLE
web: Display RAID level at the storage result (bsc#1244697)

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul 23 14:54:43 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Display RAID level at the storage results table (bsc#1244697).
+
+-------------------------------------------------------------------
 Mon Jul 21 15:07:40 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 17

--- a/web/src/components/storage/device-utils.tsx
+++ b/web/src/components/storage/device-utils.tsx
@@ -26,6 +26,7 @@ import React from "react";
 import { Label } from "@patternfly/react-core";
 
 import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
 import { deviceBaseName, deviceSize } from "~/components/storage/utils";
 import { PartitionSlot, StorageDevice } from "~/types/storage";
 
@@ -76,6 +77,12 @@ const DeviceDetails = ({ item }: { item: PartitionSlot | StorageDevice }) => {
 
   const renderContent = (device: StorageDevice) => {
     if (!device.partitionTable && device.systems?.length > 0) return device.systems.join(", ");
+
+    if (device.type === "md") {
+      // TRANSLATORS: %1$s is a description of the device (eg. "Encrypted XFS RAID") and %2$s is
+      // the RAID level (eg. "RAID0")
+      return sprintf(_("%1$s (%2$s)"), device.description, device.level.toUpperCase());
+    }
 
     return device.description;
   };


### PR DESCRIPTION
## Problem

The results table of Agama does not show the RAID level for RAID devices.

<img width="1197" height="445" alt="nolevel" src="https://github.com/user-attachments/assets/ee2b6c14-e5f4-4006-9b28-270f573a06ae" />

https://bugzilla.suse.com/show_bug.cgi?id=1244697

## Solution

Add the RAID level.

<img width="1192" height="443" alt="level" src="https://github.com/user-attachments/assets/4298ed16-1514-4c60-ae59-500486b909c0" />

The current representation may look a bit redundant in some cases, but it's the best we can do with minimal impact (eg. not modifying yast2-storage-ng). And we want impact to be minimal at the current development stage. 

## Testing

Tested manually as proven by the screenshots.