### PR TITLE
fix(web): Preserve installer options values after successful submission

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 18 08:57:11 UTC 2025 - David Diaz <dgonzalez@suse.com>
+
+- Preserve installer options values after successful submission
+  (bsc#1249636).
+
+-------------------------------------------------------------------
 Fri Sep 12 08:14:28 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Update translations (bsc#1249378)

--- a/web/src/components/core/InstallerOptions.tsx
+++ b/web/src/components/core/InstallerOptions.tsx
@@ -210,7 +210,7 @@ type Actions = {
   handleKeymapChange: (_, v: string) => void;
   handleCopyToSystemToggle: (_, v: boolean) => void;
   handleSubmitForm: (e: React.FormEvent<HTMLFormElement>) => void;
-  handleCloseDialog: () => void;
+  handleCancellation: () => void;
 };
 
 /**
@@ -324,7 +324,7 @@ const AllSettingsDialog = ({ state, formState, actions }: DialogProps) => {
               description={
                 <TextWithLinkToL10n
                   text={checkboxDescription}
-                  onClick={actions.handleCloseDialog}
+                  onClick={actions.handleCancellation}
                 />
               }
               isChecked={formState.reuseSettings}
@@ -344,7 +344,7 @@ const AllSettingsDialog = ({ state, formState, actions }: DialogProps) => {
         >
           {_("Accept")}
         </Popup.Confirm>
-        <Popup.Cancel onClick={actions.handleCloseDialog} isDisabled={state.isBusy} />
+        <Popup.Cancel onClick={actions.handleCancellation} isDisabled={state.isBusy} />
       </Popup.Actions>
     </Popup>
   );
@@ -370,7 +370,7 @@ const LanguageOnlyDialog = ({ state, formState, actions }: DialogProps) => {
               description={
                 <TextWithLinkToL10n
                   text={checkboxDescription}
-                  onClick={actions.handleCloseDialog}
+                  onClick={actions.handleCancellation}
                 />
               }
               isChecked={formState.reuseSettings}
@@ -390,7 +390,7 @@ const LanguageOnlyDialog = ({ state, formState, actions }: DialogProps) => {
         >
           {_("Accept")}
         </Popup.Confirm>
-        <Popup.Cancel onClick={actions.handleCloseDialog} isDisabled={state.isBusy} />
+        <Popup.Cancel onClick={actions.handleCancellation} isDisabled={state.isBusy} />
       </Popup.Actions>
     </Popup>
   );
@@ -402,7 +402,7 @@ const KeyboardOnlyDialog = ({ state, formState, actions }: DialogProps) => {
       <Popup isOpen={state.isOpen} variant="small" title={_("Change keyboard")}>
         {_("Cannot be changed in remote installation")}
         <Popup.Actions>
-          <Popup.Confirm onClick={actions.handleCloseDialog}>{_("Accept")}</Popup.Confirm>
+          <Popup.Confirm onClick={actions.handleCancellation}>{_("Accept")}</Popup.Confirm>
         </Popup.Actions>
       </Popup>
     );
@@ -427,7 +427,7 @@ const KeyboardOnlyDialog = ({ state, formState, actions }: DialogProps) => {
               description={
                 <TextWithLinkToL10n
                   text={checkboxDescription}
-                  onClick={actions.handleCloseDialog}
+                  onClick={actions.handleCancellation}
                 />
               }
               isChecked={formState.reuseSettings}
@@ -447,7 +447,7 @@ const KeyboardOnlyDialog = ({ state, formState, actions }: DialogProps) => {
         >
           {_("Accept")}
         </Popup.Confirm>
-        <Popup.Cancel onClick={actions.handleCloseDialog} isDisabled={state.isBusy} />
+        <Popup.Cancel onClick={actions.handleCancellation} isDisabled={state.isBusy} />
       </Popup.Actions>
     </Popup>
   );
@@ -595,7 +595,6 @@ export default function InstallerOptions({
   };
 
   const close = () => {
-    dispatch({ type: "RESET", state: initialFormState });
     dispatchDialogAction({ type: "CLOSE" });
     typeof onClose === "function" && onClose();
   };
@@ -627,7 +626,10 @@ export default function InstallerOptions({
     handleKeymapChange: (_, v) => dispatch({ type: "SET_SELECTED_KEYMAP", keymap: v }),
     handleCopyToSystemToggle: () => dispatch({ type: "TOGGLE_REUSE_SETTINGS" }),
     handleSubmitForm: onSubmit,
-    handleCloseDialog: close,
+    handleCancellation: () => {
+      dispatch({ type: "RESET", state: initialFormState });
+      close();
+    },
   };
 
   const Toggle = toggle ?? toggles[variant];

--- a/web/src/components/core/InstallerOptions.tsx
+++ b/web/src/components/core/InstallerOptions.tsx
@@ -209,7 +209,7 @@ type Actions = {
   handleLanguageChange: (_, v: string) => void;
   handleKeymapChange: (_, v: string) => void;
   handleCopyToSystemToggle: (_, v: boolean) => void;
-  handleSubmitForm: (e: React.FormEvent<HTMLFormElement>) => void;
+  handleSubmission: (e: React.FormEvent<HTMLFormElement>) => void;
   handleCancellation: () => void;
 };
 
@@ -313,7 +313,7 @@ const AllSettingsDialog = ({ state, formState, actions }: DialogProps) => {
 
   return (
     <Popup isOpen={state.isOpen} variant="small" title={_("Language and keyboard")}>
-      <Form id="installer-l10n" onSubmit={actions.handleSubmitForm}>
+      <Form id="installer-l10n" onSubmit={actions.handleSubmission}>
         <LangaugeFormInput value={formState.language} onChange={actions.handleLanguageChange} />
         <KeyboardFormInput value={formState.keymap} onChange={actions.handleKeymapChange} />
         <ReusableSettings isReuseAllowed={formState.allowReusingSettings}>
@@ -360,7 +360,7 @@ const LanguageOnlyDialog = ({ state, formState, actions }: DialogProps) => {
 
   return (
     <Popup isOpen={state.isOpen} variant="small" title={_("Change Language")}>
-      <Form id="installer-l10n" onSubmit={actions.handleSubmitForm}>
+      <Form id="installer-l10n" onSubmit={actions.handleSubmission}>
         <LangaugeFormInput value={formState.language} onChange={actions.handleLanguageChange} />
         <ReusableSettings isReuseAllowed={formState.allowReusingSettings}>
           <FormGroup fieldId="reuse-settings">
@@ -417,7 +417,7 @@ const KeyboardOnlyDialog = ({ state, formState, actions }: DialogProps) => {
 
   return (
     <Popup isOpen={state.isOpen} variant="small" title={_("Change keyboard")}>
-      <Form id="installer-l10n" onSubmit={actions.handleSubmitForm}>
+      <Form id="installer-l10n" onSubmit={actions.handleSubmission}>
         <KeyboardFormInput value={formState.keymap} onChange={actions.handleKeymapChange} />
         <ReusableSettings isReuseAllowed={formState.allowReusingSettings}>
           <FormGroup fieldId="reuse-settings">
@@ -625,7 +625,7 @@ export default function InstallerOptions({
     handleLanguageChange: (_, v) => dispatch({ type: "SET_SELECTED_LANGUAGE", language: v }),
     handleKeymapChange: (_, v) => dispatch({ type: "SET_SELECTED_KEYMAP", keymap: v }),
     handleCopyToSystemToggle: () => dispatch({ type: "TOGGLE_REUSE_SETTINGS" }),
-    handleSubmitForm: onSubmit,
+    handleSubmission: onSubmit,
     handleCancellation: () => {
       dispatch({ type: "RESET", state: initialFormState });
       close();


### PR DESCRIPTION
Ensure installer options form controls are reset to their initial values only on cancellation.  Since the form remains mounted, it should preserve the submitted state when closed after a successful submission.

Fixes  https://bugzilla.suse.com/show_bug.cgi?id=1249636 (protected link)