### PR TITLE
Decrease the Live ISO size

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -253,7 +253,9 @@ if [ -n "$python" ]; then
   echo "Python package: $python"
   python_deps=$(rpm -e "$python" 2>&1 || true)
   # avoid removing python accidentally because of some new unknown dependency
-  python_deps=$(echo "$python_deps" | grep -v -e "Failed dependencies" -e "needed by .* libpython" -e "needed by .* bcache-tools" -e "needed by .* xfsprogs" || true)
+  python_deps=$(echo "$python_deps" | grep -v -e "Failed dependencies" -e "needed by .* libpython" \
+    -e "needed by .* bcache-tools" -e "needed by .* xfsprogs" -e "needed by .* hyper-v" \
+    -e "needed by .* malcontent" -e "needed by .* gnome-shell" || true)
 
   if [ -z "$python_deps" ]; then
     echo "Removing Python..."
@@ -273,10 +275,10 @@ rm -f /usr/lib/zypper/commands/zypper-search-packages
 # delete some FireFox audio codec support
 rm -f /usr/lib64/firefox/libmozavcodec.so
 
-# uninstall libyui-qt and libqt (pulled in by the YaST dependencies),
+# uninstall the libyui packages (pulled in by the YaST dependencies),
 # not present in SLES, do not fail if not installed
-if rpm -q --whatprovides libyui-qt libyui-qt-pkg > /dev/null; then
-  rpm -q --whatprovides libyui-qt libyui-qt-pkg | xargs rpm -e --nodeps
+if rpm -q --whatprovides libyui-ncurses libyui-qt libyui-qt-pkg > /dev/null; then
+   rpm -q --whatprovides libyui-ncurses libyui-qt libyui-qt-pkg | xargs rpm -e --nodeps
 fi
 rpm -qa | grep ^libQt | xargs --no-run-if-empty rpm -e --nodeps
 
@@ -284,6 +286,32 @@ rpm -qa | grep ^libQt | xargs --no-run-if-empty rpm -e --nodeps
 #
 # Agama does not use sound, added by icewm dependencies
 rpm -e --nodeps alsa alsa-utils alsa-ucm-conf || true
+
+# Delete additional unused packages to decrease the image size
+delete_packages=(
+  dconf libdconf1
+  iso-codes
+  gtk4-tools
+  gnome-control-center
+  gnome-themes-accessibility
+  gweather4-data
+  libavcodec61
+  libvpx11
+  libavutil59
+  librav1e0_8
+)
+
+for package in "${delete_packages[@]}"
+do
+  rpm -e --nodeps "$package" || true
+done
+
+# remove gstreamer and libraries
+rpm -qa | grep -e ^libgst -e ^gstreamer | xargs --no-run-if-empty rpm -e --nodeps
+
+# remove some big files
+rm -f /usr/bin/jsonnet-lint
+rm -f /usr/lib64/firefox/crashreporter
 
 # driver and firmware cleanup
 # Note: openSUSE Tumbleweed Live completely removes firmware for some server


### PR DESCRIPTION
## Problem

- After switching to Wayland and Gnome kiosk the Live ISO size increased significantly

## Solution

- Delete some not needed packages or individual big files 
- Unfortunately most of them are pulled in by some dependencies so they need to be deleted by force (ignoring dependencies)
- It turned out that using the `patternType="onlyRequired"` option in the Kiwi file as [suggested here](https://github.com/agama-project/agama/compare/kiwi-only-required?expand=1) does not change anything. (Probably it applies only to patterns, but we install Wayland and Gnome kiosk as individual packages, we do not use a pattern for that.)

## Result

- The image size decreased from 693MB to 662MB, saving about 31MB (-4.5%).
- We can apply only a subset of the proposal if we consider some removal is dangerous.
-  Saved size for each individual part:
    - python: -11MB
    - libyui-ncurses: -1MB
    - iso-codes: -2MB
    - gtk4-tools: -2MB
    - gnome-control-center: -2MB
    - gnome-themes-accessibility: -2MB
    - gweather4-data: -1MB
    - codecs: -6MB
    - gstreamer: -3MB
    - jsonnet-lint: -3MB
    - Firefox crashreporter: -2MB

### Notes
- Due to rounding the sum of the saved parts do not exactly match the total saved space, the numbers are only approximate.
- The numbers are for the x86_64 architecture, on the other architectures the numbers will be very likely different.

## Testing

- Tested manually, the built Live ISO still boots :smiley: 

