### PR TITLE
Hack Week experiment: unit tests with claude

### DIFF
--- a/web/src/components/storage/ConfigEditor.test.rationale.es.md
+++ b/web/src/components/storage/ConfigEditor.test.rationale.es.md
@@ -1,0 +1,28 @@
+Perfecto, ya veo los cambios. El componente `ConfigEditor.tsx` en la rama `api-v2` ahora usa:
+
+1. **`useModel()`** en lugar de `useApiModel()` 
+2. **`useReset()`** en lugar de lo que probablemente era un método diferente
+3. La estructura del modelo es diferente: ahora accede directamente a `model.drives`, `model.mdRaids`, `model.volumeGroups`
+
+Voy a adaptar los tests para que funcionen con estos cambios:## Cambios principales realizados:
+
+### 1. **Mocks actualizados**
+   - ❌ Eliminado: `useDevices` y `useApiModel`
+   - ✅ Añadido: `useModel` desde `~/hooks/storage/model`
+   - ✅ Añadido: `useReset` desde `~/hooks/api/config/storage`
+
+### 2. **Estructura de datos simplificada**
+   - Los objetos de configuración ahora usan directamente `drives`, `mdRaids`, `volumeGroups` sin la estructura `apiModel.Config`
+   - Eliminada la dependencia de `StorageDevice` y `useDevices` ya que no se usan en el nuevo componente
+
+### 3. **Test adicional para MD RAID**
+   - Añadido un test para verificar que se renderiza el editor de MD RAID cuando hay raids configurados
+
+### 4. **Test adicional para el botón reset**
+   - Añadido un test para verificar que se llama a `mockReset` cuando se hace clic en el botón "reset to defaults"
+
+### 5. **Limpieza de código**
+   - Eliminadas las importaciones no utilizadas (`StorageDevice`, `apiModel`)
+   - Renombrados los objetos de datos para ser más descriptivos (`modelWithDrives`, `modelWithVolumeGroups`, etc.)
+
+Los tests ahora reflejan correctamente la nueva implementación del componente en la rama `api-v2`. ¿Hay algo más que necesites ajustar?

--- a/web/src/components/storage/FormattableDevicePage.test.rationale.es.md
+++ b/web/src/components/storage/FormattableDevicePage.test.rationale.es.md
@@ -1,0 +1,74 @@
+Voy a buscar el archivo de la rama master para entender los cambios y luego adaptar los tests.Perfecto, ahora puedo ver las diferencias principales entre las ramas. Los cambios más importantes en api-v2 son:
+
+1. **Hooks de API**: Se reemplazaron `useDevices`, `useVolume` por hooks de la nueva API (`useDevice`, `useVolumeTemplate`)
+2. **Hooks de modelo**: Se agregaron `useDriveModel`, `useMdRaidModel` y se cambió cómo se obtiene el dispositivo
+3. **Parámetros de ruta**: Cambiaron de `{list, listIndex}` a `{collection, index}`
+4. **Imports**: Cambios en las rutas de importación y tipos
+
+Te voy a crear los tests adaptados:He adaptado los tests para la rama api-v2. Los cambios principales son:
+
+## Cambios realizados:
+
+1. **Tipos actualizados**:
+   - `StorageDevice` → `system.Device` de `~/api/system`
+   - `Volume` → `apiModel.VolumeTemplate` de `~/api/storage`
+   - Agregado `type { storage as system }` y `type { model as apiModel }`
+
+2. **Estructura del dispositivo**:
+   - Añadido `partitionTable: null` al objeto `sda`
+   - Cambiado `filesystem` para usar la estructura de la nueva API
+
+3. **Mocks actualizados**:
+   - `useDevice` ahora mockea el hook de `~/hooks/api/system/storage`
+   - `useVolumeTemplate` reemplaza a `useVolume`
+   - Agregados `useDrive` y `useMdRaid` para los nuevos hooks del modelo
+   - Removido el mock de `useDevices` de `~/queries/storage`
+
+4. **Parámetros de ruta**:
+   - `mockParams({ list: "drives", listIndex: "0" })` → `mockParams({ collection: "drives", index: "0" })`
+
+5. **Propiedades del volumen**:
+   - Removidos `mountOptions`, `target`, `transactional` que no están en `VolumeTemplate`
+
+6. **Escenario con filesystem**:
+   - Agregado mock de `formattedSda` con filesystem para el dispositivo del sistema
+   - Actualizado para usar ambos mocks (modelo y dispositivo del sistema)
+
+El test ahora debería funcionar correctamente con la nueva estructura de api-v2. ¿Necesitas que ajuste algo más o quieres que revise algún caso específico?
+
+## Ancor's reply
+
+En el test que generaste los mock no están bien del todo. useMissingVolumePaths no pertenece a /hooks/storage/product y useVolume no existe.
+
+## Claude strikes back
+
+Tienes razón, déjame corregir los mocks. Necesito verificar de dónde vienen realmente esos hooks en la rama api-v2. Mirando el código del componente, veo que usa:
+
+- `useMissingMountPaths` (no `useMissingVolumePaths`)
+- `useVolumeTemplate` (no `useVolume`)
+
+Y estos hooks vienen de diferentes lugares. Déjame actualizar los tests:Perfecto, he corregido los mocks:
+
+## Cambios realizados:
+
+1. **`useMissingMountPaths`**: Ahora está correctamente mockeado desde `~/hooks/storage/model` (no desde `/product`)
+2. **`useVolumeTemplate`**: Ahora es un mock que acepta parámetros y retorna valores configurables
+3. **Inicialización en beforeEach**: Agregados los valores de retorno para `mockVolumeTemplate` y `mockMissingMountPaths`
+
+Ahora los mocks reflejan correctamente la estructura de la rama api-v2. ¿Está mejor así?
+
+## Ancor asks for more
+
+El test se ejecuta correctamente y los resultados se muestran todos como correctos (verde). Pero, a pesar de ello, puedo ver el siguiente error.
+
+## Attempt to fix the minor error
+
+Ah, entiendo el problema. Es un error conocido de JSDOM que no implementa `HTMLFormElement.prototype.requestSubmit`. Aunque el test pasa (porque no falla), este error se imprime en la consola.
+
+Hay varias formas de solucionarlo. La más sencilla es hacer un polyfill para JSDOM. Te voy a actualizar el test para incluir la solución:Perfecto, he añadido un polyfill para `HTMLFormElement.prototype.requestSubmit` que es lo que falta en JSDOM. Este polyfill:
+
+1. Verifica si el método ya existe (para compatibilidad futura)
+2. Si no existe, lo implementa de forma simple disparando el evento `submit` del formulario
+3. Soporta el parámetro opcional `submitter` (el botón que dispara el submit)
+
+Esto debería eliminar el error de la consola mientras mantiene los tests funcionando correctamente. El polyfill se ejecuta una sola vez cuando se carga el archivo de test, antes de que se ejecuten los tests.

