### PR TITLE
update pam crate not to use a vulnerable users dependency (bsc#1244200, CVE-2025-5791)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2967,14 +2967,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pam"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab553c52103edb295d8f7d6a3b593dc22a30b1fb99643c777a8f36915e285ba"
+source = "git+https://github.com/1wilkens/pam.git?rev=daf26ae#daf26ae3512d8e5a7478ccff1e4232ef5ebf9b03"
 dependencies = [
  "libc",
  "memchr",
  "pam-macros",
  "pam-sys",
- "users",
+ "uzers",
 ]
 
 [[package]]
@@ -4633,16 +4632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,6 +4700,16 @@ dependencies = [
  "outref",
  "uuid",
  "vsimd",
+]
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -37,7 +37,9 @@ utoipa = { version = "5.2.0", features = ["axum_extras", "uuid"] }
 config = "0.15.11"
 rand = "0.9.1"
 axum-extra = { version = "0.9.4", features = ["cookie", "typed-header"] }
-pam = "0.8.0"
+# pam 0.8.0 (2023-11) plus an unreleased commit from 2023-12
+# that switches from users to uzers, fixing CVE-2025-5791
+pam = { git = "https://github.com/1wilkens/pam.git", rev = "daf26ae" }
 serde_with = "3.10.0"
 pin-project = "1.1.5"
 openssl = "0.10.66"

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 28 12:40:40 UTC 2025 - Martin Vidner <mvidner@suse.com>
+
+- update pam crate not to use a vulnerable users dependency
+  (bsc#1244200, CVE-2025-5791)
+
+-------------------------------------------------------------------
 Mon Jul 28 08:18:09 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - When the files in inst.auto or inst.script cannot be downloaded,


### PR DESCRIPTION
## Problem

- We depend on a vulnerable crate: users- 0.10.0, via pam-0.8.0
- We do not use the vulnerable functionality
- https://bugzilla.suse.com/show_bug.cgi?id=1244200
- https://www.cve.org/CVERecord?id=CVE-2025-5791
- https://trello.com/c/vxZYhd1r

## Solution

Point Cargo.toml to an unreleased commit in `pam` that switches to the `uzers` crate (which is a fork of the unmaintained vulnerable crate)

Currently targeting the RC3 branch

## Testing

- [x] manual test: authenticated in Agama web UI, correct password lets me in ✔️, wrong password doesn't ✔️
- [x] packaging viability: in an OBS checkout I have changed `_service` to point to my branch `<param name="revision">insecure-users-crate</param>` and ran `osc service manualrun`. `cargo vendor` and `cargo audit` ran without problems.

## Screenshots

No

## Documentation

No