### PR TITLE
fix(rust): fix product cache

### DIFF
--- a/rust/agama-lib/src/product/client.rs
+++ b/rust/agama-lib/src/product/client.rs
@@ -55,8 +55,12 @@ pub struct ProductClient<'a> {
 
 impl<'a> ProductClient<'a> {
     pub async fn new(connection: Connection) -> Result<ProductClient<'a>, ServiceError> {
+        let product_proxy = SoftwareProductProxy::builder(&connection)
+            .cache_properties(zbus::proxy::CacheProperties::No)
+            .build()
+            .await?;
         Ok(Self {
-            product_proxy: SoftwareProductProxy::new(&connection).await?,
+            product_proxy,
             registration_proxy: RegistrationProxy::new(&connection).await?,
         })
     }

--- a/rust/agama-lib/src/software/model/packages.rs
+++ b/rust/agama-lib/src/software/model/packages.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Software service configuration (product, patterns, etc.).
-#[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareConfig {
     /// A map where the keys are the pattern names and the values whether to install them or not.

--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -392,6 +392,7 @@ async fn solve_conflicts(
 
     // refresh the config cache
     let config = read_config(&state).await?;
+    tracing::info!("Caching product configuration: {:?}", &config);
     let mut cached_config_write = state.config.write().await;
     *cached_config_write = Some(config);
 
@@ -604,6 +605,7 @@ async fn set_config(
     {
         // first invalidate cache, so if it fails later, we know we need to re-read recent data
         // use minimal context so it is released soon.
+        tracing::debug!("Invalidating product configuration cache");
         let mut cached_config_invalidate = state.config.write().await;
         *cached_config_invalidate = None;
     }
@@ -631,7 +633,7 @@ async fn set_config(
 
     // load the config cache
     let config = read_config(&state).await?;
-
+    tracing::debug!("Caching software configuration (set_config): {:?}", &config);
     let mut cached_config_write = state.config.write().await;
     *cached_config_write = Some(config);
 
@@ -656,12 +658,12 @@ async fn get_config(State(state): State<SoftwareState<'_>>) -> Result<Json<Softw
     let cached_config = state.config.read().await.clone();
 
     if let Some(config) = cached_config {
-        tracing::info!("Returning cached software config");
+        tracing::debug!("Returning cached software config: {:?}", &config);
         return Ok(Json(config));
     }
 
     let config = read_config(&state).await?;
-
+    tracing::debug!("Caching software configuration (get_config): {:?}", &config);
     let mut cached_config_write = state.config.write().await;
     *cached_config_write = Some(config.clone());
 


### PR DESCRIPTION
## Problem

According to [bsc#1247933](https://bugzilla.suse.com/show_bug.cgi?id=1247933) the product's cached is not working properly. Even if the product was selected, it does not seem to be included in the cache:

```
Aug 18 15:05:04 s390kvm112 agama-web-server[2976]: request 6755674318962757: GET /api/software/config
Aug 18 15:05:04 s390kvm112 agama-web-server[2976]: Returning cached software config
Aug 18 15:05:04 s390kvm112 agama-web-server[2976]: response for 6755674318962757: 200 OK 367.719µs
Aug 18 15:05:04 s390kvm112 agama-autoinstall[3118]: Could not load configuration from http://worker32.oqa.prg2.suse.org:20183/kiDqfTKFLnEjA2q7/files/generated_profile.json: Could not load the configuration: ✓ The profile is valid.
Aug 18 15:05:04 s390kvm112 agama-autoinstall[3118]: Cannot proceed with profile without specified product
Aug 18 15:05:04 s390kvm112 agama-web-server[2976]: request 9007474132648005: POST /api/questions
```

## Solution

After checking the code, it seems that `agama-web-server` is not able to get the proper value from D-Bus in the `read_config` function. How could it be? Well, zbus proxies keep a cache of properties and listens to `PropertiesChanged` signal to keep them up-to-date. So perhaps there is a little chance of getting the `PropertiesChanged` signal including the `SelectedProduct` too late.

## Testing

- Pending (at least it does not break other stuff).
