### PR TITLE
[SLE-16] Use the openSUSE Tumbleweed container for creating POT files

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: registry.opensuse.org/opensuse/leap:16.0
+      image: registry.opensuse.org/opensuse/tumbleweed:latest
 
     steps:
       - name: Configure and refresh repositories


### PR DESCRIPTION
- Fixes the Action problem https://github.com/agama-project/agama/actions/runs/18904457364/job/53959261619#step:7:7 (`xgettext: language 'tsx' unknown`)
- The Leap 16.0 distribution contains an old gettext which does not support TSX files. That is supported in newer gettext in Tumbleweed.
