### PR TITLE
Change the openSUSE autoinstallation product IDs (bsc#1249399)

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Sep 12 14:30:16 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Change the openSUSE Leap autoinstallation ID from "Leap_16.0"
+  to "openSUSE_Leap" and the openSUSE Leap Micro ID from
+  "LeapMicro_6.2" to "openSUSE_Leap_Micro". This allows using the
+  same autoinstallation profile in future versions. (bsc#1249399)
+
+-------------------------------------------------------------------
 Fri Sep 12 08:14:28 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Update translations (bsc#1249378)

--- a/products.d/leap_160.yaml
+++ b/products.d/leap_160.yaml
@@ -1,4 +1,4 @@
-id: Leap_16.0
+id: openSUSE_Leap
 name: Leap 16.0
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located

--- a/products.d/leap_micro_62.yaml
+++ b/products.d/leap_micro_62.yaml
@@ -1,5 +1,5 @@
-id: LeapMicro_6.2
-name: openSUSE Leap Micro 6.2 Beta
+id: openSUSE_Leap_Micro
+name: openSUSE Leap Micro 6.2
 archs: x86_64,aarch64
 # ------------------------------------------------------------------------------
 # WARNING: When changing the product description delete the translations located


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1249399
- Using the `Leap_16.0` product ID in the autoinstallation profile does not allow using the same profile in the future Leap 16.1.


## Solution

- Change the openSUSE Leap autoinstallation ID from "Leap_16.0" to "openSUSE_Leap" and the openSUSE Leap Micro ID from "LeapMicro_6.2" to "openSUSE_Leap_Micro". This allows using the same autoinstallation profile in future versions.
- Additionally removed the "Beta" label from the openSUSE Leap Micro, it has the same schedule as regular Leap 16.0 so it is no more Beta.