### PR TITLE
Security adapt

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 31 07:44:04 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Remove selinux policy from products definition as it is noop
+  after changes to agama service (bsc#1247046)
+
+-------------------------------------------------------------------
 Tue Jul 29 14:13:55 UTC 2025 - Frederic Crozat <fcrozat@suse.com>
 
 - Add more patterns to installation UI (bsc#1246947)

--- a/products.d/kalpa.yaml
+++ b/products.d/kalpa.yaml
@@ -46,7 +46,6 @@ security:
     selinux:
       patterns:
         - microos_selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -84,7 +84,6 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/leap_micro_62.yaml
+++ b/products.d/leap_micro_62.yaml
@@ -55,7 +55,6 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -132,7 +132,6 @@ security:
     selinux:
       patterns:
         - microos_selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/sles_160.yaml
+++ b/products.d/sles_160.yaml
@@ -106,7 +106,6 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/sles_sap_160.yaml
+++ b/products.d/sles_sap_160.yaml
@@ -80,7 +80,6 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: permissive
     none:
       patterns: null
 

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -74,7 +74,6 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -129,7 +129,6 @@ security:
     selinux:
       patterns:
         - selinux
-      policy: enforcing
     none:
       patterns: null
 

--- a/service/lib/agama/security.rb
+++ b/service/lib/agama/security.rb
@@ -77,7 +77,7 @@ module Agama
     def write
       # at first clear previous kernel params
       selected = lsm_selected
-      selected.reset_kernel_params if selected
+      selected&.reset_kernel_params
 
       candidate = select_software_lsm
       return unless candidate

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 31 07:34:52 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Do not set selinux policy during installation and lets keep
+  defaults provided by packages
+  (bsc#1247046)
+
+-------------------------------------------------------------------
 Thu Jul 24 21:09:25 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Make encryption work with whole formatted devices (bsc#1246939).

--- a/service/test/agama/security_test.rb
+++ b/service/test/agama/security_test.rb
@@ -72,14 +72,17 @@ describe Agama::Security do
   before do
     allow(Y2Security::LSM::Config).to receive(:instance).and_return(lsm_config)
     allow(security).to receive(:software_client).and_return(software_client)
+    allow(Yast::Bootloader).to receive(:modify_kernel_params)
+    allow(lsm_config.selected).to receive(:reset_kernel_params)
+    allow(lsm_config.selected).to receive(:kernel_params)
   end
 
   describe "#write" do
     let(:selected) { apparmor }
 
     context "when the software proposal patterns includes the LSM patterns" do
-      it "saves the LSM configuration" do
-        expect(lsm_config).to receive(:save)
+      it "saves kernel parameters for the LSM configuration" do
+        expect(Yast::Bootloader).to receive(:modify_kernel_params)
         security.write
       end
     end
@@ -104,7 +107,12 @@ describe Agama::Security do
 
       it "fallback to the first LSM which patterns are included by the software proposal" do
         expect(lsm_config).to receive(:select).with("none")
-        expect(lsm_config).to receive(:save)
+        expect(Yast::Bootloader).to receive(:modify_kernel_params)
+        security.write
+      end
+
+      it "resets bootloader params for previous selection" do
+        expect(lsm_config.selected).to receive(:reset_kernel_params)
         security.write
       end
     end


### PR DESCRIPTION
## Problem

For SLES plan is to have selinux policy driven by rpm and agama overwrites it even if selinux policy that uses permissive is installed.

- https://trello.com/c/QdrVfr8F/5198-slesfor-sap-applications-160-p1-1247046-sles160-build1221incorrect-kernel-cmdline-security-generated-when-network-installation-w


## Solution

Do not set selinux policy and keep rpm defaults.


## Testing

- *Added a new unit test*
- *Tested manually*

