### PR TITLE
Drop YaST logic to identify some software RAIDs as bootable

### DIFF
--- a/service/lib/agama/storage/config_conversions/from_model_conversions/with_encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/with_encryption.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_conversions/from_model_conversions/encryption"
+require "agama/storage/model_refuse_encryption"
 
 module Agama
   module Storage
@@ -27,6 +28,8 @@ module Agama
       module FromModelConversions
         # Mixin for encryption conversion.
         module WithEncryption
+          include ModelRefuseEncryption
+
           # @return [Configs::Encryption, nil]
           def convert_encryption
             # Do not encrypt a device that is not really going to be used
@@ -35,9 +38,20 @@ module Agama
             # Do not encrypt a reused device
             return if model_json[:name] && model_json.dig(:filesystem, :reuse)
 
+            # Do not encrypt partitions that would become useless if encrypted
+            return if refuse_encryption?
+
             return if encryption_model.nil?
 
             FromModelConversions::Encryption.new(encryption_model).convert
+          end
+
+          # @return [Boolean]
+          def refuse_encryption?
+            path = model_json[:mountPath]
+            return false unless path
+
+            refuse_encryption_path?(path)
           end
         end
       end

--- a/service/lib/agama/storage/model_refuse_encryption.rb
+++ b/service/lib/agama/storage/model_refuse_encryption.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "pathname"
+
+module Agama
+  module Storage
+    # Temporary mixin to prevent encrypting partitions that would become useless if encrypted.
+    #
+    # This module will be needed as long as the user UI does not provide a way to fine-tune
+    # encryption per partition.
+    module ModelRefuseEncryption
+      # Filesystems created on these paths should never be encrypted.
+      #
+      # The case of /boot/efi and /boot/zipl are clear, encrypting those partitions means
+      # the firmware cannot read the content.
+      #
+      # The case of /boot is more debatable, but users specifying a separate /boot very likely
+      # want that filesystem to be as "plain" as possible (no encryption, no LVM, etc.). That's,
+      # after all, the main reason to separate /boot.
+      PATHS = ["/boot/efi", "/boot/zipl", "/boot"].freeze
+      private_constant :PATHS
+
+      # Whether the model should prevent encryption for the given mount path
+      #
+      # @param path [String, Pathname]
+      # @return [Boolean]
+      def refuse_encryption_path?(path)
+        PATHS.include?(Pathname.new(path).cleanpath.to_s)
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/model_support_checker.rb
+++ b/service/lib/agama/storage/model_support_checker.rb
@@ -19,6 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/storage/model_refuse_encryption"
+
 module Agama
   module Storage
     # Class for checking whether a config is supported by the config model.
@@ -26,6 +28,8 @@ module Agama
     # Features will be added to the config model little by little. Ideally, this class will
     # dissapear once the model supports all the features provided by the config.
     class ModelSupportChecker
+      include ModelRefuseEncryption
+
       # @note A solved config is expected. Otherwise some checks cannot be done reliably.
       #
       # @param config [Storage::Config]
@@ -223,6 +227,7 @@ module Agama
           .reject(&:encryption)
           .select(&:filesystem)
           .reject { |c| c.filesystem.reuse? }
+          .reject { |c| c.filesystem.path && refuse_encryption_path?(c.filesystem.path) }
           .any?
       end
 

--- a/service/lib/agama/storage/system.rb
+++ b/service/lib/agama/storage/system.rb
@@ -79,15 +79,17 @@ module Agama
       # All mdRaid devices that are considered as a valid target for the boot partitions and,
       # as such, as candidates for a typical installation.
       #
-      # Although it could diverge in the future, this relies in the historical YaST heuristics
-      # that considers software RAIDs with partition table or without children as candidates for
-      # installation, but only when booting in EFI mode.
+      # Technically, it makes no sense to consider any software RAID as a candidate. But for
+      # historical reasons (check Y2Storage::DiskAnalyzer for background), YaST considers some
+      # software RAIDs as candidates when booting in EFI mode.
       #
-      # Check Y2Storage::DiskAnalyzer for some historical background.
+      # After checking with the involved SUSE partners, we decided Agama does not need to
+      # inherit that behavior. If needed, the variable LIBSTORAGE_MDPART can still be used to
+      # consider software RAIDs as BIOS-based RAIDs.
       #
       # @return [Array<Y2Storage::Md>]
       def candidate_md_raids
