### PR TITLE
[SLE-16] Fixed creating the web/agama.pot file (bsc#1248817)

### DIFF
--- a/web/build_pot
+++ b/web/build_pot
@@ -8,10 +8,10 @@ cd "$(dirname "$0")"
 
 OUTPUT="${1:-agama.pot}"
 
-find . ! -name cockpit.js ! -name '*.test.js' -name '*.js' -o ! -name '*.test.jsx' -name '*.jsx' \
+find . ! -name po-converter.js ! -name '*.test.js' -name '*.js' -o ! -name '*.test.jsx' -name '*.jsx' \
   -o ! -name '*.test.ts' -name '*.ts' -o ! -name '*.test.tsx' -name '*.tsx' |
 grep -vE "node_modules/|dist/|coverage/" | \
 xgettext --default-domain=agama --output="$OUTPUT" --language=C --files-from=- \
-  --keyword= --keyword=_:1 --keyword=N_:1 --keyword=n_:1,2,3t --keyword=Nn_:1,2,3t \
+  --keyword= --keyword=_:1 --keyword=N_:1 --keyword=n_:1,2 --keyword=Nn_:1,2 \
   --foreign-user --copyright-holder="SuSE Linux Products GmbH, Nuernberg" \
   --from-code=UTF-8 --add-comments=TRANSLATORS --sort-by-file


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1248817
- Some translated texts are missing in the generated POT file

## Details

The problem is with plural texts which have arguments placed on multiple lines. Example:

```js
n_(
  "The following partition will be created.",
  "The following partitions will be created.",
  num,
);
```

It turned out that the problem is caused by the trailing comma after the last argument. After removing the trailing comma the texts are extracted to the POT file correctly.

## Solution

The script which calls `xgettext` to extract the translatable string into the POT file uses the `--keyword=n_:1,2,3t` option. That tells the xgettext parser to consider the `n_()` function as a gettext call function.

The problem is that the `3t` option tells xgettext to extract the texts only if the `n_()` call has exactly 3 parameters. With that additional trailing comma the call has technically 4 parameters, even though the 4th argument is not defined.

From the [xgettext documentation](https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html):
> If *keywordspec* is of the form *‘id:…,totalnumargst’*, xgettext recognizes this argument specification only if the number of actual arguments is equal to *totalnumargs*.

## Notes

- Actually I copied these `xgettext` options from the [Cockpit xgettext invocation](https://github.com/cockpit-project/cockpit/blob/c4e1cd89bd29938d7b078c34f5b3c240a11c4f05/po/Makefile.am#L13). They need it to distinguish the standard plural form from the plural form with context which uses 4 arguments. We do not support contexts so we do not have to care about the number of arguments.
- Additionally the script ignores the `po-converter.js` file which is used for converting the *.po files to target *.js files. It does not contain any translatable texts and it not included in the built Agama files, but the xgettext parser is confused by the double quotes inside a regular expression and prints an error. So just skip the file instead of the no more present `cockpit.js` file.
- This only fixes the script which is called from CI to generate the POT file and does not fix any missing translations so there is no `*.changes` entry for it. The result of the fix will be visible only after the translators translate the newly added texts and after merging them back from Weblate.
- I think this should be fixed in the SLE-16 branch so we can include the missing translations later in the quarterly updates.

## Testing

- Tested manually

<details>
 <summary>Additional 18 messages are added into the resulting POT file (click to see the full diff)</summary>

```diff
--- agama.pot.bak	2025-09-01 16:10:57.674069189 +0200
+++ agama.pot	2025-09-01 16:17:08.120444448 +0200
@@ -8,7 +8,7 @@
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-01 16:10+0200\n"
+"POT-Creation-Date: 2025-09-01 16:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1827,6 +1827,20 @@
 msgid "Already using all available disks"
 msgstr ""
 
+#: src/components/storage/ConfigureDeviceMenu.tsx:66
+#, c-format
+msgid "Extend the installation beyond the currently selected device"
+msgid_plural "Extend the installation beyond the current %d devices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/storage/ConfigureDeviceMenu.tsx:75
+#, c-format
+msgid "Extend the installation beyond the currently selected disk"
+msgid_plural "Extend the installation beyond the current %d disks"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/ConfigureDeviceMenu.tsx:83
 msgid "Start configuring a basic installation"
 msgstr ""
@@ -2100,6 +2114,13 @@
 msgid "Change the file system or mount point"
 msgstr ""
 
+#: src/components/storage/FixableConfigInfo.tsx:48
+msgid "The configuration must be adapted to address the following issue:"
+msgid_plural ""
+"The configuration must be adapted to address the following issues:"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/FormattableDevicePage.tsx:221
 #: src/components/storage/LogicalVolumePage.tsx:248
 #: src/components/storage/PartitionPage.tsx:308
@@ -2413,6 +2434,15 @@
 msgid "Create LVM volume group on %s"
 msgstr ""
 
+#. TRANSLATORS: %s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
+#. single mount point in the singular case).
+#: src/components/storage/NewVgMenuOption.tsx:59
+#, c-format
+msgid "%s will be created as a logical volume"
+msgid_plural "%s will be created as logical volumes"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/PartitionPage.tsx:354
 msgid "The maximum must be a number followed by a unit like GiB or GB"
 msgstr ""
@@ -2477,10 +2507,34 @@
 msgid "Moreover, the following partitions will be created or mounted"
 msgstr ""
 
+#: src/components/storage/PartitionsMenu.tsx:67
+msgid "Moreover, the following partition will be created."
+msgid_plural "Moreover, the following partitions will be created."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/storage/PartitionsMenu.tsx:73
+msgid "Moreover, the following partition will be mounted."
+msgid_plural "Moreover, the following partitions will be mounted."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/PartitionsMenu.tsx:80
 msgid "The following partitions will be created or mounted"
 msgstr ""
 
+#: src/components/storage/PartitionsMenu.tsx:84
+msgid "The following partition will be created."
+msgid_plural "The following partitions will be created."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/storage/PartitionsMenu.tsx:90
+msgid "The following partition will be mounted."
+msgid_plural "The following partitions will be mounted."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/PartitionsMenu.tsx:132
 msgid "Any partition needed to boot will be configured."
 msgstr ""
@@ -2546,6 +2600,12 @@
 msgid "Invalid storage settings"
 msgstr ""
 
+#: src/components/storage/ProposalPage.tsx:77
+msgid "The current storage configuration has the following issue:"
+msgid_plural "The current storage configuration has the following issues:"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/ProposalPage.tsx:91
 msgid ""
 "You may want to discard those settings and start from scratch with a simple "
@@ -2611,6 +2671,20 @@
 msgid "Waiting for information about storage configuration"
 msgstr ""
 
+#: src/components/storage/ProposalResultSection.tsx:64
+#, c-format
+msgid "There is %d destructive action planned affecting %s"
+msgid_plural "There are %d destructive actions planned affecting %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/storage/ProposalResultSection.tsx:75
+#, c-format
+msgid "There is %d destructive action planned"
+msgid_plural "There are %d destructive actions planned"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/ProposalResultSection.tsx:94
 msgid "Collapse the list of planned actions"
 msgstr ""
@@ -2908,6 +2982,21 @@
 msgid "Format the whole device or mount an existing file system"
 msgstr ""
 
+#. TRANSLATORS: %1$s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
+#. single mount point in the singular case). %2$s is a disk name like sda.
+#: src/components/storage/VolumeGroupEditor.tsx:58
+#, c-format
+msgid "%1$s will be created as a partition at %2$s"
+msgid_plural "%1$s will be created as partitions at %2$s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/storage/VolumeGroupEditor.tsx:67
+msgid "The logical volume will also be deleted"
+msgid_plural "The logical volumes will also be deleted"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/VolumeGroupEditor.tsx:82
 msgid "Delete volume group"
 msgstr ""
@@ -2940,6 +3029,12 @@
 msgid "Add logical volume"
 msgstr ""
 
+#: src/components/storage/VolumeGroupEditor.tsx:148
+msgid "The following logical volume will be created"
+msgid_plural "The following logical volumes will be created"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/dasd/DASDFormatProgress.tsx:49
 msgid "Formatting DASD devices"
 msgstr ""
@@ -2978,6 +3073,15 @@
 msgid "Max channel"
 msgstr ""
 
+#. TRANSLATORS: message shown in bulk action toolbar when just one device
+#. is selected
+#: src/components/storage/dasd/DASDTable.tsx:227
+#, c-format
+msgid "Apply to the selected device"
+msgid_plural "Apply to the %s selected devices"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/dasd/DASDTable.tsx:254
 msgid "Select devices to enable bulk actions."
 msgstr ""
@@ -3586,6 +3690,20 @@
 msgid "No additional partitions will be created"
 msgstr ""
 
+#: src/components/storage/utils/drive.tsx:169
+#, c-format
+msgid "An existing partition will be used for %s"
+msgid_plural "Existing partitions will be used for %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/storage/utils/drive.tsx:183
+#, c-format
+msgid "A new partition will be created for %s"
+msgid_plural "New partitions will be created for %s"
+msgstr[0] ""
+msgstr[1] ""
+
 #. TRANSLATORS: %s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
 #. single mount point in the singular case).
 #: src/components/storage/utils/drive.tsx:194
@@ -3609,6 +3727,13 @@
 msgid "No logical volumes are defined yet"
 msgstr ""
 
+#: src/components/storage/utils/volume-group.tsx:36
+#, c-format
+msgid "A new volume will be created for %s"
+msgid_plural "New volumes will be created for %s"
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/storage/zfcp/ZFCPControllersTable.tsx:22
 msgid "Auto LUNs Scan"
 msgstr ""
```

</details>
