### PR TITLE
Remove spaces and indentation from translations

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -40,6 +40,7 @@ export default [
   },
   {
     rules: {
+      "agama-i18n/multiple-space": "error",
       "agama-i18n/string-literals": "error",
       "agama-i18n/top-level-translation": "error",
       "i18next/no-literal-string": "error",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,7 @@
         "xbytes": "^1.9.1"
       },
       "devDependencies": {
-        "@agama-project/eslint-plugin-agama-i18n": "^1.2.0",
+        "@agama-project/eslint-plugin-agama-i18n": "^1.3.0",
         "@babel/core": "^7.28.3",
         "@babel/eslint-parser": "^7.28.0",
         "@babel/preset-env": "^7.28.3",
@@ -101,9 +101,9 @@
       "license": "MIT"
     },
     "node_modules/@agama-project/eslint-plugin-agama-i18n": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@agama-project/eslint-plugin-agama-i18n/-/eslint-plugin-agama-i18n-1.2.0.tgz",
-      "integrity": "sha512-mI3qGf7XDuHjrO13KT2xKTrFEm5uGxBm17MApvoxStS0kU6oU+eUa6Sh2tX9J6ypvKxzdITMh3QkITeNNztfEg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agama-project/eslint-plugin-agama-i18n/-/eslint-plugin-agama-i18n-1.3.0.tgz",
+      "integrity": "sha512-es1B8wcqo7oIe+gT6w2sYmwBcz+hswBRWsteGgQ8bpfliAEcQj2mAWjGLkEf2EkW9G2cqShRWlEgEmIWxbz0HA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@agama-project/eslint-plugin-agama-i18n": "^1.2.0",
+    "@agama-project/eslint-plugin-agama-i18n": "^1.3.0",
     "@babel/core": "^7.28.3",
     "@babel/eslint-parser": "^7.28.0",
     "@babel/preset-env": "^7.28.3",

--- a/web/src/components/storage/BootSection.tsx
+++ b/web/src/components/storage/BootSection.tsx
@@ -38,8 +38,8 @@ function defaultBootLabel(device?: StorageDevice) {
     return sprintf(
       // TRANSLATORS: %s is replaced by the formatted path of the root file system (eg. "/")
       _(
-        "Partitions to boot will be set up if needed at the installation disk, \
-        based on the location of the %s file system.",
+        "Partitions to boot will be set up if needed at the installation disk, " +
+          "based on the location of the %s file system.",
       ),
       formattedPath("/"),
     );
@@ -49,8 +49,8 @@ function defaultBootLabel(device?: StorageDevice) {
     // TRANSLATORS: %1$s is replaced by a device name and size (e.g., sda (500GiB)), %2$s is
     // replaced by the formatted path of the root file system (eg. "/")
     _(
-      "Partitions to boot will be set up if needed at the installation disk. \
-      Currently %1$s, based on the location of the %2$s file system.",
+      "Partitions to boot will be set up if needed at the installation disk. " +
+        "Currently %1$s, based on the location of the %2$s file system.",
     ),
     deviceLabel(device),
     formattedPath("/"),
@@ -81,8 +81,8 @@ export default function BootSection() {
     <Stack hasGutter>
       <div className={textStyles.textColorPlaceholder}>
         {_(
-          "To ensure the new system is able to boot, the installer may need to create or configure some \
-          partitions in the appropriate disk.",
+          "To ensure the new system is able to boot, the installer may need to create or configure some " +
+            "partitions in the appropriate disk.",
         )}
       </div>
       <Content component="p" isEditorial>

--- a/web/src/components/storage/BootSelection.tsx
+++ b/web/src/components/storage/BootSelection.tsx
@@ -142,8 +142,8 @@ partitions in the appropriate disk.",
       return sprintf(
         // TRANSLATORS: %s is replaced by the formatted path of the root file system (eg. "/")
         _(
-          "Partitions to boot will be set up if needed at the installation disk, \
-          based on the location of the %s file system.",
+          "Partitions to boot will be set up if needed at the installation disk, " +
+            "based on the location of the %s file system.",
         ),
         formattedPath("/"),
       );
@@ -153,8 +153,8 @@ partitions in the appropriate disk.",
       // TRANSLATORS: %1$s is replaced by a device name and size (e.g., sda (500GiB)), %2$s is
       // replaced by the formatted path of the root file system (eg. "/")
       _(
-        "Partitions to boot will be set up if needed at the installation disk. \
-        Currently %1$s, based on the location of the %2$s file system.",
+        "Partitions to boot will be set up if needed at the installation disk. " +
+          "Currently %1$s, based on the location of the %2$s file system.",
       ),
       deviceLabel(state.defaultBootDevice),
       formattedPath("/"),

--- a/web/src/components/storage/EncryptionSection.tsx
+++ b/web/src/components/storage/EncryptionSection.tsx
@@ -47,8 +47,8 @@ export default function EncryptionSection() {
     <Stack hasGutter>
       <div className={textStyles.textColorPlaceholder}>
         {_(
-          "Protection for the information stored at \
-          the new file systems, including data, programs, and system files.",
+          "Protection for the information stored at " +
+            "the new file systems, including data, programs, and system files.",
         )}
       </div>
       <Content isEditorial>{encryptionLabel(method)}</Content>

--- a/web/src/components/storage/LvmPage.tsx
+++ b/web/src/components/storage/LvmPage.tsx
@@ -178,9 +178,9 @@ export default function LvmPage() {
           <FormGroup label={_("Disks")} role="group" style={{ justifySelf: "stretch" }} isStack>
             <Content component="small">
               {_(
-                "The needed LVM physical volumes will be added as partitions on the chosen disks, \
-                based on the sizes of the logical volumes. If you select more than one disk, the \
-                physical volumes may be distributed along several disks.",
+                "The needed LVM physical volumes will be added as partitions on the chosen disks, " +
+                  "based on the sizes of the logical volumes. If you select more than one disk, the " +
+                  "physical volumes may be distributed along several disks.",
               )}
             </Content>
             <Gallery hasGutter>
@@ -217,8 +217,8 @@ export default function LvmPage() {
               <Checkbox
                 id="moveMountPoints"
                 label={_(
-                  "Move the mount points currently configured at the selected disks to logical \
-                  volumes of this volume group.",
+                  "Move the mount points currently configured at the selected disks to logical " +
+                    "volumes of this volume group.",
                 )}
                 isChecked={moveMountPoints}
                 onChange={(_, v) => setMoveMountPoints(v)}

--- a/web/src/components/storage/zfcp/ZFCPPage.tsx
+++ b/web/src/components/storage/zfcp/ZFCPPage.tsx
@@ -50,13 +50,13 @@ const LUNScanInfo = () => {
   const { allowLunScan } = useZFCPConfig();
   // TRANSLATORS: the text in the square brackets [] will be displayed in bold
   const lunScanEnabled = _(
-    "Automatic LUN scan is [enabled]. Activating a controller which is \
-      running in NPIV mode will automatically configures all its LUNs.",
+    "Automatic LUN scan is [enabled]. Activating a controller which is " +
+      "running in NPIV mode will automatically configures all its LUNs.",
   );
   // TRANSLATORS: the text in the square brackets [] will be displayed in bold
   const lunScanDisabled = _(
-    "Automatic LUN scan is [disabled]. LUNs have to be manually \
-      configured after activating a controller.",
+    "Automatic LUN scan is [disabled]. LUNs have to be manually " +
+      "configured after activating a controller.",
   );
 
   const msg = allowLunScan ? lunScanEnabled : lunScanDisabled;


### PR DESCRIPTION
## Problem

- Some translatable texts in Agama contain indentation spaces, like [here](https://github.com/agama-project/agama/blob/87a04f1769e5d83439f7b1298fc486908ef511da/web/src/components/storage/EncryptionSection.tsx#L50-L51).

Example:

```js
{
  {
    {
      const message = _("Some very long message \
        which spans across multiple lines.");
    }
  }
}
```

The problem is that the indentation on the second line is actually included in the message text. The HTML collapses multiple spaces to a single space when rendered in a browser so in the end it is not a visible problem for users. But it still might be confusing for the translators.

- See related https://github.com/agama-project/eslint-plugin-agama-i18n/pull/7

## Solution

- Enable eslint check
- Fix the reported problems

## TODO

- [ ] Manually fix the translations in Weblate using `sed` to avoid invalidating the existing translations.