### PR TITLE
fix(rust): print download error earlier

### DIFF
--- a/rust/agama-autoinstall/src/auto_loader.rs
+++ b/rust/agama-autoinstall/src/auto_loader.rs
@@ -77,8 +77,8 @@ impl ConfigAutoLoader {
         for url in urls {
             println!("Loading configuration from {url}");
             while let Err(error) = loader.load(url).await {
+                eprintln!("Could not load configuration from {url}: {error}");
                 if !self.should_retry(url).await? {
-                    println!("Could not load configuration from {url}");
                     return Err(error);
                 }
             }

--- a/rust/agama-autoinstall/src/scripts.rs
+++ b/rust/agama-autoinstall/src/scripts.rs
@@ -98,8 +98,8 @@ impl ScriptsRunner {
     async fn save_script(&self, url: &str, path: &PathBuf) -> anyhow::Result<()> {
         let mut file = Self::create_file(&path, 0o700)?;
         while let Err(error) = Transfer::get(url, &mut file, self.insecure) {
+            eprintln!("Could not load configuration from {url}: {error}");
             if !self.should_retry(&url).await? {
-                println!("Could not load configuration from {url}");
                 return Err(anyhow!(error));
             }
         }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 28 08:18:09 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- When the files in inst.auto or inst.script cannot be downloaded,
+  write the errors earlier (gh#agama-project/agama#2168).
+
+-------------------------------------------------------------------
 Thu Jul 24 13:19:52 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Introduce inst.auto_insecure and inst.script_insecure to disable


### PR DESCRIPTION
## Problem

If you inspect the logs when Agama fails to download an installation profile, you will not see the error. It is printed only after the user answers the "retry?" question, which is wrong.

## Solution

Write the error to the logs earlier.
