### PR TITLE
fix(web): map zh_* to zh_Han*

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Sep  1 18:22:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The Chinese languages do not include the territory (bsc#1248826).
+
+-------------------------------------------------------------------
 Thu Aug 28 05:26:38 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Report the underlying problem for the "load.retry" question

--- a/web/share/update-languages.py
+++ b/web/share/update-languages.py
@@ -45,9 +45,6 @@ class Locale:
     def code(self):
         return f"{self.file_language}-{self.territory}"
 
-    def normalized_language(self):
-        return Locale.languages_map.get(self.code(), self.language)
-
     def name(self, include_territory: bool = False):
         if include_territory:
             return language_name(languageId=self.language,

--- a/web/share/update-languages.py
+++ b/web/share/update-languages.py
@@ -35,12 +35,18 @@ class Locale:
     language: str
     territory: Optional[str]
 
+    languages_map = { "zh-CN": "zh_Hans", "zh-TW": "zh_Hant" }
+
     def __init__(self, language: str, territory: Optional[str] = None):
-        self.language = language
+        self.file_language = language
         self.territory = territory
+        self.language = Locale.languages_map.get(self.code(), language)
 
     def code(self):
-        return f"{self.language}-{self.territory}"
+        return f"{self.file_language}-{self.territory}"
+
+    def normalized_language(self):
+        return Locale.languages_map.get(self.code(), self.language)
 
     def name(self, include_territory: bool = False):
         if include_territory:


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1248876

The description of the Chinese languages should not include the territory.

## Solution

Map `zh-CH` to `zh_Hans` and `zh-TW` to `zh-Hant`.

## Testing

- *Tested manually*

Here is the content of the `locales.json` after applying this change:

```json
{
  "ca-ES": "Català",
  "de-DE": "Deutsch",
  "en-US": "English",
  "es-ES": "Español",
  "fr-FR": "Français",
  "id-ID": "Indonesia",
  "it-IT": "Italiano",
  "ja-JP": "日本語",
  "ka-KZ": "ქართული",
  "pt-BR": "Português",
  "ru-RU": "Русский",
  "sv-SE": "Svenska",
  "tr-TR": "Türkçe",
  "uk-UA": "Українська",
  "zh-CN": "简体中文",
  "zh-TW": "繁體中文"
}
```
