### PR TITLE
feat(web): Usability: focus the password field on the login page

### DIFF
--- a/web/src/components/core/LoginPage.test.tsx
+++ b/web/src/components/core/LoginPage.test.tsx
@@ -64,6 +64,13 @@ describe("LoginPage", () => {
       screen.getAllByText(/root/);
     });
 
+    it("focuses the password input", () => {
+      installerRender(<LoginPage />);
+      const form = screen.getByRole("form", { name: "Login form" });
+      const passwordInput = within(form).getByLabelText("Password input");
+      expect(passwordInput).toHaveFocus();
+    });
+
     it("allows entering a password", async () => {
       const { user } = installerRender(<LoginPage />);
       const form = screen.getByRole("form", { name: "Login form" });

--- a/web/src/components/core/LoginPage.tsx
+++ b/web/src/components/core/LoginPage.tsx
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Navigate } from "react-router";
 import {
   Alert,
@@ -63,6 +63,11 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [authError, setAuthError] = useState(false);
   const { isLoggedIn, login: loginFn, error: loginError } = useAuth();
+  const passwordInput = useRef<HTMLInputElement>();
+
+  useEffect(() => {
+    passwordInput.current?.focus();
+  }, []);
 
   const login = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -137,6 +142,7 @@ user privileges.",
                       aria-label={_("Password input")}
                       onChange={(_, v) => setPassword(v)}
                       reminders={["capslock"]}
+                      inputRef={passwordInput}
                     />
                   </FormGroup>
                   {authError && (


### PR DESCRIPTION


## Problem

When you test Agama and it presents you with a **Login as root** page, you have to click or press Tab to focus the Password field.

## Solution

Autofocus the input field.

With Gemini, 15 minutes for an improvement I would not do otherwise.

## Testing

- Added a new unit test (!)
- Tested manually

## Screenshots

Easy to imagine

## Documentation

Not needed