### PR TITLE
Add an issue when the product must be registered

### DIFF
--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -355,10 +355,16 @@ impl ZyppServer {
             zypp_agama::ResolvableSelected::Installation,
         );
         if let Err(error) = result {
-            let message = format!("Could not select the product '{}'", &state.product);
-            issues.push(
-                Issue::new("software.select_product", &message).with_details(&error.to_string()),
-            );
+            let issue = if state.allow_registration {
+                Issue::new(
+                    "software.missing_registration",
+                    &gettext("The product must be registered"),
+                )
+            } else {
+                let message = format!("Could not select the product '{}'", &state.product);
+                Issue::new("software.missing_product", &message).with_details(&error.to_string())
+            };
+            issues.push(issue);
         }
         for (name, r#type, selection) in &state.resolvables.to_vec() {
             match selection {

--- a/rust/agama-software/tests/zypp_server.rs
+++ b/rust/agama-software/tests/zypp_server.rs
@@ -139,7 +139,7 @@ async fn test_start_zypp_server() {
         1,
         "There are unexpected issues size {issues:#?}"
     );
-    assert_eq!(issues[0].class, "software.select_product");
+    assert_eq!(issues[0].class, "software.missing_product");
 
     let questions = question_handler
         .call(question::message::Get)


### PR DESCRIPTION
Register an issue when the product must be registered (`software.missing_registration`). If the product cannot be registered and the base product is not available, just report a `software.missing_product` error.