### PR TITLE
bsc#1247248: only complain about the missing product in some cases

### DIFF
--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -187,6 +187,9 @@ impl Store {
         if let Some(security) = &settings.security {
             self.security.store(security).await?;
         }
+        if let Some(user) = &settings.user {
+            self.users.store(user).await?;
+        }
         // order is important here as network can be critical for connection
         // to registration server and selecting product is important for rest
         if let Some(product) = &settings.product {
@@ -198,12 +201,6 @@ impl Store {
         if let Some(localization) = &settings.localization {
             Store::ensure_selected_product(is_product_selected)?;
             self.localization.store(localization).await?;
-        }
-        // import the users (esp. the root password) before initializing software,
-        // if software fails the Web UI would be stuck in the root password dialog
-        if let Some(user) = &settings.user {
-            Store::ensure_selected_product(is_product_selected)?;
-            self.users.store(user).await?;
         }
         if let Some(software) = &settings.software {
             Store::ensure_selected_product(is_product_selected)?;

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 29 09:50:59 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not complain about missing a selected product when it is not
+  required (bsc#1247248).
+
+-------------------------------------------------------------------
 Mon Jul 28 08:18:09 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - When the files in inst.auto or inst.script cannot be downloaded,


### PR DESCRIPTION
## Problem

#2570 introduced a check to make sure that a product is selected in some cases when the user tries to load a configuration that contains some specific sections (basically software and storage-related ones).

However, `agama config load` now complains *always*.

## Solution

The root cause is that, when deserializing the settings, a users section is *always* present (still investigating why). However, the users section does not require the product anymore.

## Testing

- Tested manually