### PR TITLE
[rc3] live: do not fail if there are no rpm scriplets to clean

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sun Jul 27 09:44:04 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Do not fail if there are no rpm scriptlets to clean. 
+
+-------------------------------------------------------------------
 Wed Jul 23 14:18:38 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Ensure iSCSI initiator name is unique (bsc#1246280).

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -27,7 +27,7 @@ EOF
 # for reproducible builds:
 echo -n > /var/log/alternatives.log
 sed -i 's/# AutoInstalled generated.*/# AutoInstalled generated in kiwi reproducible build/' /var/lib/zypp/AutoInstalled # drop timestamp
-rm /var/tmp/rpm-tmp.*
+rm -f /var/tmp/rpm-tmp.*
 
 # enable the corresponding repository
 DISTRO=$(grep "^NAME" /etc/os-release | cut -f2 -d\= | tr -d '"' | tr " " "_")


### PR DESCRIPTION
Recent libzypp versions would ensure that there are no stray rpm scriptlets left in /var/tmp [0], so ensure we don't fail if there aren't any.

[0] https://github.com/openSUSE/libzypp/commit/760882b533903da9420fd4525938a73c743b5764


Backport of #2616 to `rc3` branch.