### PR TITLE
Allow to set the search domain via kernel boot option

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network-compat.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-cmdline/agama-network-compat.sh
@@ -193,7 +193,6 @@ translate_ifcfg() {
 
   return 0
 }
-
 parse_domain() {
   local domain
 
@@ -203,7 +202,7 @@ parse_domain() {
     echo "### Processing domain search list '$domain'"
     mkdir -p /run/NetworkManager/conf.d
     echo "[global-dns]" >/run/NetworkManager/conf.d/10-agama-domain.conf
-    echo "searches=$domain" >>/run/NetworkManager/conf.d/10-agama-domain.conf
+    echo "searches=${domain// /,}" >>/run/NetworkManager/conf.d/10-agama-domain.conf
   fi
 
   return 0


### PR DESCRIPTION
## Problem

In #1957 we added support for translating the **linuxrc ifcfg options** to the equivalents in **NetworkManager dracut module** but the **`domain`** option argument was omitted.

## Solution

The solution proposed by **Raymund Will** is to write the searches domain to the **global-dns** section in `/run/NetworkManager/conf.d/10-agama-domain.conf`. We probably will need to persist it to the target system too.