### PR TITLE
fix(storage): format and encrypt devices

### DIFF
--- a/service/lib/agama/storage/config.rb
+++ b/service/lib/agama/storage/config.rb
@@ -190,14 +190,37 @@ module Agama
         drives + drives.flat_map(&:partitions)
       end
 
-      # All encryption configs.
+      # Encryption configs, excluding encryptions from skipped devices.
       #
       # @return [Array<Configs::Encryption>]
-      def encryptions
+      def valid_encryptions
+        valid_devices = supporting_encryption.reject { |c| skipped?(c) }
+
         [
-          supporting_encryption.map(&:encryption),
+          valid_devices.map(&:encryption),
           volume_groups.map(&:physical_volumes_encryption)
         ].flatten.compact
+      end
+
+      # Drive configs, excluding skipped ones.
+      #
+      # @return [Array<Configs::Drive>]
+      def valid_drives
+        drives.reject { |d| skipped?(d) }
+      end
+
+      # MD RAID configs, excluding skipped ones.
+      #
+      # @return [Array<Configs::MdRaid>]
+      def valid_md_raids
+        md_raids.reject { |r| skipped?(r) }
+      end
+
+      # Partitions configs, excluding skipped ones.
+      #
+      # @return [Array<Configs::Partition>]
+      def valid_partitions
+        partitions.reject { |p| skipped?(p) }
       end
 
       # Configs directly using a device with the given alias.
@@ -277,6 +300,16 @@ module Agama
         else
           false
         end
+      end
+
+      # Whether the config is skipped.
+      #
+      # @param config
+      # @return [Boolean]
+      def skipped?(config)
+        return false unless config.respond_to?(:skipped?)
+
+        config.skipped?
       end
     end
   end

--- a/service/lib/agama/storage/config.rb
+++ b/service/lib/agama/storage/config.rb
@@ -190,6 +190,16 @@ module Agama
         drives + drives.flat_map(&:partitions)
       end
 
+      # All encryption configs.
+      #
+      # @return [Array<Configs::Encryption>]
+      def encryptions
+        [
+          supporting_encryption.map(&:encryption),
+          volume_groups.map(&:physical_volumes_encryption)
+        ].flatten.compact
+      end
+
       # Configs directly using a device with the given alias.
       #
       # @note Devices using the given alias as a target device (e.g., for creating physical volumes)

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/drive.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/drive.rb
@@ -75,12 +75,6 @@ module Agama
               partitions:  convert_partitions(encryption_model)
             }
           end
-
-          # @see WithEncryption
-          def convert_encryption
-            # Do not encrypt if the drive is not going to be formatted.
-            super if drive_model[:filesystem]
-          end
         end
       end
     end

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/drive.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/drive.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_conversions/from_model_conversions/base"
+require "agama/storage/config_conversions/from_model_conversions/with_encryption"
 require "agama/storage/config_conversions/from_model_conversions/with_filesystem"
 require "agama/storage/config_conversions/from_model_conversions/with_partitions"
 require "agama/storage/config_conversions/from_model_conversions/with_ptable_type"
@@ -32,6 +33,7 @@ module Agama
       module FromModelConversions
         # Drive conversion from model according to the JSON schema.
         class Drive < Base
+          include WithEncryption
           include WithFilesystem
           include WithPtableType
           include WithPartitions
@@ -67,10 +69,17 @@ module Agama
           def conversions
             {
               search:      convert_search,
+              encryption:  convert_encryption,
               filesystem:  convert_filesystem,
               ptable_type: convert_ptable_type,
               partitions:  convert_partitions(encryption_model)
             }
+          end
+
+          # @see WithEncryption
+          def convert_encryption
+            # Do not encrypt if the drive is not going to be formatted.
+            super if drive_model[:filesystem]
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/md_raid.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/md_raid.rb
@@ -75,12 +75,6 @@ module Agama
               partitions:  convert_partitions(encryption_model)
             }
           end
-
-          # @see WithEncryption
-          def convert_encryption
-            # Do not encrypt if the MD RAID is not going to be formatted.
-            super if md_raid_model[:filesystem]
-          end
         end
       end
     end

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/md_raid.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/md_raid.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_conversions/from_model_conversions/base"
+require "agama/storage/config_conversions/from_model_conversions/with_encryption"
 require "agama/storage/config_conversions/from_model_conversions/with_filesystem"
 require "agama/storage/config_conversions/from_model_conversions/with_partitions"
 require "agama/storage/config_conversions/from_model_conversions/with_ptable_type"
