### PR TITLE
Conversion of devicegraph to json

### DIFF
--- a/service/lib/agama/storage/devicegraph_conversions.rb
+++ b/service/lib/agama/storage/devicegraph_conversions.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json"
+
+module Agama
+  module Storage
+    # Conversions for the Y2Storage devicegraph
+    module DevicegraphConversion
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/device"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      # Devicegraph conversion to JSON array according to schema.
+      class ToJSON
+        # @param devicegraph [Y2Storage::Devicegraph]
+        def initialize(devicegraph)
+          @devicegraph = devicegraph
+        end
+
+        # Performs the conversion to array according to the JSON schema.
+        #
+        # @return [Hash]
+        def convert
+          original_devices.map { |d| ToJSONConversions::Device.new(d).convert }
+        end
+
+      private
+
+        # @return [Y2Storage::Devicegraph]
+        attr_reader :devicegraph
+
+        # First-level devices to be included in the JSON representation.
+        #
+        # @return [Array<Y2Storage::Device>]
+        def original_devices
+          devicegraph.disk_devices +
+            devicegraph.stray_blk_devices +
+            devicegraph.software_raids +
+            devicegraph.lvm_vgs
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/block.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/block.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+require "agama/storage/device_shrinking"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with properties for block devices.
+        class Block < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:blk_device)
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            {
+              start:     block_start,
+              active:    block_active,
+              encrypted: block_encrypted,
+              udevIds:   block_udev_ids,
+              udevPaths: block_udev_paths,
+              size:      block_size,
+              shrinking: block_shrinking,
+              systems:   block_systems
+            }
+          end
+
+          # Position of the first block of the region.
+          #
+          # @return [Integer]
+          def block_start
+            storage_device.start
+          end
+
+          # Whether the block device is currently active
+          #
+          # @return [Boolean]
+          def block_active
+            storage_device.active?
+          end
+
+          # Whether the block device is encrypted.
+          #
+          # @return [Boolean]
+          def block_encrypted
+            storage_device.encrypted?
+          end
+
+          # Name of the udev by-id links
+          #
+          # @return [Array<String>]
+          def block_udev_ids
+            storage_device.udev_ids
+          end
+
+          # Name of the udev by-path links
+          #
+          # @return [Array<String>]
+          def block_udev_paths
+            storage_device.udev_paths
+          end
+
+          # Size of the block device in bytes
+          #
+          # @return [Integer]
+          def block_size
+            storage_device.size.to_i
+          end
+
+          # Shrinking information.
+          #
+          # @return [Hash]
+          def block_shrinking
+            shrinking = Agama::Storage::DeviceShrinking.new(storage_device)
+
+            if shrinking.supported?
+              { supported: shrinking.min_size.to_i }
+            else
+              { unsupported: shrinking.unsupported_reasons }
+            end
+          end
+
+          # Name of the currently installed systems
+          #
+          # @return [Array<String>]
+          def block_systems
+            return @systems if @systems
+
+            filesystems = storage_device.descendants.select { |d| d.is?(:filesystem) }
+            @systems = filesystems.map(&:system_name).compact
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/device.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/device.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/sections"
+require "y2storage/device_description"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Device conversion to JSON hash according to schema.
+        class Device
+          # @param storage_device [Y2Storage::Device]
+          def initialize(storage_device)
+            @storage_device = storage_device
+          end
+
+          # Hash representing the Y2Storage device
+          #
+          # @return [Hash]
+          def convert
+            result = {
+              sid:         device_sid,
+              name:        device_name,
+              description: device_description
+            }
+            add_sections(result)
+            add_nested_devices(result)
+            result
+          end
+
+        private
+
+          # Device to convert
+          # @return [Y2Storage::Device]
+          attr_reader :storage_device
+
+          # sid of the device.
+          #
+          # @return [Integer]
+          def device_sid
+            storage_device.sid
+          end
+
+          # Name to represent the device.
+          #
+          # @return [String] e.g., "/dev/sda".
+          def device_name
+            storage_device.display_name || ""
+          end
+
+          # Description of the device.
+          #
+          # @return [String] e.g., "EXT4 Partition".
+          def device_description
+            Y2Storage::DeviceDescription.new(storage_device, include_encryption: true).to_s
+          end
+
+          # Adds the required sub-sections according to the storage object.
+          #
+          # @param hash [Hash] the argument gets modified
+          def add_sections(hash)
+            conversions = Section.subclasses.select { |c| c.apply?(storage_device) }
+
+            conversions.each do |conversion|
+              hash.merge!(conversion.new(storage_device).convert)
+            end
+          end
+
+          # Add nested devices like partitions or LVM logical volumes
+          #
+          # @param hash [Hash] the argument gets modified
+          def add_nested_devices(hash)
+            add_partitions(hash)
+            add_logical_volumes(hash)
+          end
+
+          # @see #add_nested_devices
+          def add_partitions(hash)
+            return unless PartitionTable.apply?(storage_device)
+
+            hash[:partitions] = storage_device.partition_table.partitions.map do |part|
+              self.class.new(part).convert
+            end
+          end
+
+          # @see #add_nested_devices
+          def add_logical_volumes(hash)
+            return unless VolumeGroup.apply?(storage_device)
+
+            hash[:logicalVolumes] = storage_device.lvm_lvs.map do |lv|
+              self.class.new(lv).convert
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/drive.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/drive.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with properties for drive devices.
+        class Drive < Section
+          # Whether this section should be exported for the given device.
+          #
+          # Drive and disk device are very close concepts, but there are subtle differences. For
+          # example, a MD RAID is never considered as a drive.
+          #
+          # TODO: Revisit the defintion of drive. Maybe some MD devices could implement the drive
+          #   interface if hwinfo provides useful information for them.
+          #
+          # @param storage_device [Y2Storage::Device]
+          # @return [Boolean]
+          def self.apply?(storage_device)
+            storage_device.is?(:disk, :dm_raid, :multipath, :dasd) &&
+              storage_device.is?(:disk_device)
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            {
+              type:      drive_type,
+              vendor:    drive_vendor,
+              model:     drive_model,
+              bus:       drive_bus,
+              busId:     drive_bus_id,
+              driver:    drive_driver,
+              transport: drive_transport,
+              info:      drive_info
+            }
+          end
+
+          # Drive type
+          #
+          # @return ["disk", "raid", "multipath", "dasd", nil] Nil if type is unknown.
+          def drive_type
+            if storage_device.is?(:disk)
+              "disk"
+            elsif storage_device.is?(:dm_raid)
+              "raid"
+            elsif storage_device.is?(:multipath)
+              "multipath"
+            elsif storage_device.is?(:dasd)
+              "dasd"
+            end
+          end
+
+          # Vendor name
+          #
+          # @return [String, nil]
+          def drive_vendor
+            storage_device.vendor
+          end
+
+          # Model name
+          #
+          # @return [String, nil]
+          def drive_model
+            storage_device.model
+          end
+
+          # Bus name
+          #
+          # @return [String, nil]
+          def drive_bus
+            # FIXME: not sure whether checking for "none" is robust enough
+            return if storage_device.bus.nil? || storage_device.bus.casecmp?("none")
+
+            storage_device.bus
+          end
+
+          # Bus Id for DASD
+          #
+          # @return [String, nil]
+          def drive_bus_id
+            return unless storage_device.respond_to?(:bus_id)
+
+            storage_device.bus_id
+          end
+
+          # Kernel drivers used by the device
+          #
+          # @return [Array<String>]
+          def drive_driver
+            storage_device.driver
+          end
+
+          # Data transport layer, if any
+          #
+          # @return [String, nil]
+          def drive_transport
+            return unless storage_device.respond_to?(:transport)
+
+            transport = storage_device.transport
+            return if transport.nil? || transport.is?(:unknown)
+
+            # FIXME: transport does not have proper i18n support at yast2-storage-ng, so we are
+            # just duplicating some logic from yast2-storage-ng here
+            return "USB" if transport.is?(:usb)
+            return "IEEE 1394" if transport.is?(:sbp)
+
+            transport.to_s
+          end
+
+          # More info about the device
+          #
+          # @return [Hash]
+          def drive_info
+            {
+              sdCard:   storage_device.sd_card?,
+              dellBoss: storage_device.boss?
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/filesystem.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/filesystem.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+require "y2storage/filesystem_label"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with properties for formatted devices.
+        class Filesystem < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:blk_device) && !storage_device.filesystem.nil?
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            {
+              sid:       filesystem_sid,
+              type:      filesystem_type,
+              mountPath: filesystem_mount_path,
+              label:     filesystem_label
+            }
+          end
+
+          # SID of the file system.
+          #
+          # It is useful to detect whether a file system is new.
+          #
+          # @return [Integer]
+          def filesystem_sid
+            storage_device.filesystem.sid
+          end
+
+          # File system type.
+          #
+          # @return [String] e.g., "ext4"
+          def filesystem_type
+            storage_device.filesystem.type.to_s
+          end
+
+          # Mount path of the file system.
+          #
+          # @return [String, nil] Nil if not mounted.
+          def filesystem_mount_path
+            storage_device.filesystem.mount_path
+          end
+
+          # Label of the file system.
+          #
+          # @return [String, nil] Nil if it has no label.
+          def filesystem_label
+            label = Y2Storage::FilesystemLabel.new(storage_device).to_s
+            return if label.empty?
+
+            label
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/md.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/md.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with the properties of MD RAID devices.
+        class Md < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:md)
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            {
+              uuid:    md_uuid,
+              level:   md_level,
+              devices: md_devices
+            }
+          end
+
+          # UUID of the MD RAID
+          #
+          # @return [String, nil]
+          def md_uuid
+            storage_device.uuid
+          end
+
+          # RAID level
+          #
+          # @return [String]
+          def md_level
+            storage_device.md_level.to_s
+          end
+
+          # SIDs of the objects representing the devices of the MD RAID.
+          #
+          # @return [Array<Integer>]
+          def md_devices
+            storage_device.plain_devices.map(&:sid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/multipath.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/multipath.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with properties for multipath devices.
+        class Multipath < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:multipath)
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            { wireNames: multipath_wire_names }
+          end
+
+          # Name of the multipath wires.
+          #
+          # @note: The multipath wires are not exported yet.
+          #
+          # @return [Array<String>]
+          def multipath_wire_names
+            storage_device.parents.map(&:name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/partition.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/partition.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with properties for partitions.
+        class Partition < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:partition)
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            { efi: partition_efi }
+          end
+
+          # Whether it is a (valid) EFI System partition
+          #
+          # @return [Boolean]
+          def partition_efi
+            storage_device.efi_system?
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/partition_table.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/partition_table.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section for devices that contain a partition table.
+        class PartitionTable < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:blk_device) &&
+              storage_device.respond_to?(:partition_table?) &&
+              storage_device.partition_table?
+          end
+
+        private
+
+          # @see Section.conversions
+          def conversions
+            {
+              type:        partition_table_type,
+              unusedSlots: partition_table_unused_slots
+            }
+          end
+
+          # Type of the partition table
+          #
+          # @return [String]
+          def partition_table_type
+            storage_device.partition_table.type.to_s
+          end
+
+          # Available slots within a partition table, that is, the spaces that can be used to
+          # create a new partition.
+          #
+          # @return [Array<Array(Integer, Integer)>] The first block and the size of each slot.
+          def partition_table_unused_slots
+            storage_device.partition_table.unused_partition_slots.map do |slot|
+              [slot.region.start, slot.region.size.to_i]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/section.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/section.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Base class for all the sub-sections that are only included for certain types of devices.
+        class Section
+          # Whether it makes sense to export this section as part of the hash.
+          #
+          # To be redefined by every subclass.
+          #
+          # @param _storage_device [Y2Storage::Device] device to describe
+          # @return [Boolean]
+          def self.apply?(_storage_device)
+            false
+          end
+
+          # @param storage_device [Y2Storage::Device]
+          def initialize(storage_device)
+            @storage_device = storage_device
+          end
+
+          # Hash representing the section with information about the Y2Storage device.
+          #
+          # @return [Hash]
+          def convert
+            { section_name => conversions.compact }
+          end
+
+        private
+
+          # Device to convert
+          # @return [Y2Storage::Device]
+          attr_reader :storage_device
+
+          # Name of the section
+          #
+          # @return [Symbol]
+          def section_name
+            name = class_basename
+            (name[0].downcase + name[1..-1]).to_sym
+          end
+
+          # Properties included in the section
+          #
+          # To be defined by every subclass
+          #
+          # @return [Hash]
+          def conversions
+            {}
+          end
+
+          # @see #section_name
+          def class_basename
+            self.class.name.split("::").last
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/sections.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/sections.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+require "agama/storage/devicegraph_conversions/to_json_conversions/block"
+require "agama/storage/devicegraph_conversions/to_json_conversions/drive"
+require "agama/storage/devicegraph_conversions/to_json_conversions/filesystem"
+require "agama/storage/devicegraph_conversions/to_json_conversions/md"
+require "agama/storage/devicegraph_conversions/to_json_conversions/multipath"
+require "agama/storage/devicegraph_conversions/to_json_conversions/partition"
+require "agama/storage/devicegraph_conversions/to_json_conversions/partition_table"
+require "agama/storage/devicegraph_conversions/to_json_conversions/volume_group"

