### PR TITLE
fix(web): do not encode connection name in POST payload (rc3)

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 25 19:42:18 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Fix an issue preventing connections from being set as
+  "installation-only" in the web interface
+  (gh#agama-project/agama#2613).
+
+-------------------------------------------------------------------
 Wed Jul 23 14:54:43 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Display RAID level at the storage results table (bsc#1244697).

--- a/web/src/api/network.ts
+++ b/web/src/api/network.ts
@@ -91,7 +91,7 @@ const disconnect = (name: string) =>
  * Make the connection persistent after the installation
  */
 const persist = (name: string, value: boolean) =>
-  post(`/api/network/connections/persist`, { only: [encodeURIComponent(name)], value });
+  post(`/api/network/connections/persist`, { only: [name], value });
 
 export {
   fetchState,


### PR DESCRIPTION
:information_source:  **Same than #2613 but against `rc3` branch.**

---

## Problem

#2576 went too far and encoded not only the connection name in the URL, but also the POST payload for the _persist_ request, which is not correct.

As a result, the _Use for installation only_ switch is actually not working in the web interface. What is worse, it  even appears to work, due to the fatal combination of an optimistic interface update and the backend not complaining but still responding with a `204` status (i.e., no chances for rolling back the optimistic update).

## Solution

Stop encoding the connection name in the POST payload.

## Testing

Tested manually only, as there's currently no support for automating this type of API test.

### Payload before the change

```json
{"only":["Wired%20%231"],"value":false}
```

### Payload after the change

```json
{"only":["Wired #1"],"value":false}
```
