### PR TITLE
Remove kernel-default-{extra,optional} from SLES

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 22 05:34:43 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove kernel-default-extra and kernel-default-optional from
+  SLES 16 images (bsc#1249690).
+
+-------------------------------------------------------------------
 Tue Oct 21 20:10:44 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Enable plymouth bootsplash for agama and also propose it for

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -162,8 +162,6 @@
     </packages>
     <packages type="image" profiles="SUSE_SLE_16">
         <package name="MozillaFirefox-branding-SLE"/>
-        <package name="kernel-default-extra"/>
-        <package name="kernel-default-optional"/>
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
## Problem

The installation media includes kernel modules that are not supported in SLES.

- [bsc#1249690](https://bugzilla.suse.com/show_bug.cgi?id=1249690)

## Solution

According to [bsc#1249690](https://bugzilla.suse.com/show_bug.cgi?id=1249690#c32) stop including
`kernel-default-extra` and `kernel-default-optional` packages in the live media. Keep them for Leap.
