### PR TITLE
web: change format of username in users summary

### DIFF
--- a/web/src/components/overview/UsersSummary.tsx
+++ b/web/src/components/overview/UsersSummary.tsx
@@ -21,14 +21,14 @@
  */
 
 import React from "react";
-import { sprintf } from "sprintf-js";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { useConfig } from "~/hooks/model/config";
 import { useIssues } from "~/hooks/model/issue";
-import { USER } from "~/routes/paths";
-import { _ } from "~/i18n";
 import Summary from "~/components/core/Summary";
 import Link from "~/components/core/Link";
+import Text from "~/components/core/Text";
+import { USER } from "~/routes/paths";
+import { _ } from "~/i18n";
 
 const rootConfigured = (config) => {
   if (!config.root) return false;
@@ -59,11 +59,18 @@ const Value = () => {
   if (root && !user) return _("Configured for the root user");
 
   const userName = config.user.userName;
-  // TRANSLATORS: %s is a username like 'jdoe'
-  if (root) return sprintf(_("Configured for root and user '%s'"), userName);
+  const text = root
+    ? // TRANSLATORS: %s is a username like 'jdoe'
+      _("Configured for root and user %s")
+    : // TRANSLATORS: %s is a username like 'jdoe'
+      _("Configured for user %s");
+  const [textStart, textEnd] = text.split("%s");
 
-  // TRANSLATORS: %s is a username like 'jdoe'
-  return sprintf(_("Configured for user '%s'"), userName);
+  return (
+    <>
+      {textStart} <Text isBold>{userName}</Text> {textEnd}
+    </>
+  );
 };
 
 /**


### PR DESCRIPTION
Instead of wrapping the username in single quotes, it uses a Text#isBold to make it consistent how other summaries renders their content.

Additionally, going that way we can update these summaries to display these values with language-specific quotes via CSS if really needed.


|Before |After |
|-|-|
| <img width="2048" height="1476" alt="localhost_8080_ (56)" src="https://github.com/user-attachments/assets/94385c01-6888-4087-9156-39686b0d1424" /> | <img width="2048" height="1476" alt="localhost_8080_ (53)" src="https://github.com/user-attachments/assets/5cd804ff-8430-4a41-802f-39ca0694e400" /> |
| <img width="2048" height="1476" alt="localhost_8080_ (55)" src="https://github.com/user-attachments/assets/aa6f3e98-b167-4b79-847c-5ceeaa7d2084" /> | <img width="2048" height="1476" alt="localhost_8080_ (54)" src="https://github.com/user-attachments/assets/8356f5f5-7ab2-4a43-a67f-f8decfc781b7" /> |