-        available_md_raids.select { |r| analyzer.supports_boot_partitions?(r) }
+        available_md_raids.reject { |r| r.is?(:software_raid) }
       end
 
       # Whether the device is usable as drive or mdRaid
@@ -107,7 +109,7 @@ module Agama
       # @param device [Y2Storage::Partitionable, Y2Storage::Md]
       # @return [Boolean]
       def candidate?(device)
-        analyzer.supports_boot_partitions?(device) && available?(device)
+        available?(device) && device.is?(:disk_device)
       end
 
       # Devicegraph representing the system.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug 20 10:16:04 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Removed the heuristic that used to consider some software RAID as
+  bootable devices under some circumstances (bsc#1248195).
+- Ensure that /boot/efi and /boot/zipl partitions created using the
+  web UI are never encrypted (bsc#1248189, bsc#1247447).
+
+-------------------------------------------------------------------
 Thu Aug  7 10:57:30 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Do not use 'retry' as default answer for questions (bsc#1247436).

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -487,6 +487,50 @@ describe Agama::Storage::ModelSupportChecker do
       end
     end
 
+    context "if the config includes encryption for everything except an arbitrary partition" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: [
+                { filesystem: { path: "/home" } },
+                {
+                  encryption: { luks1: { password: "12345" } },
+                  filesystem: { path: "/" }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(subject.supported?).to eq(false)
+      end
+    end
+
+    context "if the config includes encryption for everything except /boot/zipl" do
+      let(:config_json) do
+        {
+          drives: [
+            {
+              partitions: [
+                { filesystem: { path: "/boot/zipl" } },
+                {
+                  encryption: { luks1: { password: "12345" } },
+                  filesystem: { path: "/" }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "returns true" do
+        expect(subject.supported?).to eq(true)
+      end
+    end
+
     context "if the config is totally supported" do
       let(:scenario) { "md_raids.yaml" }
 

--- a/service/test/agama/storage/configurator_test.rb
+++ b/service/test/agama/storage/configurator_test.rb
@@ -111,29 +111,30 @@ describe Agama::Storage::Configurator do
         expect(proposal).to_not receive(:calculate_from_json).with(storage_json)
       end
 
-      it "calculates a proposal using MD RAIDs first and then drives" do
-        expect_calculated(md0)
-        expect_calculated(md2)
+      it "calculates a proposal using drives and not considering software RAIDs" do
         expect_calculated(vda)
         expect_calculated(vdb)
         # Repeats the first config if everything fails.
-        expect_calculated(md0)
+        expect_calculated(vda)
+        expect_not_calculated(md0)
+        expect_not_calculated(md1)
+        expect_not_calculated(md2)
         subject.configure
       end
 
       context "if there are removable devices" do
         before do
           allow(vda).to receive(:usb?).and_return(true)
-          allow(md0).to receive(:sd_card?).and_return(true)
         end
 
         it "calculates a proposal using the removable devices as last resort" do
-          expect_calculated(md2)
           expect_calculated(vdb)
-          expect_calculated(md0)
           expect_calculated(vda)
           # Repeats the first config if everything fails.
-          expect_calculated(md2)
+          expect_calculated(vdb)
+          expect_not_calculated(md0)
+          expect_not_calculated(md1)
+          expect_not_calculated(md2)
           subject.configure
         end
       end
@@ -141,16 +142,14 @@ describe Agama::Storage::Configurator do
       context "if there are BOSS devices" do
         before do
           allow(vdb).to receive(:boss?).and_return(true)
-          allow(md0).to receive(:boss?).and_return(true)
         end
 
         it "calculates a proposal only for the BOSS devices" do
-          expect_calculated(md0)
           expect_calculated(vdb)
-          # Repeats the first config if everything fails.
-          expect_calculated(md0)
           expect_not_calculated(vda)
+          expect_not_calculated(md0)
           expect_not_calculated(md1)
+          expect_not_calculated(md2)
           subject.configure
         end
       end
@@ -160,10 +159,11 @@ describe Agama::Storage::Configurator do
         let(:max) { "50 GiB" }
 
         it "does not calculate a proposal for the rest of configs" do
-          expect_calculated(md0)
-          expect_calculated(md2)
-          expect_not_calculated(vda)
+          expect_calculated(vda)
           expect_not_calculated(vdb)
+          expect_not_calculated(md0)
+          expect_not_calculated(md1)
+          expect_not_calculated(md2)
           subject.configure
         end
       end

--- a/service/test/agama/storage/system_test.rb
+++ b/service/test/agama/storage/system_test.rb
@@ -38,7 +38,7 @@ describe Agama::Storage::System do
 
     it "includes all devices suitable for installation" do
       expect(subject.candidate_devices.map(&:name))
-        .to contain_exactly("/dev/vda", "/dev/vdb", "/dev/md0", "/dev/md1")
+        .to contain_exactly("/dev/vda", "/dev/vdb")
     end
   end
 
@@ -81,12 +81,8 @@ describe Agama::Storage::System do
   describe "#candidate_md_raids" do
     let(:scenario) { "md_raids.yaml" }
 
-    before do
-      allow(disk_analyzer).to receive(:supports_boot_partitions?) { |d| d.name == "/dev/md1" }
-    end
-
-    it "includes all MD RAIDs considered by Y2Storage as suitable for installation" do
-      expect(subject.candidate_md_raids.map(&:name)).to contain_exactly("/dev/md1")
+    it "returns an empty list if there are only software RAIDs" do
+      expect(subject.candidate_md_raids).to be_empty
     end
   end
 end

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 20 10:20:22 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Enforce ESP partition id for /boot/efi partitions manually
+  defined (bsc#1248189).
+
+-------------------------------------------------------------------
 Wed Aug 13 13:20:17 UTC 2025 - Jan Papež <honyczek@centrum.cz>
 
 - Fix messages about automatic storage sizes

--- a/web/src/helpers/storage/api-model.ts
+++ b/web/src/helpers/storage/api-model.ts
@@ -78,6 +78,9 @@ function buildPartition(data: data.Partition): apiModel.Partition {
     ...data,
     filesystem: buildFilesystem(data.filesystem),
     size: buildSize(data.size),
+    // Using the ESP partition id for /boot/efi may not be strictly required, but it is
+    // a good practice. Let's force it here since it cannot be selected in the UI.
+    id: data.mountPath === "/boot/efi" ? "esp" : undefined,
   };
 }
 


### PR DESCRIPTION
## Problem 1

YaST includes some heuristic to identify certain software-defined MD RAID devices as bootable devices under some circumstances. That has always been controversial and a source for bug reports, but it was done that way to please a SUSE partner shipping some RAID controllers that were a bit special (kind of an hybrid between software and firmware based).

That behavior was inherited by Agama and is causing confusion on some testers. Since the UI is different, some testers are trying different things and finding the (strange) behavior that was always there. 

Fortunately, the partner confirmed last week that they not longer need the special logic at SLE-16 because they will not be supporting in the future the hardware that caused the logic to be introduced.

## Solution to problem 1

Removing that logic will hurt no-one and will save Agama (and SLE-16) from inheriting an historical SLE-15 problem.

If someone needs the (debatable) behavior back, it can be somehow reproduced by setting a special ENV variable during boot (`LIBSTORAGE_MDPART`). That variable is present and documented for YaST and all previous versions of (open)SUSE and is also honored by Agama.

## Problem 2

Sometimes users don't like the partitions proposed by Agama for booting (`/boot/efi` for EFI systems, `/boot/zipl` for s390x, etc.). Of course they can define their own partitions and Agama will not override their definitions. BUT...

While the Agama JSON configuration allows to tweak every aspect of the custom partitions, the web UI is more limited. For example, there is no way to exclude a particular partition from the encryption defined globaly or to specify the partition ID at the partition table.

## Solution to problem 2

Do small adjustments on the web UI. Even if encryption is globally enabled, the `/boot/efi` and `/boot/zipl` partitions will not be enabled because that makes no sense. In addition, the partition ID of `/boot/efi` is adjusted to always be ESP.

## Testing

- Adapted existing unit tests to reflect the new behavior
- Added new unit tests
- Tested manually on a new installation