### PR TITLE
[PoC] Dynamically change the default item in the Live boot menu

### DIFF
--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -36,7 +36,17 @@ cat >$dst/boot/grub2/grub.cfg <<XXX
 # Agama generated grub2 config file
 set btrfs_relative_path="y"
 export btrfs_relative_path
-set default=0
+
+# if any installed SUSE OS is found then boot from disk by default
+if search --no-floppy --file /etc/products.d/baseproduct --set product_device; then
+  echo "Found (\$product_device)/etc/products.d/baseproduct, preselecting boot from hard disk"
+  set default=0
+else
+  # else boot the installer
+  echo "No installed SUSE OS found, preselecting the installer"
+  set default=1
+fi
+
 if [ -n "\$extra_cmdline" ]; then
   submenu "Bootable snapshot \$snapshot_num" {
     menuentry "If OK, run snapper rollback and reboot." { true; }


### PR DESCRIPTION
## Problem

- Originally we always booted the Agama installer, later that was changed to booting from harddisk.
- But having a fixed boot option is not nice. If the system does not contain any OS then always booting from harddisk does not make sense. Or the other way round, booting the installer is probably not a good idea if a system is already installed.

## Solution

- Preselect the default boot option dynamically depending on the current system state.
- If a SUSE OS is already installed then by default boot from harddisk. Assume that a system has been just installed. Unfortunately we cannot find which (open)SUSE distribution or version is installed. Ideally we should check for SLE16 or Leap 16 or Tumbleweed (probably any release), but that's not possible because Grub scripting is very limited. (Or we would have to implement our special Grub module for that.)
- If a SUSE OS is not detected then preselect the installer option. That will apply in a completely clean system or in systems with Windows or other Linuxes (assume the user wants a dual boot with SUSE/openSUSE). 

## Notes

- Still just a proof of concept
- So far only for x86_64, but aarch64 should be the same, ppc64le is a question but hopefully should work the same way. Booting s390x is already black magic so I do not expect it is possible to do something similar there. Or it needs a real s390 expert. :smiley: 
- Does not handle encrypted partitions, might not work with RAIDs or LVMs (not tested)
- We could make the check less strict, i.e. boot from harddisk if any Linux system is detected (probably by checking existence of `/etc/passwd` or similar file on any partition) or change the logic. This is just the initial proposal for testing the concept.

## Testing

Tested manually with a locally built image in VirtualBox VMs.

### No system installed yet

In a fresh and clean virtual machine by default the installer option is preselected in the boot menu.

UEFI boot:

<img width="1024" height="768" alt="agama-boot-empty-system-uefi" src="https://github.com/user-attachments/assets/8c3b6541-3d51-4349-8269-6a95e0dd7865" />

Classic BIOS boot:

<img width="640" height="480" alt="agama-boot-empty-system-bios" src="https://github.com/user-attachments/assets/e3e21191-9aa4-469a-9e4d-65e50fffba59" />

### Installed system

Tested with preinstalled SLES 16 (default installation, root with Btrfs, no RAID or LVM).

UEFI boot:

<img width="1024" height="768" alt="agama-boot-installed-system-uefi" src="https://github.com/user-attachments/assets/fe148b58-0455-4fc1-94a6-a01dc873dd26" />

Classic BIOS boot:

<img width="640" height="480" alt="agama-boot-installed-system-bios" src="https://github.com/user-attachments/assets/9ee76966-7ce9-4779-aa1f-513fa204ae4b" />

 ### Summary

At the first boot in clean system the installer is selected, after installing the system in the next reboots it will always select booting from harddisk. I think this is how most users would expect it to behave.