@@ -32,6 +33,7 @@ module Agama
       module FromModelConversions
         # MD RAID conversion from model according to the JSON schema.
         class MdRaid < Base
+          include WithEncryption
           include WithFilesystem
           include WithPtableType
           include WithPartitions
@@ -67,10 +69,17 @@ module Agama
           def conversions
             {
               search:      convert_search,
+              encryption:  convert_encryption,
               filesystem:  convert_filesystem,
               ptable_type: convert_ptable_type,
               partitions:  convert_partitions(encryption_model)
             }
+          end
+
+          # @see WithEncryption
+          def convert_encryption
+            # Do not encrypt if the MD RAID is not going to be formatted.
+            super if md_raid_model[:filesystem]
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/partition.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/partition.rb
@@ -72,12 +72,6 @@ module Agama
             }
           end
 
-          # @see WithEncryption
-          def convert_encryption
-            # Do not encrypt if the partition is going to be deleted.
-            super unless partition_model[:delete] || partition_model[:deleteIfNeeded]
-          end
-
           # @return [Y2Storage::PartitionId, nil]
           def convert_id
             value = partition_model[:id]

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/partition.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/partition.rb
@@ -72,6 +72,12 @@ module Agama
             }
           end
 
+          # @see WithEncryption
+          def convert_encryption
+            # Do not encrypt if the partition is going to be deleted.
+            super unless partition_model[:delete] || partition_model[:deleteIfNeeded]
+          end
+
           # @return [Y2Storage::PartitionId, nil]
           def convert_id
             value = partition_model[:id]

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/with_encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/with_encryption.rb
@@ -29,6 +29,12 @@ module Agama
         module WithEncryption
           # @return [Configs::Encryption, nil]
           def convert_encryption
+            # Do not encrypt a device that is not really going to be used
+            return if model_json[:name] && !model_json[:mountPath]
+
+            # Do not encrypt a reused device
+            return if model_json[:name] && model_json.dig(:filesystem, :reuse)
+
             return if encryption_model.nil?
 
             FromModelConversions::Encryption.new(encryption_model).convert

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/with_encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/with_encryption.rb
@@ -29,9 +29,6 @@ module Agama
         module WithEncryption
           # @return [Configs::Encryption, nil]
           def convert_encryption
-            # Do not encrypt a reused device.
-            return if model_json[:name]
-
             return if encryption_model.nil?
 
             FromModelConversions::Encryption.new(encryption_model).convert

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/with_partitions.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/with_partitions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -27,8 +27,10 @@ module Agama
       module ToJSONConversions
         # Mixin for partitions conversion to JSON.
         module WithPartitions
-          # @return [Array<Hash>]
+          # @return [Array<Hash>, nil]
           def convert_partitions
+            return if config.partitions.none?
+
             config.partitions
               .map { |p| ToJSONConversions::Partition.new(p).convert }
               .compact

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/config.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/config.rb
@@ -58,7 +58,7 @@ module Agama
 
           # @return [Hash]
           def convert_encryption
-            encryption = base_encryption
+            encryption = config.encryptions.first
             return unless encryption
 
             ToModelConversions::Encryption.new(encryption).convert
@@ -87,43 +87,6 @@ module Agama
           # @return [Array<Configs::MdRaid>]
           def valid_md_raids
             config.md_raids.reject { |r| r.search&.skip_device? }
-          end
-
-          # TODO: proper support for a base encryption.
-          #   The current implementation is a temporary solution which assumes that all the
-          #   partitions are encrypted in the very same way (encryption method, password, etc).
-          #
-          # Detects the base encryption.
-          #
-          # @return [Configs::Encryption, nil] nil if there is no encrypted partition.
-          def base_encryption
-            root_encryption || first_encryption
-          end
-
-          # Encryption for root.
-          #
-          # @note If root is a logical volume, then the encryption of the automatically generated
-          #   physical volumes is considered. Encryption from logical volumes is ignored.
-          #
-          # @return [Configs::Encryption, nil] nil if there is no encryption for root.
-          def root_encryption
-            root_partition&.encryption || config.root_volume_group&.physical_volumes_encryption
-          end
-
-          # Partition config for root.
-          #
-          # @return [Configs::Partition, nil]
-          def root_partition
-            config.partitions.find(&:root?)
-          end
-
-          # Encryption from the first encrypted partition or from the first volume group with
-          # automatically generated and encrypted physical volumes.
-          #
-          # @return [Configs::Encryption, nil]
-          def first_encryption
-            config.partitions.find(&:encryption)&.encryption ||
-              config.volume_groups.find(&:physical_volumes_encryption)&.physical_volumes_encryption
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/config.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/config.rb
@@ -58,7 +58,7 @@ module Agama
 
           # @return [Hash]
           def convert_encryption
