### PR TITLE
bsc#1247266: make RPMs given via inst.dud installable

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -67,7 +67,8 @@ apply_updates() {
 
 # Applies an update from an RPM package
 #
-# It extracts the RPM content and adjust the alternative links.
+#   1. It extracts the RPM content and adjust the alternative links.
+#   2. Copy the packages to the $DUD_RPM_REPOSITORY.
 apply_rpm_update() {
   file=$1
   dir=$2
@@ -75,6 +76,8 @@ apply_rpm_update() {
   echo "Apply update from an RPM package"
   unpack_rpm "$file" "$dir"
   install_update "$dir"
+  mkdir -p "$DUD_RPM_REPOSITORY"
+  cp "$file" "$DUD_RPM_REPOSITORY"
 }
 
 # Applies an update from an RPM package

--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -232,7 +232,7 @@ update_kernel_modules() {
   find_kernel_modules "$dud_modules_dir" dud_modules
 
   # finish if no kernel module is included in DUD
-  if (( ${#dud_modules[@]} == 0 )); then
+  if ((${#dud_modules[@]} == 0)); then
     echo "Skipping kernel modules update"
     return
   fi

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,8 +1,13 @@
 -------------------------------------------------------------------
+Tue Jul 29 12:51:21 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Make RPMs given via inst.dud available for installation (bsc#1247266).
+
+-------------------------------------------------------------------
 Sun Jul 27 09:44:04 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Do not fail if there are no rpm scriptlets to clean
-  (gh#agama-project/agama#2617). 
+  (gh#agama-project/agama#2617).
 
 -------------------------------------------------------------------
 Wed Jul 23 14:18:38 UTC 2025 - José Iván López González <jlopez@suse.com>


### PR DESCRIPTION
## Problem

The Agama DUD mechanism works in the following way when it comes to RPM handling:

* If you are using an RPM, it just patches the installation media.
* If you are using a DUD (created by mkdud), it sets up a repository containing the RPMs to make them available during installation (if the `--install repo` method is included).
* 
The reporter of the [bsc#1247266](https://bugzilla.suse.com/show_bug.cgi?id=1247266) expected that an RPM given as `inst.dud=` option would be available for installation.

## Solution

Include any RPM package specified as `inst.dud=` in the DUD repository for installation.

## Testing

- *Tested manually*

## Open question

* Is this actually a good idea? We could ask the users to use a DUD if they want this behavior.