### PR TITLE
try to fix vendoring of submodules

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "agama-locale-data",
     "agama-network",
     "agama-utils",
+    "zypp-c-api/rust/zypp-agama",
+    "zypp-c-api/rust/zypp-agama-sys",
     "xtask",
 ]
 resolver = "2"


### PR DESCRIPTION
By adding directly members of zypp-C-API cargo vendor should see it and parse it.
