### PR TITLE
Use the YaST arch to filter the list of repos

### DIFF
--- a/rust/agama-utils/src/arch.rs
+++ b/rust/agama-utils/src/arch.rs
@@ -49,6 +49,16 @@ impl Arch {
             .try_into()
             .map_err(|_| Error::Unknown(arch_str))
     }
+
+    /// Returns the identifier used in the products definition.
+    pub fn to_yast_id(&self) -> String {
+        match &self {
+            Arch::AARCH64 => "aarch64".to_string(),
+            Arch::PPC64LE => "ppc".to_string(),
+            Arch::S390X => "s390".to_string(),
+            Arch::X86_64 => "x86_64".to_string(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -69,6 +79,14 @@ mod tests {
         assert_eq!(Arch::PPC64LE.to_string(), "ppc64le".to_string());
         assert_eq!(Arch::S390X.to_string(), "s390x".to_string());
         assert_eq!(Arch::X86_64.to_string(), "x86_64".to_string());
+    }
+
+    #[test]
+    fn test_to_product_string() {
+        assert_eq!(Arch::AARCH64.to_yast_id(), "aarch64".to_string());
+        assert_eq!(Arch::PPC64LE.to_yast_id(), "ppc".to_string());
+        assert_eq!(Arch::S390X.to_yast_id(), "s390".to_string());
+        assert_eq!(Arch::X86_64.to_yast_id(), "x86_64".to_string());
     }
 
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
## Problem

The recently introduced [Arch](https://github.com/agama-project/agama/blob/master/rust/agama-utils/src/arch.rs) enum uses the following ids to detect each architecture: "aarch64", "ppc64le", "s390x" and "x86_64". These ids come from the `uname -m` command are used, for instance, in OBS.

However, we use different ids in the products specs: "aarch64", "ppc", "s390" and "x86_64" (coming from the YaST code).

## Solution

Instead of changing the product's definition, because it might affect the storage code, maps the new ids to the YaST ones.

## Testing

- *Added a new unit test*