### PR TITLE
Update patterns and packages Leap Micro 6.2

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Sep 29 04:56:47 UTC 2025 - Lubos Kocman <lubos.kocman@suse.com>
+
+- Update patterns and packages Leap Micro 6.2
+  Fixes install issues of Leap Micro 6.2 (boo#1250435)
+- Explicitly add opensuse-migration-tool
+ 
+
+-------------------------------------------------------------------
 Fri Sep 12 14:30:16 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Change the openSUSE Leap autoinstallation ID from "Leap_16.0"

--- a/products.d/leap_micro_62.yaml
+++ b/products.d/leap_micro_62.yaml
@@ -25,8 +25,7 @@ software:
   mandatory_patterns:
     - cockpit
     - base
-    - transactional
-    - traditional
+    - base_transactional
     - hardware
     - selinux
 
@@ -44,8 +43,18 @@ software:
     - sssd_ldap
 
   mandatory_packages:
+    - firewalld
+    - kernel-firmware-all
+    - kernel-default-extra
+    - libpwquality-tools
+    - lzop
     - NetworkManager
     - openSUSE-repos-LeapMicro
+    - suseconnect-ng
+    - systemd-default-settings-branding-SLE-Micro
+    - wpa_supplicant
+    - opensuse-migration-tool
+
   optional_packages: null
   base_product: Leap-Micro
 


### PR DESCRIPTION
  Update patterns and packages Leap Micro 6.2

PR: for main https://github.com/agama-project/agama/pull/2725
    
* Drop traditional
* Fixes install issues of Leap Micro 6.2 (boo#1250435)
* Explicitly add opensuse-migration-tool
* Tested also with all optional packages
* Add most packages from agama-full kiwi profile

<img width="2558" height="1373" alt="image" src="https://github.com/user-attachments/assets/bd6afff4-43c4-43a8-93ed-dcdbd67ce0c7" />
