### PR TITLE
Add Slowroll update repo

### DIFF
--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -45,6 +45,8 @@ software:
       archs: x86_64
     - url: https://download.opensuse.org/slowroll/repo/non-oss/
       archs: x86_64
+    - url: https://download.opensuse.org/update/slowroll/repo/oss/
+      archs: x86_64
 
   mandatory_patterns:
     - enhanced_base


### PR DESCRIPTION

## Problem

Agama installs Slowroll without updates, so it installs outdated versions and we need to pull many more updates after install.
Also it initially installs the Tumbleweed wallpaper/branding, because the Slowroll branding only lives in the update repo. This can cause confusion for users.

## Solution

We add the Slowroll update repo during install.

It would be good to adjust repository `priority`, but I only see this defined for `extraRepositories`

## Testing

- *None yet*

## Screenshots

N/A

## Documentation

N/A

note: a similar change could be useful for Leap 16.