### PR TITLE
Software summary screen

### DIFF
--- a/rust/agama-server/src/software/web.rs
+++ b/rust/agama-server/src/software/web.rs
@@ -731,10 +731,10 @@ async fn read_config(state: &SoftwareState<'_>) -> Result<SoftwareConfig, Error>
 pub struct SoftwareProposal {
     /// Space required for installation. It is returned as a formatted string which includes
     /// a number and a unit (e.g., "GiB").
-    size: String,
+    pub size: String,
     /// Patterns selection. It is represented as a hash map where the key is the pattern's name
     /// and the value why the pattern is selected.
-    patterns: HashMap<String, SelectedBy>,
+    pub patterns: HashMap<String, SelectedBy>,
 }
 
 /// Returns the proposal information.

--- a/rust/agama-server/src/software_ng/backend/client.rs
+++ b/rust/agama-server/src/software_ng/backend/client.rs
@@ -91,4 +91,20 @@ impl SoftwareServiceClient {
         })?;
         Ok(())
     }
+
+    pub async fn get_resolvables(
+        &self,
+        id: &str,
+        r#type: ResolvableType,
+        optional: bool,
+    ) -> Result<Vec<String>, SoftwareServiceError> {
+        let (tx, rx) = oneshot::channel();
+        self.actions.send(SoftwareAction::GetResolvables {
+            tx,
+            id: id.to_string(),
+            r#type,
+            optional,
+        })?;
+        Ok(rx.await?)
+    }
 }