-            encryption = config.encryptions.first
+            encryption = config.valid_encryptions.first
             return unless encryption
 
             ToModelConversions::Encryption.new(encryption).convert
@@ -66,27 +66,17 @@ module Agama
 
           # @return [Array<Hash>]
           def convert_drives
-            valid_drives.map { |d| ToModelConversions::Drive.new(d).convert }
+            config.valid_drives.map { |d| ToModelConversions::Drive.new(d).convert }
           end
 
           # @return [Array<Hash>]
           def convert_md_raids
-            valid_md_raids.map { |r| ToModelConversions::MdRaid.new(r).convert }
+            config.valid_md_raids.map { |r| ToModelConversions::MdRaid.new(r).convert }
           end
 
           # @return [Array<Hash>]
           def convert_volume_groups
             config.volume_groups.map { |v| ToModelConversions::VolumeGroup.new(v, config).convert }
-          end
-
-          # @return [Array<Configs::Drive>]
-          def valid_drives
-            config.drives.reject { |d| d.search&.skip_device? }
-          end
-
-          # @return [Array<Configs::MdRaid>]
-          def valid_md_raids
-            config.md_raids.reject { |r| r.search&.skip_device? }
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/with_partitions.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/with_partitions.rb
@@ -29,14 +29,10 @@ module Agama
         module WithPartitions
           # @return [Array<Hash>]
           def convert_partitions
-            valid_partitions
+            config.partitions
+              .reject(&:skipped?)
               .map { |p| ToModelConversions::Partition.new(p).convert }
               .compact
-          end
-
-          # @return [Array<Configs::Partition>]
-          def valid_partitions
-            config.partitions.reject { |p| p.search&.skip_device? }
           end
         end
       end

--- a/service/lib/agama/storage/configs/encryption.rb
+++ b/service/lib/agama/storage/configs/encryption.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,6 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast2/equatable"
 require "y2storage/secret_attributes"
 
 module Agama
@@ -26,7 +27,10 @@ module Agama
     module Configs
       # Configuration setting describing the desired encryption for a device
       class Encryption
+        include Yast2::Equatable
         include Y2Storage::SecretAttributes
+
+        eql_attr :eql_method, :password, :eql_pbkd_function, :label, :cipher, :key_size
 
         # @return [Y2Storage::EncryptionMethod::Base, nil]
         attr_accessor :method
@@ -64,6 +68,22 @@ module Agama
           return false unless method&.password_required?
 
           password.nil? || password.empty?
+        end
+
+      private
+
+        # Value to compare the encryption method.
+        #
+        # @return [Symbol, nil]
+        def eql_method
+          method&.to_sym
+        end
+
+        # Value to compare the PBKD function.
+        #
+        # @return [Symbol, nil]
+        def eql_pbkd_function
+          pbkd_function&.to_sym
         end
       end
     end

--- a/service/lib/agama/storage/configs/with_search.rb
+++ b/service/lib/agama/storage/configs/with_search.rb
@@ -65,6 +65,13 @@ module Agama
 
           search.create_device?
         end
+
+        # Whether the config is skipped.
+        #
+        # @return [Boolean]
+        def skipped?
+          search&.skip_device? || false
+        end
       end
     end
   end

--- a/service/lib/agama/storage/model_support_checker.rb
+++ b/service/lib/agama/storage/model_support_checker.rb
@@ -201,7 +201,7 @@ module Agama
       #
       # @return [Boolean]
       def any_different_encryption?
-        config.encryptions.uniq.size > 1
+        config.valid_encryptions.uniq.size > 1
       end
 
       # Whether an encryption is missing.
@@ -216,9 +216,9 @@ module Agama
       #
       # @return [Boolean]
       def any_missing_device_encryption?
-        return false if config.encryptions.none?
+        return false if config.valid_encryptions.none?
 
