### PR TITLE
Keep the AMD GPU firmware files (bsc#1250952)

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Nov  5 09:17:43 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Include the AMD GPU firmware files (bsc#1250952)
+
+-------------------------------------------------------------------
 Mon Nov  3 07:54:50 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Improved installer self-update (jsc#PED-12506):

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -334,9 +334,6 @@ if [ "$(arch)" == "aarch64" ]; then
 	echo 'install_items+=" /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcadsp8280.mbn.xz /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qccdsp8280.mbn.xz "' >> /etc/dracut.conf.d/x13s_modules.conf
 fi
 
-# delete some AMD GPU firmware
-rm -rf /lib/firmware/amdgpu/{gc_,isp,psp}*
-
 # Decompress kernel modules, better for squashfs (boo#1192457)
 find /lib/modules/*/kernel -name '*.ko.xz' -exec xz -d {} +
 find /lib/modules/*/kernel -name '*.ko.zst' -exec zstd --rm -d {} +


### PR DESCRIPTION
## Problem

- Missing AMD GPU firmware causes using the EFI framebuffer fallback
- https://bugzilla.suse.com/show_bug.cgi?id=1250952

## Solution

- Do not delete the firmware files

## Testing

- Tested manually (but only tested building the Live ISO, not tested with real hardware)
