### PR TITLE
fix(live): fix handling of local DUDs

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 11 09:42:22 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix handling of Driver Update Disks when they are placed in local
+  file systems (bsc#1247682, bsc#1247776).
+
+-------------------------------------------------------------------
 Thu Aug  7 15:39:03 UTC 2025 - Steffen Winterfeldt <snwint@suse.com>
 
 - fix DUD application in 99-agama-dud-apply.sh (jsc#PED-13262)
@@ -13,7 +19,7 @@ Thu Jul 31 16:58:42 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 Sun Jul 27 09:44:04 UTC 2025 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
 
 - Do not fail if there are no rpm scriptlets to clean
-  (gh#agama-project/agama#2617). 
+  (gh#agama-project/agama#2617).
 
 -------------------------------------------------------------------
 Wed Jul 23 14:18:38 UTC 2025 - José Iván López González <jlopez@suse.com>


### PR DESCRIPTION
## Problem

- [bsc#1247776](https://bugzilla.suse.com/show_bug.cgi?id=1247776)
- [bsc#1247682](https://bugzilla.suse.com/show_bug.cgi?id=1247682)

It is not possible to load a Driver Update from a local device.

## Solution

To avoid adding more stuff to the initrd, we are running the commands to apply a DUD from the `/sysroot`. However, that was not the case with the `agama download` command.

This PR fixes the invocation of the `agama download` command. To make it work, we need to mount the `/dev` and `/sys` file systems too.

## Testing

- Tested manually
