### PR TITLE
Do not build on 32bit architectures (and PPC64-BE) (bsc#1251846)

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 13 13:30:58 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not build on 32bit arches (like i586) and PPC64-BE,
+  the dependant libsuseconnect is 64bit only (bsc#1251846)
+
+-------------------------------------------------------------------
 Thu Nov 13 09:39:58 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix removal of kalpa to work also in SLE

--- a/products.d/agama-products.spec
+++ b/products.d/agama-products.spec
@@ -26,6 +26,9 @@ URL:            https://github.com/agama-project/agama
 BuildArch:      noarch
 Source0:        agama.tar
 
+# do not include in the 32bit repos, the Agama is 64bit only
+ExcludeArch:    %ix86 s390 ppc64
+
 %description
 Products definition for Agama installer.
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 19 14:49:59 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not build on 32bit arches (like i586) and PPC64-BE,
+  the dependant libsuseconnect does not support these (bsc#1251846)
+
+-------------------------------------------------------------------
 Tue Nov 18 08:47:11 UTC 2025 - Michal Filka <mfilka@suse.com>
 
 - Fixed passing arguments when "agama config generate" with an

--- a/rust/package/agama.spec
+++ b/rust/package/agama.spec
@@ -27,6 +27,9 @@ Url:            https://github.com/agama-project/agama
 Source0:        agama.tar
 Source1:        vendor.tar.zst
 
+# do not build on 32bits, the dependant libsuseconnect is 64bit only
+ExcludeArch:    %ix86 s390 ppc64
+
 # defines the "limit_build" macro used in the "build" section below
 BuildRequires:  memory-constraints
 BuildRequires:  cargo-packaging

--- a/service/agama-yast.spec.in
+++ b/service/agama-yast.spec.in
@@ -27,6 +27,9 @@ BuildRequires:  gettext-runtime
 Requires:       dbus-1-common
 Requires:       rubygem(agama-yast)
 
+# do not build on 32bits, the dependant libsuseconnect is 64bit only
+ExcludeArch:    %ix86 s390 ppc64
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  ruby-macros >= 5
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 13 13:30:58 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not build on 32bit arches (like i586) and PPC64-BE,
+  the dependant libsuseconnect does not support these (bsc#1251846)
+
+-------------------------------------------------------------------
 Wed Nov 12 15:42:26 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 18

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 13 13:30:58 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not build on 32bit arches (like i586) and PPC64-BE,
+  the dependant libsuseconnect does not support these (bsc#1251846)
+
+-------------------------------------------------------------------
 Wed Nov 12 15:42:28 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 18

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -33,6 +33,9 @@ BuildArch:      noarch
 BuildRequires:  local-npm-registry
 BuildRequires:  appstream-glib
 
+# do not include in the 32bit repos, the Agama is 64bit only
+ExcludeArch:    %ix86 s390 ppc64
+
 %description
 Agama web UI for the experimental Agama installer.
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1251846
- Agama does not build on i586
- The reason is that the dependant libsuseconnect does not support that architecture (because of [this line](https://github.com/SUSE/connect-ng/blob/5a200487c50d9c955708b34d0d35ebef47dc5a3e/internal/util/system.go#L24-L27))

## Solution

- Disable the same architectures also in Agama builds, use [the same line](https://github.com/SUSE/connect-ng/blob/5a200487c50d9c955708b34d0d35ebef47dc5a3e/build/packaging/suseconnect-ng.spec#L42) from libsuseconnect to be compatible with it (this also disables build on PPC64-BE)
- I was wondering whether `ExcludeArch` is allowed for noarch packages but the [Fedora packaging documentation](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_noarch_with_unported_dependencies) actually suggests this approach exactly for this situation.

## Testing

- Tested manually with agama-web-ui, the package built fine locally 

