### PR TITLE
Fix sending the POT files to Weblate

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -235,8 +235,8 @@ jobs:
         if: steps.check_rust_changes.outputs.pot_updated == 'true'
         run: |
           cd agama-weblate
-          git add service/agama.pot
-          git commit -m "Update service POT file"$'\n\n'"Agama commit: $GITHUB_SHA"
+          git add rust/agama.pot
+          git commit -m "Update rust POT file"$'\n\n'"Agama commit: $GITHUB_SHA"
           git push
 
       - name: (rust) Merge new POT to PO translations


### PR DESCRIPTION
## Problem

- The action for updating the POT files in Weblate does not work correctly.

## Solution

- Fix sending the Rust POT file
- The Ruby gettext creates the "PO-Revision-Date:" header flag with the current date, ignore that line when detecting changes. (The other POT files contain just a static template line `PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n` which does not change so they are not affected.)