-        [config.drives, config.md_raids, config.partitions]
+        [config.valid_drives, config.valid_md_raids, config.valid_partitions]
           .flatten
           .reject(&:encryption)
           .select(&:filesystem)
@@ -231,7 +231,7 @@ module Agama
       #
       # @return [Boolean]
       def any_missing_volume_group_encryption?
-        return false if config.encryptions.none?
+        return false if config.valid_encryptions.none?
 
         config.volume_groups
           .reject { |c| c.physical_volumes_devices.none? }
@@ -246,7 +246,7 @@ module Agama
       #
       # @return [Boolean]
       def any_extra_encryption?
-        [config.drives, config.md_raids, config.partitions]
+        [config.valid_drives, config.valid_md_raids, config.valid_partitions]
           .flatten
           .select(&:encryption)
           .select { |c| c.filesystem.nil? || c.filesystem.reuse? }

--- a/service/lib/agama/storage/model_support_checker.rb
+++ b/service/lib/agama/storage/model_support_checker.rb
@@ -50,14 +50,16 @@ module Agama
       # Whether the config is not supported by the config model.
       #
       # @return [Boolean]
-      def unsupported_config? # rubocop:disable Metrics/CyclomaticComplexity
+      def unsupported_config? # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         any_unsupported_device? ||
           any_partitionable_without_name? ||
           any_volume_group_without_name? ||
           any_volume_group_with_pvs? ||
           any_partition_without_mount_path? ||
           any_logical_volume_without_mount_path? ||
-          any_logical_volume_with_encryption?
+          any_logical_volume_with_encryption? ||
+          any_missing_encryption? ||
+          any_different_encryption?
       end
 
       # Whether there is any device that is not supported by the model.
@@ -190,6 +192,70 @@ module Agama
           partition_config.size &&
           !partition_config.size.default? &&
           partition_config.size.min == Y2Storage::DiskSize.zero
+      end
+
+      # Whether an encryption is missing.
+      #
+      # Right now, the model only supports a general encryption that applies to everything.
+      #
+      # @return [Boolean]
+      def any_missing_encryption?
+        return false if config.encryptions.none?
+
+        any_missing_drive_encryption? ||
+          any_missing_md_raid_encryption? ||
+          any_missing_partition_encryption? ||
+          any_missing_volume_group_encryption?
+      end
+
+      # Whether there is a drive with a missing encryption (see {#any_missing_encryption?}).
+      #
+      # @return [Boolean]
+      def any_missing_drive_encryption?
+        config.drives
+          .select(&:filesystem)
+          .reject(&:encryption)
+          .any?
+      end
+
+      # Whether there is a MD RAID with a missing encryption (see {#any_missing_encryption?}).
+      #
+      # @return [Boolean]
+      def any_missing_md_raid_encryption?
+        config.md_raids
+          .select(&:filesystem)
+          .reject(&:encryption)
+          .any?
+      end
+
+      # Whether there is a partition with a missing encryption (see {#any_missing_encryption?}).
+      #
+      # @return [Boolean]
+      def any_missing_partition_encryption?
+        config.partitions
+          .reject(&:delete?)
+          .reject(&:delete_if_needed?)
+          .reject(&:encryption)
+          .any?
+      end
+
+      # Whether there is a volume group with a missing encryption (see {#any_missing_encryption?}).
+      #
+      # @return [Boolean]
+      def any_missing_volume_group_encryption?
+        config.volume_groups
+          .reject { |c| c.physical_volumes_devices.none? }
+          .reject(&:physical_volumes_encryption)
+          .any?
+      end
+
+      # Whether there are different encryptions.
+      #
+      # Right now, the model only supports a general encryption that applies to everything.
+      #
+      # @return [Boolean]
+      def any_different_encryption?
+        config.encryptions.uniq.size > 1
       end
     end
   end

--- a/service/lib/agama/storage/model_support_checker.rb
+++ b/service/lib/agama/storage/model_support_checker.rb
@@ -53,7 +53,6 @@ module Agama
       def unsupported_config? # rubocop:disable Metrics/CyclomaticComplexity
         any_unsupported_device? ||
           any_partitionable_without_name? ||
-          any_partitionable_with_encryption? ||
           any_volume_group_without_name? ||
           any_volume_group_with_pvs? ||
           any_partition_without_mount_path? ||
@@ -87,13 +86,6 @@ module Agama
             !device_config.search&.skip_device? &&
             !device_config.search&.name
         end
