### PR TITLE
feat: embed questions configuration in the profile

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -999,6 +999,12 @@
           "title": "Answer for a password-based question",
           "description": "Answer to use for a question that expects an answer",
           "type": "string"
+        },
+        "data": {
+          "title": "Additional data for matching questions",
+          "description": "Additional data for matching questions and answers",
+          "type": "object",
+          "example": [{ "device": "/dev/sda" }]
         }
       }
     }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -271,7 +271,8 @@
           "title": "Policy to answer questions",
           "description": "Ask questions to the user or select the default value",
           "type": "string",
-          "enum": ["auto", "user"]
+          "enum": ["auto", "user"],
+          "default": "user"
         },
         "answers": {
           "title": "Pre-defined answer for a matching question",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -267,10 +267,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "interactive": {
-          "title": "Interactive mode",
-          "description": "Whether to run Agama in interactive mode. If set to false, Agama will use the default values for each question.",
-          "type": "boolean"
+        "policy": {
+          "title": "Policy to answer questions",
+          "description": "Ask questions to the user or select the default value",
+          "type": "string",
+          "enum": ["auto", "user"]
         },
         "answers": {
           "title": "Pre-defined answer for a matching question",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -262,6 +262,25 @@
         }
       }
     },
+    "questions": {
+      "title": "How to handle Agama questions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "interactive": {
+          "title": "Interactive mode",
+          "description": "Whether to run Agama in interactive mode. If set to false, Agama will use the default values for each question.",
+          "type": "boolean"
+        },
+        "answers": {
+          "title": "Pre-defined answer for each question.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/answer"
+          }
+        }
+      }
+    },
     "product": {
       "title": "Product to install",
       "type": "object",
@@ -954,6 +973,34 @@
       },
       "required": ["destination"],
       "oneOf": [{ "required": ["url"] }, { "required": ["content"] }]
