### PR TITLE
Redirect libzypp logs to systemd journal

### DIFF
--- a/rust/zypp-agama/zypp-agama-sys/build.rs
+++ b/rust/zypp-agama/zypp-agama-sys/build.rs
@@ -56,6 +56,7 @@ fn main() {
     );
     println!("cargo::rustc-link-lib=static=agama-zypp");
     println!("cargo::rustc-link-lib=dylib=zypp");
+    println!("cargo::rustc-link-lib=dylib=systemd");
     // NOTE: install the matching library for your compiler version, for example
     // libstdc++6-devel-gcc13.rpm
     println!("cargo::rustc-link-lib=dylib=stdc++");

--- a/rust/zypp-agama/zypp-agama-sys/c-layer/Makefile
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/Makefile
@@ -1,6 +1,6 @@
 AR=ar
 CXX=g++
-CXXFLAGS=-Wall -I./include -I./internal -Izypp -Wall -std=c++14 -lzypp -fPIE
+CXXFLAGS=-Wall -I./include -I./internal -Izypp -Wall -std=c++14 -lzypp -lsystemd -fPIE
 DEPS = include/lib.h include/callbacks.h internal/callbacks.hxx
 OBJ = lib.o callbacks.o
 

--- a/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
@@ -28,6 +28,8 @@
 
 extern "C" {
 
+#include <systemd/sd-journal.h>
+
 struct Zypp {
   zypp::ZYpp::Ptr zypp_pointer;
   zypp::RepoManager *repo_manager;
@@ -35,6 +37,81 @@ struct Zypp {
 
 static struct Zypp the_zypp {
   .zypp_pointer = NULL, .repo_manager = NULL,
+};
+
+// formatter which actually logs the messages to the systemd journal,
+// that is a bit hacky but in the logger we receive an already formatted
+// message as a single string and it would not be easy to get back the original
+// components of the message
+struct AgamaFormatter : public zypp::base::LogControl::LineFormater {
+  virtual std::string format(const std::string &zypp_group,
+                             zypp::base::logger::LogLevel zypp_level,
+                             const char *zypp_file, const char *zypp_func,
+                             int zypp_line, const std::string &zypp_message) {
+    // the systemd/syslog compatible log level
+    int level;
+
+    // convert the zypp log level to the systemd/syslog log level
+    switch (zypp_level) {
+    // for details about the systemd levels see
+    // https://www.freedesktop.org/software/systemd/man/latest/sd-daemon.html
+    case zypp::base::logger::E_DBG:
+      level = LOG_DEBUG;
+      break;
+    case zypp::base::logger::E_MIL:
+      level = LOG_INFO;
+      break;
+    case zypp::base::logger::E_WAR:
+      level = LOG_WARNING;
+      break;
+    case zypp::base::logger::E_ERR:
+      level = LOG_ERR;
+      break;
+    case zypp::base::logger::E_SEC:
+      // security error => critical
+      level = LOG_CRIT;
+      break;
+    case zypp::base::logger::E_INT:
+      // internal error => critical
+      level = LOG_CRIT;
+      break;
+    // libzypp specific level
+    case zypp::base::logger::E_USR:
+      level = LOG_INFO;
+      break;
+    // libzypp specific level
+    case zypp::base::logger::E_XXX:
+      level = LOG_CRIT;
+      break;
+    }
+
+    // unlike the other values, the location needs to be sent in an already
+    // formatted strings
+    std::string file("CODE_FILE=");
+    file.append(zypp_file);
+    std::string line("CODE_LINE=");
+    line.append(std::to_string(zypp_line));
+
+    // this will log the message with libzypp location, not from *this* file,
+    // see "man sd_journal_send_with_location"
+    sd_journal_send_with_location(
+        file.c_str(), line.c_str(), zypp_func, "PRIORITY=%i", level,
+        "MESSAGE=[%s] %s", zypp_group.c_str(), zypp_message.c_str(),
+        // some custom data to allow easy filtering of the libzypp messages
+        "COMPONENT=libzypp", "ZYPP_GROUP=%s", zypp_group.c_str(),
+        "ZYPP_LEVEL=%i", zypp_level, NULL);
+
+    // libzypp aborts when the returned message is empty,
+    // return some static fake data to make it happy
+    return "msg";
+  }
+};
+
+// a dummy logger
+struct AgamaLogger : public zypp::base::LogControl::LineWriter {
+  virtual void writeOut(const std::string &formatted) {
+    // do nothing, the message has been already logged by the formatter
+  }
 };
 
 void free_zypp(struct Zypp *zypp) noexcept {
@@ -48,10 +125,15 @@ void free_zypp(struct Zypp *zypp) noexcept {
 }
 
 static zypp::ZYpp::Ptr zypp_ptr() {
-  // set logging to ~/zypp-agama.log for now. For final we need to decide it
-  zypp::Pathname home(getenv("HOME"));
-  zypp::Pathname log_path = home.cat("zypp-agama.log");
-  zypp::base::LogControl::instance().logfile(log_path);
+  sd_journal_print(LOG_NOTICE, "Redirecting libzypp logs to systemd journal");
+
+  // log to systemd journal using our specific formatter
+  boost::shared_ptr<AgamaFormatter> formatter(new AgamaFormatter);
+  zypp::base::LogControl::instance().setLineFormater(formatter);
+  // use a dummy logger, using a NULL logger would skip the formatter completely
+  // so the messages would not be logged in the end
+  boost::shared_ptr<AgamaLogger> logger(new AgamaLogger);
+  zypp::base::LogControl::instance().setLineWriter(logger);
 
   int max_count = 5;
   unsigned int seconds = 3;


### PR DESCRIPTION
## Problem

- Logging to `~/zypp-agama.log` is not nice

## Solution

- Log to systemd journal
- Use the libzypp code location
- Add special custom flags so we can distinguish between the Agama messages and libzypp messages

## Testing

- Tested manually

## Screenshots

`journalctl -u agama-web-server.service` output (notice the missing libzypp code locations which are present in the YaST or in the previous `~/zypp-agama.log` file) :
<img width="1492" height="905" alt="image" src="https://github.com/user-attachments/assets/0434da43-39bb-49f6-87af-595afec7227f" />


The location can be obtained from the verbose output (`journalctl -o verbose -u agama-web-server.service`):
<img width="1492" height="905" alt="image" src="https://github.com/user-attachments/assets/343916ae-fcde-4146-a13a-8553f02d3a5f" />

And it is possible to display only the libzypp messages (`journalctl COMPONENT=libzypp -u agama-web-server.service`)
<img width="1492" height="905" alt="image" src="https://github.com/user-attachments/assets/9c57a27b-22ab-44e0-9604-191dd5d972ae" />

Unfortunately the opposite (displaying other messages than from libzypp) is currently not possible. :worried:)
