### PR TITLE
SSL and GPG related options for self-update

### DIFF
--- a/live/live-root/usr/bin/live-self-update
+++ b/live/live-root/usr/bin/live-self-update
@@ -171,19 +171,6 @@ add_update_repos() {
         zypper_options="--gpgcheck-allow-unsigned-repo"
       fi
 
-      # allow using unsigned packages
-      if grep -q "\binst.self_update_unsigned_package=1\b" /run/agama/cmdline.d/agama.conf; then
-        warning "Unsigned packages are allowed"
-        zypper_options="$zypper_options --gpgcheck-allow-unsigned-package"
-      fi
-
-      # allow using unsigned repository and packages (for some reason zypper complains when using
-      # both options above together and implements a special switch for this)
-      if grep -q "\binst.self_update_unsigned=1\b" /run/agama/cmdline.d/agama.conf; then
-        warning "Unsigned repository and packages are allowed"
-        zypper_options="$zypper_options --gpgcheck-allow-unsigned"
-      fi
-
       # completely disable GPG checks, not recommended, if possible the options
       # above should be preferred
       if grep -q "\binst.self_update_gpg=0\b" /run/agama/cmdline.d/agama.conf; then


### PR DESCRIPTION
## Problem

- Missing RMT support for self-update (allow using a self-signed SSL certificate)
- Cannot use a testing self-update repository with unknown GPG or an unsigned testing repository

## Solution

- Added `inst.self_update_ssl=0` boot option for ignoring SSL problems when contacting the registration server (should be only used for RMT or when using a custom repository, never for the official SCC server) and when using the repository returned by the registration server.   
  *Note: This is basically almost the same as using the plain HTTP protocol, in the future we probably should add an option to allow specifying the SSL certificate fingerprint on boot command line and if matched the certificate would be automatically imported into the system.*
- Added GPG related options:
  - `inst.self_update_unsigned_repo=1` - allow using an unsigned repository (but the packages are still verified)
  - `inst.self_update_unsigned_package=1` - allow installing an unsigned RPM package (the repository or the other signed packages are still verified)
  - `inst.self_update_unsigned=1` - allow using unsigned repository and unsigned packages (zypper has for some reason a special option for this and complains when using the above two options together)
  - `inst.self_update_import_key=1` - automatically trust and import the GPG key from the repository
  - `inst.self_update_gpg=0` - the ultimate option, completely disables GPG checks, allows installing packages with unknown signature or even broken or modified packages. If possible the options above should be preferred.

I'm not sure if we need to support all GPG related zypper options but they are cheap, it is just a trvial "if" in the code so maybe why not?

I'd like to avoid using the ultimate `inst.self_update_gpg=0` option if possible. The other options should be preferred, this option should be only used as the last resort if anything else fails.

## Testing

- Tested manually

<img width="1280" height="800" alt="agama-self-update-log2" src="https://github.com/user-attachments/assets/5c6757cd-c66d-413d-bf1d-f62031832e77" />


<details>

<summary>Full log from an example run</summary>

- Test run with `inst.self_update_ssl=0`, `inst.self_update_gpg=0` and `inst.self_update_import_key=1` option. Yes, that is a bit weird combination when you disable GPG checks completely but I wanted to test passing the parameters to zypper.
- Output from `journalctl -o cat -t live-self-update` (without timestamps and host name to make it shorter):

```
Will use the default registration server https://scc.suse.com for obtaining the self-update repository
Enabling network configuration
Using default DHCP network configuration
+ '[' -e /dracut-state.sh ']'
+ . /dracut-state.sh
++ export 'CMDLINE= root=live:LABEL=Install-SUSE-SLE-16-x86_64 root_disk=live:LABEL=Install-SUSE-SLE-16-x86_64 rd.neednet=1 ip=dhcp   BOOT_IMAGE=(cd0)/boot/x86_64/loader/linux splash=silent inst.self_update_ssl=0 inst.self_update_gpg=0 inst.self_update_import_key=1'
++ CMDLINE=' root=live:LABEL=Install-SUSE-SLE-16-x86_64 root_disk=live:LABEL=Install-SUSE-SLE-16-x86_64 rd.neednet=1 ip=dhcp   BOOT_IMAGE=(cd0)/boot/x86_64/loader/linux splash=silent inst.self_update_ssl=0 inst.self_update_gpg=0 inst.self_update_import_key=1'
++ export CURL_HOME=/run/initramfs/url-lib
++ CURL_HOME=/run/initramfs/url-lib
++ export DEBUG_MEM_LEVEL=0
++ DEBUG_MEM_LEVEL=0
++ export DRACUT_SYSTEMD=1
++ DRACUT_SYSTEMD=1
++ export INVOCATION_ID=ecc0971e522f4f17a00dc1db3223773c
++ INVOCATION_ID=ecc0971e522f4f17a00dc1db3223773c
++ export JOURNAL_STREAM=9:474
++ JOURNAL_STREAM=9:474
++ export LANG=C.UTF-8
++ LANG=C.UTF-8
++ export NEWROOT=/sysroot
++ NEWROOT=/sysroot
++ export OLDPWD
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
++ export PWD=/
++ PWD=/
++ export RD_DEBUG=no
++ RD_DEBUG=no
++ export SHLVL=1
++ SHLVL=1
++ export SYSTEMD_EXEC_PID=349
++ SYSTEMD_EXEC_PID=349
++ export TERM=linux
++ TERM=linux
++ export USER=root
++ USER=root
++ export fstype=auto
++ fstype=auto
++ export hookdir=/lib/dracut/hooks
++ hookdir=/lib/dracut/hooks
++ export netroot
++ export rflags=
++ rflags=
++ export root=live:/dev/disk/by-label/Install-SUSE-SLE-16-x86_64
++ root=live:/dev/disk/by-label/Install-SUSE-SLE-16-x86_64
++ dirname /usr/bin/live-self-update
+ . /usr/bin/../lib/live-self-update/conf.sh
++ RUN_DIR=/run/live-self-update
++ REPO_FILE=/run/live-self-update/repositories
++ SERVER_FILE=/run/live-self-update/server
++ SKIP_FILE=/run/live-self-update/skip
++ CONFIG_DIR=/etc/live-self-update
++ CONFIG_FALLBACK_FILE=/etc/live-self-update/fallback_url
++ CONFIG_DEFAULT_REG_SERVER_FILE=/etc/live-self-update/default_reg_server_url
++ FALLBACK_REPOS_FILE=/etc/live-self-update/fallback_url_expanded
+ RESPONSE_FILE=/run/live-self-update/server_response
+ REG_REPO_FILE=/run/live-self-update/reg_repos
+ OSR=/etc/os-release
++ uname -m
+ ARCH=x86_64
+ trap cleanup_chroot EXIT
+ install_updates
+ index=0
+ self_update_repos=()
+ '[' -f /run/live-self-update/repositories ']'
+ query_reg_server
+ local server
+ '[' -f /run/live-self-update/server ']'
+ '[' -f /etc/live-self-update/default_reg_server_url ']'
+ server=https://scc.suse.com
+ '[' -n https://scc.suse.com ']'
+ read_os_release
+ '[' -f /etc/os-release ']'
+ . /etc/os-release
++ NAME=SLES
++ VARIANT='Enterprise Server'
++ VARIANT_ID=server
++ VERSION_ID=16.0
++ ANSI_COLOR='0;32'
++ ID=sles
++ ID_LIKE='suse opensuse'
++ CPE_NAME=cpe:/o:suse:sles:16:16.0
++ SUSE_SUPPORT_PRODUCT='SUSE Linux Enterprise Server'
++ SUSE_SUPPORT_PRODUCT_VERSION=16.0
++ HOME_URL=https://www.suse.com/products/server/
++ DOCUMENTATION_URL=https://documentation.suse.com/sles/16.0/
++ LOGO=distributor-logo
++ VERSION='16.0 dracut-059+suse.696.g950c4798-160000.1.2'
++ PRETTY_NAME='SUSE Linux Enterprise Server 16.0 dracut-059+suse.696.g950c4798-160000.1.2 (Initramfs)'
++ DRACUT_VERSION=059+suse.696.g950c4798-160000.1.2
+ local query
+ query='https://scc.suse.com/connect/repositories/installer?identifier=SLES&version=16.0&arch=x86_64'
+ info 'Running query https://scc.suse.com/connect/repositories/installer?identifier=SLES&version=16.0&arch=x86_64....'
Running query https://scc.suse.com/connect/repositories/installer?identifier=SLES&version=16.0&arch=x86_64....
+ local curl_options
+ grep -q '\binst.self_update_ssl=0\b' /run/agama/cmdline.d/agama.conf
+ warning 'Disabling SSL check for https://scc.suse.com'
Disabling SSL check for https://scc.suse.com
+ curl_options=--insecure
+ curl --insecure --silent --globoff --location --retry 3 --retry-connrefused --connect-timeout 20 --max-time 10 --fail --show-error --output /run/live-self-update/server_response -- 'https://scc.suse.com/connect/repositories/installer?identifier=SLES&version=16.0&arch=x86_64'
++ jq -r '.[] | select(.installer_updates==true) | .description' /run/live-self-update/server_response
+ info 'Found self-update repository:  '
Found self-update repository:
+ jq -r '.[] | select(.installer_updates==true) | .url' /run/live-self-update/server_response
+ '[' -s /run/live-self-update/reg_repos ']'
+ '[' -s /etc/live-self-update/fallback_url ']'
+ milestone 'Using fallback repository'
Using fallback repository
+ read_fallback_repos
+ sed -e 's/$os_release_name/SLES/g' -e 's/$os_release_id/sles/g' -e 's/$os_release_version_id/16.0/g' -e 's/$os_release_version/16.0 dracut-059+suse.696.g950c4798-160000.1.2/g' -e 's/$arch/x86_64/g' /etc/live-self-update/fallback_url
+ prepare_chroot
+ '[' -n /sysroot ']'
+ milestone 'Preparing for the self update...'
Preparing for the self update...
+ mount -o bind /run /sysroot/run
+ mount -o bind /sys /sysroot/sys
+ mount -o bind /proc /sysroot/proc
+ mount -o bind /dev /sysroot/dev
+ '[' -f /run/NetworkManager/resolv.conf ']'
+ cp /run/NetworkManager/resolv.conf /sysroot/etc/resolv.conf
+ rm -f
+ add_update_repos /etc/live-self-update/fallback_url_expanded
+ milestone 'Adding self update repositories...'
Adding self update repositories...
+ read -r update_url
+ '[' -n https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/ ']'
+ local repo
+ repo=self-update-0
+ grep -q '\binst.self_update_ssl=0\b' /run/agama/cmdline.d/agama.conf
+ warning 'Disabling SSL check for repository https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/'
Disabling SSL check for repository https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/
+ local base
+ local query
+ query=https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/
+ base=https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/
+ '[' -z https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/ ']'
+ '[' https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/ = https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/ ']'
+ update_url='https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/?ssl_verify=no'
+ local zypper_options
+ grep -q '\binst.self_update_unsigned_repo=1\b' /run/agama/cmdline.d/agama.conf
+ grep -q '\binst.self_update_unsigned_package=1\b' /run/agama/cmdline.d/agama.conf
+ grep -q '\binst.self_update_unsigned=1\b' /run/agama/cmdline.d/agama.conf
+ grep -q '\binst.self_update_gpg=0\b' /run/agama/cmdline.d/agama.conf
+ warning 'Disabling all GPG checks!'
Disabling all GPG checks!
+ zypper_options=' --no-gpgcheck'
+ run_command zypper addrepo --no-gpgcheck -f 'https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/?ssl_verify=no' self-update-0
+ '[' -z /sysroot ']'
+ /sysroot/usr/bin/chroot /sysroot zypper addrepo --no-gpgcheck -f 'https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/?ssl_verify=no' self-update-0
Adding repository 'self-update-0' [.....done]
Warning: GPG checking is disabled in configuration of repository 'self-update-0'. Integrity and origin of packages cannot be verified.
Repository 'self-update-0' successfully added
URI         : https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/16.0/x86_64/product/?ssl_verify=no
Enabled     : Yes
GPG Check   : No
Autorefresh : Yes
Priority    : 99 (default priority)
Repository priorities are without effect. All enabled repositories share the same priority.
+ self_update_repos+=("$repo")
+ (( ++index ))
+ read -r update_url
+ local zypper_options
+ grep -q '\binst.self_update_import_key=1\b' /run/agama/cmdline.d/agama.conf
+ warning 'Enabled GPG key autoimport'
Enabled GPG key autoimport
+ zypper_options=--gpg-auto-import-keys
+ milestone 'Loading repositories...'
Loading repositories...
+ run_command zypper --gpg-auto-import-keys refresh self-update-0
+ '[' -z /sysroot ']'
+ /sysroot/usr/bin/chroot /sysroot zypper --gpg-auto-import-keys refresh self-update-0
Retrieving repository 'self-update-0' metadata [....done]
Building repository 'self-update-0' cache [....done]
Specified repositories have been refreshed.
+ repo_options=()
+ for repo in "${self_update_repos[@]}"
+ repo_options+=("--repo" "$repo")
+ milestone 'Updating packages...'
Updating packages...
+ run_command zypper --non-interactive update --allow-downgrade --allow-vendor-change --details --no-recommends --repo self-update-0
+ '[' -z /sysroot ']'
+ /sysroot/usr/bin/chroot /sysroot zypper --non-interactive update --allow-downgrade --allow-vendor-change --details --no-recommends --repo self-update-0
Loading repository data...
Reading installed packages...
Nothing to do.
+ milestone 'Cleaning the system...'
Cleaning the system...
+ run_command zypper clean --all
+ '[' -z /sysroot ']'
+ /sysroot/usr/bin/chroot /sysroot zypper clean --all
All repositories have been cleaned up.
+ for repo in "${self_update_repos[@]}"
+ run_command zypper modifyrepo --disable self-update-0
+ '[' -z /sysroot ']'
+ /sysroot/usr/bin/chroot /sysroot zypper modifyrepo --disable self-update-0
Repository 'self-update-0' has been successfully disabled.
+ cleanup_chroot
+ '[' 0 '!=' 0 ']'
+ milestone 'Self update successfully finished'
Self update successfully finished
+ '[' -n /sysroot ']'
+ rm -f /sysroot/etc/resolv.conf
+ findmnt /sysroot/run
+ umount /sysroot/run
+ findmnt /sysroot/sys
+ umount /sysroot/sys
+ findmnt /sysroot/proc
+ umount /sysroot/proc
+ findmnt /sysroot/dev
+ umount /sysroot/dev
```

</details>

