### PR TITLE
fix DUD application in 99-agama-dud-apply.sh (jsc#PED-13262)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Aug  7 15:39:03 UTC 2025 - Steffen Winterfeldt <snwint@suse.com>
+
+- fix DUD application in 99-agama-dud-apply.sh (jsc#PED-13262)
+
+-------------------------------------------------------------------
 Thu Jul 31 16:58:42 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Boot by default from disk to avoid endless loop in unattended


### PR DESCRIPTION
## Problem

https://jira.suse.com/browse/PED-13262

Agama's driver update parser does not handle typical driver updates. The format is a bit more flexible than what the parser expects - see example below.

## Solution

Split `apply_dud_update` into `unpack_dud_update` (the unpacking part) and  `apply_dud_update` (the application part).
Run `apply_dud_update` also on the initrd root to catch any driver updates there.

## Bonus

Also look for (unpacked) driver updates contained in the initrd directly, matching SLE-15 behavior.

## Testing
- Tested manually

## DUD example, consisting of two individual DUDs

```
├── 03
│   └── linux
│       └── suse
│           ├── aarch64-sled16 -> x86_64-sled16
│           ├── aarch64-sles16 -> x86_64-sles16
│           ├── armv7l-sled16 -> x86_64-sled16
│           ├── armv7l-sles16 -> x86_64-sles16
│           ├── i386-sled16 -> x86_64-sled16
│           ├── i386-sles16 -> x86_64-sles16
│           ├── ia64-sled16 -> x86_64-sled16
│           ├── ia64-sles16 -> x86_64-sles16
│           ├── ppc-sled16 -> x86_64-sled16
│           ├── ppc-sles16 -> x86_64-sles16
│           ├── ppc64-sled16 -> x86_64-sled16
│           ├── ppc64-sles16 -> x86_64-sles16
│           ├── ppc64le-sled16 -> x86_64-sled16
│           ├── ppc64le-sles16 -> x86_64-sles16
│           ├── s390-sled16 -> x86_64-sled16
│           ├── s390-sles16 -> x86_64-sles16
│           ├── s390x-sled16 -> x86_64-sled16
│           ├── s390x-sles16 -> x86_64-sles16
│           ├── x86_64-sled16
│           │   ├── dud.config
│           │   ├── inst-sys
│           │   │   └── foo
│           │   │       └── bar
│           │   └── install
│           │       ├── mkdud-1.55-160000.1.1.noarch.rpm
│           │       ├── update.post2
│           │       └── update.pre
│           └── x86_64-sles16 -> x86_64-sled16
└── linux
    └── suse
        └── x86_64-sles16
            ├── dud.config
            ├── inst-sys
            │   └── foo
            │       └── bar
            └── install
                ├── mkdud-1.55-160000.1.1.noarch.rpm
                ├── update.post2
                └── update.pre
```