### PR TITLE
Disable the Kalpa definition

### DIFF
--- a/products.d/agama-products.spec
+++ b/products.d/agama-products.spec
@@ -50,8 +50,9 @@ rm -f %{buildroot}%{_datadir}/agama/products.d/tumbleweed.yaml
 rm -f %{buildroot}%{_datadir}/agama/products.d/slowroll.yaml
 %endif
 
-# Keep TW-based distros on TW (drop Leap + Leap Micro)
+# Keep TW-based distros on TW (drop Kalpa + Leap + Leap Micro)
 %if 0%{?is_opensuse} && 0%{?suse_version} > 1600
+rm -f %{buildroot}%{_datadir}/agama/products.d/kalpa.yaml
 rm -f %{buildroot}%{_datadir}/agama/products.d/leap*.yaml
 %endif
 


### PR DESCRIPTION
After merging #2817, `agama-products` fails to build as the Kalpa definition is still on the repository. We are renaming it to `kalpa.conf.disabled` so it is not considered by our installation script.