-      end
-
-      # Whether there is any mandatory drive with encryption.
-      #
-      # @return [Boolean]
-      def any_partitionable_with_encryption?
-        config.supporting_partitions.any? { |d| !d.search&.skip_device? && !d.encryption.nil? }
       end
 
       # Whether there is any volume group without a name.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 24 21:09:25 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Make encryption work with whole formatted devices (bsc#1246939).
+- Do not export partitions to json if there is no partition
+  (bsc#1246940).
+
+-------------------------------------------------------------------
 Mon Jul 21 15:07:39 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 17

--- a/service/test/agama/storage/config_conversions/from_model_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_test.rb
@@ -1120,8 +1120,13 @@ describe Agama::Storage::ConfigConversions::FromModel do
               name:       "/dev/vda",
               partitions: [
                 {
-                  name:      "/dev/vda1",
-                  mountPath: "/test"
+                  name:       "/dev/vda1",
+                  mountPath:  "/test"
+                },
+                {
+                  name:       "/dev/vda2",
+                  mountPath:  "/test2",
+                  filesystem: { reuse: true }
                 },
                 {}
               ]
@@ -1145,15 +1150,20 @@ describe Agama::Storage::ConfigConversions::FromModel do
         }
       end
 
-      it "sets #encryption to the new partitions" do
+      it "sets #encryption to the newly formatted partitions" do
         config = subject.convert
         partitions = config.partitions
         new_partitions = partitions.reject(&:search)
         reused_partitions = partitions.select(&:search)
+        mounted_partitions, reformatted_partitions = reused_partitions.partition do |part|
+          part.filesystem.reuse?
+        end
 
         expect(new_partitions.map { |p| p.encryption.method.id }).to all(eq(:luks1))
         expect(new_partitions.map { |p| p.encryption.password }).to all(eq("12345"))
-        expect(reused_partitions.map(&:encryption)).to all(be_nil)
+        expect(reformatted_partitions.map { |p| p.encryption.method.id }).to all(eq(:luks1))
+        expect(reformatted_partitions.map { |p| p.encryption.password }).to all(eq("12345"))
+        expect(mounted_partitions.map(&:encryption)).to all(be_nil)
       end
 
       it "sets #encryption for the automatically created physical volumes" do

--- a/service/test/agama/storage/config_conversions/from_model_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_test.rb
@@ -1120,8 +1120,8 @@ describe Agama::Storage::ConfigConversions::FromModel do
               name:       "/dev/vda",
               partitions: [
                 {
-                  name:       "/dev/vda1",
-                  mountPath:  "/test"
+                  name:      "/dev/vda1",
+                  mountPath: "/test"
                 },
                 {
                   name:       "/dev/vda2",

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -155,8 +155,8 @@ describe Agama::Storage::ModelSupportChecker do
       context "and the device is not going to be skipped" do
         let(:condition) { nil }
 
-        it "returns false" do
-          expect(subject.supported?).to eq(false)
+        it "returns true" do
+          expect(subject.supported?).to eq(true)
         end
       end
     end
@@ -492,7 +492,10 @@ describe Agama::Storage::ModelSupportChecker do
               partitions: [
                 { search: "*", delete: true },
                 {
-                  filesystem: { path: "/home", type: "xfs" }
+                  filesystem: { path: "/home", type: "xfs" },
+                  encryption: {
+                    luks1: { password: "12345" }
+                  }
                 }
               ]
             }
@@ -500,7 +503,16 @@ describe Agama::Storage::ModelSupportChecker do
           volumeGroups: [
             {
               name:            "data",
-              physicalVolumes: [{ generate: ["pv"] }],
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["pv"],
+                    encryption: {
+                      luks1: { password: "12345" }
+                    }
+                  }
+                }
+              ],
               logicalVolumes:  [
                 {
                   filesystem: { path: "/data" },

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -507,7 +507,7 @@ describe Agama::Storage::ModelSupportChecker do
                 {
                   generate: {
                     targetDevices: ["pv"],
-                    encryption: {
+                    encryption:    {
                       luks1: { password: "12345" }
                     }
                   }

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -146,6 +146,7 @@ describe Agama::Storage::ModelSupportChecker do
     shared_examples "partitionable with encryption" do
       context "and the device is going to be skipped" do
         let(:condition) { { name: "/not/found" } }
+        let(:filesystem) { nil }
 
         it "returns true" do
           expect(subject.supported?).to eq(true)
@@ -155,8 +156,30 @@ describe Agama::Storage::ModelSupportChecker do
       context "and the device is not going to be skipped" do
         let(:condition) { nil }
 
-        it "returns true" do
-          expect(subject.supported?).to eq(true)
+        context "and the device has no filesystem" do
+          let(:filesystem) { nil }
+
+          it "returns false" do
+            expect(subject.supported?).to eq(false)
+          end
+        end
+
+        context "and the device has filesystem" do
+          context "and the filesystem is going to be created" do
+            let(:filesystem) { { reuseIfPossible: false } }
+
+            it "returns true" do
+              expect(subject.supported?).to eq(true)
+            end
+          end
+
+          context "and the filesystem is going to be reused" do
+            let(:filesystem) { { reuseIfPossible: true } }
+
+            it "returns false" do
+              expect(subject.supported?).to eq(false)
+            end
+          end
         end
       end
     end
@@ -172,7 +195,8 @@ describe Agama::Storage::ModelSupportChecker do
               },
               encryption: {
                 luks1: { password: "12345" }
-              }
+              },
+              filesystem: filesystem
             }
           ]
         }
