### PR TITLE
fix(rust): fix set_config_locales test

### DIFF
--- a/rust/agama-server/tests/l10n.rs
+++ b/rust/agama-server/tests/l10n.rs
@@ -107,6 +107,9 @@ async fn test_timezones() -> Result<(), Box<dyn Error>> {
 // FIXME: temporarily skip the test in CI
 #[cfg(not(ci))]
 async fn test_set_config_locales() -> Result<(), Box<dyn Error>> {
+    use agama_lib::auth::ClientId;
+    use std::sync::Arc;
+
     let dbus_server = DBusServer::new().start().await?;
     let service = build_service(dbus_server.connection()).await;
 
@@ -114,6 +117,7 @@ async fn test_set_config_locales() -> Result<(), Box<dyn Error>> {
     let body = Body::from(content);
     let request = Request::patch("/config")
         .header("Content-Type", "application/json")
+        .extension(Arc::new(ClientId::new()))
         .body(body)?;
     let response = service.clone().oneshot(request).await?;
     assert_eq!(response.status(), StatusCode::NO_CONTENT);


### PR DESCRIPTION
## Problem

After introducing the [client ID](https://github.com/agama-project/agama/pull/2627), the `test_set_config_locales` does not work anymore.

## Solution

Add the extension to the request. It should fix [bsc#1247744](https://bugzilla.suse.com/show_bug.cgi?id=1247744).


## Testing

- Added a new unit test
- Tested manually
