### PR TITLE
Create the SLE-16 product translation PR correctly against the SLE-16 branch

### DIFF
--- a/.github/workflows/weblate-merge-products-po-sle16.yml
+++ b/.github/workflows/weblate-merge-products-po-sle16.yml
@@ -109,7 +109,7 @@ jobs:
         if: steps.check_changes.outputs.products_updated == 'true'
         working-directory: ./agama
         run: |
-          gh pr create -B master -H "products_po_merge_sle16_${GITHUB_RUN_ID}" \
+          gh pr create -B SLE-16 -H "products_po_merge_sle16_${GITHUB_RUN_ID}" \
             --label translations --label bot \
             --title "Update translations in the product files (SLE-16)" \
             --body "Updating the product translations from the agama-weblate repository"


### PR DESCRIPTION
## Problem

- The SLE-16 product translations PR was incorrectly created against the `master` branch instead of `SLE-16`.

Note: The other jobs for SLE-16 are correct, this is the only case.