### PR TITLE
web: improve product selection submit feedback

### DIFF
--- a/web/src/components/product/ProductSelectionPage.test.tsx
+++ b/web/src/components/product/ProductSelectionPage.test.tsx
@@ -70,16 +70,16 @@ jest.mock("~/api", () => ({
   patchConfig: (payload) => mockPatchConfigFn(payload),
 }));
 
-jest.mock("~/hooks/api/system", () => ({
-  ...jest.requireActual("~/hooks/api/system"),
+jest.mock("~/hooks/model/system", () => ({
+  ...jest.requireActual("~/hooks/model/system"),
   useSystem: (): ReturnType<typeof useSystem> => ({
     products: [tumbleweed, microOs],
     network,
   }),
 }));
 
-jest.mock("~/hooks/api/config", () => ({
-  ...jest.requireActual("~/hooks/api/config"),
+jest.mock("~/hooks/model/config", () => ({
+  ...jest.requireActual("~/hooks/model/config"),
   useProduct: (): ReturnType<typeof useProduct> => mockSelectedProduct(),
 }));
 

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -146,7 +146,8 @@ function ProductSelectionPage() {
 
   const selectionHasChanged = nextProduct && nextProduct !== selectedProduct;
   const mountLicenseCheckbox = !isEmpty(nextProduct?.license);
-  const isSelectionDisabled = !selectionHasChanged || (mountLicenseCheckbox && !licenseAccepted);
+  const isSelectionDisabled =
+    isWaiting || !selectionHasChanged || (mountLicenseCheckbox && !licenseAccepted);
 
   const [eulaTextStart, eulaTextLink, eulaTextEnd] = sprintf(
     // TRANSLATORS: Text used for the license acceptance checkbox. %s will be
@@ -212,7 +213,12 @@ function ProductSelectionPage() {
               </StackItem>
               <StackItem>
                 <Split hasGutter>
-                  <Page.Submit form="productSelectionForm" isDisabled={isSelectionDisabled}>
+                  <Page.Submit
+                    form="productSelectionForm"
+                    isDisabled={isSelectionDisabled}
+                    isLoading={isWaiting}
+                    variant={isWaiting ? "secondary" : "primary"}
+                  >
                     {_("Select")}
                   </Page.Submit>
                   {selectedProduct && <BackLink />}


### PR DESCRIPTION
Set product selection submit button to a loading state on form submission so users receive immediate visual feedback that the action has started.

It also fix mockings in test.
