### PR TITLE
Dump or copy some data from the Live root image directly to the ISO image

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Tue Sep  9 12:47:15 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Dump some Live ISO root image data directly to the ISO image,
+  added files:
+  /LiveOS/.info - a copy of the /var/log/build/info file from
+    the root image
+  /LiveOS/.packages.gz - list of installed package (plain text,
+    basically a `rpm -qa` dump)
+  /LiveOS/.packages.json.gz - list of installed packages (JSON
+    format, better suitable for processing by scripts or tools)
+  (gh#agama-project/agama#2717)
+
+-------------------------------------------------------------------
 Mon Sep  8 10:13:30 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Remove PXE images as it was agreed to use the Live iso (squashfs

--- a/live/src/fix_bootconfig
+++ b/live/src/fix_bootconfig
@@ -42,7 +42,7 @@ cat <<XXX >/usr/local/bin/xorriso
 
 set -x
 
-# get ISO file name and ISO volume id from xorriso parameters
+# get the output ISO file name and the input directory from the xorriso parameters
 for i in "\$@" ; do
   if [ -n "\$iso_opt" ] ; then
     iso_opt=
@@ -53,7 +53,49 @@ for i in "\$@" ; do
     iso_opt=1
     continue
   fi
+  if [ -n "\$map_opt" ] ; then
+    map_opt=
+    target_dir="\$i"
+    continue
+  fi
+  if [ "\$i" = "-map" ] ; then
+    map_opt=1
+    continue
+  fi
 done
+
+# dump or copy some data from the Live system root image directly to the ISO image to avoid
+# complicated processing (the ISO image contains a squashfs image which contains ext4 image which
+# finally contains the needed files)
+if [ -n "\$target_dir" ]; then
+  mount_dir1=\$(mktemp -d)
+  mount_dir2=\$(mktemp -d)
+
+  mount -o loop "\$target_dir"/LiveOS/squashfs.img "\$mount_dir1"
+  mount -o loop "\$mount_dir1"/LiveOS/rootfs.img "\$mount_dir2"
+
+  # dump the list of the installed packages
+  rpm --root "\$mount_dir2" -qa | sort | gzip > "\$target_dir/LiveOS/.packages.gz"
+
+  # dump the same list also in JSON format for easier processing,
+  # use jq for sorting the array (case insensitive), for merging to a single
+  # array and also for formatting the final JSON output
+  rpm --root "\$mount_dir2" -qa --queryformat \\
+    '\\{"name":"%{NAME}","version":"%{VERSION}","release":"%{RELEASE}","arch":"%{ARCH}"\\}' \\
+    | jq -s 'sort_by(.name|ascii_downcase)' | gzip > "\$target_dir/LiveOS/.packages.json.gz"
+
+  # copy the build info file if present
+  if [ -f "\$mount_dir2"/var/log/build/info ]; then
+    cp -a "\$mount_dir2"/var/log/build/info "\$target_dir/LiveOS/.info"
+  fi
+
+  # unmount in reverse(!) order
+  umount "\$mount_dir2"
+  umount "\$mount_dir1"
+
+  rmdir "\$mount_dir1"
+  rmdir "\$mount_dir2"
+fi
 
 profile=$(echo "$kiwi_profiles" | tr "_" "-")
 # keep in sync with ISO Volume ID set in the config.sh script


### PR DESCRIPTION
## Problem

- Getting some data from the Live ISO image requires booting the image or using complicated mounting of nested images. The Live ISO image contains a squashfs image which contains an ext4 image which finally contains the needed files.
- Mounting requires `root` permissions which is bad. That makes the process less comfortable for users and potentially insecure for tools and automation (you definitely do not want to run some parts of the openQA as `root`).
 - The openQA team would like to do some things differently depending on the exact Agama version included in the Live ISO so they need some easy and safe access to the installed package versions.

## Solution

- Place the data directly in the ISO image level, that data can be easily extracted by tools like `isoinfo` or `xorriso` even without mounting the images so it does not require `root` permissions

## New files

The Live ISO contains the `/LiveOS/squashfs.img` root image file, now there are some more files added to that directory:

- `/LiveOS/.info` - a copy of the `/var/log/build/info` file from the root image for easier verification of the origin of the image
- `/LiveOS/.packages.gz` - list of installed package in the Live system (in plain text, basically it is an `rpm -qa` dump)
- `/LiveOS/.packages.json.gz` - the same content but in JSON format (it is better suitable for processing by scripts or tools)

The files are very small, in total they require less than 20kB so the Live ISO image size is basically not affected by this change.

## Examples

Here are some examples how to use the new files.

Note: The `isoinfo` tool is included in the `mkisofs` RPM package.

### The image build data

To extract the `/LiveOS/.info` file from an ISO image run this:

```console
> isoinfo -j UTF-8 -R -x /LiveOS/.info -i *.iso 
Build date:    2025-09-09 12:40:52 UTC
Build number:  Build0
Image profile: openSUSE
Image version: 18.pre.0.0
Image type:    iso
Source URL:    https://local/package/show/local/local?rev=local
```

Of course, you can still mount the image and dump the file if you prefer the old way.

Note: The testing image was built locally, in that case the build number and the source URL are bogus. They contain correct data when running in a real OBS build.

### Get the Agama package versions

To get versions of all Agama packages in a plain text format run this:

```console
> isoinfo -j UTF-8 -R -x /LiveOS/.packages.gz -i *.iso | gunzip | grep agama
agama-17+381.737e17ae6-269.1.x86_64
agama-autoinstall-17+381.737e17ae6-269.1.x86_64
agama-cli-17+381.737e17ae6-269.1.x86_64
agama-cli-bash-completion-17+381.737e17ae6-269.1.noarch
agama-integration-tests-1741002027.084bcd3-33.10.noarch
agama-products-opensuse-17+390.1f4393971-111.1.noarch
agama-web-ui-17+394.ef831c016-292.1.noarch
agama-yast-17.devel394.ef831c016-1.1.x86_64
ruby3.4-rubygem-agama-yast-17.devel394.ef831c016-1.1.x86_64
```

### Getting structured data

To get the details of the installed `agama` package from the JSON file run this:

```console
> isoinfo -j UTF-8 -R -x /LiveOS/.packages.json.gz -i *.iso | gunzip | jq -r '.[] | select(.name=="agama")'
{
  "name": "agama",
  "version": "17+381.737e17ae6",
  "release": "269.1",
  "arch": "x86_64"
}
```

### Getting package details

To get just the version (without release) of a specific package run this:

```console
> isoinfo -j UTF-8 -R -x /LiveOS/.packages.json.gz -i *.iso | gunzip | jq -r '.[] | select(.name=="agama") | .version'
17+381.737e17ae6
```

## Testing

- Tested manually, see the examples above