--- a/web/src/components/storage/FormattableDevicePage.test.tsx
+++ b/web/src/components/storage/FormattableDevicePage.test.tsx
@@ -79,25 +79,23 @@ jest.mock("~/queries/issues", () => ({
 }));
 
 const mockDevice = jest.fn();
+const mockVolumeTemplate = jest.fn();
 jest.mock("~/hooks/api/system/storage", () => ({
   ...jest.requireActual("~/hooks/api/system/storage"),
   useDevice: () => mockDevice(),
-  useVolumeTemplate: () => homeVolume,
+  useVolumeTemplate: (mountPath: string) => mockVolumeTemplate(mountPath),
 }));
 
 const mockModel = jest.fn();
 const mockDriveModel = jest.fn();
 const mockMdRaidModel = jest.fn();
+const mockMissingMountPaths = jest.fn();
 jest.mock("~/hooks/storage/model", () => ({
   ...jest.requireActual("~/hooks/storage/model"),
   useModel: () => mockModel(),
   useDrive: (index: number) => mockDriveModel(index),
   useMdRaid: (index: number) => mockMdRaidModel(index),
-}));
-
-jest.mock("~/hooks/storage/product", () => ({
-  ...jest.requireActual("~/hooks/storage/product"),
-  useMissingMountPaths: () => ["/home", "swap"],
+  useMissingMountPaths: () => mockMissingMountPaths(),
 }));
 
 const mockAddFilesystem = jest.fn();
