### PR TITLE
fix(storage): md raid checker

### DIFF
--- a/service/lib/agama/storage/config_checkers/md_raid.rb
+++ b/service/lib/agama/storage/config_checkers/md_raid.rb
@@ -274,7 +274,7 @@ module Agama
         # @param device [Y2Storage::BlkDevice]
         # @return [Issue, nil]
         def parent_reused_member_issue(device)
-          return false unless device.respond_to?(:partitionable)
+          return unless device.respond_to?(:partitionable)
 
           parent_config = find_config(device.partitionable)
           return unless parent_config&.filesystem

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug  5 14:01:23 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Fix MD RAID config checker to avoid generating a list of issues
+  including a false value (bsc#1247557, bsc#1247585).
+
+-------------------------------------------------------------------
 Thu Jul 31 07:34:52 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not set selinux policy during installation and lets keep

--- a/service/test/agama/storage/config_checkers/md_raid_test.rb
+++ b/service/test/agama/storage/config_checkers/md_raid_test.rb
@@ -306,5 +306,23 @@ describe Agama::Storage::ConfigCheckers::MdRaid do
         expect(subject.issues).to eq([])
       end
     end
+
+    context "if the reused MD RAID is valid" do
+      let(:scenario) { "md_disks.yaml" }
+
+      let(:config_json) do
+        {
+          mdRaids: [
+            { search: "/dev/md0" }
+          ]
+        }
+      end
+
+      before { solve_config }
+
+      it "does not report issues" do
+        expect(subject.issues).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

The config checker for MD RAIDs was generating a list of issues including a `false` value. Then, the code fails because the list of issues is expected to contain `Issue` objects.

* https://bugzilla.suse.com/show_bug.cgi?id=1247557
* https://bugzilla.suse.com/show_bug.cgi?id=1247585

## Solution

Fix the checker to avoid including `false`.

## Testing

- Added a new unit test
