### PR TITLE
Fix the variable field in JSonnet example

### DIFF
--- a/rust/agama-lib/share/examples/post-script.jsonnet
+++ b/rust/agama-lib/share/examples/post-script.jsonnet
@@ -15,7 +15,7 @@
       {
         name: 'enable-sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/bin/bash
           systemctl enable sshd
         |||,


### PR DESCRIPTION
## Problem

The [post-script.jsonnet](https://github.com/agama-project/agama/blob/8db0ce2ea37b2ef4af82e40a9ce7c342a2a3a34e/rust/agama-lib/share/examples/post-script.jsonnet) examples does not validate.

- See #2662

## Solution

Use `content` instead of the deprecated `body`.

## Testing

- *Tested manually*