### PR TITLE
Create the libzypp lock also in the target directory

### DIFF
--- a/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
@@ -135,23 +135,9 @@ static zypp::ZYpp::Ptr zypp_ptr() {
   boost::shared_ptr<AgamaLogger> logger(new AgamaLogger);
   zypp::base::LogControl::instance().setLineWriter(logger);
 
-  int max_count = 5;
-  unsigned int seconds = 3;
-
-  zypp::ZYpp::Ptr zypp = NULL;
-  while (zypp == NULL && max_count > 0) {
-    try {
-      zypp = zypp::getZYpp();
-
-      return zypp;
-    } catch (const zypp::Exception &excpt) {
-      max_count--;
-
-      sleep(seconds);
-    }
-  }
-
-  return NULL;
+  // do not do any magic waiting for lock as in agama context we work
+  // on our own root, so there should be no need to wait
+  return zypp::getZYpp();
 }
 
 void switch_target(struct Zypp *zypp, const char *root,
@@ -212,6 +198,11 @@ struct Zypp *init_target(const char *root, struct Status *status,
     if (progress != NULL)
       progress("Initializing the Target System", 0, 2, user_data);
     the_zypp.zypp_pointer = zypp_ptr();
+    if (the_zypp.zypp_pointer == NULL) {
+        STATUS_ERROR(status, "Failed to obtain zypp pointer. "
+                         "See journalctl for details.");
+        return NULL;
+    }
     zypp = &the_zypp;
     zypp->zypp_pointer->initializeTarget(root_str, false);
     if (progress != NULL)


### PR DESCRIPTION
## Problem

- Cannot use `zypper` command in the Live ISO system while Agama is running:
```console
agama:~ # zypper install foo
System management is locked by the application with pid 18394 (/usr/bin/agama-web-server).
Close this application before trying again.
```
- From the log:
```
[zypp] Open lockfile /run/zypp.pid
[zypp] read: Lockfile /run/zypp.pid has pid 3041 (our pid: 7060)
```
- This is the global libzypp lock

## Solution

- Create the lock in the temporary libzypp target, the [same way as the old Ruby service did](https://github.com/agama-project/agama/blob/07fb25d080fa66b58038fc0f7e56221b09765125/service/lib/agama/software/manager.rb#L198)


## Testing

- Tested manually, calling `zypper install` works fine while Agama is running
- From the log:
```
[zypp] Open lockfile /run/agama/software_ng_zypp/run/zypp.pid
[zypp] read: Lockfile /run/agama/software_ng_zypp/run/zypp.pid has pid 0 (our pid: 70302)
```
- Now it uses a separate lock