### PR TITLE
Fix POT update - the openSUSE:repo-openh264 repo is missing in Tumbleweed

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Configure and refresh repositories
         # disable unused repositories to have a faster refresh
-        run: zypper modifyrepo -d openSUSE:repo-openh264 && zypper ref
+        run: zypper ref
 
       - name: Install Default Ruby
         run: zypper --non-interactive install --no-recommends ruby


### PR DESCRIPTION
## Problem

The GitHub action fails because the openSUSE:repo-openh264 repository is present only in Leap, not in Tumbleweed.