### PR TITLE
Add ostruct gem dependency for ruby >= 3.5

### DIFF
--- a/service/agama-yast.gemspec
+++ b/service/agama-yast.gemspec
@@ -64,5 +64,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logger", "~> 1.5"
   # here we have problem as ruby3.2 on SLFO does not provide rubygem-ostruct, but newer ruby will separate it after 3.4
   # but dynamic dependencies are not possible in gemspec
-  # spec.add_dependency "ostruct", "~> 0.6.1"
+  spec.add_dependency "ostruct", "~> 0.6.1" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.5")
 end


### PR DESCRIPTION
## Problem

After an upgrade in Tumbleweed my system is now using ruby version 4 and the service started to fail because of missing ostruct dependency which is not part of Ruby anymore since version 3.5.

## Solution

Added the ostruct gem dependency for ruby versions greater than 3.5


## Testing

- *Tested manually*
