### PR TITLE
fix: stop logging the events

### DIFF
--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -56,7 +56,6 @@ mod ws;
 use agama_lib::{connection, error::ServiceError, http::Event};
 use common::{IssuesService, ProgressService};
 pub use config::ServiceConfig;
-use event::log_event;
 pub use event::{EventsReceiver, EventsSender};
 pub use service::MainServiceBuilder;
 use std::path::Path;
@@ -190,7 +189,6 @@ async fn run_events_monitor(dbus: zbus::Connection, events: EventsSender) -> Res
     tokio::pin!(stream);
     let e = events.clone();
     while let Some((_, event)) = stream.next().await {
-        log_event(&event);
         _ = e.send(event);
     }
     Ok(())

--- a/rust/agama-server/src/web/common/progress.rs
+++ b/rust/agama-server/src/web/common/progress.rs
@@ -35,7 +35,7 @@
 //!
 //! At this point, it only handles the progress that are exposed through D-Bus.
 
-use crate::web::{event::log_event, EventsSender};
+use crate::web::EventsSender;
 use agama_lib::{
     event,
     http::Event,
@@ -175,7 +175,6 @@ impl ProgressService {
             path: path.to_string(),
             progress,
         });
-        log_event(&event);
         self.events.send(event)?;
         Ok(())
     }

--- a/rust/agama-server/src/web/event.rs
+++ b/rust/agama-server/src/web/event.rs
@@ -23,11 +23,3 @@ use tokio::sync::broadcast::{Receiver, Sender};
 
 pub type EventsSender = Sender<Event>;
 pub type EventsReceiver = Receiver<Event>;
-
-pub fn log_event(event: &Event) {
-    tracing::info!("event(debug): {:?}", &event);
-    match serde_json::to_string(&event) {
-        Ok(json) => tracing::info!("event: {json}"),
-        Err(_) => tracing::info!("event (not serialized): {:?}", &event),
-    }
-}

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -273,6 +273,7 @@ module Agama
           Yast::Execute.locally(
             "agama", "logs", "store", "--destination", path
           )
+          FileUtils.chmod(0o640, Dir.glob("#{path}*"))
         end
 
         def logs_dir


### PR DESCRIPTION
- **fix(rust): do not log the events**
- **fix(ruby): fix logs file permissions**

## Problem

- [bsc#1249622](https://bugzilla.suse.com/show_bug.cgi?id=1249622).

## Solution

- Do not log the events to avoid leaking passwords. We might need a better solution for 16.1, but now we are in a hurry.
- Fix `/var/log/agama-installation/logs.tar.gz`.
