### PR TITLE
Fixed creating `/LiveOS/.packages.json.gz` file in SLE builds

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 30 14:54:18 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed creating the /LiveOS/.packages.json.gz file in SLE builds
+  (gh#agama-project/agama#2771)
+
+-------------------------------------------------------------------
 Tue Sep 16 07:21:28 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not have on SLES media internal agama staging repository

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -35,7 +35,7 @@ REPO="/etc/zypp/repos.d/agama-${DISTRO}.repo"
 if [ -f "${REPO}.disabled" ]; then
   mv "${REPO}.disabled" $REPO
 fi
-rm /etc/zypp/repos.d/*.disabled
+rm -f /etc/zypp/repos.d/*.disabled
 
 # configure the repositories in the Live system
 # import the OBS key for the systemsmanagement OBS project

--- a/live/src/fix_bootconfig
+++ b/live/src/fix_bootconfig
@@ -82,7 +82,8 @@ if [ -n "\$target_dir" ]; then
   # array and also for formatting the final JSON output
   rpm --root "\$mount_dir2" -qa --queryformat \\
     '\\{"name":"%{NAME}","version":"%{VERSION}","release":"%{RELEASE}","arch":"%{ARCH}"\\}' \\
-    | jq -s 'sort_by(.name|ascii_downcase)' | gzip > "\$target_dir/LiveOS/.packages.json.gz"
+    | chroot "\$mount_dir2" /usr/bin/jq -s 'sort_by(.name|ascii_downcase)' \\
+    | gzip > "\$target_dir/LiveOS/.packages.json.gz"
 
   # copy the build info file if present
   if [ -f "\$mount_dir2"/var/log/build/info ]; then


### PR DESCRIPTION
## Problem

- The created `/LiveOS/.packages.json.gz` file in SLE builds is empty, in openSUSE builds it contains correct content
- This is a fix up for #2717

## Details

- It turned out that for some reason the SLE build root does not contain the jq package. The package is installed into the target Live ISO, but it is missing in the build root. In openSUSE builds it is present, either it uses some different defaults or some tool depend on that...

## Solution

- Run the `jq` tool from the installed chroot directory, we install it in the Live ISO so it is guaranteed to be there.
- Alternatively it should be possible to tweak the OBS project config to add more packages into the build root. But that would require to change the project config in all places (OBS, IBS...). As we install the jq tool into the image anyway then just use it from the image.
- Additionally fixed deleting repofiles, that fails if there is no disabled repository


## Testing

- Tested manually, both SLE and openSUSE builds contain a correct `.packages.json.gz` file
