### PR TITLE
User patterns selection

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -195,12 +195,10 @@
       "type": "object",
       "properties": {
         "patterns": {
-          "title": "List of patterns to install",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "examples": ["minimal_base"]
-          }
+          "anyOf": [
+            { "$ref": "#/$defs/patternsArray" },
+            { "$ref": "#/$defs/patternsObject" }
+          ]
         },
         "packages": {
           "title": "List of packages to install",
@@ -1004,6 +1002,26 @@
           "description": "Additional data for matching questions and answers",
           "type": "object",
           "examples": [{ "device": "/dev/sda" }]
+        }
+      }
+    },
+    "patternsArray": {
+      "title": "List of user-selected patterns to install",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "examples": ["minimal_base"]
+      }
+    },
+    "patternsObject": {
+      "title": "Modifications for the list of user-selected patterns to install",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "add": {
+          "title": "List of user-selected patterns to add to the list",
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     }

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1022,6 +1022,11 @@
           "title": "List of user-selected patterns to add to the list",
           "type": "array",
           "items": { "type": "string" }
+        },
+        "remove": {
+          "title": "List of user-selected patterns to remove from the list",
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     }

--- a/rust/agama-lib/src/software/settings.rs
+++ b/rust/agama-lib/src/software/settings.rs
@@ -32,7 +32,7 @@ use super::model::RepositoryParams;
 pub struct SoftwareSettings {
     /// List of user selected patterns to install.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub patterns: Option<PatternsDefinition>,
+    pub patterns: Option<PatternsSettings>,
     /// List of user selected packages to install.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packages: Option<Vec<String>>,
@@ -44,26 +44,28 @@ pub struct SoftwareSettings {
     pub only_required: Option<bool>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum PatternsSettings {
+    PatternsList(Vec<String>),
+    PatternsMap(PatternsMap),
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
-pub struct PatternsDefinition {
+pub struct PatternsMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub add: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remove: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub set: Option<Vec<String>>,
 }
 
-impl From<Vec<String>> for PatternsDefinition {
+impl From<Vec<String>> for PatternsSettings {
     fn from(list: Vec<String>) -> Self {
-        PatternsDefinition {
-            set: Some(list),
-            ..Default::default()
-        }
+        Self::PatternsList(list)
     }
 }
 
-impl From<HashMap<String, Vec<String>>> for PatternsDefinition {
+impl From<HashMap<String, Vec<String>>> for PatternsSettings {
     fn from(map: HashMap<String, Vec<String>>) -> Self {
         let add = if let Some(to_add) = map.get("add") {
             Some(to_add.to_owned())
@@ -77,11 +79,7 @@ impl From<HashMap<String, Vec<String>>> for PatternsDefinition {
             None
         };
 
-        PatternsDefinition {
-            add,
-            remove,
-            set: None,
-        }
+        Self::PatternsMap(PatternsMap { add, remove })
     }
 }
 

--- a/rust/agama-lib/src/software/settings.rs
+++ b/rust/agama-lib/src/software/settings.rs
@@ -20,6 +20,8 @@
 
 //! Representation of the software settings
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::model::RepositoryParams;
@@ -30,7 +32,7 @@ use super::model::RepositoryParams;
 pub struct SoftwareSettings {
     /// List of user selected patterns to install.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub patterns: Option<Vec<String>>,
+    pub patterns: Option<PatternsDefinition>,
     /// List of user selected packages to install.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packages: Option<Vec<String>>,
@@ -40,6 +42,47 @@ pub struct SoftwareSettings {
     /// Flag indicating if only hard requirements should be used by solver.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub only_required: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct PatternsDefinition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub add: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remove: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub set: Option<Vec<String>>,
+}
+
+impl From<Vec<String>> for PatternsDefinition {
+    fn from(list: Vec<String>) -> Self {
+        PatternsDefinition {
+            set: Some(list),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<HashMap<String, Vec<String>>> for PatternsDefinition {
+    fn from(map: HashMap<String, Vec<String>>) -> Self {
+        let add = if let Some(to_add) = map.get("add") {
+            Some(to_add.to_owned())
+        } else {
+            None
+        };
+
+        let remove = if let Some(to_remove) = map.get("remove") {
+            Some(to_remove.to_owned())
+        } else {
+            None
+        };
+
+        PatternsDefinition {
+            add,
+            remove,
+            set: None,
+        }
+    }
 }
 
 impl SoftwareSettings {

--- a/rust/agama-lib/src/software/store.rs
+++ b/rust/agama-lib/src/software/store.rs
@@ -155,9 +155,13 @@ mod test {
 
         let store = software_store(url);
         let settings = store.load().await?;
+        let patterns_definition = PatternsDefinition {
+            set: Some(vec!["xfce".to_owned()]),
+            ..Default::default()
+        };
 
         let expected = SoftwareSettings {
-            patterns: Some(vec!["xfce".to_owned()]),
+            patterns: Some(patterns_definition),
             packages: Some(vec!["vim".to_owned()]),
             extra_repositories: None,
             only_required: None,
@@ -184,8 +188,13 @@ mod test {
         let url = server.url("/api");
 
         let store = software_store(url);
+        let patterns_definition = PatternsDefinition {
+            set: Some(vec!["xfce".to_owned()]),
+            ..Default::default()
+        };
+
         let settings = SoftwareSettings {
-            patterns: Some(vec!["xfce".to_owned()]),
+            patterns: Some(patterns_definition),
             packages: Some(vec!["vim".to_owned()]),
             extra_repositories: None,
             only_required: None,
@@ -215,8 +224,12 @@ mod test {
         let url = server.url("/api");
 
         let store = software_store(url);
+        let patterns_definition = PatternsDefinition {
+            set: Some(vec!["no_such_pattern".to_owned()]),
+            ..Default::default()
+        };
         let settings = SoftwareSettings {
-            patterns: Some(vec!["no_such_pattern".to_owned()]),
+            patterns: Some(patterns_definition),
             packages: Some(vec!["vim".to_owned()]),
             extra_repositories: None,
             only_required: None,

--- a/rust/agama-network/src/nm/adapter.rs
+++ b/rust/agama-network/src/nm/adapter.rs
@@ -130,12 +130,6 @@ impl Adapter for NetworkManagerAdapter<'_> {
             return Err(NetworkAdapterError::Write(anyhow!(e)));
         }
 
-        let devices = self
-            .client
-            .devices()
-            .await
-            .map_err(|e| NetworkAdapterError::Read(anyhow!(e)))?;
-
         for conn in ordered_connections(network) {
             let ctrl = conn
                 .controller

--- a/rust/agama-network/src/nm/model.rs
+++ b/rust/agama-network/src/nm/model.rs
@@ -282,11 +282,3 @@ impl fmt::Display for NmMethod {
         write!(f, "{}", &self.0)
     }
 }
-
-#[derive(Debug, Default, PartialEq)]
-pub struct NmIp4Config {
-    pub addresses: Vec<(String, u32)>,
-    pub nameservers: Vec<String>,
-    pub gateway: Option<String>,
-    pub method: NmMethod,
-}

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -602,7 +602,7 @@ async fn set_config(
     Json(config): Json<SoftwareConfig>,
 ) -> Result<(), Error> {
     {
-        // first invalidate cache, so it if failed later, we know we need to re-read recent data
+        // first invalidate cache, so if it fails later, we know we need to re-read recent data
         // use minimal context so it is released soon.
         let mut cached_config_invalidate = state.config.write().await;
         *cached_config_invalidate = None;

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug  7 11:47:55 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Allow to "add" or "remove" patterns from the current or defined
+  user selection patterns list (bsc#1247456).
+
+-------------------------------------------------------------------
 Wed Aug  6 12:52:41 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Emit HTTP event when storage is configured, including the client
@@ -9,7 +15,7 @@ Mon Aug  4 09:29:29 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not return an Err when a connection is not activated or 
   deactivated when adding or updating it but just log the error
-  and write the connections profiles (bs#1245548).
+  and write the connections profiles (bsc#1245548).
 
 -------------------------------------------------------------------
 Fri Aug  1 10:10:40 UTC 2025 - Martin Vidner <mvidner@suse.com>


### PR DESCRIPTION
## Problem

The list of patterns included in the profile will replace the whole list of patterns to install (except those that are mandatory). It would be nice to be able to modify the list of patterns without having to set it entirely.

- https://trello.com/c/NNkJVdwD/5204-3-sles160-adding-patterns-instead-of-replacing-the-list
- https://bugzilla.suse.com/show_bug.cgi?id=1247456

## Solution

Allow to add or remove patterns from the user patterns selection apart of set it completely.

## Testing

- *Tested manually*

```bash
$ cat software.json
{
  "software": {
    "patterns": {
      "remove": ["selinux"]
    }
  }
}
$ agama config load software.json
✓ The profile is valid.
$ cat software.json
{
  "software": {
    "patterns": {
      "add": ["selinux"]
    }
  }
}
$ agama config load software.json
✓ The profile is valid.
$ agama config show 
{
  ...
  "software": {
    "patterns": [
      "selinux"
    ],
    "packages": []
  },
  ...
}
```

<img width="1090" height="842" alt="Screenshot From 2025-08-08 12-02-03" src="https://github.com/user-attachments/assets/b9ef855e-306b-4cf5-b5d1-05c20d420ba7" />
<img width="1090" height="842" alt="Screenshot From 2025-08-08 12-02-45" src="https://github.com/user-attachments/assets/f33b68c7-0461-4743-b571-6c9b545b5e1e" />
