### PR TITLE
fix(docs): move wrong entry to agama-web-ui

### DIFF
--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,10 +1,4 @@
 -------------------------------------------------------------------
-Thu Aug 28 05:26:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
-
-- Report the underlying problem for the "load.retry" question
-  (related to bsc#1248779).
-
--------------------------------------------------------------------
 Wed Aug 27 10:23:31 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix calling GPG import callbacks for unattended installation for

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 28 05:26:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Report the underlying problem for the "load.retry" question
+  (related to bsc#1248779).
+
+-------------------------------------------------------------------
 Wed Aug 20 10:27:07 UTC 2025 - David Diaz <dgonzalez@suse.com>
 
 - Refactor DASD page to make it more usable and improve its


### PR DESCRIPTION
Move a changes entry that went to `rubygem-agama-yast` instead of `agama-web-ui`.
