### PR TITLE
Retry registration when a network error happens during autoinstallation

### DIFF
--- a/rust/agama-lib/src/product/http_client.rs
+++ b/rust/agama-lib/src/product/http_client.rs
@@ -30,7 +30,7 @@ pub enum ProductHTTPClientError {
     #[error(transparent)]
     HTTP(#[from] BaseHTTPClientError),
     #[error("Registration failed: {0}")]
-    FailedRegistration(String),
+    FailedRegistration(String, Option<u32>),
 }
 
 pub struct ProductHTTPClient {
@@ -113,15 +113,18 @@ impl ProductHTTPClient {
             return Ok(());
         };
 
+        let mut id: Option<u32> = None;
+
         let message = match error {
             BaseHTTPClientError::BackendError(_, details) => {
                 let details: RegistrationError = serde_json::from_str(&details).unwrap();
+                id = Some(details.id);
                 format!("{} (error code: {})", details.message, details.id)
             }
             _ => format!("Could not register the product: #{error:?}"),
         };
 
-        Err(ProductHTTPClientError::FailedRegistration(message))
+        Err(ProductHTTPClientError::FailedRegistration(message, id))
     }
 
     /// register addon
@@ -143,15 +146,18 @@ impl ProductHTTPClient {
             return Ok(());
         };
 
+        let mut id: Option<u32> = None;
+
         let message = match error {
             BaseHTTPClientError::BackendError(_, details) => {
                 println!("Details: {:?}", details);
                 let details: RegistrationError = serde_json::from_str(&details).unwrap();
+                id = Some(details.id);
                 format!("{} (error code: {})", details.message, details.id)
             }
             _ => format!("Could not register the addon: #{error:?}"),
         };
 
-        Err(ProductHTTPClientError::FailedRegistration(message))
+        Err(ProductHTTPClientError::FailedRegistration(message, id))
     }
 }

--- a/rust/agama-lib/src/product/http_client.rs
+++ b/rust/agama-lib/src/product/http_client.rs
@@ -29,6 +29,7 @@ use super::settings::AddonSettings;
 pub enum ProductHTTPClientError {
     #[error(transparent)]
     HTTP(#[from] BaseHTTPClientError),
+    // If present, the number is already printed in the String part
     #[error("Registration failed: {0}")]
     FailedRegistration(String, Option<u32>),
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug  6 15:37:52 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Automatically retry registration when a network error happens
+  during autoinstallation (bsc#1246990)
+
+-------------------------------------------------------------------
 Mon Aug  4 09:29:29 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not return an Err when a connection is not activated or 


### PR DESCRIPTION
## Problem

- In most cases the network is already configured when Agama starts.
- But in some rare scenarios the network needs to be configured from the installation profile itself to get it running.
- The problem is that the NetworkManager configures the network asynchronously (in backgroung), at the point when the system is being registered the network might not be configured yet and the registration fails.
- https://bugzilla.suse.com/show_bug.cgi?id=1246990

<img width="1282" height="145" alt="image" src="https://github.com/user-attachments/assets/70ea4bf9-023d-4639-b4f9-f9a72bf34283" />

## Solution

- Pass the registration error details (the error code) from the HTTP client
- The CLI tool then checks the error code and if it is a network error or a timeout then it tries the registration again after a small delay (4 attempts with exponential backoff: 2,4,8,16 second delays)
- The Web UI is not changed, it fails immediately without any retry. If a retry is needed user can just press the button again.

<img width="1280" height="210" alt="image" src="https://github.com/user-attachments/assets/be345880-24b8-4a27-8151-fc93ce6b4e53" />


## Testing

- Tested manually
