### PR TITLE
Fixed plymouth configuration, start it already in the initramfs

### DIFF
--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -24,8 +24,16 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>bgrt</bootsplash-theme>
+    </preferences>
+    <!-- different boot menu theme for openSUSE and SLES, actually this is
+    ignored as the fix_bootconfig script automatically checks which theme is
+    present, but keep the option here otherwise a text mode boot menu is
+    displayed -->
+    <preferences profiles="openSUSE,Leap_16.0">
         <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences profiles="SUSE_SLE_16">
+        <bootloader-theme>SLE</bootloader-theme>
     </preferences>
     <!-- the ISO Volume ID is set by the fix_bootconfig script -->
     <preferences arch="ppc64le" profiles="openSUSE,SUSE_SLE_16,Leap_16.0">
@@ -117,6 +125,7 @@
         <package name="tpm2.0-tools" />
         <!-- plymouth bsc#1248507 -->
         <package name="plymouth" />
+        <package name="plymouth-dracut" />
     </packages>
 
     <!-- packages for local installation (desktop, browser, etc.) -->
@@ -142,6 +151,7 @@
         <package name="openSUSE-build-key"/>
         <package name="patterns-openSUSE-base"/>
         <package name="staging-build-key"/>
+        <package name="plymouth-branding-openSUSE" />
     </packages>
     <!-- additional packages for the Leap distributions -->
     <packages type="image" profiles="Leap_16.0">


### PR DESCRIPTION
## Problem

- The SLE-16 image currently does not build
- It reports error "KiwiCommandError: chroot: stderr: /usr/share/plymouth/themes/bgrt/bgrt.plymouth does not exist"

## Details

- This is related to #2820 
- Unfortunately the Kiwi file uses the openSUSE "bgrt" theme globally for all profiles, including SLES which does not contain this theme

## Solution

- Initially I wanted to have a separate configuration for each openSUSE and SLES, but it turned out that the default is actually correctly configured by the respective "plymouth-branding-*" package so in the end we do not need this config option in the Kiwi file and simply use the distribution default.

## Additional fixes

- A similar problem exists with the bootloader theme, but as we generate the boot menu completely by the `fix_bootconfig` scripts then this problem does not happen in the end. The script itself checks which theme is present and uses the correct one. But to avoid confusion that the "openSUSE" value is also configured for SLES I have moved that to two separate sections. Unfortunately when removing the option a text mode boot menu was displayed so unlike the splash theme this really needs to be present.
- Explicitly added the "plymouth-branding-openSUSE" package in openSUSE. In theory it should not be needed, but when building the image for Tumbleweed I got "have choice for plymouth-branding needed by plymouth: plymouth-branding-openSUSE plymouth-branding-upstream" error and this resolves the problem. In SLES the SLES branding is correctly selected without any problems.
- Added the "plymouth-dracut" package to include the splash screen already in the initramfs system, otherwise in is installed only in the root image and then the splash screen is displayed too late in the process. Basically just few seconds before starting the Firefox browser so then it is more or less useless.

## Testing

- Tested manually in both SLES-16 and openSUSE Tumbleweed images

## Screenshots

### Tumbleweed Live ISO

The BGRT openSUSE theme reuses the logo image provided by the UEFI firmware, so in VirtualBox it displays its logo. This is vendor dependent, in different systems you might see different logos.

[agama-splash-boot-opensuse-screen0.webm](https://github.com/user-attachments/assets/9e746fc5-1ac5-465e-9792-06d80b84c9f5)

### SLE-16 Live ISO

Unfortunately for some reason the splash screen just flashes and then it disappears. But the systemd output is not displayed on the console anymore so it seems it is still at least partly running.

This does not look like related to Agama or the Live ISO configuration. The problem is either in kernel or in plymouth, definitely not in Agama Live ISO as the config is the same as in Tumbleweed which works quite fine (see above). I'll open a bug report for that.

[agama-manual-splash-test-screen0.webm](https://github.com/user-attachments/assets/1c950fa7-bb44-446b-a936-4a9f537256ed)

