### PR TITLE
allow to set bootloader and files section without specified product

### DIFF
--- a/rust/agama-lib/src/store.rs
+++ b/rust/agama-lib/src/store.rs
@@ -250,7 +250,6 @@ impl Store {
             self.storage.store(&settings.into()).await?
         }
         if let Some(bootloader) = &settings.bootloader {
-            Store::ensure_selected_product(is_product_selected)?;
             self.bootloader.store(bootloader).await?;
         }
         if let Some(hostname) = &settings.hostname {
@@ -258,7 +257,6 @@ impl Store {
             self.hostname.store(hostname).await?;
         }
         if let Some(files) = &settings.files {
-            Store::ensure_selected_product(is_product_selected)?;
             self.files.store(files).await?;
         }
 


### PR DESCRIPTION
## Problem

openQA is using bootloader section together with pre-script to setup environment for agama including interactive one which does not define product in profile and instead clicking on it. This is not possible as bootloader section require specified product.

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1247248

## Solution

Allow to set bootloader and also files section as they are not affected by product selection.