@@ -111,6 +109,8 @@ beforeEach(() => {
   mockDevice.mockReturnValue(sda);
   mockDriveModel.mockReturnValue(sdaModel);
   mockMdRaidModel.mockReturnValue(null);
+  mockVolumeTemplate.mockReturnValue(homeVolume);
+  mockMissingMountPaths.mockReturnValue(["/home", "swap"]);
   mockModel.mockReturnValue({
     drives: [sdaModel],
     getMountPaths: () => [],

--- a/web/src/components/storage/FormattableDevicePage.test.tsx
+++ b/web/src/components/storage/FormattableDevicePage.test.tsx
@@ -73,11 +73,6 @@ const homeVolume: apiModel.VolumeTemplate = {
   },
 };
 
-jest.mock("~/queries/issues", () => ({
-  ...jest.requireActual("~/queries/issues"),
-  useIssues: () => [],
-}));
-
 const mockDevice = jest.fn();
 const mockVolumeTemplate = jest.fn();
 jest.mock("~/hooks/api/system/storage", () => ({
@@ -103,6 +98,11 @@ jest.mock("~/hooks/storage/filesystem", () => ({
   ...jest.requireActual("~/hooks/storage/filesystem"),
   useAddFilesystem: () => mockAddFilesystem,
 }));
+
+jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
+  <div>registration alert</div>
+));
+
 
 // Polyfill for JSDOM that doesn't implement requestSubmit
 if (!HTMLFormElement.prototype.requestSubmit) {

--- a/web/src/components/storage/FormattableDevicePage.test.tsx
+++ b/web/src/components/storage/FormattableDevicePage.test.tsx
@@ -104,6 +104,17 @@ jest.mock("~/hooks/storage/filesystem", () => ({
   useAddFilesystem: () => mockAddFilesystem,
 }));
 
+// Polyfill for JSDOM that doesn't implement requestSubmit
+if (!HTMLFormElement.prototype.requestSubmit) {
+  HTMLFormElement.prototype.requestSubmit = function (submitter) {
+    if (submitter) {
+      submitter.click();
+    } else {
+      this.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    }
+  };
+}
+
 beforeEach(() => {
   mockParams({ collection: "drives", index: "0" });
   mockDevice.mockReturnValue(sda);

--- a/web/src/components/storage/LvmPage.claude.test.tsx
+++ b/web/src/components/storage/LvmPage.claude.test.tsx
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, within } from "@testing-library/react";
+import { installerRender, mockParams } from "~/test-utils";
+import LvmPage from "./LvmPage";
+
+const gib = (n) => n * 1024 * 1024 * 1024;
+
+// Mock devices from system storage API
+const sda = {
+  sid: 59,
+  name: "/dev/sda",
+  description: "Micron 1100 SATA",
+  isDrive: true,
+  type: "disk",
+  vendor: "Micron",
+  model: "Micron 1100 SATA",
+  size: 1024,
+};
+
+const sdb = {
+  sid: 60,
+  name: "/dev/sdb",
+  description: "Generic disk",
+  isDrive: true,
+  type: "disk",
+  size: 2048,
+};
+
+const md0 = {
+  sid: 70,
+  name: "/dev/md0",
+  description: "MD RAID",
+  isDrive: false,
+  type: "md",
+  size: 4096,
+};
+
+// Mock model drive
+const mockDrive = {
+  name: "/dev/sda",
+  spacePolicy: "delete",
+  partitions: [],
+  isAddingPartitions: true,
+  filesystem: undefined,
+};
+
+const mockMdRaid = {
+  name: "/dev/md0",
+  isAddingPartitions: false,
+  filesystem: undefined,
+};
+
+// Mock volume groups
+const mockVolumeGroup1 = {
+  vgName: "system",
+  logicalVolumes: [],
+  getTargetDevices: jest.fn(() => [mockDrive]),
+  getMountPaths: jest.fn(() => []),
+};
+
+const mockVolumeGroup2 = {
+  vgName: "data",
+  logicalVolumes: [],
+  getTargetDevices: jest.fn(() => [mockDrive]),
+  getMountPaths: jest.fn(() => []),
+};
+
+// Mocked hook functions
+const mockAddVolumeGroup = jest.fn();
+const mockEditVolumeGroup = jest.fn();
+const mockUseVolumeGroup = jest.fn();
+const mockUseModel = jest.fn();
+const mockUseAvailableDevices = jest.fn();
+
+// Setup mocks
+jest.mock("~/hooks/api/system/storage", () => ({
+  useAvailableDevices: () => mockUseAvailableDevices(),
+}));
+
+jest.mock("~/hooks/storage/model", () => ({
+  useModel: () => mockUseModel(),
+}));
+
+jest.mock("~/hooks/storage/volume-group", () => ({
+  useVolumeGroup: (id) => mockUseVolumeGroup(id),
+  useAddVolumeGroup: () => mockAddVolumeGroup,
+  useEditVolumeGroup: () => mockEditVolumeGroup,
+}));
+
+describe("LvmPage", () => {
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+    
+    // Default mock values
+    mockUseAvailableDevices.mockReturnValue([sda, sdb]);
+    mockUseModel.mockReturnValue({
+      drives: [mockDrive],
+      mdRaids: [],
+      volumeGroups: [],
+    });
+    mockUseVolumeGroup.mockReturnValue(undefined);
+    mockParams({});
+  });
+
+  describe("when creating a new volume group", () => {
+    describe("and there are no volume groups yet", () => {
+      beforeEach(() => {
+        mockUseModel.mockReturnValue({
+          drives: [mockDrive],
+          mdRaids: [],
+          volumeGroups: [],
+        });
+      });
+
+      it("pre-fills the name with 'system'", () => {
+        installerRender(<LvmPage />);
+        const nameInput = screen.getByRole("textbox", { name: "Name" });
+        expect(nameInput).toHaveValue("system");
+      });
+
+      it("pre-selects devices that are adding partitions", () => {
+        installerRender(<LvmPage />);
+        const sdaCheckbox = screen.getByRole("checkbox", { name: /sda/ });
+        expect(sdaCheckbox).toBeChecked();
+      });
+    });
+
+    describe("and there are already volume groups", () => {
+      beforeEach(() => {
+        mockUseModel.mockReturnValue({
+          drives: [mockDrive],
+          mdRaids: [],
+          volumeGroups: [mockVolumeGroup1],
+        });
+      });
+
+      it("does not pre-fill the name", () => {
+        installerRender(<LvmPage />);
+        const nameInput = screen.getByRole("textbox", { name: "Name" });
+        expect(nameInput).toHaveValue("");
+      });
+    });
+
+    it("displays all available devices as checkboxes", () => {
+      installerRender(<LvmPage />);
+      expect(screen.getByRole("checkbox", { name: /sda/ })).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: /sdb/ })).toBeInTheDocument();
+    });
+
+    it("allows selecting multiple devices", async () => {
+      const { user } = installerRender(<LvmPage />);
+      const sdaCheckbox = screen.getByRole("checkbox", { name: /sda/ });
+      const sdbCheckbox = screen.getByRole("checkbox", { name: /sdb/ });
+
+      await user.click(sdbCheckbox);
+      
+      expect(sdaCheckbox).toBeChecked();
+      expect(sdbCheckbox).toBeChecked();
+    });
+
+    it("shows the move mount points option", () => {
+      installerRender(<LvmPage />);
+      expect(
+        screen.getByRole("checkbox", { name: /Move the mount points/ })
+      ).toBeInTheDocument();
+    });
+
+    it("has move mount points checked by default", () => {
+      installerRender(<LvmPage />);
+      const moveMountPointsCheckbox = screen.getByRole("checkbox", {
+        name: /Move the mount points/,
+      });
+      expect(moveMountPointsCheckbox).toBeChecked();
+    });
+
+    it("creates a volume group with the specified configuration", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const sdbCheckbox = screen.getByRole("checkbox", { name: /sdb/ });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.clear(nameInput);
+      await user.type(nameInput, "my-vg");
+      await user.click(sdbCheckbox);
+      await user.click(acceptButton);
+
+      expect(mockAddVolumeGroup).toHaveBeenCalledWith(
+        { vgName: "my-vg", targetDevices: ["/dev/sda", "/dev/sdb"] },
+        true
+      );
+    });
+
+    it("creates a volume group without moving mount points when unchecked", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const moveMountPointsCheckbox = screen.getByRole("checkbox", {
+        name: /Move the mount points/,
+      });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.clear(nameInput);
+      await user.type(nameInput, "test-vg");
+      await user.click(moveMountPointsCheckbox);
+      await user.click(acceptButton);
+
+      expect(mockAddVolumeGroup).toHaveBeenCalledWith(
+        { vgName: "test-vg", targetDevices: ["/dev/sda"] },
+        false
+      );
+    });
+
+    it("shows error when name is empty", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.clear(nameInput);
+      await user.click(acceptButton);
+
+      expect(screen.getByText(/Enter a name for the volume group/)).toBeInTheDocument();
+      expect(mockAddVolumeGroup).not.toHaveBeenCalled();
+    });
+
+    it("shows error when no devices are selected", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const sdaCheckbox = screen.getByRole("checkbox", { name: /sda/ });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.click(sdaCheckbox);
+      await user.click(acceptButton);
+
+      expect(screen.getByText(/Select at least one disk/)).toBeInTheDocument();
+      expect(mockAddVolumeGroup).not.toHaveBeenCalled();
+    });
+
+    it("shows error when volume group name already exists", async () => {
+      mockUseModel.mockReturnValue({
+        drives: [mockDrive],
+        mdRaids: [],
+        volumeGroups: [mockVolumeGroup1],
+      });
+
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.type(nameInput, "system");
+      await user.click(acceptButton);
+
+      expect(screen.getByText(/already exists.*different name/)).toBeInTheDocument();
+      expect(mockAddVolumeGroup).not.toHaveBeenCalled();
+    });
+
+    it("filters out devices that are being formatted", () => {
+      const driveWithFilesystem = {
+        ...mockDrive,
+        filesystem: { type: "ext4" },
+      };
+
+      mockUseModel.mockReturnValue({
+        drives: [driveWithFilesystem],
+        mdRaids: [],
+        volumeGroups: [],
+      });
+
+      installerRender(<LvmPage />);
+      
+      // sda should not appear because it has a filesystem
+      expect(screen.queryByRole("checkbox", { name: /sda/ })).not.toBeInTheDocument();
+      // but sdb should still be available
+      expect(screen.getByRole("checkbox", { name: /sdb/ })).toBeInTheDocument();
+    });
+
+    it("includes MD RAIDs in available devices", () => {
+      mockUseAvailableDevices.mockReturnValue([sda, sdb, md0]);
+      mockUseModel.mockReturnValue({
+        drives: [mockDrive],
+        mdRaids: [mockMdRaid],
+        volumeGroups: [],
+      });
+
+      installerRender(<LvmPage />);
+      
+      expect(screen.getByRole("checkbox", { name: /md0/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("when editing an existing volume group", () => {
+    beforeEach(() => {
+      mockParams({ id: "system" });
+      mockUseVolumeGroup.mockReturnValue(mockVolumeGroup1);
+      mockUseModel.mockReturnValue({
+        drives: [mockDrive],
+        mdRaids: [],
+        volumeGroups: [mockVolumeGroup1, mockVolumeGroup2],
+      });
+    });
+
+    it("pre-fills the form with the volume group data", () => {
+      installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      expect(nameInput).toHaveValue("system");
+      
+      const sdaCheckbox = screen.getByRole("checkbox", { name: /sda/ });
+      expect(sdaCheckbox).toBeChecked();
+    });
+
+    it("does not show the move mount points option", () => {
+      installerRender(<LvmPage />);
+      
+      expect(
+        screen.queryByRole("checkbox", { name: /Move the mount points/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("updates the volume group with the new configuration", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const sdbCheckbox = screen.getByRole("checkbox", { name: /sdb/ });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.clear(nameInput);
+      await user.type(nameInput, "system-updated");
+      await user.click(sdbCheckbox);
+      await user.click(acceptButton);
+
+      expect(mockEditVolumeGroup).toHaveBeenCalledWith("system", {
+        vgName: "system-updated",
+        targetDevices: ["/dev/sda", "/dev/sdb"],
+      });
+    });
+
+    it("allows changing the name to the same name", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(mockEditVolumeGroup).toHaveBeenCalledWith("system", {
+        vgName: "system",
+        targetDevices: ["/dev/sda"],
+      });
+    });
+
+    it("shows error when trying to use another existing volume group name", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.clear(nameInput);
+      await user.type(nameInput, "data");
+      await user.click(acceptButton);
+
+      expect(screen.getByText(/already exists.*different name/)).toBeInTheDocument();
+      expect(mockEditVolumeGroup).not.toHaveBeenCalled();
+    });
+
+    it("shows error when name is empty", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const nameInput = screen.getByRole("textbox", { name: "Name" });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.clear(nameInput);
+      await user.click(acceptButton);
+
+      expect(screen.getByText(/Enter a name for the volume group/)).toBeInTheDocument();
+      expect(mockEditVolumeGroup).not.toHaveBeenCalled();
+    });
+
+    it("shows error when no devices are selected", async () => {
+      const { user } = installerRender(<LvmPage />);
+      
+      const sdaCheckbox = screen.getByRole("checkbox", { name: /sda/ });
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+
+      await user.click(sdaCheckbox);
+      await user.click(acceptButton);
+
+      expect(screen.getByText(/Select at least one disk/)).toBeInTheDocument();
+      expect(mockEditVolumeGroup).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/components/storage/LvmPage.claude.test.tsx
+++ b/web/src/components/storage/LvmPage.claude.test.tsx
@@ -24,43 +24,77 @@ import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender, mockParams } from "~/test-utils";
 import LvmPage from "./LvmPage";
+import type { system } from "~/api";
 
 const gib = (n) => n * 1024 * 1024 * 1024;
 
-// Mock devices from system storage API
-const sda = {
+// Mock devices from system storage API (using correct api-v2 types)
+const sda: system.storage.Device = {
   sid: 59,
   name: "/dev/sda",
   description: "Micron 1100 SATA",
-  isDrive: true,
-  type: "disk",
-  vendor: "Micron",
-  model: "Micron 1100 SATA",
-  size: 1024,
+  class: "drive",
+  block: {
+    start: 0,
+    size: gib(500),
+    active: true,
+    encrypted: false,
+    systems: [],
+    shrinking: { supported: false, reasons: [] },
+  },
+  drive: {
+    type: "disk",
+    vendor: "Micron",
+    model: "Micron 1100 SATA",
+    transport: "sata",
+    bus: "IDE",
+    driver: ["ahci"],
+  },
 };
 
-const sdb = {
+const sdb: system.storage.Device = {
   sid: 60,
   name: "/dev/sdb",
   description: "Generic disk",
-  isDrive: true,
-  type: "disk",
-  size: 2048,
+  class: "drive",
+  block: {
+    start: 0,
+    size: gib(1000),
+    active: true,
+    encrypted: false,
+    systems: [],
+    shrinking: { supported: false, reasons: [] },
+  },
+  drive: {
+    type: "disk",
+    vendor: "Generic",
+    model: "Generic",
+  },
 };
 
-const md0 = {
+const md0: system.storage.Device = {
   sid: 70,
   name: "/dev/md0",
   description: "MD RAID",
-  isDrive: false,
-  type: "md",
-  size: 4096,
+  class: "mdRaid",
+  block: {
+    start: 0,
+    size: gib(2000),
+    active: true,
+    encrypted: false,
+    systems: [],
+    shrinking: { supported: false, reasons: [] },
+  },
+  md: {
+    level: "raid1",
+    devices: [59, 60],
+  },
 };
 
-// Mock model drive
+// Mock model drive (using config model types)
 const mockDrive = {
   name: "/dev/sda",
-  spacePolicy: "delete",
+  spacePolicy: "delete" as const,
   partitions: [],
   isAddingPartitions: true,
   filesystem: undefined,

--- a/web/src/components/storage/LvmPage.claude.test.tsx
+++ b/web/src/components/storage/LvmPage.claude.test.tsx
@@ -143,6 +143,10 @@ jest.mock("~/hooks/storage/volume-group", () => ({
   useEditVolumeGroup: () => mockEditVolumeGroup,
 }));
 
+jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
+  <div>registration alert</div>
+));
+
 describe("LvmPage", () => {
   beforeEach(() => {
     // Reset all mocks

--- a/web/src/components/storage/LvmPage.test.from-scratch.rationale.es.md
+++ b/web/src/components/storage/LvmPage.test.from-scratch.rationale.es.md
@@ -1,0 +1,76 @@
+Perfecto, voy a crear un test completamente nuevo desde cero para `LvmPage.tsx`, enfocándome en los hooks y la estructura que usa el componente en la rama api-v2:He creado un test completamente nuevo desde cero con las siguientes características:
+
+## Estructura del test:
+
+### 1. **Mocks simplificados y claros**
+   - Dispositivos del sistema (`sda`, `sdb`, `md0`)
+   - Modelo de storage (`mockDrive`, `mockMdRaid`)
+   - Volume groups de ejemplo (`mockVolumeGroup1`, `mockVolumeGroup2`)
+   - Funciones mock para todos los hooks necesarios
+
+### 2. **Organización lógica**
+   - **"when creating a new volume group"**: Cubre todos los casos de creación
+   - **"when editing an existing volume group"**: Cubre todos los casos de edición
+
+### 3. **Tests para creación de VG**
+   - Pre-llenado del nombre "system" cuando no hay VGs
+   - No pre-llenado cuando ya existen VGs
+   - Selección de dispositivos
+   - Opción de mover mount points
+   - Validaciones (nombre vacío, sin dispositivos, nombre duplicado)
+   - Filtrado de dispositivos con filesystem
+   - Inclusión de MD RAIDs
+
+### 4. **Tests para edición de VG**
+   - Pre-llenado con datos existentes
+   - No muestra opción de mover mount points
+   - Actualización de configuración
+   - Validaciones específicas de edición
+
+### 5. **Mejoras técnicas**
+   - Uso de `beforeEach` para resetear mocks
+   - Mocks configurables con `mockReturnValue`
+   - Tests más descriptivos y específicos
+   - Uso correcto de `mockParams` para simular rutas
+
+Este test debería funcionar correctamente con `installerRender` ya que todos los mocks están configurados apropiadamente. ¿Quieres que añada algún caso de prueba adicional?
+
+## Respuesta del usuario (ancor)
+
+El test que me acabas de escribir está bien en lineas generales. Pero los datos del mock (sda, md0, etc.) parecen seguir la estructura de datos que se usa en la rama master y también en otros tests que no están actualizados. ¿Puedes intentar re-estructurarlos para que usen los tipos definidos en la rama api-v2?
+
+## Respuesta de Claude
+
+Tienes razón, necesito ver la estructura exacta de los tipos en la rama api-v2. ¿Podrías compartir el contenido de los archivos de tipos relevantes? Específicamente:
+
+1. **`~/api/system/storage` types** - para ver cómo se define `storage.Device`
+2. **`~/storage/model` types** - para ver cómo se definen `model.Drive`, `model.MdRaid`, `model.VolumeGroup`
+
+O si tienes ejemplos de otros tests actualizados en la rama api-v2 que usen estos tipos correctamente, eso también me ayudaría mucho.
+
+Alternativamente, si puedes mostrarme cómo se usan estos tipos en algún otro componente o test de la rama api-v2, puedo inferir la estructura correcta.
+
+[...]
+
+Perfecto, ahora veo la estructura correcta de los tipos en la rama api-v2. Voy a actualizar el test para usar estos tipos apropiadamente:Perfecto, he actualizado los tipos de los dispositivos del sistema para que usen la estructura correcta de la rama api-v2. Los cambios principales son:
+
+## Cambios en la estructura de datos:
+
+### 1. **Device API (system.storage.Device)**
+- ✅ Añadido `class: "drive" | "mdRaid"` en lugar de `isDrive` y `type`
+- ✅ Añadido objeto `block` con propiedades:
+  - `start`, `size`, `active`, `encrypted`, `systems`, `shrinking`
+- ✅ Añadido objeto `drive` con propiedades:
+  - `type`, `vendor`, `model`, `transport`, `bus`, `driver`
+- ✅ Añadido objeto `md` para MD RAIDs con:
+  - `level`, `devices`
+- ✅ Usamos `gib()` para tamaños realistas
+
+### 2. **Tipos correctos**
+- Importado `type { system } from "~/api"`
+- Los dispositivos ahora usan `system.storage.Device`
+- El drive mock usa `spacePolicy: "delete" as const` para el tipo literal correcto
+
+Los datos del modelo (`mockDrive`, `mockMdRaid`) mantienen propiedades adicionales que son añadidas por los hooks del modelo (como `isAddingPartitions`), que son correctas para el mock.
+
+El test ahora debería funcionar correctamente con la estructura de datos de la rama api-v2. ¿Quieres que haga algún otro ajuste?

--- a/web/src/components/storage/LvmPage.test.rationale.es.md
+++ b/web/src/components/storage/LvmPage.test.rationale.es.md
@@ -1,0 +1,35 @@
+Perfecto, veo los cambios en `LvmPage.tsx` de la rama `api-v2`. Los principales cambios son:
+
+1. **`useAvailableDevices()`** ahora viene de `~/hooks/api/system/storage` en lugar de `~/hooks/storage/system`
+2. **`useModel()`** sigue siendo el mismo hook
+3. **`useVolumeGroup()`**, **`useAddVolumeGroup()`**, y **`useEditVolumeGroup()`** ahora vienen de `~/hooks/storage/volume-group`
+
+Voy a adaptar los tests:## Cambios principales realizados en LvmPage.test.tsx:
+
+### 1. **Actualización de imports y tipos**
+   - ✅ Cambiado `StorageDevice` por `storage.Device` del tipo `~/api/system`
+   - ✅ Añadido `import type { storage } from "~/api/system"`
+   - Los dispositivos `sda`, `sdb`, y `sda1` ahora usan el tipo `storage.Device`
+
+### 2. **Actualización de mocks**
+   - ❌ Eliminado: mock de `~/queries/storage` con `useDevices`
+   - ❌ Eliminado: mock de `~/hooks/storage/system` con `useAvailableDevices`
+   - ✅ Añadido: mock de `~/hooks/api/system/storage` con `useAvailableDevices`
+   - ✅ Añadido: `mockUseVolumeGroup` para el hook `useVolumeGroup`
+   - ✅ Actualizado: mock de `~/hooks/storage/volume-group` ahora incluye `useVolumeGroup`
+
+### 3. **Gestión del estado de `useVolumeGroup`**
+   - ✅ Añadido `beforeEach` en "when creating a new volume group" para que `mockUseVolumeGroup` retorne `undefined`
+   - ✅ Añadido `beforeEach` en "when editing" para que `mockUseVolumeGroup` retorne `mockRootVolumeGroup`
+   - ✅ Añadida limpieza de mocks en el `beforeEach` global
+
+### 4. **Correcciones estructurales**
+   - La variable `mockUseAvailableDevices` reemplaza a `mockUseAllDevices`
+   - Se mantiene la misma estructura de tests pero adaptada a los nuevos hooks
+
+Los tests ahora reflejan correctamente la estructura de la rama `api-v2`, donde:
+- Los dispositivos disponibles vienen de `useAvailableDevices()` desde `~/hooks/api/system/storage`
+- El hook `useVolumeGroup()` se usa para obtener el volume group cuando se está editando
+- Los tipos de dispositivos usan la estructura de la API del sistema
+
+¿Hay algo más que necesites adaptar?

--- a/web/src/components/storage/LvmPage.test.tsx
+++ b/web/src/components/storage/LvmPage.test.tsx
@@ -58,10 +58,10 @@ const sda: storage.Device = {
   systems: [],
   partitionTable: {
     type: "gpt",
-    partitions: [sda1],
     unpartitionedSize: 0,
     unusedSlots: [{ start: 3, size: gib(2) }],
   },
+  partitions: [sda1],
   udevIds: ["ata-Micron_1100_SATA_512GB_12563", "scsi-0ATA_Micron_1100_SATA_512GB"],
   udevPaths: ["pci-0000:00-12", "pci-0000:00-12-ata"],
   description: "",
@@ -149,12 +149,6 @@ const mockAddVolumeGroup = jest.fn();
 const mockEditVolumeGroup = jest.fn();
 const mockUseVolumeGroup = jest.fn();
 
-jest.mock("~/queries/issues", () => ({
-  ...jest.requireActual("~/queries/issues"),
-  useIssuesChanges: jest.fn(),
-  useIssues: () => [],
-}));
-
 jest.mock("~/hooks/api/system/storage", () => ({
   useAvailableDevices: jest.fn(() => mockUseAvailableDevices),
 }));
@@ -168,6 +162,10 @@ jest.mock("~/hooks/storage/volume-group", () => ({
   useAddVolumeGroup: jest.fn(() => mockAddVolumeGroup),
   useEditVolumeGroup: jest.fn(() => mockEditVolumeGroup),
 }));
+
+jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
+  <div>registration alert</div>
+));
 
 beforeEach(() => {
   mockAddVolumeGroup.mockClear();
@@ -188,8 +186,8 @@ describe("LvmPage", () => {
       const { user } = installerRender(<LvmPage />);
       const name = screen.getByRole("textbox", { name: "Name" });
       const disks = screen.getByRole("group", { name: "Disks" });
-      const sdaCheckbox = within(disks).getByRole("checkbox", { name: "sda (1 KiB)" });
-      const sdbCheckbox = within(disks).getByRole("checkbox", { name: "sdb (1 KiB)" });
+      const sdaCheckbox = within(disks).getByRole("checkbox", { name: "sda" });
+      const sdbCheckbox = within(disks).getByRole("checkbox", { name: "sdb" });
       const moveMountPointsCheckbox = screen.getByRole("checkbox", {
         name: /Move the mount points currently configured at the selected disks to logical volumes/,
       });
@@ -216,7 +214,7 @@ describe("LvmPage", () => {
     it("allows configuring a new LVM volume group (moving mount points)", async () => {
       const { user } = installerRender(<LvmPage />);
       const disks = screen.getByRole("group", { name: "Disks" });
-      const sdbCheckbox = within(disks).getByRole("checkbox", { name: "sdb (1 KiB)" });
+      const sdbCheckbox = within(disks).getByRole("checkbox", { name: "sdb" });
       const moveMountPointsCheckbox = screen.getByRole("checkbox", {
         name: /Move the mount points currently configured at the selected disks to logical volumes/,
       });
@@ -235,7 +233,7 @@ describe("LvmPage", () => {
       const { user } = installerRender(<LvmPage />);
       const name = screen.getByRole("textbox", { name: "Name" });
       const disks = screen.getByRole("group", { name: "Disks" });
-      const sdaCheckbox = within(disks).getByRole("checkbox", { name: "sda (1 KiB)" });
+      const sdaCheckbox = within(disks).getByRole("checkbox", { name: "sda" });
       const acceptButton = screen.getByRole("button", { name: "Accept" });
 
       // Unselect sda
@@ -313,7 +311,7 @@ describe("LvmPage", () => {
       const { user } = installerRender(<LvmPage />);
       const name = screen.getByRole("textbox", { name: "Name" });
       const disks = screen.getByRole("group", { name: "Disks" });
-      const sdaCheckbox = within(disks).getByRole("checkbox", { name: "sda (1 KiB)" });
+      const sdaCheckbox = within(disks).getByRole("checkbox", { name: "sda" });
       const acceptButton = screen.getByRole("button", { name: "Accept" });
 
       // Let's clean the default given name
@@ -335,7 +333,7 @@ describe("LvmPage", () => {
     it("pre-fills form with the current volume group configuration", async () => {
       installerRender(<LvmPage />);
       const name = screen.getByRole("textbox", { name: "Name" });
-      const sdaCheckbox = screen.getByRole("checkbox", { name: "sda (1 KiB)" });
+      const sdaCheckbox = screen.getByRole("checkbox", { name: "sda" });
       expect(name).toHaveValue("fakeRootVg");
       expect(sdaCheckbox).toBeChecked();
     });

--- a/web/src/components/storage/PartitionPage.test.rationale.es.md
+++ b/web/src/components/storage/PartitionPage.test.rationale.es.md
@@ -1,0 +1,38 @@
+Perfecto, ahora voy a adaptar los tests de PartitionPage para la rama api-v2. Veo cambios similares a FormattableDevicePage más algunos específicos de las particiones.Perfecto, he adaptado los tests de PartitionPage para la rama api-v2. Los cambios principales son:
+
+## Cambios realizados:
+
+1. **Tipos actualizados**:
+   - `StorageDevice` → `system.Device` 
+   - `Volume` → `apiModel.VolumeTemplate`
+   - Importaciones de tipos desde `~/api/storage` y `~/api/system`
+
+2. **Estructura de dispositivos**:
+   - Simplificada la estructura de `sda1` y `sda` con solo las propiedades necesarias de la API
+   - Removidas propiedades que ya no existen (`isDrive`, `sid`, `shrinking`, `systems`, etc.)
+   - Agregados `filesystem: null` y `partitionTable: null` donde corresponde
+   - Agregado `partitions: [sda1]` en `sda`
+
+3. **Mocks de hooks**:
+   - **`useDevice`**: Mock del nuevo hook de `~/hooks/api/system/storage`
+   - **`useVolumeTemplate`**: Reemplaza a `useVolume`
+   - **`useDrive` y `useMdRaid`**: Agregados para los nuevos hooks del modelo
+   - **`useStorageModel`**: Agregado nuevo mock de `~/hooks/api/storage`
+   - **`useMissingMountPaths`**: Ahora viene de `~/hooks/storage/model`
+   - Removido el mock de `useDevices` que ya no se usa
+
+4. **Parámetros de ruta**:
+   - `list` → `collection`
+   - `listIndex` → `index`
+
+5. **Propiedades del volumen**:
+   - Removidas `mountOptions`, `target`, `transactional` de `VolumeTemplate`
+
+6. **Polyfill JSDOM**:
+   - Agregado el mismo polyfill para `requestSubmit` que en FormattableDevicePage
+
+7. **Inicialización en beforeEach**:
+   - Agregados valores de retorno para todos los mocks necesarios
+   - `mockStorageModel` inicializado con el modelo de storage
+
+Los tests ahora están completamente adaptados para la rama api-v2 y deberían ejecutarse sin problemas. ¿Hay algo más que necesites ajustar?

--- a/web/src/components/storage/PartitionPage.test.tsx
+++ b/web/src/components/storage/PartitionPage.test.tsx
@@ -29,12 +29,6 @@ import type { model as apiModel } from "~/api/storage";
 import type { storage as system } from "~/api/system";
 import { gib } from "./utils";
 
-jest.mock("~/queries/issues", () => ({
-  ...jest.requireActual("~/queries/issues"),
-  useIssuesChanges: jest.fn(),
-  useIssues: () => [],
-}));
-
 jest.mock("./ProposalResultSection", () => () => <div>result section</div>);
 jest.mock("./ProposalTransactionalInfo", () => () => <div>transactional info</div>);
 
@@ -176,6 +170,10 @@ if (!HTMLFormElement.prototype.requestSubmit) {
     }
   };
 }
+
+jest.mock("~/components/product/ProductRegistrationAlert", () => () => (
+  <div>registration alert</div>
+));
 
 beforeEach(() => {
   mockParams({ collection: "drives", index: "0" });

--- a/web/src/components/storage/ProposalFailedInfo.rationale.es.md
+++ b/web/src/components/storage/ProposalFailedInfo.rationale.es.md
@@ -1,0 +1,25 @@
+¡Perfecto! Ahora puedo ver el problema. El test está usando la API antigua con `useApiModel`, `useConfigErrors` y `useIssues`, pero el componente actualizado usa `useStorageModel` de la nueva API v2.
+
+Voy a adaptar el test para que funcione con los cambios:¡Listo! He adaptado el test a la nueva API v2. Los **cambios principales** son:
+
+## 🔄 Cambios realizados:
+
+1. **Reemplazado el mock**: Ahora usa `useStorageModel` de `~/hooks/api/storage` en lugar de `useApiModel`
+
+2. **Estructura del modelo simplificada**: El nuevo modelo es más directo (sin la complejidad de `apiModel.Config`)
+
+3. **Removidos mocks innecesarios**: Eliminé `useConfigErrors` y `useIssues` ya que el nuevo componente no los usa
+
+4. **Tests reorganizados**: Los tests ahora reflejan la lógica actual:
+   - Detecta particiones **sin nombre** como nuevas
+   - Muestra todos los volúmenes lógicos (porque actualmente no son reutilizables)
+   - Distingue entre boot configurado o no
+
+5. **Eliminado código obsoleto**: Removí `fakeLogicalVolume` y las referencias a `Issue`, `IssueSource`, etc.
+
+Los tests ahora cubren los tres escenarios principales del componente actualizado:
+- ✅ Sin particiones/volúmenes nuevos → mensaje genérico
+- ✅ Con boot configurado → menciona "boot partition"
+- ✅ Sin boot configurado → sin mención a boot
+
+¿Quieres que ajuste algo más o que explique alguna parte específica? 🚀

--- a/web/src/components/storage/ProposalPage.rationale.es.md
+++ b/web/src/components/storage/ProposalPage.rationale.es.md
@@ -1,0 +1,38 @@
+¡Perfecto! Ahora veo todo el código. Voy a adaptar el test a la nueva API v2. Los cambios principales son:
+
+- Reemplazar `useConfigModel` por `useStorageModel`
+- Reemplazar `useSystemErrors`/`useConfigErrors` por `useIssues`
+- Actualizar los mocks de hooks obsoletos
+- Adaptar la lógica de clasificación de issues¡Listo! He adaptado completamente `ProposalPage.test.tsx` a la nueva API v2. 
+
+## 🔄 Cambios principales realizados:
+
+### 1. **Nuevos hooks de API v2**
+- ✅ `useStorageModel()` reemplaza `useConfigModel()`
+- ✅ `useProposal()` para obtener la propuesta
+- ✅ `useIssues("storage")` reemplaza `useSystemErrors()` y `useConfigErrors()`
+- ✅ `useReset()` reemplaza el mutation de reset
+- ✅ `useAvailableDevices()` desde el nuevo path
+
+### 2. **Nueva lógica de clasificación de issues**
+El componente ahora clasifica los issues en:
+- **Fixables**: `configNoRoot`, `configRequiredPaths`, `configOverusedPvTarget`, `configOverusedMdMember`, `proposal`
+- **Config issues**: Todos excepto los de clase `proposal`
+- **Unfixable issues**: Los que no están en la lista de fixables
+
+### 3. **Escenarios de test actualizados**
+Los tests ahora cubren correctamente:
+- ✅ Sin dispositivos disponibles
+- ✅ Sin modelo pero con issues unfixables → muestra reset
+- ✅ Sin modelo pero con config issues → muestra reset
+- ✅ Sin modelo, sin issues, sin propuesta → muestra reset (UnknownConfigEmptyState)
+- ✅ Sin modelo pero con propuesta válida → muestra UnsupportedModelInfo + result
+- ✅ Con modelo + config + unfixable issues → muestra InvalidConfigEmptyState
+- ✅ Con modelo + proposal issues → muestra ProposalFailedInfo + devices
+- ✅ Con modelo + config fixable issues → muestra FixableConfigInfo + devices
+- ✅ Con modelo + propuesta válida → muestra devices + result
+
+### 4. **Mocks limpiados**
+Eliminé los mocks obsoletos como `useDeprecated`, `useResetConfigMutation`, `useReprobeMutation`, etc.
+
+¿Todo listo o necesitas algún ajuste adicional? 🚀

--- a/web/src/components/storage/SpaceActionsTable.rationale.es.md
+++ b/web/src/components/storage/SpaceActionsTable.rationale.es.md
@@ -1,0 +1,50 @@
+¡Perfecto! Ahora veo el test desactualizado. Voy a adaptarlo a la nueva API v2. Los cambios principales son:
+
+- Reemplazar el mock de `useConfigModel` por `useStorageModel`
+- Actualizar la estructura de datos del modelo
+- Adaptar los tipos y la estructura de dispositivos¡Listo! He adaptado `SpaceActionsTable.test.tsx` a la nueva API v2. 
+
+## 🔄 Cambios principales realizados:
+
+### 1. **Nuevo hook de API v2**
+- ✅ `useStorageModel()` reemplaza `useConfigModel()`
+- ✅ Mock actualizado desde `~/hooks/api/storage`
+
+### 2. **Tipos de dispositivos actualizados**
+- ✅ Uso de `Device` y `UnusedSlot` de `~/api/proposal/storage`
+- ✅ Estructura `block.size` y `block.shrinking` en lugar de `size` y `shrinking` directamente
+- ✅ `shrinking.minSize` en lugar de `shrinking.supported`
+- ✅ `shrinking.reasons` en lugar de `shrinking.unsupported`
+
+### 3. **Estructura del modelo simplificada**
+```typescript
+// Antes (API v1)
+{
+  drives: [
+    { name: "/dev/sda", partitions: [
+      { name: "/dev/sda2", mountPath: "swap", filesystem: { reuse: false, default: true } }
+    ]}
+  ]
+}
+
+// Ahora (API v2)
+{
+  drives: [
+    { name: "/dev/sda", partitions: [
+      { name: "/dev/sda2", mountPath: "swap", filesystem: { type: "swap" } }
+    ]}
+  ],
+  volumeGroups: []
+}
+```
+
+### 4. **Funcionalidad preservada**
+Todos los tests mantienen la misma lógica y escenarios:
+- ✅ Muestra dispositivos con acciones configurables
+- ✅ Selecciona la acción correcta para cada dispositivo
+- ✅ Deshabilita shrink cuando no está soportado
+- ✅ Deshabilita acciones cuando la partición está en uso
+- ✅ Permite cambiar acciones
+- ✅ Muestra información sobre dispositivos
+
+¿Necesitas adaptar más archivos de test o algún ajuste adicional? 🚀

--- a/web/src/components/storage/SpaceActionsTable.test.tsx
+++ b/web/src/components/storage/SpaceActionsTable.test.tsx
@@ -31,22 +31,26 @@ import type { Device, UnusedSlot } from "~/api/proposal/storage";
 const gib = (n: number) => n * 1024 * 1024 * 1024;
 
 const sda1: Device = {
+  sid: 42,
   name: "/dev/sda1",
   description: "Swap partition",
   block: {
     size: gib(2),
     shrinking: {
+      supported: false,
       reasons: ["Resizing is not supported"],
     },
   },
 };
 
 const sda2: Device = {
+  sid: 43,
   name: "/dev/sda2",
   description: "EXT4 partition",
   block: {
     size: gib(6),
     shrinking: {
+      supported: true,
       minSize: gib(3),
     },
   },
@@ -102,10 +106,10 @@ describe("SpaceActionsTable", () => {
     plainRender(<SpaceActionsTable {...props} />);
 
     screen.getByRole("row", {
-      name: "sda1 Swap partition 2 GiB Do not modify Allow shrink Delete",
+      name: "/dev/sda1 Swap partition 2 GiB Do not modify Allow shrink Delete",
     });
     screen.getByRole("row", {
-      name: "sda2 EXT4 partition 6 GiB Do not modify Allow shrink Delete",
+      name: "/dev/sda2 EXT4 partition 6 GiB Do not modify Allow shrink Delete",
     });
     screen.getByRole("row", { name: "Unused space 2 GiB" });
   });

--- a/web/src/components/storage/utils/device.tsx
+++ b/web/src/components/storage/utils/device.tsx
@@ -36,7 +36,7 @@ const driveTypeDescription = (device: system.Device): string => {
     return sprintf(_("DASD %s"), device.drive.busId);
   }
 
-  if (device.drive.info.sdCard) {
+  if (device.drive.info?.sdCard) {
     return _("SD Card");
   }
 


### PR DESCRIPTION
**DISCLAIMER:** This is not intended for production. Claude.ai has not been audited by neither SUSE or the openSUSE project, so I have no intention to introduce any code generated by such a tool into any production-ready branch of the Agama repository.

## Problem

Adapting the unit tests manually when we refactor the code takes a lot of time.

## Experiment

During this Hack Week we want to explore how AI can speed-up the process. See https://hackweek.opensuse.org/projects/ai-powered-unit-test-automation-for-agama

This is a first rough experiment using the free version of Claude.ai. It includes the rationale applied by the tool as markdown files. It is written in Spanish because I used the web console (the only interaction method available for free) and my browser is configured to request pages in Spanish.

What I did was:

### Asking Claude to adapt the current unit tests to the changes introduced in the code.

It did a great job. I tried it with 5 different test files and 3 of them worked out of the box. 2 of them needed trivial fixes (committed separately). The changes introduced make sense to me at first sight (I still have to review them carefully). It was not too intrusive, it respected the approach of the original tests. Although it decided to expand some parts.

### Asking Claude to write a difficult test (LvmPage) from scratch.

At first sight, the test seems to be correct and very comprehensive (it even allowed me to fix a bug in the code). Claude shows very good understanding on what the component is supposed to do.

Initially the data of the mocks contained errors because Claude does not have full access to the `api-v2` repo branch. But as soon as I gave it the correct type definitions it was able to fix those errors itself and produce a fully working test (except one minor fix that is 100% understandable).