--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/volume_group.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/volume_group.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/devicegraph_conversions/to_json_conversions/section"
+
+module Agama
+  module Storage
+    module DevicegraphConversions
+      module ToJSONConversions
+        # Section with the properties of an LVM Volume Group.
+        class VolumeGroup < Section
+          # @see Section.apply?
+          def self.apply?(storage_device)
+            storage_device.is?(:lvm_vg)
+          end
+
+        private
+
+          # @see Section#conversions
+          def conversions
+            {
+              size:            lvm_vg_size,
+              physicalVolumes: lvm_vg_pvs
+            }
+          end
+
+          # Size of the volume group in bytes
+          #
+          # @return [Integer]
+          def lvm_vg_size
+            storage_device.size.to_i
+          end
+
+          # D-Bus paths of the objects representing the physical volumes.
+          #
+          # @return [Array<String>]
+          def lvm_vg_pvs
+            storage_device.lvm_pvs.map(&:sid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/devicegraph_conversions/to_json_test.rb
+++ b/service/test/agama/storage/devicegraph_conversions/to_json_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../storage_helpers"
+require "agama/storage/devicegraph_conversions"
+require "y2storage/refinements"
+
+using Y2Storage::Refinements::SizeCasts
+
+describe Agama::Storage::DevicegraphConversions::ToJSON do
+  include Agama::RSpec::StorageHelpers
+
+  before do
+    mock_storage(devicegraph: scenario)
+    allow_any_instance_of(Y2Storage::Partition).to receive(:resize_info).and_return(resize_info)
+  end
+
+  subject { described_class.new(devicegraph) }
+
+  let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
+
+  let(:resize_info) do
+    instance_double(
+      Y2Storage::ResizeInfo, resize_ok?: true, reasons: [],
+      min_size: Y2Storage::DiskSize.GiB(20), max_size: Y2Storage::DiskSize.GiB(40)
+    )
+  end
+
+  describe "#convert" do
+    describe "for a devicegraph with several disks" do
+      let(:scenario) { "disks.yaml" }
+
+      it "generates an entry for each disk" do
+        json = subject.convert
+        expect(json.map { |e| e[:name] }).to contain_exactly("/dev/vda", "/dev/vdb", "/dev/vdc")
+      end
+
+      it "exports the block device sizes in bytes" do
+        json = subject.convert
+        expect(json.map { |e| e[:block][:size] }).to all eq(50 * 1024 * 1024 * 1024)
+      end
+
+      it "generates the :partitions and :partitionTable entries only for partitioned disks" do
+        json = subject.convert
+
+        vda = json.find { |d| d[:name] == "/dev/vda" }
+        expect(vda[:partitions].size).to eq 3
+        expect(vda[:partitionTable][:type]).to eq "gpt"
+
+        vdb = json.find { |d| d[:name] == "/dev/vdb" }
+        expect(vdb.keys).to_not include :partitions
+        expect(vdb.keys).to_not include :partitionTable
+
+        vdc = json.find { |d| d[:name] == "/dev/vdc" }
+        expect(vdc.keys).to_not include :partitions
+        expect(vdc.keys).to_not include :partitionTable
+      end
+
+      it "generates the :filesystem entry only for formatted disks" do
+        json = subject.convert
+
+        vda = json.find { |d| d[:name] == "/dev/vda" }
+        expect(vda.keys).to_not include :filesystem
+
+        vdb = json.find { |d| d[:name] == "/dev/vdb" }
+        expect(vdb.keys).to_not include :filesystem
+
+        vdc = json.find { |d| d[:name] == "/dev/vdc" }
+        expect(vdc.keys).to include :filesystem
+        expect(vdc[:filesystem][:type]).to eq "ext4"
+      end
+    end
+
+    describe "for a devicegraph with LVM" do
+      let(:scenario) { "trivial_lvm.yml" }
+
+      it "generates an entry for each disk and volume group" do
+        json = subject.convert
+        expect(json.map { |e| e[:name] }).to contain_exactly("/dev/sda", "/dev/vg0")
+      end
+
+      it "exports the size and physical volumes of the LVM volume group" do
+        json = subject.convert
+        vg0 = json.find { |d| d[:name] == "/dev/vg0" }
+        expect(vg0[:volumeGroup][:size]).to eq (100 * 1024 * 1024 * 1024) - (4 * 1024 * 1024)
+        pvs = vg0[:volumeGroup][:physicalVolumes]
+        expect(pvs).to be_a Array
+        expect(pvs.size).to eq 1
+      end
+
+      it "generates the :logicalVolumes entries only for LVM volume groups" do
+        json = subject.convert
+
+        sda = json.find { |d| d[:name] == "/dev/sda" }
+        expect(sda.keys).to_not include :logicalVolumes
+
+        vg0 = json.find { |d| d[:name] == "/dev/vg0" }
+        lvs = vg0[:logicalVolumes]
+        expect(lvs.map { |lv| lv[:name] }).to eq ["/dev/vg0/lv1"]
+        expect(lvs.first[:block].keys).to include :size
+      end
+
+      it "generates the :filesystem entry for formatted logical volumes" do
+        json = subject.convert
+        vg0 = json.find { |d| d[:name] == "/dev/vg0" }
+        lv = vg0[:logicalVolumes].first
+
+        expect(lv.keys).to include :filesystem
+        expect(lv[:filesystem][:type]).to eq "btrfs"
+      end
+    end
+
+    describe "for a devicegraph with MD RAIDs" do
+      let(:scenario) { "md_disks.yaml" }
+
+      it "generates an entry for each disk and MD RAID" do
+        json = subject.convert
+        expect(json.map { |e| e[:name] }).to contain_exactly("/dev/vda", "/dev/vdb", "/dev/md0")
+      end
+
+      it "exports the level and members of the MD RAIDs" do
+        json = subject.convert
+        md0 = json.find { |d| d[:name] == "/dev/md0" }
+        expect(md0[:md][:level]).to eq "raid0"
+        members = md0[:md][:devices]
+        expect(members).to be_a Array
+        expect(members.size).to eq 2
+      end
+    end
+
+    describe "for a devicegraph with multipath devices" do
+      let(:scenario) { "multipath-formatted.xml" }
+
+      it "generates an entry for each multipath device" do
+        json = subject.convert
+        expect(json.map { |e| e[:name] }).to eq ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"]
+      end
+
+      it "exports the name of the multipath wires" do
+        json = subject.convert
+        wires = json.first[:multipath][:wireNames]
+        expect(wires).to contain_exactly("/dev/sda", "/dev/sdb")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pull request created to discuss some aspects about the code organization.

1. I created the concept of `Section` for stuff that used to be D-Bus interfaces (Drive, Block, Filesystem, etc.) But I didn't group all the sections at a separate namespace because I felt that `Agama::Storage::DevicegraphConversions::ToJSONConversions::Section::Block` was already too much.
2. ~~For symmetry with the other conversions, I created a `DevicegraphConversions::ToJSON` class and a `DevicegraphConversions::ToJSONConversions::Devicegraph` one. But I find the second to be unnecessary. It's just one extra level but with the same responsibilities and API.~~
3. I decided to nest the partitions directly on the "partitionable" device instead of doing it inside of `:partition_table` (that is, inside the PartitionTable interface). That's a change compared to the D-BUS interface (they are nested within PartitionTable there). It kind of makes sense from the organization point of view and also from the code point of view (see below), but I'm not 100% sure.
4. I separated the concept of sections and nested devices. There is indeed a semantical difference. But honestly I only separated the concept to avoid some kind of "circular dependency" (it is not elegant if the sections create devices because then `ToJSONConversions::Device` would require the sections and some section may require `ToJSONConversions::Device`).
