### PR TITLE
Show localized products descriptions

### DIFF
--- a/rust/agama-server/src/products.rs
+++ b/rust/agama-server/src/products.rs
@@ -26,7 +26,10 @@
 
 use serde::{Deserialize, Deserializer};
 use serde_with::{formats::CommaSeparator, serde_as, StringWithSeparator};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProductsRegistryError {
@@ -110,6 +113,8 @@ pub struct ProductSpec {
     pub description: String,
     pub icon: String,
     #[serde(default)]
+    pub translations: TranslationsSpec,
+    #[serde(default)]
     pub registration: bool,
     pub version: Option<String>,
     pub software: SoftwareSpec,
@@ -128,6 +133,11 @@ where
     D: Deserializer<'de>,
 {
     Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct TranslationsSpec {
+    description: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -198,6 +208,11 @@ mod test {
         assert_eq!(tw.icon, "Tumbleweed.svg");
         assert_eq!(tw.registration, false);
         assert_eq!(tw.version, None);
+
+        let translations = &tw.translations;
+        let description = &translations.description;
+        assert!(description["cs"].contains("verze"));
+
         let software = &tw.software;
         assert_eq!(software.installation_repositories.len(), 12);
         assert_eq!(software.installation_labels.len(), 4);


### PR DESCRIPTION
(part of the Rust based software service, #1829)

## Problem

- The product selection is always in English
- https://trello.com/c/n0FURZGd

## Solution

*Short description of the fix.*


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

## Documentation

*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
*other times they need advertisement and explanation.*

*Look for relevant sections and adjust:*
- The description parts of the [JSON schema][profile.schema.json]
- Is the CLI affected? See [cli.md][] for a complete overview,
  change the `///` comments (rust doc)
  and update the .md with `cargo xtask markdown`
- <https://agama-project.github.io/> ([source][gh.io])
- Run: `git ls-files '*.md'`

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md
[profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
[gh.io]: https://github.com/agama-project/agama-project.github.io/
