### PR TITLE
feat: add a client ID to be used in signals

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "url",
  "utoipa",
+ "uuid",
  "zbus",
 ]
 
@@ -4694,12 +4695,14 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.2",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -45,6 +45,7 @@ fluent-uri = { version = "0.3.2", features = ["serde"] }
 tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 tokio-native-tls = "0.3.1"
 percent-encoding = "2.3.1"
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/rust/agama-lib/src/auth.rs
+++ b/rust/agama-lib/src/auth.rs
@@ -216,7 +216,7 @@ impl Default for TokenClaims {
 }
 
 /// Identifies a client.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ClientId(Uuid);
 
 impl ClientId {

--- a/rust/agama-lib/src/auth.rs
+++ b/rust/agama-lib/src/auth.rs
@@ -56,6 +56,7 @@ use chrono::{Duration, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use uuid::Uuid;
 
 #[derive(Error, Debug)]
 #[error("Invalid authentication token: {0}")]
@@ -195,8 +196,10 @@ impl Display for AuthToken {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TokenClaims {
     pub exp: i64,
+    pub client_id: ClientId,
 }
 
+// FIXME: replace with TokenClaims::new, as it does not exist a "default" token.
 impl Default for TokenClaims {
     fn default() -> Self {
         let mut exp = Utc::now();
@@ -207,7 +210,18 @@ impl Default for TokenClaims {
 
         Self {
             exp: exp.timestamp(),
+            client_id: ClientId::new(),
         }
+    }
+}
+
+/// Identifies a client.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClientId(Uuid);
+
+impl ClientId {
+    pub fn new() -> Self {
+        ClientId(Uuid::new_v4())
     }
 }
 

--- a/rust/agama-lib/src/auth.rs
+++ b/rust/agama-lib/src/auth.rs
@@ -216,7 +216,7 @@ impl Default for TokenClaims {
 }
 
 /// Identifies a client.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClientId(Uuid);
 
 impl ClientId {

--- a/rust/agama-lib/src/http.rs
+++ b/rust/agama-lib/src/http.rs
@@ -22,7 +22,7 @@ mod base_http_client;
 pub use base_http_client::{BaseHTTPClient, BaseHTTPClientError};
 
 mod event;
-pub use event::Event;
+pub use event::{Event, EventPayload};
 
 mod websocket;
 pub use websocket::{WebSocketClient, WebSocketError};

--- a/rust/agama-lib/src/http/event.rs
+++ b/rust/agama-lib/src/http/event.rs
@@ -19,6 +19,7 @@
 // find current contact information at www.suse.com.
 
 use crate::{
+    auth::ClientId,
     jobs::Job,
     localization::model::LocaleConfig,
     manager::InstallationPhase,
@@ -42,6 +43,11 @@ use crate::issue::Issue;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum Event {
+    ClientConnected {
+        // FIXME: use #[serde(rename_all = "camelCase")]
+        #[serde(rename = "clientId")]
+        client_id: ClientId,
+    },
     L10nConfigChanged(LocaleConfig),
     LocaleChanged {
         locale: String,

--- a/rust/agama-lib/src/http/event.rs
+++ b/rust/agama-lib/src/http/event.rs
@@ -184,6 +184,50 @@ pub enum EventPayload {
     },
 }
 
+/// Makes it easier to create an event, reducing the boilerplate.
+///
+/// # Event without additional data
+///
+/// ```
+/// # use agama_lib::{event, http::EventPayload};
+/// let my_event = event!(ClientConnected);
+/// assert!(matches!(my_event.payload, EventPayload::ClientConnected));
+/// assert!(my_event.client_id.is_none());
+/// ```
+///
+/// # Event with some additional data
+///
+/// ```
+/// # use agama_lib::{event, http::EventPayload};
+/// let my_event = event!(LocaleChanged { locale: "es_ES".to_string() });
+/// assert!(matches!(
+///    my_event.payload,
+///    EventPayload::LocaleChanged { locale: _ }
+/// ));
+/// ```
+///
+/// # Adding the client ID
+///
+/// ```
+/// # use agama_lib::{auth::ClientId, event, http::EventPayload};
+/// let client_id = ClientId::new();
+/// let my_event = event!(ClientConnected, &client_id);
+/// assert!(matches!(my_event.payload, EventPayload::ClientConnected));
+/// assert!(my_event.client_id.is_some());
+/// ```
+///
+/// # Add the client ID to a complex event
+///
+/// ```
+/// # use agama_lib::{auth::ClientId, event, http::EventPayload};
+/// let client_id = ClientId::new();
+/// let my_event = event!(LocaleChanged { locale: "es_ES".to_string() }, &client_id);
+/// assert!(matches!(
+///    my_event.payload,
+///    EventPayload::LocaleChanged { locale: _ }
+/// ));
+/// assert!(my_event.client_id.is_some());
+/// ```
 #[macro_export]
 macro_rules! event {
     ($variant:ident) => {
@@ -204,38 +248,4 @@ macro_rules! event {
     ($variant:ident $inner:tt) => {
         agama_lib::http::Event::new(agama_lib::http::EventPayload::$variant $inner)
     };
-}
-
-#[cfg(test)]
-mod test {
-    use crate as agama_lib;
-    use crate::{auth::ClientId, http::EventPayload};
-
-    #[test]
-    fn test_event_macro() {
-        let subject = event!(ClientConnected);
-        assert!(matches!(subject.payload, EventPayload::ClientConnected));
-        assert!(subject.client_id.is_none());
-
-        let subject = event!(LocaleChanged {
-            locale: "es_ES".to_string()
-        });
-        assert!(matches!(
-            subject.payload,
-            EventPayload::LocaleChanged { locale: _ }
-        ));
-
-        let client_id = ClientId::new();
-        let subject = event!(ClientConnected, &client_id);
-        assert_eq!(subject.client_id, Some(client_id));
-
-        let client_id = ClientId::new();
-        let subject = event!(
-            LocaleChanged {
-                locale: "es_ES".to_string()
-            },
-            &client_id
-        );
-        assert_eq!(subject.client_id, Some(client_id));
-    }
 }

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -55,7 +55,9 @@ use std::collections::HashMap;
 use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::{
-    http::{BaseHTTPClient, BaseHTTPClientError, Event, WebSocketClient, WebSocketError},
+    http::{
+        BaseHTTPClient, BaseHTTPClientError, Event, EventPayload, WebSocketClient, WebSocketError,
+    },
     manager::{InstallationPhase, InstallerStatus},
     progress::Progress,
 };
@@ -223,16 +225,16 @@ impl Monitor {
     ///
     /// * `event`: Agama event.
     fn handle_event(&mut self, event: Event) {
-        match event {
-            Event::ProgressChanged { path, progress } => {
+        match event.payload {
+            EventPayload::ProgressChanged { path, progress } => {
                 self.status.update_progress(path, progress);
             }
-            Event::ServiceStatusChanged { service, status } => {
+            EventPayload::ServiceStatusChanged { service, status } => {
                 if service.as_str() == MANAGER_PROGRESS_OBJECT_PATH {
                     self.status.set_is_busy(status == 1);
                 }
             }
-            Event::InstallationPhaseChanged { phase } => {
+            EventPayload::InstallationPhaseChanged { phase } => {
                 self.status.set_phase(phase);
             }
             _ => {}

--- a/rust/agama-server/src/l10n/web.rs
+++ b/rust/agama-server/src/l10n/web.rs
@@ -26,7 +26,9 @@ use super::{
 };
 use crate::{error::Error, web::EventsSender};
 use agama_lib::{
-    error::ServiceError, http::Event, localization::model::LocaleConfig, localization::LocaleProxy,
+    error::ServiceError,
+    event,
+    localization::{model::LocaleConfig, LocaleProxy},
     proxies::LocaleMixinProxy as ManagerLocaleProxy,
 };
 use agama_locale_data::LocaleId;
@@ -160,10 +162,9 @@ async fn set_config(
         let locale_string = locale.to_string();
         state.manager_proxy.set_locale(&locale_string).await?;
         changes.ui_locale = Some(locale_string);
-
-        _ = state.events.send(Event::LocaleChanged {
+        _ = state.events.send(event!(LocaleChanged {
             locale: locale.to_string(),
-        });
+        }));
     }
 
     if let Some(ui_keymap) = &value.ui_keymap {
@@ -174,7 +175,7 @@ async fn set_config(
     if let Err(e) = update_dbus(&state.proxy, &changes).await {
         tracing::warn!("Could not synchronize settings in the localization D-Bus service: {e}");
     }
-    _ = state.events.send(Event::L10nConfigChanged(changes));
+    _ = state.events.send(event!(L10nConfigChanged(changes)));
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/rust/agama-server/src/manager/web.rs
+++ b/rust/agama-server/src/manager/web.rs
@@ -27,7 +27,7 @@
 
 use agama_lib::{
     error::ServiceError,
-    logs,
+    event, logs,
     manager::{FinishMethod, InstallationPhase, InstallerStatus, ManagerClient},
     proxies::Manager1Proxy,
 };
@@ -71,7 +71,7 @@ pub async fn manager_stream(
         .then(|change| async move {
             if let Ok(phase) = change.get().await {
                 match InstallationPhase::try_from(phase) {
-                    Ok(phase) => Some(Event::InstallationPhaseChanged { phase }),
+                    Ok(phase) => Some(event!(InstallationPhaseChanged { phase })),
                     Err(error) => {
                         tracing::warn!("Ignoring the installation phase change. Error: {}", error);
                         None

--- a/rust/agama-server/src/network/web.rs
+++ b/rust/agama-server/src/network/web.rs
@@ -21,7 +21,6 @@
 //! This module implements the web API for the network module.
 
 use crate::{error::Error, web::EventsSender};
-use agama_lib::http::Event;
 use anyhow::Context;
 use axum::{
     extract::{Path, State},
@@ -34,6 +33,7 @@ use uuid::Uuid;
 
 use agama_lib::{
     error::ServiceError,
+    event,
     network::{
         error::NetworkStateError,
         model::{AccessPoint, Connection, Device, GeneralState},
@@ -100,7 +100,8 @@ pub async fn network_service<T: Adapter + Send + Sync + 'static>(
         loop {
             match changes.recv().await {
                 Ok(message) => {
-                    if let Err(e) = events.send(Event::NetworkChange { change: message }) {
+                    let change = event!(NetworkChange { change: message });
+                    if let Err(e) = events.send(change) {
                         eprintln!("Could not send the event: {}", e);
                     }
                 }

--- a/rust/agama-server/src/questions/web.rs
+++ b/rust/agama-server/src/questions/web.rs
@@ -28,6 +28,7 @@
 use crate::error::Error;
 use agama_lib::{
     error::ServiceError,
+    event,
     http::Event,
     proxies::questions::{GenericQuestionProxy, QuestionWithPasswordProxy, QuestionsProxy},
     questions::model::{Answer, GenericQuestion, PasswordAnswer, Question, QuestionWithPassword},
@@ -274,11 +275,11 @@ pub async fn questions_stream(
     let add_stream = proxy
         .receive_interfaces_added()
         .await?
-        .then(|_| async move { Event::QuestionsChanged });
+        .then(|_| async move { event!(QuestionsChanged) });
     let remove_stream = proxy
         .receive_interfaces_removed()
         .await?
-        .then(|_| async move { Event::QuestionsChanged });
+        .then(|_| async move { event!(QuestionsChanged) });
     let stream = StreamExt::merge(add_stream, remove_stream);
     Ok(Box::pin(stream))
 }

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -25,7 +25,10 @@
 //! * `storage_service` which returns the Axum service.
 //! * `storage_stream` which offers an stream that emits the storage events coming from D-Bus.
 
+use std::sync::Arc;
+
 use agama_lib::{
+    auth::ClientId,
     error::ServiceError,
     storage::{
         model::{Action, Device, DeviceSid, ProposalSettings, ProposalSettingsPatch, Volume},
@@ -37,7 +40,7 @@ use anyhow::Context;
 use axum::{
     extract::{Query, State},
     routing::{get, post, put},
-    Json, Router,
+    Extension, Json, Router,
 };
 use iscsi::storage_iscsi_service;
 use serde::{Deserialize, Serialize};
@@ -218,7 +221,9 @@ async fn set_config(
 )]
 async fn get_config_model(
     State(state): State<StorageState<'_>>,
+    Extension(client_id): Extension<Arc<ClientId>>,
 ) -> Result<Json<Box<RawValue>>, Error> {
+    tracing::debug!("{client_id:?}");
     let config_model = state
         .client
         .get_config_model()

--- a/rust/agama-server/src/storage/web.rs
+++ b/rust/agama-server/src/storage/web.rs
@@ -30,6 +30,8 @@ use std::sync::Arc;
 use agama_lib::{
     auth::ClientId,
     error::ServiceError,
+    event,
+    http::Event,
     storage::{
         model::{Action, Device, DeviceSid, ProposalSettings, ProposalSettingsPatch, Volume},
         proxies::Storage1Proxy,
@@ -63,7 +65,6 @@ use crate::{
         ProgressClient, ProgressRouterBuilder,
     },
 };
-use agama_lib::http::Event;
 
 pub async fn storage_streams(dbus: zbus::Connection) -> Result<EventStreams, Error> {
     let mut result: EventStreams = vec![(
@@ -87,7 +88,7 @@ async fn devices_dirty_stream(dbus: zbus::Connection) -> Result<impl Stream<Item
         .await
         .then(|change| async move {
             if let Ok(value) = change.get().await {
-                return Some(Event::DevicesDirty { dirty: value });
+                return Some(event!(DevicesDirty { dirty: value }));
             }
             None
         })

--- a/rust/agama-server/src/storage/web/dasd/stream.rs
+++ b/rust/agama-server/src/storage/web/dasd/stream.rs
@@ -24,6 +24,7 @@ use std::{collections::HashMap, task::Poll};
 
 use agama_lib::{
     error::ServiceError,
+    event,
     http::Event,
     storage::{
         client::dasd::DASDClient,
@@ -137,19 +138,19 @@ impl DASDDeviceStream {
         match change {
             DBusObjectChange::Added(path, values) => {
                 let device = Self::update_device(cache, path, values)?;
-                Ok(Event::DASDDeviceAdded {
+                Ok(event!(DASDDeviceAdded {
                     device: device.clone(),
-                })
+                }))
             }
             DBusObjectChange::Changed(path, updated) => {
                 let device = Self::update_device(cache, path, updated)?;
-                Ok(Event::DASDDeviceChanged {
+                Ok(event!(DASDDeviceChanged {
                     device: device.clone(),
-                })
+                }))
             }
             DBusObjectChange::Removed(path) => {
                 let device = Self::remove_device(cache, path)?;
-                Ok(Event::DASDDeviceRemoved { device })
+                Ok(event!(DASDDeviceRemoved { device }))
             }
         }
     }
@@ -251,10 +252,10 @@ impl DASDFormatJobStream {
             );
         }
 
-        Some(Event::DASDFormatJobChanged {
+        Some(event!(DASDFormatJobChanged {
             job_id: path.to_string(),
             summary: format_summary,
-        })
+        }))
     }
 }
 

--- a/rust/agama-server/src/storage/web/iscsi.rs
+++ b/rust/agama-server/src/storage/web/iscsi.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 use agama_lib::{
     error::ServiceError,
+    event,
     http::Event,
     storage::{
         client::iscsi::{ISCSIAuth, ISCSIInitiator, ISCSINode, LoginResult},
@@ -104,7 +105,7 @@ fn handle_initiator_change(change: PropertiesChanged) -> Result<Option<Event>, S
     let changes = to_owned_hash(args.changed_properties())?;
     let name = get_optional_property(&changes, "InitiatorName")?;
     let ibft = get_optional_property(&changes, "IBFT")?;
-    Ok(Some(Event::ISCSIInitiatorChanged { ibft, name }))
+    Ok(Some(event!(ISCSIInitiatorChanged { ibft, name })))
 }
 
 #[derive(Clone)]

--- a/rust/agama-server/src/storage/web/iscsi/stream.rs
+++ b/rust/agama-server/src/storage/web/iscsi/stream.rs
@@ -22,6 +22,7 @@ use std::{collections::HashMap, task::Poll};
 
 use agama_lib::{
     error::ServiceError,
+    event,
     http::Event,
     storage::{ISCSIClient, ISCSINode},
 };
@@ -131,15 +132,15 @@ impl ISCSINodeStream {
         match change {
             DBusObjectChange::Added(path, values) => {
                 let node = Self::update_node(cache, path, values)?;
-                Ok(Event::ISCSINodeAdded { node: node.clone() })
+                Ok(event!(ISCSINodeAdded { node: node.clone() }))
             }
             DBusObjectChange::Changed(path, updated) => {
                 let node = Self::update_node(cache, path, updated)?;
-                Ok(Event::ISCSINodeChanged { node: node.clone() })
+                Ok(event!(ISCSINodeChanged { node: node.clone() }))
             }
             DBusObjectChange::Removed(path) => {
                 let node = Self::remove_node(cache, path)?;
-                Ok(Event::ISCSINodeRemoved { node })
+                Ok(event!(ISCSINodeRemoved { node }))
             }
         }
     }

--- a/rust/agama-server/src/storage/web/zfcp/stream.rs
+++ b/rust/agama-server/src/storage/web/zfcp/stream.rs
@@ -24,6 +24,7 @@ use std::{collections::HashMap, task::Poll};
 
 use agama_lib::{
     error::ServiceError,
+    event,
     http::Event,
     storage::{
         client::zfcp::ZFCPClient,
@@ -127,19 +128,19 @@ impl ZFCPDiskStream {
         match change {
             DBusObjectChange::Added(path, values) => {
                 let device = Self::update_device(cache, path, values)?;
-                Ok(Event::ZFCPDiskAdded {
+                Ok(event!(ZFCPDiskAdded {
                     device: device.clone(),
-                })
+                }))
             }
             DBusObjectChange::Changed(path, updated) => {
                 let device = Self::update_device(cache, path, updated)?;
-                Ok(Event::ZFCPDiskChanged {
+                Ok(event!(ZFCPDiskChanged {
                     device: device.clone(),
-                })
+                }))
             }
             DBusObjectChange::Removed(path) => {
                 let device = Self::remove_device(cache, path)?;
-                Ok(Event::ZFCPDiskRemoved { device })
+                Ok(event!(ZFCPDiskRemoved { device }))
             }
         }
     }
@@ -260,19 +261,19 @@ impl ZFCPControllerStream {
         match change {
             DBusObjectChange::Added(path, values) => {
                 let device = Self::update_device(cache, path, values)?;
-                Ok(Event::ZFCPControllerAdded {
+                Ok(event!(ZFCPControllerAdded {
                     device: device.clone(),
-                })
+                }))
             }
             DBusObjectChange::Changed(path, updated) => {
                 let device = Self::update_device(cache, path, updated)?;
-                Ok(Event::ZFCPControllerChanged {
+                Ok(event!(ZFCPControllerChanged {
                     device: device.clone(),
-                })
+                }))
             }
             DBusObjectChange::Removed(path) => {
                 let device = Self::remove_device(cache, path)?;
-                Ok(Event::ZFCPControllerRemoved { device })
+                Ok(event!(ZFCPControllerRemoved { device }))
             }
         }
     }

--- a/rust/agama-server/src/users/web.rs
+++ b/rust/agama-server/src/users/web.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 use agama_lib::{
     error::ServiceError,
+    event,
     http::Event,
     users::{model::RootPatchSettings, proxies::Users1Proxy, FirstUser, RootUser, UsersClient},
 };
@@ -54,7 +55,7 @@ struct UsersState<'a> {
 
 /// Returns streams that emits users related events coming from D-Bus.
 ///
-/// It emits the Event::RootPasswordChange, Event::RootSSHKeyChanged and Event::FirstUserChanged events.
+/// It emits the RootPasswordChange, RootSSHKeyChanged and FirstUserChanged events.
 ///
 /// * `connection`: D-Bus connection to listen for events.
 pub async fn users_streams(dbus: zbus::Connection) -> Result<EventStreams, Error> {
@@ -89,7 +90,7 @@ async fn first_user_changed_stream(
                     password: user.2,
                     hashed_password: user.3,
                 };
-                return Some(Event::FirstUserChanged(user_struct));
+                return Some(event!(FirstUserChanged(user_struct)));
             }
             None
         })
@@ -107,7 +108,7 @@ async fn root_user_changed_stream(
         .then(|change| async move {
             if let Ok(user) = change.get().await {
                 if let Ok(root) = RootUser::from_dbus(user) {
-                    return Some(Event::RootUserChanged(root));
+                    return Some(event!(RootUserChanged(root)));
                 }
             }
             None

--- a/rust/agama-server/src/web/common.rs
+++ b/rust/agama-server/src/web/common.rs
@@ -22,7 +22,7 @@
 
 use std::pin::Pin;
 
-use agama_lib::{error::ServiceError, proxies::ServiceStatusProxy};
+use agama_lib::{error::ServiceError, event, proxies::ServiceStatusProxy};
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
 use tokio_stream::{Stream, StreamExt};
@@ -115,10 +115,10 @@ pub async fn service_status_stream(
         .await
         .then(move |change| async move {
             if let Ok(status) = change.get().await {
-                Some(Event::ServiceStatusChanged {
+                Some(event!(ServiceStatusChanged {
                     service: destination.to_string(),
                     status,
-                })
+                }))
             } else {
                 None
             }

--- a/rust/agama-server/src/web/common/issues.rs
+++ b/rust/agama-server/src/web/common/issues.rs
@@ -36,7 +36,7 @@
 //! At this point, it only handles the issues that are exposed through D-Bus.
 
 use crate::web::EventsSender;
-use agama_lib::{http::Event, issue::Issue};
+use agama_lib::{event, http::Event, issue::Issue};
 use agama_utils::dbus::build_properties_changed_stream;
 use axum::{extract::State, routing::get, Json, Router};
 use std::collections::HashMap;
@@ -172,10 +172,10 @@ impl IssuesService {
 
         self.cache.insert(path.to_string(), issues.clone());
 
-        let event = Event::IssuesChanged {
+        let event = event!(IssuesChanged {
             path: path.to_string(),
             issues,
-        };
+        });
         self.events.send(event)?;
         Ok(())
     }

--- a/rust/agama-server/src/web/common/jobs.rs
+++ b/rust/agama-server/src/web/common/jobs.rs
@@ -22,6 +22,8 @@ use std::{collections::HashMap, pin::Pin, task::Poll};
 
 use agama_lib::{
     error::ServiceError,
+    event,
+    http::Event,
     jobs::{client::JobsClient, Job},
 };
 use agama_utils::{dbus::get_optional_property, property_from_dbus};
@@ -35,7 +37,6 @@ use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue};
 use crate::{
     dbus::{DBusObjectChange, DBusObjectChangesStream, ObjectsCache},
     error::Error,
-    web::Event,
 };
 
 /// Builds a router for the jobs objects.
@@ -162,15 +163,15 @@ impl JobsStream {
         match change {
             DBusObjectChange::Added(path, values) => {
                 let job = Self::update_job(cache, path, values)?;
-                Ok(Event::JobAdded { job: job.clone() })
+                Ok(event!(JobAdded { job: job.clone() }))
             }
             DBusObjectChange::Changed(path, updated) => {
                 let job = Self::update_job(cache, path, updated)?;
-                Ok(Event::JobChanged { job: job.clone() })
+                Ok(event!(JobChanged { job: job.clone() }))
             }
             DBusObjectChange::Removed(path) => {
                 let job = Self::remove_job(cache, path)?;
-                Ok(Event::JobRemoved { job })
+                Ok(event!(JobRemoved { job }))
             }
         }
     }

--- a/rust/agama-server/src/web/common/progress.rs
+++ b/rust/agama-server/src/web/common/progress.rs
@@ -37,6 +37,7 @@
 
 use crate::web::{event::log_event, EventsSender};
 use agama_lib::{
+    event,
     http::Event,
     progress::{Progress, ProgressSequence},
     proxies::{ProgressChanged, ProgressProxy},
@@ -170,10 +171,10 @@ impl ProgressService {
         };
         self.cache.insert(path.to_string(), sequence.clone());
 
-        let event = Event::ProgressChanged {
+        let event = event!(ProgressChanged {
             path: path.to_string(),
             progress,
-        };
+        });
         log_event(&event);
         self.events.send(event)?;
         Ok(())

--- a/rust/agama-server/src/web/ws.rs
+++ b/rust/agama-server/src/web/ws.rs
@@ -23,7 +23,7 @@
 use std::sync::Arc;
 
 use super::{state::ServiceState, EventsSender};
-use agama_lib::{auth::ClientId, http::Event};
+use agama_lib::auth::ClientId;
 use axum::{
     extract::{
         ws::{Message, WebSocket},
@@ -44,9 +44,7 @@ pub async fn ws_handler(
 async fn handle_socket(mut socket: WebSocket, events: EventsSender, client_id: Arc<ClientId>) {
     let mut rx = events.subscribe();
 
-    let conn_event = Event::ClientConnected {
-        client_id: client_id.as_ref().clone(),
-    };
+    let conn_event = agama_lib::event!(ClientConnected, client_id.as_ref());
     if let Ok(json) = serde_json::to_string(&conn_event) {
         _ = socket.send(Message::Text(json)).await;
     }


### PR DESCRIPTION
## Problem

This PR adds a client ID that can be used in signals, making it easy to find out who originated a change.

## Solution

Add an UUID as a client ID to the JWT. Any handler can access the client ID using the [Axum's Extension extractor](https://docs.rs/axum/latest/axum/struct.Extension.html). Accessing the client ID is easy (see 018478c).

## Testing

- *Tested manually*
