### PR TITLE
Log error when activation fails but continue

### DIFF
--- a/rust/agama-network/src/nm/adapter.rs
+++ b/rust/agama-network/src/nm/adapter.rs
@@ -130,6 +130,12 @@ impl Adapter for NetworkManagerAdapter<'_> {
             return Err(NetworkAdapterError::Write(anyhow!(e)));
         }
 
+        let devices = self
+            .client
+            .devices()
+            .await
+            .map_err(|e| NetworkAdapterError::Read(anyhow!(e)))?;
+
         for conn in ordered_connections(network) {
             let ctrl = conn
                 .controller

--- a/rust/agama-network/src/nm/client.rs
+++ b/rust/agama-network/src/nm/client.rs
@@ -297,6 +297,8 @@ impl<'a> NetworkManagerClient<'a> {
                 .map_err(NmError::FailedNmVersionParse)?,
         );
 
+        let devices = self.devices().await?;
+
         let path = if let Ok(proxy) = self.get_connection_proxy(conn.uuid).await {
             let original = proxy.get_settings().await?;
             let merged = merge_dbus_connections(&original, &new_conn)?;
@@ -305,6 +307,7 @@ impl<'a> NetworkManagerClient<'a> {
             } else {
                 UpdateFlags::InMemoryOnly
             };
+
             proxy
                 .update2(merged, persist as u32, Default::default())
                 .await?;
@@ -328,14 +331,44 @@ impl<'a> NetworkManagerClient<'a> {
         // FIXME: Do not like that an activation/deactivation could not apply the changes because of
         // a roolback when calling this method with an error.
         if conn.is_up() {
+            if let Some(interface) = &conn.interface {
+                for device in devices {
+                    if interface.to_string() == device.name {
+                        if let Some(device_conn) = device.connection {
+                            if device_conn != conn.id {
+                                tracing::info!(
+                                    "Disconnecting {} because the connection is {}",
+                                    &device_conn,
+                                    &conn.id,
+                                );
+                                self.disconnect_device(device.name).await?;
+                            }
+                        }
+                    }
+                }
+            }
+
             // FIXME: If it is a wireless and wireless is disabled it will fail, and if it is a
             // device which is not available it will also fail.
+
+            tracing::info!("Activating connection {}", &conn.id);
             self.activate_connection(path).await?;
         } else {
             if conn.is_down() || conn.is_removed() {
+                tracing::info!("Deactivating connection {}", &conn.id);
                 self.deactivate_connection(path).await?;
             }
         }
+        Ok(())
+    }
+
+    /// Disconnect the device with the given name.
+    pub async fn disconnect_device(&self, device: String) -> Result<(), NmError> {
+        let proxy = self.get_device_proxy(device.clone()).await?;
+        if let Err(e) = proxy.disconnect().await {
+            tracing::error!("Error disconnecting {}: {:?}", device, e);
+        }
+
         Ok(())
     }
 
@@ -374,9 +407,13 @@ impl<'a> NetworkManagerClient<'a> {
     async fn activate_connection(&self, path: OwnedObjectPath) -> Result<(), NmError> {
         let proxy = NetworkManagerProxy::new(&self.connection).await?;
         let root = ObjectPath::try_from("/").unwrap();
-        proxy
+        if let Err(e) = proxy
             .activate_connection(&path.as_ref(), &root, &root)
-            .await?;
+            .await
+        {
+            tracing::error!("Could not activate connection {}: {:?}", path, e);
+        }
+
         Ok(())
     }
 
@@ -409,6 +446,37 @@ impl<'a> NetworkManagerClient<'a> {
             .build()
             .await?;
         Ok(proxy)
+    }
+
+    async fn get_device_proxy(&self, name: String) -> Result<DeviceProxy, NmError> {
+        let proxy = NetworkManagerProxy::new(&self.connection).await?;
+        let mut device_path: Option<OwnedObjectPath> = None;
+        for path in &self.nm_proxy.get_all_devices().await? {
+            let proxy = DeviceProxy::builder(&self.connection)
+                .path(path.as_str())?
+                .build()
+                .await?;
+
+            if let Ok(device) = DeviceFromProxyBuilder::new(&self.connection, &proxy)
+                .build()
+                .await
+            {
+                if device.name == name {
+                    device_path = Some(path.to_owned());
+                }
+            } else {
+                tracing::warn!("Ignoring network device on path {}", &path);
+            }
+        }
+
+        if let Some(path) = device_path {
+            Ok(DeviceProxy::builder(&self.connection)
+                .path(path)?
+                .build()
+                .await?)
+        } else {
+            Err(NmError::InvalidDeviceName(name))
+        }
     }
 
     /// Retrieves the `org.freedesktop.NetworkManager.ActiveConnection` object

--- a/rust/agama-network/src/nm/error.rs
+++ b/rust/agama-network/src/nm/error.rs
@@ -48,6 +48,8 @@ pub enum NmError {
     UnsupporedWirelessMode(String),
     #[error("Missing connection information")]
     MissingConnectionSection,
+    #[error("Invalid device name: '{0}'")]
+    InvalidDeviceName(String),
     #[error("Invalid network UUID")]
     InvalidNetworkUUID(#[from] uuid::Error),
     #[error("Connection type not supported for '{0}'")]


### PR DESCRIPTION
## Problem

Currently the add_or_update_connection client method not only add_or_update a connection in NetworkManager but it also tries to activate or deactivate it based on the status property. The problem is that the activation could fail in some situations like:

  - The interface bind to the connection is not present.
  - The interface bind to the connection is already applying other connection.
  - In case of Wireless, wireless could be disabled by hardware.
  
.... and other cases.

When this happen it returns with an error and the write operation does a rollback to the checkpoint created before starting with the write.

## Solution

- When the activation or deactivation of a connection return an error it will be just logged in order to finish with the write of the connections.
- Before activating a connection, if it is bind to an specific interface which is applying a different connection then the device will be disconnected in order to be able to activate the latest one. Example, the default connection created by dracut which could be applied to multiple-connections.

## Testing

- https://trello.com/c/c7HAWvBz/5020-1245548-modifying-a-network-connection-binding-settings-does-not-apply-the-changes-to-the-active-connection