@@ -194,7 +218,8 @@ describe Agama::Storage::ModelSupportChecker do
               },
               encryption: {
                 luks1: { password: "12345" }
-              }
+              },
+              filesystem: filesystem
             }
           ]
         }

--- a/service/test/agama/storage/config_conversions/to_json_conversions/config_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/config_test.rb
@@ -97,11 +97,10 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Config do
         expect(config_json[:drives]).to eq(
           [
             {
-              search:     {
+              search: {
                 condition:  { name: "/dev/vda" },
                 ifNotFound: "error"
-              },
-              partitions: []
+              }
             },
             {
               search:     {
@@ -113,8 +112,7 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Config do
                 mountOptions:    [],
                 path:            "/",
                 reuseIfPossible: false
-              },
-              partitions: []
+              }
             }
           ]
         )
@@ -136,9 +134,8 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Config do
         expect(config_json[:mdRaids]).to eq(
           [
             {
-              level:      "raid1",
-              devices:    ["disk1", "disk2"],
-              partitions: []
+              level:   "raid1",
+              devices: ["disk1", "disk2"]
             }
           ]
         )

--- a/service/test/agama/storage/config_conversions/to_json_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/examples.rb
@@ -86,7 +86,7 @@ shared_examples "without partitions" do
 
     it "generates the expected JSON" do
       config_json = subject.convert
-      expect(config_json[:partitions]).to eq([])
+      expect(config_json.keys).to_not include(:partitions)
     end
   end
 end

--- a/service/test/agama/storage/config_conversions/to_json_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_test.rb
@@ -123,9 +123,8 @@ describe Agama::Storage::ConfigConversions::ToJSON do
           ],
           mdRaids:      [
             {
-              level:      "raid0",
-              devices:    ["p2", "p3"],
-              partitions: []
+              level:   "raid0",
+              devices: ["p2", "p3"]
             }
           ],
           volumeGroups: [

--- a/service/test/agama/storage/config_conversions/to_model_conversions/config_test.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/config_test.rb
@@ -320,8 +320,8 @@ describe Agama::Storage::ConfigConversions::ToModelConversions::Config do
 
             expect(encryption_model).to eq(
               {
-                method:   "luks2",
-                password: "54321"
+                method:   "luks1",
+                password: "12345"
               }
             )
           end

--- a/service/test/agama/storage/proposal_test.rb
+++ b/service/test/agama/storage/proposal_test.rb
@@ -407,9 +407,11 @@ describe Agama::Storage::Proposal do
             storage: {
               drives: [
                 {
-                  encryption: {
-                    luks1: { password: "12345" }
-                  }
+                  partitions: [
+                    {
+                      encryption: { luks1: { password: "12345" } }
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
### Problem

Agama supports formatting drives and MD RAIDS, but the devices were not encrypted when the encryption is enabled in the UI, see https://bugzilla.suse.com/show_bug.cgi?id=1246939.

Moreover, the generated JSON does not match the schema if there is a formatted device, see https://bugzilla.suse.com/show_bug.cgi?id=1246940.

### Solution

* Adapt conversion from/to model to properly encrypt formatted devices . 
* Fix conversion to JSON.
* Improve the model support checker to properly check the encryption configs.