+    },
+    "answer": {
+      "title": "Automatic answer to questions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "title": "Question class",
+          "description": "Each question has a \"class\" which works as an identifier.",
+          "type": "string",
+          "examples": ["storage.activate_multipath"]
+        },
+        "text": {
+          "title": "Question text",
+          "description": "Question full text",
+          "type": "string"
+        },
+        "answer": {
+          "title": "Question answer",
+          "description": "Answer to use for the question.",
+          "type": "string"
+        },
+        "password": {
+          "title": "Answer for a password-based question",
+          "description": "Answer to use for a question that expects an answer",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -273,7 +273,7 @@
           "type": "boolean"
         },
         "answers": {
-          "title": "Pre-defined answer for each question.",
+          "title": "Pre-defined answer for a matching question",
           "type": "array",
           "items": {
             "$ref": "#/$defs/answer"
@@ -996,8 +996,7 @@
           "type": "string"
         },
         "password": {
-          "title": "Answer for a password-based question",
-          "description": "Answer to use for a question that expects an answer",
+          "title": "Password provided as response to a password-based question",
           "type": "string"
         },
         "data": {

--- a/rust/agama-lib/src/install_settings.rs
+++ b/rust/agama-lib/src/install_settings.rs
@@ -26,6 +26,7 @@ use crate::context::InstallationContext;
 use crate::file_source::{FileSourceError, WithFileSource};
 use crate::files::model::UserFile;
 use crate::hostname::model::HostnameSettings;
+use crate::questions::config::QuestionsConfig;
 use crate::security::settings::SecuritySettings;
 use crate::storage::settings::zfcp::ZFCPConfig;
 use crate::{
@@ -87,6 +88,8 @@ pub struct InstallSettings {
     pub scripts: Option<ScriptsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zfcp: Option<ZFCPConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub questions: Option<QuestionsConfig>,
 }
 
 impl InstallSettings {

--- a/rust/agama-lib/src/proxies/questions/base.rs
+++ b/rust/agama-lib/src/proxies/questions/base.rs
@@ -51,6 +51,9 @@ pub trait Questions {
     /// AddAnswerFile method
     fn add_answer_file(&self, path: &str) -> zbus::Result<()>;
 
+    /// Remove Answers method
+    fn remove_answers(&self) -> zbus::Result<()>;
+
     /// Delete method
     fn delete(&self, question: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
 

--- a/rust/agama-lib/src/questions.rs
+++ b/rust/agama-lib/src/questions.rs
@@ -21,6 +21,7 @@
 //! Data model for Agama questions
 
 use std::collections::HashMap;
+pub mod answers;
 pub mod config;
 pub mod http_client;
 pub mod model;

--- a/rust/agama-lib/src/questions.rs
+++ b/rust/agama-lib/src/questions.rs
@@ -23,9 +23,11 @@
 use std::collections::HashMap;
 pub mod answers;
 pub mod config;
+pub mod error;
 pub mod http_client;
 pub mod model;
 pub mod store;
+pub use error::QuestionsError;
 
 /// Basic generic question that fits question without special needs
 ///

--- a/rust/agama-lib/src/questions.rs
+++ b/rust/agama-lib/src/questions.rs
@@ -21,8 +21,10 @@
 //! Data model for Agama questions
 
 use std::collections::HashMap;
+pub mod config;
 pub mod http_client;
 pub mod model;
+pub mod store;
 
 /// Basic generic question that fits question without special needs
 ///

--- a/rust/agama-lib/src/questions/answers.rs
+++ b/rust/agama-lib/src/questions/answers.rs
@@ -1,0 +1,22 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+mod strategy;
+pub use strategy::AnswerStrategy;

--- a/rust/agama-lib/src/questions/answers/custom.rs
+++ b/rust/agama-lib/src/questions/answers/custom.rs
@@ -20,19 +20,17 @@
 
 use std::collections::HashMap;
 
-use agama_lib::questions::GenericQuestion;
+use crate::questions::{GenericQuestion, QuestionsError};
 use serde::{Deserialize, Serialize};
 
-use agama_lib::questions::answers::AnswerStrategy;
-
-use super::QuestionsError;
+use super::AnswerStrategy;
 
 /// Data structure for single JSON answer. For variables specification see
 /// corresponding [agama_lib::questions::GenericQuestion] fields.
 /// The *matcher* part is: `class`, `text`, `data`.
 /// The *answer* part is: `answer`, `password`.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-struct Answer {
+pub struct Answer {
     pub class: Option<String>,
     pub text: Option<String>,
     /// A matching GenericQuestion can have other data fields too
@@ -111,7 +109,7 @@ impl AnswerStrategy for Answers {
 
     fn answer_with_password(
         &self,
-        question: &agama_lib::questions::WithPassword,
+        question: &crate::questions::WithPassword,
     ) -> (Option<String>, Option<String>) {
         // use here fact that with password share same matchers as generic one
         let answer = self.find_answer(&question.base);
@@ -125,7 +123,7 @@ impl AnswerStrategy for Answers {
 
 #[cfg(test)]
 mod tests {
-    use agama_lib::questions::{answers::AnswerStrategy, GenericQuestion, WithPassword};
+    use crate::questions::{answers::AnswerStrategy, GenericQuestion, WithPassword};
 
     use super::*;
 

--- a/rust/agama-lib/src/questions/answers/custom.rs
+++ b/rust/agama-lib/src/questions/answers/custom.rs
@@ -29,15 +29,19 @@ use super::AnswerStrategy;
 /// corresponding [agama_lib::questions::GenericQuestion] fields.
 /// The *matcher* part is: `class`, `text`, `data`.
 /// The *answer* part is: `answer`, `password`.
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, utoipa::ToSchema)]
 pub struct Answer {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// A matching GenericQuestion can have other data fields too
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<HashMap<String, String>>,
     /// The answer text is the only mandatory part of an Answer
     pub answer: String,
     /// All possible mixins have to be here, so they can be specified in an Answer
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
 }
 
@@ -81,6 +85,9 @@ pub struct Answers {
 }
 
 impl Answers {
+    pub fn new(answers: Vec<Answer>) -> Self {
+        Self { answers }
+    }
     pub fn new_from_file(path: &str) -> Result<Self, QuestionsError> {
         let f = std::fs::File::open(path).map_err(QuestionsError::IO)?;
         let result: Self = serde_json::from_reader(f).map_err(QuestionsError::Deserialize)?;

--- a/rust/agama-lib/src/questions/answers/default.rs
+++ b/rust/agama-lib/src/questions/answers/default.rs
@@ -18,11 +18,29 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-mod strategy;
-pub use strategy::AnswerStrategy;
+use crate::questions::{GenericQuestion, WithPassword};
 
-mod default;
-pub use default::DefaultAnswers;
+use super::AnswerStrategy;
 
-mod custom;
-pub use custom::{Answer, Answers};
+/// AnswerStrategy that provides as answer the default option.
+pub struct DefaultAnswers;
+
+impl DefaultAnswers {
+    pub fn id() -> u8 {
+        1
+    }
+}
+
+impl AnswerStrategy for DefaultAnswers {
+    fn id(&self) -> u8 {
+        DefaultAnswers::id()
+    }
+
+    fn answer(&self, question: &GenericQuestion) -> Option<String> {
+        Some(question.default_option.clone())
+    }
+
+    fn answer_with_password(&self, question: &WithPassword) -> (Option<String>, Option<String>) {
+        (Some(question.base.default_option.clone()), None)
+    }
+}

--- a/rust/agama-lib/src/questions/answers/strategy.rs
+++ b/rust/agama-lib/src/questions/answers/strategy.rs
@@ -1,0 +1,45 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use crate::questions::{GenericQuestion, WithPassword};
+
+/// Trait for objects that can provide answers to all kind of Question.
+///
+/// If no strategy is selected or the answer is unknown, then ask to the user.
+pub trait AnswerStrategy {
+    /// Id for quick runtime inspection of strategy type
+    fn id(&self) -> u8;
+    /// Provides answer for generic question
+    ///
+    /// I gets as argument the question to answer. Returned value is `answer`
+    /// property or None. If `None` is used, it means that this object does not
+    /// answer to given question.
+    fn answer(&self, question: &GenericQuestion) -> Option<String>;
+    /// Provides answer and password for base question with password
+    ///
+    /// I gets as argument the question to answer. Returned value is pair
+    /// of `answer` and `password` properties. If `None` is used in any
+    /// position it means that this object does not respond to given property.
+    ///
+    /// It is object responsibility to provide correct pair. For example if
+    /// possible answer can be "Ok" and "Cancel". Then for `Ok` password value
+    /// should be provided and for `Cancel` it can be `None`.
+    fn answer_with_password(&self, question: &WithPassword) -> (Option<String>, Option<String>);
+}

--- a/rust/agama-lib/src/questions/config.rs
+++ b/rust/agama-lib/src/questions/config.rs
@@ -22,12 +22,21 @@ use serde::{Deserialize, Serialize};
 
 use super::answers::Answer;
 
+#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum QuestionsPolicy {
+    /// Automatically answer questions.
+    Auto,
+    /// Ask the user.
+    User,
+}
+
 /// Questions configuration.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QuestionsConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interactive: Option<bool>,
+    pub policy: Option<QuestionsPolicy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub answers: Option<Vec<Answer>>,
 }

--- a/rust/agama-lib/src/questions/config.rs
+++ b/rust/agama-lib/src/questions/config.rs
@@ -20,7 +20,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Answer;
+use super::answers::Answer;
 
 /// Questions configuration.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]

--- a/rust/agama-lib/src/questions/config.rs
+++ b/rust/agama-lib/src/questions/config.rs
@@ -1,0 +1,33 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use serde::{Deserialize, Serialize};
+
+use super::model::Answer;
+
+/// Questions configuration.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestionsConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interactive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answers: Option<Vec<Answer>>,
+}

--- a/rust/agama-lib/src/questions/error.rs
+++ b/rust/agama-lib/src/questions/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2024] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -18,11 +18,10 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-mod strategy;
-pub use strategy::AnswerStrategy;
-
-mod default;
-pub use default::DefaultAnswers;
-
-mod custom;
-pub use custom::{Answer, Answers};
+#[derive(thiserror::Error, Debug)]
+pub enum QuestionsError {
+    #[error("Could not read the answers file: {0}")]
+    IO(std::io::Error),
+    #[error("Could not deserialize the answers file: {0}")]
+    Deserialize(serde_json::Error),
+}

--- a/rust/agama-lib/src/questions/http_client.rs
+++ b/rust/agama-lib/src/questions/http_client.rs
@@ -25,7 +25,10 @@ use tokio::time::sleep;
 
 use crate::http::{BaseHTTPClient, BaseHTTPClientError};
 
-use super::model::{self, Answer, Question};
+use super::{
+    config::QuestionsConfig,
+    model::{self, Answer, Question},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum QuestionsHTTPClientError {
@@ -89,6 +92,17 @@ impl HTTPClient {
     pub async fn delete_question(&self, question_id: u32) -> Result<(), QuestionsHTTPClientError> {
         let path = format!("/questions/{}", question_id);
         Ok(self.client.delete_void(path.as_str()).await?)
+    }
+
+    pub async fn get_config(&self) -> Result<QuestionsConfig, QuestionsHTTPClientError> {
+        Ok(QuestionsConfig::default())
+    }
+
+    pub async fn set_config(
+        &self,
+        config: &QuestionsConfig,
+    ) -> Result<(), QuestionsHTTPClientError> {
+        Ok(self.client.put_void("/questions/config", config).await?)
     }
 }
 

--- a/rust/agama-lib/src/questions/store.rs
+++ b/rust/agama-lib/src/questions/store.rs
@@ -1,0 +1,53 @@
+// Copyright (c) [2025] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+use crate::http::BaseHTTPClient;
+
+use super::{
+    config::QuestionsConfig,
+    http_client::{HTTPClient as QuestionsHTTPClient, QuestionsHTTPClientError},
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error("Error processing questions settings: {0}")]
+pub struct QuestionsStoreError(#[from] QuestionsHTTPClientError);
+
+type QuestionsStoreResult<T> = Result<T, QuestionsStoreError>;
+
+/// Loads and stores the questions settings from/to the HTTP API.
+pub struct QuestionsStore {
+    questions_client: QuestionsHTTPClient,
+}
+
+impl QuestionsStore {
+    pub fn new(client: BaseHTTPClient) -> Self {
+        Self {
+            questions_client: QuestionsHTTPClient::new(client),
+        }
+    }
+
+    pub async fn load(&self) -> QuestionsStoreResult<Option<QuestionsConfig>> {
+        Ok(None)
+    }
+
+    pub async fn store(&self, config: &QuestionsConfig) -> QuestionsStoreResult<()> {
+        Ok(self.questions_client.set_config(config).await?)
+    }
+}

--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -31,6 +31,7 @@ use crate::{
     manager::{http_client::ManagerHTTPClientError, InstallationPhase, ManagerHTTPClient},
     network::{NetworkStore, NetworkStoreError},
     product::{ProductHTTPClient, ProductStore, ProductStoreError},
+    questions::store::{QuestionsStore, QuestionsStoreError},
     scripts::{ScriptsClient, ScriptsClientError, ScriptsGroup, ScriptsStore, ScriptsStoreError},
     security::store::{SecurityStore, SecurityStoreError},
     software::{SoftwareStore, SoftwareStoreError},
@@ -62,6 +63,8 @@ pub enum StoreError {
     Users(#[from] UsersStoreError),
     #[error(transparent)]
     Network(#[from] NetworkStoreError),
+    #[error(transparent)]
+    Questions(#[from] QuestionsStoreError),
     #[error(transparent)]
     Product(#[from] ProductStoreError),
     #[error(transparent)]
@@ -102,6 +105,7 @@ pub struct Store {
     hostname: HostnameStore,
     users: UsersStore,
     network: NetworkStore,
+    questions: QuestionsStore,
     product: ProductStore,
     security: SecurityStore,
     software: SoftwareStore,
@@ -124,6 +128,7 @@ impl Store {
             localization: LocalizationStore::new(http_client.clone()),
             users: UsersStore::new(http_client.clone()),
             network: NetworkStore::new(http_client.clone()),
+            questions: QuestionsStore::new(http_client.clone()),
             product: ProductStore::new(http_client.clone()),
             security: SecurityStore::new(http_client.clone()),
             software: SoftwareStore::new(http_client.clone()),
@@ -144,6 +149,8 @@ impl Store {
             files: self.files.load().await?,
             hostname: Some(self.hostname.load().await?),
             network: Some(self.network.load().await?),
+            // FIXME: do not export questions yet.
+            questions: self.questions.load().await?,
             security: self.security.load().await?.to_option(),
             software: self.software.load().await?.to_option(),
             user: Some(self.users.load().await?),
@@ -177,6 +184,10 @@ impl Store {
             if scripts.pre.as_ref().is_some_and(|s| !s.is_empty()) {
                 self.run_pre_scripts().await?;
             }
+        }
+
+        if let Some(questions) = &settings.questions {
+            self.questions.store(questions).await?;
         }
 
         if let Some(network) = &settings.network {

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -18,7 +18,7 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use agama_lib::error::ServiceError;
+use agama_lib::{error::ServiceError, questions::QuestionsError};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -28,7 +28,6 @@ use serde_json::json;
 
 use crate::{
     l10n::LocaleError,
-    questions::QuestionsError,
     users::password::PasswordCheckerError,
     web::common::{IssuesServiceError, ProgressServiceError},
 };

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -244,17 +244,13 @@ impl Questions {
         tracing::info!("Adding answer file {}", path);
         let answers = Answers::new_from_file(path.as_str())
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
-        self.answer_strategies.push(Box::new(answers));
+        self.answer_strategies.insert(0, Box::new(answers));
         Ok(())
     }
 
     fn remove_answers(&mut self) -> zbus::fdo::Result<()> {
-        let ids: Vec<_> = self.answer_strategies.iter().map(|s| s.id()).collect();
-        tracing::info!("before ids: {ids:?}");
         self.answer_strategies
             .retain(|s| s.id() == DefaultAnswers::id());
-        let ids: Vec<_> = self.answer_strategies.iter().map(|s| s.id()).collect();
-        tracing::info!("after ids: {ids:?}");
         Ok(())
     }
 }

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -20,7 +20,8 @@
 
 use std::collections::HashMap;
 
-use agama_lib::questions::{self, GenericQuestion, WithPassword};
+use agama_lib::questions::{self, model::Answer, GenericQuestion, WithPassword};
+use serde::Serialize;
 use zbus::{fdo::ObjectManager, interface, zvariant::ObjectPath, Connection};
 
 mod answers;
@@ -299,6 +300,12 @@ impl Questions {
         let answers = answers::Answers::new_from_file(path.as_str())
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
         self.answer_strategies.push(Box::new(answers));
+        Ok(())
+    }
+
+    fn remove_answers(&mut self) -> zbus::fdo::Result<()> {
+        self.answer_strategies
+            .retain(|s| s.id() == DefaultAnswers::id());
         Ok(())
     }
 }

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -219,12 +219,9 @@ impl Questions {
     /// default answer
     #[zbus(property)]
     fn interactive(&self) -> bool {
-        let last = self.answer_strategies.last();
-        if let Some(real_strategy) = last {
-            real_strategy.id() != DefaultAnswers::id()
-        } else {
-            true
-        }
+        self.answer_strategies
+            .iter()
+            .all(|s| s.id() != DefaultAnswers::id())
     }
 
     #[zbus(property)]
@@ -236,7 +233,8 @@ impl Questions {
 
         tracing::info!("set interactive to {}", value);
         if value {
-            self.answer_strategies.pop();
+            self.answer_strategies
+                .retain(|s| s.id() == DefaultAnswers::id());
         } else {
             self.answer_strategies.push(Box::new(DefaultAnswers {}));
         }
@@ -251,8 +249,12 @@ impl Questions {
     }
 
     fn remove_answers(&mut self) -> zbus::fdo::Result<()> {
+        let ids: Vec<_> = self.answer_strategies.iter().map(|s| s.id()).collect();
+        tracing::info!("before ids: {ids:?}");
         self.answer_strategies
             .retain(|s| s.id() == DefaultAnswers::id());
+        let ids: Vec<_> = self.answer_strategies.iter().map(|s| s.id()).collect();
+        tracing::info!("after ids: {ids:?}");
         Ok(())
     }
 }

--- a/rust/agama-server/src/questions.rs
+++ b/rust/agama-server/src/questions.rs
@@ -20,8 +20,7 @@
 
 use std::collections::HashMap;
 
-use agama_lib::questions::{self, model::Answer, GenericQuestion, WithPassword};
-use serde::Serialize;
+use agama_lib::questions::{self, answers::AnswerStrategy, GenericQuestion, WithPassword};
 use zbus::{fdo::ObjectManager, interface, zvariant::ObjectPath, Connection};
 
 mod answers;
@@ -104,30 +103,6 @@ impl WithPasswordObject {
 enum QuestionType {
     Base,
     BaseWithPassword,
-}
-
-/// Trait for objects that can provide answers to all kind of Question.
-///
-/// If no strategy is selected or the answer is unknown, then ask to the user.
-trait AnswerStrategy {
-    /// Id for quick runtime inspection of strategy type
-    fn id(&self) -> u8;
-    /// Provides answer for generic question
-    ///
-    /// I gets as argument the question to answer. Returned value is `answer`
-    /// property or None. If `None` is used, it means that this object does not
-    /// answer to given question.
-    fn answer(&self, question: &GenericQuestion) -> Option<String>;
-    /// Provides answer and password for base question with password
-    ///
-    /// I gets as argument the question to answer. Returned value is pair
-    /// of `answer` and `password` properties. If `None` is used in any
-    /// position it means that this object does not respond to given property.
-    ///
-    /// It is object responsibility to provide correct pair. For example if
-    /// possible answer can be "Ok" and "Cancel". Then for `Ok` password value
-    /// should be provided and for `Cancel` it can be `None`.
-    fn answer_with_password(&self, question: &WithPassword) -> (Option<String>, Option<String>);
 }
 
 /// AnswerStrategy that provides as answer the default option.

--- a/rust/agama-server/src/questions/answers.rs
+++ b/rust/agama-server/src/questions/answers.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use agama_lib::questions::GenericQuestion;
 use serde::{Deserialize, Serialize};
 
-use crate::questions::AnswerStrategy;
+use agama_lib::questions::answers::AnswerStrategy;
 
 use super::QuestionsError;
 
@@ -125,9 +125,7 @@ impl AnswerStrategy for Answers {
 
 #[cfg(test)]
 mod tests {
-    use agama_lib::questions::{GenericQuestion, WithPassword};
-
-    use crate::questions::AnswerStrategy;
+    use agama_lib::questions::{answers::AnswerStrategy, GenericQuestion, WithPassword};
 
     use super::*;
 

--- a/rust/agama-server/src/questions/answers.rs
+++ b/rust/agama-server/src/questions/answers.rs
@@ -23,6 +23,8 @@ use std::collections::HashMap;
 use agama_lib::questions::GenericQuestion;
 use serde::{Deserialize, Serialize};
 
+use crate::questions::AnswerStrategy;
+
 use super::QuestionsError;
 
 /// Data structure for single JSON answer. For variables specification see
@@ -97,7 +99,7 @@ impl Answers {
     }
 }
 
-impl crate::questions::AnswerStrategy for Answers {
+impl AnswerStrategy for Answers {
     fn id(&self) -> u8 {
         Answers::id()
     }

--- a/rust/agama-server/src/questions/web.rs
+++ b/rust/agama-server/src/questions/web.rs
@@ -32,7 +32,7 @@ use agama_lib::{
     proxies::questions::{GenericQuestionProxy, QuestionWithPasswordProxy, QuestionsProxy},
     questions::{
         answers::{self, Answers},
-        config::QuestionsConfig,
+        config::{QuestionsConfig, QuestionsPolicy},
         model::{self, GenericQuestion, PasswordAnswer, Question, QuestionWithPassword},
     },
 };
@@ -430,7 +430,12 @@ async fn set_config(
     State(state): State<QuestionsState<'_>>,
     Json(config): Json<QuestionsConfig>,
 ) -> Result<(), Error> {
-    if let Some(interactive) = config.interactive {
+    if let Some(policy) = config.policy {
+        let interactive = match policy {
+            QuestionsPolicy::User => true,
+            QuestionsPolicy::Auto => false,
+        };
+
         state.questions.set_interactive(interactive).await?;
     }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 31 11:54:49 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for a "questions" section in the Agama configuration
+  that allows defining how to answer questions (bsc#1246997).
+
+-------------------------------------------------------------------
 Tue Jul 29 09:50:59 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not complain about missing a selected product when it is not

--- a/service/lib/agama/software/callbacks/script.rb
+++ b/service/lib/agama/software/callbacks/script.rb
@@ -32,16 +32,6 @@ module Agama
       class Script < Base
         include Yast::I18n
 
-        # Constructor
-        #
-        # @param questions_client [Agama::DBus::Clients::Questions]
-        # @param logger [Logger]
-        def initialize(questions_client, logger)
-          textdomain "agama"
-          @questions_client = questions_client
-          @logger = logger
-        end
-
         # Register the callbacks
         def setup
           Yast::Pkg.CallbackScriptProblem(

--- a/service/lib/agama/software/callbacks/script.rb
+++ b/service/lib/agama/software/callbacks/script.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "agama/question"
+require "agama/software/callbacks/base"
 
 Yast.import "Pkg"
 
@@ -28,7 +29,7 @@ module Agama
   module Software
     module Callbacks
       # Script callbacks
-      class Script
+      class Script < Base
         include Yast::I18n
 
         # Constructor
@@ -60,12 +61,12 @@ module Agama
           question = Agama::Question.new(
             qclass:         "software.script_problem",
             text:           message,
-            options:        [:Retry, :Ignore],
-            default_option: :Retry,
+            options:        [retry_label, continue_label],
+            default_option: retry_label.to_sym,
             data:           { "details" => description }
           )
           questions_client.ask(question) do |question_client|
-            (question_client.answer == :Retry) ? "R" : "I"
+            (question_client.answer == retry_label.to_sym) ? "R" : "I"
           end
         end
 

--- a/service/test/agama/software/callbacks/script_test.rb
+++ b/service/test/agama/software/callbacks/script_test.rb
@@ -31,7 +31,7 @@ describe Agama::Software::Callbacks::Script do
 
   let(:logger) { Logger.new($stdout, level: :warn) }
 
-  let(:answer) { :Retry }
+  let(:answer) { subject.retry_label.to_sym }
 
   let(:description) { "Some description" }
 
@@ -53,8 +53,8 @@ describe Agama::Software::Callbacks::Script do
       subject.script_problem(description)
     end
 
-    context "when the user answers :Retry" do
-      let(:answer) { :Retry }
+    context "when the user asks to retry" do
+      let(:answer) { subject.retry_label.to_sym }
 
       it "returns 'R'" do
         ret = subject.script_problem(description)
@@ -62,8 +62,8 @@ describe Agama::Software::Callbacks::Script do
       end
     end
 
-    context "when the user answers :Ignore" do
-      let(:answer) { :Ignore }
+    context "when the user asks to continue" do
+      let(:answer) { subject.continue_label.to_sym }
 
       it "returns 'I'" do
         ret = subject.script_problem(description)


### PR DESCRIPTION
## Problem

* Bug [bsc#1246997](https://bugzilla.suse.com/show_bug.cgi?id=1246997)

To answer questions in advance when using the unattended mode, it is required to use a pre-script. If you just want Agama to use the default values, it is kind of straight-forward:

```jsonnet
  scripts: {
    pre: [
      {
        name: 'disable-questions',
	content: |||
          #!/usr/bin/bash
          agama questions mode non-interactive
	|||
      }
    ]
  }
```

However, if you want to answer an specific question (e.g., providing a password for an existing encrypted file system) it is kind of tricky. You might need to create a file like this:

```json
  {
    "answers": [
      {
        "password": "my-password",
        "class": "storage.luks_activation"
      },
    ]
  }
```

And the load it using a pre-script:

```jsonnet
  scripts: {
    pre: [
      {
        name: 'disable-questions',
	content: |||
          #!/usr/bin/bash
          agama download http://my-server.lan/answers.json answers.json
          agama questions answers answers.json
	|||
      }
    ]
  }
```

## Solution

Allow embedding the answers in the profile.

```json
  "questions": {
    "policy": "auto",
    "answers": [
      { "class": "storage.luks_activation", "password": "nots3cr3t" }
    ]
```

* `policy`: ask the user (`user`) or choose the default option (`auto`).
* `answers`: list of answers to the given question.

## Testing

- *Added a new unit test*
- *Tested manually*