### PR TITLE
fix starting installation

### DIFF
--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -390,7 +390,7 @@ async fn get_license(
 
 #[utoipa::path(
     post,
-    path = "/actions",
+    path = "/action",
     context_path = "/api/v2",
     responses(
         (status = 200, description = "Action successfully run."),

--- a/web/src/model/manager.ts
+++ b/web/src/model/manager.ts
@@ -39,12 +39,15 @@ const probe = () => post("/api/manager/probe_sync");
  */
 const reprobe = () => post("/api/manager/reprobe_sync");
 
+// we need wrapper here to pass it as plain string json
+/* eslint-disable no-new-wrappers */
+const install_action: object = new String("install");
 /**
  * Starts the installation process.
  *
  * The progress of the installation process can be tracked through installer signals.
  */
-const startInstallation = () => post("/api/manager/install");
+const startInstallation = () => post("/api/v2/action", install_action);
 
 /**
  * Clean-up when installation is done.


### PR DESCRIPTION
## Problem

Install button calls wrong API which do nothing.

## Solution

Fix install button to call new API for start of installation. It do not touch rest of UI which do not switch to different stage when installation starts, but it is possible to observe progress of installation. Also fix path in openapi, as it already twice confuse me :)


## Testing

- *Tested manually*