### PR TITLE
fix: BLS env config

### DIFF
--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -35,7 +35,6 @@ require "agama/with_progress_manager"
 require "yast"
 require "y2storage/clients/inst_prepdisk"
 require "y2storage/luks"
-require "y2storage/storage_env"
 require "y2storage/storage_manager"
 
 module Agama
@@ -56,7 +55,7 @@ module Agama
       def initialize(logger: nil)
         @logger = logger || Logger.new($stdout)
         @bootloader = Bootloader.new(logger)
-        @no_bls_bootloader = Y2Storage::StorageEnv.instance.no_bls_bootloader
+        @yast_no_bls_boot = ENV["YAST_NO_BLS_BOOT"]
         self.product_config = Agama::Config.new
       end
 
@@ -191,7 +190,7 @@ module Agama
       # we want to use BLS only for Tumbleweed / Slowroll
       def configure_no_bls_bootloader
         # Keep original value of the env variable or set it if needed.
-        value = product_config.boot_strategy&.casecmp("BLS") ? @no_bls_bootloader : "1"
+        value = product_config.boot_strategy&.casecmp("BLS") ? @yast_no_bls_boot : "1"
         ENV["YAST_NO_BLS_BOOT"] = value
         # Avoiding problems with cached values
         Y2Storage::StorageEnv.instance.reset_cache

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -36,7 +36,6 @@ require "agama/storage/volume"
 require "agama/dbus"
 require "y2storage/issue"
 require "y2storage/luks"
-require "y2storage/storage_env"
 require "yast2/fs_snapshot"
 require "yaml"
 
@@ -265,7 +264,7 @@ describe Agama::Storage::Manager do
     context "if the product requires bls boot explicitly" do
       before do
         allow(ENV).to receive(:[]=)
-        allow(Y2Storage::StorageEnv.instance).to receive(:no_bls_bootloader).and_return("0")
+        allow(ENV).to receive(:[]).with("YAST_NO_BLS_BOOT").and_return("0")
       end
 
       let(:config) do


### PR DESCRIPTION
## Problem

Configuration of env variable to avoid BLS boot is making the storage D-Bus service to fail.
The error was introduced by https://github.com/agama-project/agama/pull/3011.

## Solution

Assign a proper value to the env variable.
