### PR TITLE
Add the SLE-16 CI translation jobs

### DIFF
--- a/.github/workflows/weblate-merge-po-sle16.yml
+++ b/.github/workflows/weblate-merge-po-sle16.yml
@@ -1,0 +1,128 @@
+name: Weblate Merge PO (SLE-16)
+
+permissions:
+  # it merges the updated translations and creates a pull request with the changes
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    # run every Monday at 2:35AM UTC
+    - cron: "35 2 * * 0"
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  merge-po:
+    # allow pushing and creating pull requests
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # do not run in forks
+    if: ${{ !github.event.repository.fork }}
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: registry.opensuse.org/opensuse/leap:16.0
+      volumes:
+        # bind mount the GitHub CLI tool from the Ubuntu host,
+        # it is a statically linked binary so it should work also in Leap
+        - /usr/bin/gh:/usr/bin/gh
+
+    steps:
+      - name: Configure and refresh repositories
+        run: |
+          # disable unused repositories to have a faster refresh
+          zypper modifyrepo -d openSUSE:repo-openh264 && zypper ref && \
+            zypper --non-interactive ref
+
+      - name: Install tools
+        run: zypper --non-interactive install --no-recommends nodejs npm git gettext-tools python3-langtable
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "YaST Bot"
+          git config --global user.email "yast-devel@opensuse.org"
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          path: agama
+          # checkout the SLE-16 branch
+          ref: SLE-16
+
+      - name: Checkout Agama-weblate sources
+        uses: actions/checkout@v4
+        with:
+          path: agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
+          # checkout the SLE-16 branch
+          ref: SLE-16
+
+      - name: Install NPM packages
+        working-directory: ./agama/web/share/po
+        run: npm ci
+
+      - name: Validate the PO files
+        working-directory: ./agama-weblate
+        run:  ls web/*.po | xargs -n1 msgfmt --check-format -o /dev/null
+
+      - name: Update JS translations
+        working-directory: ./agama
+        run: |
+          mkdir -p web/src/po
+          # delete the current translations
+          find web/src/po -name '*.js' -exec git rm '{}' ';'
+
+          # update the list of supported languages, it is used by the PO->JS converter in the next step
+          web/share/update-languages.py --po-directory ../agama-weblate/web > web/src/languages.json
+
+          # rebuild the JS files
+          (cd web/src/po && SRCDIR=../../../../agama-weblate/web ../../share/po/po-converter.js)
+
+          # stage the changes
+          git add web/src/po/*.js web/src/languages.json
+
+      # any changes detected?
+      - name: Check changes
+        id: check_changes
+        working-directory: ./agama
+        run: |
+          git diff --staged web | tee tr.diff
+
+          if [ -s tr.diff ]; then
+            echo "Translations updated"
+            # this is an Output Parameter
+            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+            echo "updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "Translations not changed"
+            echo "updated=false" >> $GITHUB_OUTPUT
+          fi
+
+          rm tr.diff
+
+      - name: Push updated PO files
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.updated == 'true'
+        working-directory: ./agama
+        run: |
+          # use an unique branch to avoid possible conflicts with already existing branches
+          git checkout -b "po_merge_sle16_${GITHUB_RUN_ID}"
+          git commit -a -m "Update web translation files"$'\n\n'"Agama-weblate commit: `git -C ../agama-weblate rev-parse HEAD`"
+          git push origin "po_merge_sle16_${GITHUB_RUN_ID}"
+
+      - name: Create pull request
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.updated == 'true'
+        working-directory: ./agama
+        run: |
+          gh pr create -B SLE-16 -H "po_merge_sle16_${GITHUB_RUN_ID}" \
+            --label translations --label bot \
+            --title "Update web translation files (SLE-16)" \
+            --body "Updating the web translation files from the agama-weblate repository"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/weblate-merge-products-po-sle16.yml
+++ b/.github/workflows/weblate-merge-products-po-sle16.yml
@@ -1,0 +1,117 @@
+name: Weblate Merge Product PO (SLE-16)
+
+permissions:
+  # it merges the updated translations and creates a pull request with the changes
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    # run every Monday at 2:35AM UTC
+    - cron: "35 2 * * 0"
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  merge-po:
+    # allow pushing and creating pull requests
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # do not run in forks
+    if: ${{ !github.event.repository.fork }}
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: registry.opensuse.org/opensuse/leap:16.0
+      volumes:
+        # bind mount the GitHub CLI tool from the Ubuntu host,
+        # it is a statically linked binary so it should work also in Leap
+        - /usr/bin/gh:/usr/bin/gh
+
+    steps:
+      - name: Configure and refresh repositories
+        run: |
+          # disable unused repositories to have a faster refresh
+          zypper modifyrepo -d openSUSE:repo-openh264 && \
+            zypper --non-interactive ref
+
+      - name: Install tools
+        run: zypper --non-interactive install --no-recommends git gettext-tools npm-default
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "YaST Bot"
+          git config --global user.email "yast-devel@opensuse.org"
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          path: agama
+          # checkout the SLE-16 branch
+          ref: SLE-16
+
+      - name: Checkout Agama-weblate sources
+        uses: actions/checkout@v4
+        with:
+          path: agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
+          # checkout the SLE-16 branch
+          ref: SLE-16
+  
+      - name: Validate the product PO files
+        working-directory: ./agama-weblate
+        run:  ls products/*.po | xargs -n1 msgfmt --check-format -o /dev/null
+  
+      - name: Install NPM packages
+        working-directory: ./agama/.github/workflows/product_translations
+        run:  npm ci
+  
+      - name: Update product files with translations
+        env:
+          NODE_PATH: ./agama/.github/workflows/product_translations
+        run: |
+          ${NODE_PATH}/merge_po agama-weblate/products agama/products.d
+
+      - name: Check changes
+        id: check_changes
+        working-directory: ./agama
+        run: |
+          git diff products.d > po.diff
+
+          if [ -s po.diff ]; then
+            echo "Product files updated"
+            # this is an Output Parameter
+            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+            echo "products_updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "Product files unchanged"
+            echo "products_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+          rm po.diff
+
+      - name: Push updated product files
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.products_updated == 'true'
+        working-directory: ./agama
+        run: |
+          # use a unique branch to avoid possible conflicts with already existing branches
+          git checkout -b "products_po_merge_sle16_${GITHUB_RUN_ID}"
+          git commit -a -m "Update translations in the product files"$'\n\n'"Agama-weblate commit: `git -C ../agama-weblate rev-parse HEAD`"
+          git push origin "products_po_merge_sle16_${GITHUB_RUN_ID}"
+
+      - name: Create pull request
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.products_updated == 'true'
+        working-directory: ./agama
+        run: |
+          gh pr create -B master -H "products_po_merge_sle16_${GITHUB_RUN_ID}" \
+            --label translations --label bot \
+            --title "Update translations in the product files (SLE-16)" \
+            --body "Updating the product translations from the agama-weblate repository"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/weblate-merge-service-po-sle16.yml
+++ b/.github/workflows/weblate-merge-service-po-sle16.yml
@@ -1,0 +1,121 @@
+name: Weblate Merge Service PO (SLE-16)
+
+permissions:
+  # it merges the updated translations and creates a pull request with the changes
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    # run every Monday at 2:35AM UTC
+    - cron: "35 2 * * 0"
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  merge-po:
+    # allow pushing and creating pull requests
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # do not run in forks
+    if: ${{ !github.event.repository.fork }}
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: registry.opensuse.org/opensuse/leap:16.0
+      volumes:
+        # bind mount the GitHub CLI tool from the Ubuntu host,
+        # it is a statically linked binary so it should work also in Leap
+        - /usr/bin/gh:/usr/bin/gh
+
+    steps:
+      - name: Configure and refresh repositories
+        run: |
+          # disable unused repositories to have a faster refresh
+          zypper modifyrepo -d openSUSE:repo-openh264 && \
+            zypper --non-interactive ref
+
+      - name: Install tools
+        run: zypper --non-interactive install --no-recommends git gettext-tools
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "YaST Bot"
+          git config --global user.email "yast-devel@opensuse.org"
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          path: agama
+          # checkout the SLE-16 branch
+          ref: SLE-16
+
+      - name: Checkout Agama-weblate sources
+        uses: actions/checkout@v4
+        with:
+          path: agama-weblate
+          repository: ${{ github.repository_owner }}/agama-weblate
+          # checkout the SLE-16 branch
+          ref: SLE-16
+  
+      - name: Validate the service PO files
+        working-directory: ./agama-weblate
+        run:  ls service/*.po | xargs -n1 msgfmt --check-format -o /dev/null
+
+      - name: Update PO files
+        working-directory: ./agama
+        run: |
+          mkdir -p service/po
+          # delete the current translations
+          find service/po -name '*.po' -exec git rm '{}' ';'
+
+          # copy the new ones
+          mkdir -p service/po
+          cp -a ../agama-weblate/service/*.po service/po
+          git add service/po/*.po
+
+      # any changes besides the timestamps in the PO files?
+      - name: Check changes
+        id: check_changes
+        working-directory: ./agama
+        run: |
+          git diff --staged --ignore-matching-lines="POT-Creation-Date:" \
+            --ignore-matching-lines="PO-Revision-Date:" service/po > po.diff
+
+          if [ -s po.diff ]; then
+            echo "PO files updated"
+            # this is an Output Parameter
+            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+            echo "po_updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "PO files unchanged"
+            echo "po_updated=false" >> $GITHUB_OUTPUT
+          fi
+
+          rm po.diff
+
+      - name: Push updated PO files
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.po_updated == 'true'
+        working-directory: ./agama
+        run: |
+          # use a unique branch to avoid possible conflicts with already existing branches
+          git checkout -b "po_service_merge_sle16_${GITHUB_RUN_ID}"
+          git commit -a -m "Update service PO files"$'\n\n'"Agama-weblate commit: `git -C ../agama-weblate rev-parse HEAD`"
+          git push origin "po_service_merge_sle16_${GITHUB_RUN_ID}"
+
+      - name: Create pull request
+        # run only when a PO file has been updated
+        if: steps.check_changes.outputs.po_updated == 'true'
+        working-directory: ./agama
+        run: |
+          gh pr create -B SLE-16 -H "po_service_merge_sle16_${GITHUB_RUN_ID}" \
+            --label translations --label bot \
+            --title "Update service PO files (SLE-16)" \
+            --body "Updating the service translation files from the agama-weblate repository"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description

- Related to #2699 
- GitHub Actions support scheduled jobs only in the default branch so we need to define the SLE-16 jobs in the `master` branch
- Fortunately it is possible checkout a different branch in the CI worker when running, so we explicitly checkout the "SLE-16" branch in these jobs.

## Details

Changes to the `master` branch jobs:

- Use the Leap 16.0 container image to have more stable environment and to be more close to SLE-16 runtime (instead of Tumbleweed in `master`)
- Explicitly checkout the `SLE-16` branch instead of the default `master`, the pull requests are created against the `SLE-16` branch
- Scheduled in a different time to not create load peaks