### PR TITLE
fix(web): allow adding /boot/efi

### DIFF
--- a/web/src/helpers/storage/api-model.ts
+++ b/web/src/helpers/storage/api-model.ts
@@ -76,6 +76,7 @@ function buildLogicalVolume(data: data.LogicalVolume): apiModel.LogicalVolume {
 function buildPartition(data: data.Partition): apiModel.Partition {
   return {
     ...data,
+    id: data.mountPath === "/boot/efi" ? "esp" : undefined,
     filesystem: buildFilesystem(data.filesystem),
     size: buildSize(data.size),
   };


### PR DESCRIPTION
## Problem

The UI does not allow adding a */boot/efi* partition using the correct partition id (ESP). 

## Solution

Automatically add the partition id for */boot/efi*.

Note: the UI is losing the partition ids coming from the model, but it is something we need to fix for all partitions.