--- a/rust/agama-server/src/software_ng/backend/server.rs
+++ b/rust/agama-server/src/software_ng/backend/server.rs
@@ -179,7 +179,7 @@ impl SoftwareServiceServer {
                 let result = self
                     .software_selection
                     .get(&id, r#type, optional)
-                    .unwrap_or(vec![]);
+                    .unwrap_or(vec![]); // Option::unwrap is OK
                 tx.send(result)
                     .map_err(|_| SoftwareServiceError::ResponseChannelClosed)?;
             }

--- a/rust/agama-server/src/software_ng/backend/server.rs
+++ b/rust/agama-server/src/software_ng/backend/server.rs
@@ -176,8 +176,10 @@ impl SoftwareServiceServer {
                 r#type,
                 optional,
             } => {
-                let result = self.software_selection
-                    .get(&id, r#type, optional).unwrap_or(vec![]);
+                let result = self
+                    .software_selection
+                    .get(&id, r#type, optional)
+                    .unwrap_or(vec![]);
                 tx.send(result)
                     .map_err(|_| SoftwareServiceError::ResponseChannelClosed)?;
             }

--- a/rust/agama-server/src/software_ng/web.rs
+++ b/rust/agama-server/src/software_ng/web.rs
@@ -25,12 +25,12 @@ use agama_lib::{
     issue::Issue,
     product::Product,
     software::{
-        model::{RegistrationInfo, ResolvableParams, SoftwareConfig},
+        model::{RegistrationInfo, ResolvableParams, ResolvableType, SoftwareConfig},
         Pattern, SelectedBy,
     },
 };
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     routing::{get, post, put},
     Json, Router,
 };
@@ -53,7 +53,7 @@ pub async fn software_router(client: SoftwareServiceClient) -> Result<Router, Se
         .route("/config", put(set_config).get(get_config))
         .route("/probe", post(probe))
         .route("/proposal", get(get_proposal))
-        .route("/resolvables/:id", put(set_resolvables))
+        .route("/resolvables/:id", put(set_resolvables).get(get_resolvables))
         .route("/issues/product", get(product_issues))
         .route("/issues/software", get(software_issues))
         .route("/registration", get(get_registration))
@@ -262,4 +262,38 @@ async fn set_resolvables(
         .client
         .set_resolvables(&id, params.r#type, &names, params.optional)?;
     Ok(Json(()))
+}
+
+/// Returns the resolvables list with the given `id`.
+#[utoipa::path(
+    get,
+    path = "/resolvables/:id",
+    context_path = "/api/software",
+    responses(
+        (status = 200, description = "Read repositresolvable list"),
+        (status = 400, description = "The D-Bus service could not perform the action
+")
+    )
+)]
+async fn get_resolvables(
+    State(state): State<SoftwareState>,
+    Path(id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Result<Json<Vec<String>>, Error> {
+    let default = "package".to_string();
+    let typ = query.get("type").unwrap_or(&default);
+    let typ = match typ.as_str() {
+        // TODO: support more and move to Resolvable Kind
+        "package" => Ok(ResolvableType::Package),
+        "pattern" => Ok(ResolvableType::Pattern),
+        _ => Err(anyhow::Error::msg("Unknown resolveble type"))
+    }?;
+
+    let optional = query.get("optional").map_or(false, |v| v.as_str() == "true");
+
+
+    let result = state
+        .client
+        .get_resolvables(&id, typ, optional).await?;
+    Ok(Json(result))
 }

--- a/rust/agama-server/src/software_ng/web.rs
+++ b/rust/agama-server/src/software_ng/web.rs
@@ -174,7 +174,11 @@ async fn get_proposal(State(state): State<SoftwareState>) -> Result<Json<Softwar
     let patterns = config.patterns.unwrap_or(HashMap::new());
     let proposal = SoftwareProposal {
         size: "TODO".to_string(),
-        patterns: patterns.iter().filter(|(_name, selected)| **selected).map(|(name,_selected)| (name.clone(), SelectedBy::User)).collect()
+        patterns: patterns
+            .iter()
+            .filter(|(_name, selected)| **selected)
+            .map(|(name, _selected)| (name.clone(), SelectedBy::User))
+            .collect(),
     };
 
     Ok(Json(proposal))

--- a/rust/agama-server/src/software_ng/web.rs
+++ b/rust/agama-server/src/software_ng/web.rs
@@ -53,7 +53,10 @@ pub async fn software_router(client: SoftwareServiceClient) -> Result<Router, Se
         .route("/config", put(set_config).get(get_config))
         .route("/probe", post(probe))
         .route("/proposal", get(get_proposal))
-        .route("/resolvables/:id", put(set_resolvables).get(get_resolvables))
+        .route(
+            "/resolvables/:id",
+            put(set_resolvables).get(get_resolvables),
+        )
         .route("/issues/product", get(product_issues))
         .route("/issues/software", get(software_issues))
         .route("/registration", get(get_registration))
@@ -286,14 +289,13 @@ async fn get_resolvables(
         // TODO: support more and move to Resolvable Kind
         "package" => Ok(ResolvableType::Package),
         "pattern" => Ok(ResolvableType::Pattern),
-        _ => Err(anyhow::Error::msg("Unknown resolveble type"))
+        _ => Err(anyhow::Error::msg("Unknown resolveble type")),
     }?;
 
-    let optional = query.get("optional").map_or(false, |v| v.as_str() == "true");
+    let optional = query
+        .get("optional")
+        .map_or(false, |v| v.as_str() == "true");
 
-
-    let result = state
-        .client
-        .get_resolvables(&id, typ, optional).await?;
+    let result = state.client.get_resolvables(&id, typ, optional).await?;
     Ok(Json(result))
 }

--- a/rust/agama-server/src/software_ng/web.rs
+++ b/rust/agama-server/src/software_ng/web.rs
@@ -286,7 +286,7 @@ async fn get_resolvables(
     let default = "package".to_string();
     let typ = query.get("type").unwrap_or(&default);
     let typ = match typ.as_str() {
-        // TODO: support more and move to Resolvable Kind
+        // TODO: support more and move to ResolvableKind
         "package" => Ok(ResolvableType::Package),
         "pattern" => Ok(ResolvableType::Pattern),
         _ => Err(anyhow::Error::msg("Unknown resolveble type")),

--- a/rust/agama-server/src/software_ng/web.rs
+++ b/rust/agama-server/src/software_ng/web.rs
@@ -18,13 +18,15 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
+use std::collections::HashMap;
+
 use agama_lib::{
     error::ServiceError,
     issue::Issue,
     product::Product,
     software::{
         model::{RegistrationInfo, ResolvableParams, SoftwareConfig},
-        Pattern,
+        Pattern, SelectedBy,
     },
 };
 use axum::{
@@ -168,7 +170,14 @@ async fn probe(State(state): State<SoftwareState>) -> Result<Json<()>, Error> {
     )
 )]
 async fn get_proposal(State(state): State<SoftwareState>) -> Result<Json<SoftwareProposal>, Error> {
-    unimplemented!("get the software proposal");
+    let config = state.client.get_config().await?;
+    let patterns = config.patterns.unwrap_or(HashMap::new());
+    let proposal = SoftwareProposal {
+        size: "TODO".to_string(),
+        patterns: patterns.iter().filter(|(_name, selected)| **selected).map(|(name,_selected)| (name.clone(), SelectedBy::User)).collect()
+    };
+
+    Ok(Json(proposal))
 }
 
 /// Returns the product issues

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -153,8 +153,6 @@ package contains a systemd service to run scripts when booting the installed sys
 # Require at least 1.3GB RAM per each parallel job (the size is in MB),
 # this can limit the number of parallel jobs on systems with relatively small memory.
 %{limit_build -m 1300}
-# remove project cargo files from submodules to avoid confusion of tools
-rm zypp-c-api/rust/Cargo.*
 
 %{cargo_build}
 cargo run --package xtask -- manpages

--- a/service/lib/agama/dbus/y2dir/manager/modules/PackagesProposal.rb
+++ b/service/lib/agama/dbus/y2dir/manager/modules/PackagesProposal.rb
@@ -31,30 +31,30 @@ module Yast
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L118
     def AddResolvables(unique_id, type, resolvables, optional: false)
-      orig_resolvables = client.get_resolvables(unique_id, type, optional)
+      orig_resolvables = client.get_resolvables(unique_id, type, optional: optional)
       orig_resolvables += resolvables
       orig_resolvables.uniq!
-      SetResolvables(unique_id, type, orig_resolvables, optional)
+      SetResolvables(unique_id, type, orig_resolvables, optional: optional)
       true
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L145
     def SetResolvables(unique_id, type, resolvables, optional: false)
-      client.set_resolvables(unique_id, type, resolvables || [], optional: optional)
+      client.set_resolvables(unique_id, type, resolvables || [], optional)
       true
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L285
     def GetResolvables(unique_id, type, optional: false)
-      client.get_resolvables(unique_id, type, optional: optional)
+      client.get_resolvables(unique_id, type, optional)
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L177
     def RemoveResolvables(unique_id, type, resolvables, optional: false)
-      orig_resolvables = client.get_resolvables(unique_id, type, optional)
+      orig_resolvables = client.get_resolvables(unique_id, type, optional: optional)
       orig_resolvables -= resolvables
       orig_resolvables.uniq!
-      SetResolvables(unique_id, type, orig_resolvables, optional)
+      SetResolvables(unique_id, type, orig_resolvables, optional: optional)
       true
     end
 

--- a/service/lib/agama/http/clients/software.rb
+++ b/service/lib/agama/http/clients/software.rb
@@ -64,7 +64,7 @@ module Agama
 
         def errors?
           # TODO: severity as integer is nasty for http API
-          JSON.parse(get("software/issues/software"))&.select{ |i| i["severity"] == 1}&.any?
+          JSON.parse(get("software/issues/software"))&.select { |i| i["severity"] == 1 }&.any?
         end
 
         def get_resolvables(unique_id, type, optional)

--- a/service/lib/agama/http/clients/software.rb
+++ b/service/lib/agama/http/clients/software.rb
@@ -67,9 +67,8 @@ module Agama
           JSON.parse(get("software/issues/software"))&.select{ |i| i["severity"] == 1}&.any?
         end
 
-        def get_resolvables(_unique_id, _type, _optional)
-          # TODO: implement on backend
-          JSON.parse(get("software/config"))
+        def get_resolvables(unique_id, type, optional)
+          JSON.parse(get("software/resolvables/#{unique_id}?type=#{type}&optional=#{optional}"))
         end
 
         def provisions_selected?(_provisions)
@@ -87,14 +86,13 @@ module Agama
           true
         end
 
-        def set_resolvables(_unique_id, type, resolvables, optional)
-          # TODO: implement at backend proposal id
+        def set_resolvables(unique_id, type, resolvables, optional)
           data = {
             "names"    => resolvables,
             "type"     => type,
             "optional" => optional
           }
-          JSON.parse(put("software/config"), data)
+          JSON.parse(put("software/resolvables/#{unique_id}"), data)
         end
 
         def add_patterns(patterns)

--- a/service/lib/agama/http/clients/software.rb
+++ b/service/lib/agama/http/clients/software.rb
@@ -63,8 +63,8 @@ module Agama
         end
 
         def errors?
-          # TODO: implement it together with checking type error
-          JSON.parse(get("software/issues/software"))
+          # TODO: severity as integer is nasty for http API
+          JSON.parse(get("software/issues/software"))&.select{ |i| i["severity"] == 1}&.any?
         end
 
         def get_resolvables(_unique_id, _type, _optional)

--- a/service/lib/agama/http/clients/software.rb
+++ b/service/lib/agama/http/clients/software.rb
@@ -92,7 +92,7 @@ module Agama
             "type"     => type,
             "optional" => optional
           }
-          JSON.parse(put("software/resolvables/#{unique_id}"), data)
+          put("software/resolvables/#{unique_id}", data)
         end
 
         def add_patterns(patterns)

--- a/service/lib/agama/http/clients/software.rb
+++ b/service/lib/agama/http/clients/software.rb
@@ -64,7 +64,7 @@ module Agama
 
         def errors?
           # TODO: implement it together with checking type error
-          JSON.parse(get("software/issues"))
+          JSON.parse(get("software/issues/software"))
         end
 
         def get_resolvables(_unique_id, _type, _optional)


### PR DESCRIPTION
Goal of this pull request is to get successfully in web UI to the initial summary screen. Mocking and fake values are possible as we need to setup foundation where to start with filling implementation.

Status after this pull request:

- it possible to reach summary screen with fake value about size
- it is not possible to manage patterns
- after click on install, it will do storage part, but failed afterwards