### PR TITLE
Added "--insecure" option to "agama config load" and "agama config generate" commands

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -41,7 +41,7 @@ apply_updates() {
     file="${DUD_DIR}/${filename}"
     # FIXME: use an index because two updates, coming from different places, can have the same name.
     echo "Fetching a Driver Update Disk from $dud_url to ${file}"
-    if ! $AGAMA_CLI download $options "$dud_url" "${file}"; then
+    if ! $AGAMA_CLI $options download "$dud_url" "${file}"; then
       warn "Failed to fetch the Driver Update Disk"
       continue
     fi

--- a/rust/agama-cli/src/cli_input.rs
+++ b/rust/agama-cli/src/cli_input.rs
@@ -120,7 +120,7 @@ impl CliInput {
     // Does it belong here?
     // vs the downloading code in web ProfileQuery::retrieve_profile
     // put it in agama-lib?
-    pub fn read_to_string(self) -> anyhow::Result<String> {
+    pub fn read_to_string(self, insecure: bool) -> anyhow::Result<String> {
         match self {
             Self::Full(s) => Ok(s),
             Self::Stdin => Self::stdin_to_string().map_err(|e| e.into()),
@@ -131,7 +131,7 @@ impl CliInput {
             }
             Self::Url(url_string) => {
                 let mut bytebuf = Vec::new();
-                Transfer::get(&url_string, &mut bytebuf, false)
+                Transfer::get(&url_string, &mut bytebuf, insecure)
                     .context(format!("Retrieving data from URL {}", url_string))?;
                 let s = String::from_utf8(bytebuf)
                     .context(format!("Invalid UTF-8 data at URL {}", url_string))?;

--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -104,9 +104,6 @@ pub enum Commands {
         url: String,
         /// File name
         destination: PathBuf,
-        /// Disables SSL verification for HTTPS downloads
-        #[arg(short, long)]
-        insecure: bool,
     },
     /// Finish the installation.
     Finish {

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -52,9 +52,6 @@ pub enum ConfigCommands {
     Load {
         /// JSON file: URL or path or `-` for standard input
         url_or_path: Option<CliInput>,
-        /// Disables SSL verification for HTTPS downloads
-        #[arg(short, long)]
-        insecure: bool,
     },
 
     /// Validate a profile using JSON Schema
@@ -83,9 +80,6 @@ pub enum ConfigCommands {
     Generate {
         /// JSON file: URL or path or `-` for standard input
         url_or_path: Option<CliInput>,
-        /// Disables SSL verification for HTTPS downloads
-        #[arg(short, long)]
-        insecure: bool,
     },
 
     /// Edit and update installation option using an external editor.
@@ -105,6 +99,7 @@ pub async fn run(
     http_client: BaseHTTPClient,
     monitor: MonitorClient,
     subcommand: ConfigCommands,
+    insecure: bool
 ) -> anyhow::Result<()> {
     let store = SettingsStore::new(http_client.clone()).await?;
 
@@ -122,7 +117,6 @@ pub async fn run(
         }
         ConfigCommands::Load {
             url_or_path,
-            insecure,
         } => {
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
             let contents = url_or_path.read_to_string(insecure)?;
@@ -138,7 +132,6 @@ pub async fn run(
         ConfigCommands::Validate { url_or_path } => validate(&http_client, url_or_path).await,
         ConfigCommands::Generate {
             url_or_path,
-            insecure,
         } => {
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
 

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -30,7 +30,7 @@ use console::style;
 use fluent_uri::Uri;
 use tempfile::Builder;
 
-use crate::{cli_input::CliInput, cli_output::CliOutput, show_progress};
+use crate::{cli_input::CliInput, cli_output::CliOutput, show_progress, GlobalOpts};
 
 const DEFAULT_EDITOR: &str = "/usr/bin/vi";
 
@@ -99,7 +99,7 @@ pub async fn run(
     http_client: BaseHTTPClient,
     monitor: MonitorClient,
     subcommand: ConfigCommands,
-    insecure: bool,
+    opts: GlobalOpts,
 ) -> anyhow::Result<()> {
     let store = SettingsStore::new(http_client.clone()).await?;
 
@@ -117,7 +117,7 @@ pub async fn run(
         }
         ConfigCommands::Load { url_or_path } => {
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
-            let contents = url_or_path.read_to_string(insecure)?;
+            let contents = url_or_path.read_to_string(opts.insecure)?;
             // FIXME: invalid profile still gets loaded
             validate(&http_client, CliInput::Full(contents.clone())).await?;
             let result = InstallSettings::from_json(&contents, &InstallationContext::from_env()?)?;
@@ -131,7 +131,7 @@ pub async fn run(
         ConfigCommands::Generate { url_or_path } => {
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
 
-            generate(&http_client, url_or_path, insecure).await
+            generate(&http_client, url_or_path, opts.insecure).await
         }
         ConfigCommands::Edit { editor } => {
             let model = store.load().await?;

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -99,7 +99,7 @@ pub async fn run(
     http_client: BaseHTTPClient,
     monitor: MonitorClient,
     subcommand: ConfigCommands,
-    insecure: bool
+    insecure: bool,
 ) -> anyhow::Result<()> {
     let store = SettingsStore::new(http_client.clone()).await?;
 
@@ -115,9 +115,7 @@ pub async fn run(
             validate(&http_client, CliInput::Full(json.clone())).await?;
             Ok(())
         }
-        ConfigCommands::Load {
-            url_or_path,
-        } => {
+        ConfigCommands::Load { url_or_path } => {
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
             let contents = url_or_path.read_to_string(insecure)?;
             // FIXME: invalid profile still gets loaded
@@ -130,9 +128,7 @@ pub async fn run(
             Ok(())
         }
         ConfigCommands::Validate { url_or_path } => validate(&http_client, url_or_path).await,
-        ConfigCommands::Generate {
-            url_or_path,
-        } => {
+        ConfigCommands::Generate { url_or_path } => {
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
 
             generate(&http_client, url_or_path, insecure).await

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -322,10 +322,9 @@ pub async fn run_command(cli: Cli) -> anyhow::Result<()> {
             let client = build_http_client(api_url, cli.opts.insecure, true).await?;
             run_logs_cmd(client, subcommand).await?
         }
-        Commands::Download {
-            url,
-            destination,
-        } => download_file(&url, &destination, cli.opts.insecure)?,
+        Commands::Download { url, destination } => {
+            download_file(&url, &destination, cli.opts.insecure)?
+        }
         Commands::Auth(subcommand) => {
             let client = build_http_client(api_url, cli.opts.insecure, false).await?;
             run_auth_cmd(client, subcommand).await?;

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -293,7 +293,7 @@ pub async fn run_command(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::Config(subcommand) => {
             let (client, monitor) = build_clients(api_url, cli.opts.insecure).await?;
-            run_config_cmd(client, monitor, subcommand).await?
+            run_config_cmd(client, monitor, subcommand, cli.opts.insecure).await?
         }
         Commands::Probe => {
             let (client, monitor) = build_clients(api_url, cli.opts.insecure).await?;
@@ -325,8 +325,7 @@ pub async fn run_command(cli: Cli) -> anyhow::Result<()> {
         Commands::Download {
             url,
             destination,
-            insecure,
-        } => download_file(&url, &destination, insecure)?,
+        } => download_file(&url, &destination, cli.opts.insecure)?,
         Commands::Auth(subcommand) => {
             let client = build_http_client(api_url, cli.opts.insecure, false).await?;
             run_auth_cmd(client, subcommand).await?;

--- a/rust/agama-cli/src/lib.rs
+++ b/rust/agama-cli/src/lib.rs
@@ -60,7 +60,7 @@ use std::{
 use url::Url;
 
 /// Agama's CLI global options
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct GlobalOpts {
     #[clap(long, default_value = "http://localhost")]
     /// URI pointing to Agama's remote host.
@@ -288,12 +288,12 @@ pub async fn show_progress(monitor: MonitorClient, stop_on_idle: bool) {
 }
 
 pub async fn run_command(cli: Cli) -> anyhow::Result<()> {
-    let api_url = api_url(cli.opts.host)?;
+    let api_url = api_url(cli.opts.clone().host)?;
 
     match cli.command {
         Commands::Config(subcommand) => {
             let (client, monitor) = build_clients(api_url, cli.opts.insecure).await?;
-            run_config_cmd(client, monitor, subcommand, cli.opts.insecure).await?
+            run_config_cmd(client, monitor, subcommand, cli.opts).await?
         }
         Commands::Probe => {
             let (client, monitor) = build_clients(api_url, cli.opts.insecure).await?;

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 23 14:48:53 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Added "--insecure" option to "agama config load" and
+  "agama config generate" commands (related to bsc#1246836)
+
+-------------------------------------------------------------------
 Tue Jul 22 07:53:34 UTC 2025 - Martin Vidner <mvidner@suse.com>
 
 - fix .changes errors reported by obs-service-source_validator


### PR DESCRIPTION
## Problem

- Agama does not allow to disable SSL certificate check for `inst.auto` and `inst.script` boot options
- https://bugzilla.suse.com/show_bug.cgi?id=1246836

## Solution

- This is the first step, add `--insecure` option to `agama config load` and `agama config generate` commands which are internally used for these boot options
- Use the global `--insecure` option

## Testing

- Tested manually

```console
agama:~ # agama config generate https://192.168.1.8:4433/auto.json
Retrieving data from URL https://192.168.1.8:4433/auto.json

Caused by:
    0: Could not retrieve https://192.168.1.8:4433/auto.json
    1: [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: self-signed certificate)
agama:~ # agama --insecure config generate https://192.168.1.8:4433/auto.json
{
  "user": {
    "fullName": "test",
    "password": "test",
    "hashedPassword": false,
    "userName": "test"
  },
  "root": {
    "password": "linux",
    "hashedPassword": false
  },
  "product": {
    "id": "Tumbleweed"
  }
}
✓ The profile is valid.

agama:~ # agama config load https://192.168.1.8:4433/auto.json
Retrieving data from URL https://192.168.1.8:4433/auto.json

Caused by:
    0: Could not retrieve https://192.168.1.8:4433/auto.json
    1: [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: self-signed certificate)
agama:~ # agama --insecure config load https://192.168.1.8:4433/auto.json
✓ The profile is valid.

[1/2] Analyze disks
[2/2] Configure software
```