### PR TITLE
Boot from the hard disk by default

### DIFF
--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -76,6 +76,9 @@ if [ -f (\$root)/boot/grub2/themes/$theme/theme.txt ];then
 fi
 terminal_input console
 terminal_output gfxterm
+menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
+  exit
+}
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
@@ -103,9 +106,6 @@ menuentry "Rescue System" --class os --unrestricted {
     linux (\$root)/boot/aarch64/loader/linux \${extra_cmdline} \${isoboot} $RESCUE_SYSTEM_BOOT_SETTINGS
     echo Loading initrd...
     initrd (\$root)/boot/aarch64/loader/initrd
-}
-menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
-  exit
 }
 if [ -f "/.snapshots/grub-snapshot.cfg" ]; then
     source "/.snapshots/grub-snapshot.cfg"

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -76,6 +76,17 @@ if [ -f (\$root)/boot/grub2/themes/$theme/theme.txt ];then
 fi
 terminal_input console
 terminal_output gfxterm
+menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
+  if search --no-floppy --file /efi/boot/fallback.efi --set ; then
+    for os in opensuse sles leap suse; do
+      if [ -f /efi/\$os/grub.efi ] ; then
+        chainloader /efi/\$os/grub.efi
+        boot
+      fi
+    done
+  fi
+  exit
+}
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
@@ -104,17 +115,7 @@ menuentry "Rescue System" --class os --unrestricted {
     echo Loading initrd...
     initrd (\$root)/boot/x86_64/loader/initrd
 }
-menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
-  if search --no-floppy --file /efi/boot/fallback.efi --set ; then
-    for os in opensuse sles leap suse; do
-      if [ -f /efi/\$os/grub.efi ] ; then
-        chainloader /efi/\$os/grub.efi
-        boot
-      fi
-    done
-  fi
-  exit
-}
+
 if [ -f "/.snapshots/grub-snapshot.cfg" ]; then
     source "/.snapshots/grub-snapshot.cfg"
 fi

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 31 16:58:42 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Boot by default from disk to avoid endless loop in unattended
+  installation (bsc#1247438)
+
+-------------------------------------------------------------------
 Sun Jul 27 09:44:04 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Do not fail if there are no rpm scriptlets to clean


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1247438
- https://trello.com/c/9yAyyDZ1/1952-sles160-agama-live-iso-reboots-into-the-installer-again

The default option in grub menu is Install XXX. It has consequence that unattended installation where boot entry cannot be modified is still the same in endless loop.


## Solution

Use same behavior as SLES15 and have boot from hard disk first and default option.


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

<img width="650" height="478" alt="new_boot_order" src="https://github.com/user-attachments/assets/663099f2-7637-42ec-b801-5f6a8b8499da" />
