### PR TITLE
Autoinstallation schema improvements

### DIFF
--- a/rust/agama-lib/share/iscsi.schema.json
+++ b/rust/agama-lib/share/iscsi.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/iscsi.schema.json",
+  "$id": "https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/iscsi.schema.json",
   "title": "Config",
   "description": "iSCSI config.",
   "type": "object",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1,11 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/profile.schema.json",
+  "$id": "https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json",
   "title": "Profile",
   "description": "Profile definition for automated installation",
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "title": "URL of the JSON validation schema",
+      "description": "The schema location is ignored by the installer, it always uses the built-in schema, but it can be useful for automatic validation and code completion in some editors",
+      "type": "string",
+      "examples": [
+        "https://raw.githubusercontent.com/agama-project/agama/refs/heads/SLE-16/rust/agama-lib/share/profile.schema.json",
+        "https://raw.githubusercontent.com/agama-project/agama/refs/heads/master/rust/agama-lib/share/profile.schema.json"
+      ]
+    },
     "files": {
       "title": "User-defined files to deploy",
       "description": "User-defined files to deploy after installation just before post install scripts",
@@ -290,7 +299,17 @@
         "id": {
           "title": "Product identifier",
           "description": "The id field from a products.d/foo.yaml file",
-          "type": "string"
+          "type": "string",
+          "examples": [
+            "Kalpa",
+            "MicroOS",
+            "openSUSE_Leap_Micro",
+            "openSUSE_Leap",
+            "SLES_SAP",
+            "SLES",
+            "Slowroll",
+            "Tumbleweed"
+          ]
         },
         "registrationCode": {
           "title": "Product registration code",

--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Based on doc/auto_storage.md",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/storage.schema.json",
+  "$id": "https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/storage.schema.json",
   "title": "Config",
   "description": "Storage config.",
   "type": "object",


### PR DESCRIPTION
## Small improvements for the autoinstallation schema

- Added product name examples (so they are used in autocompletion)
- Allow using "$schema" key for linking the schema definition, some editors like VSCode use that for validating the JSON file automatically when pointed to the schema location
- Use "agama-project" in the GitHub URLs

## Testing

Tested in local VSCode and the online [VSCode for web](https://vscode.dev/):

<img width="1042" height="945" alt="vscode-agama-profile-products" src="https://github.com/user-attachments/assets/ebdf27c7-d99c-44cb-bb56-8fe5ccd97600" />
