### PR TITLE
Do not miss to extract new translatable strings on Friday

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   schedule:
     # at 9:45 UTC every day from Monday to Friday
-    - cron: "45 9 * * 1-5"
+    - cron: "45 9 * * Mon-Fri"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-po-sle16.yml
+++ b/.github/workflows/weblate-merge-po-sle16.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:35AM UTC
-    - cron: "35 2 * * 0"
+    - cron: "35 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:42AM UTC
-    - cron: "42 2 * * 0"
+    - cron: "42 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-products-po-sle16.yml
+++ b/.github/workflows/weblate-merge-products-po-sle16.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:35AM UTC
-    - cron: "35 2 * * 0"
+    - cron: "35 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:45AM UTC
-    - cron: "45 2 * * 0"
+    - cron: "45 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-rust-po.yml
+++ b/.github/workflows/weblate-merge-rust-po.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:47AM UTC
-    - cron: "47 2 * * 0"
+    - cron: "47 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-service-po-sle16.yml
+++ b/.github/workflows/weblate-merge-service-po-sle16.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:35AM UTC
-    - cron: "35 2 * * 0"
+    - cron: "35 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   schedule:
     # run every Monday at 2:45AM UTC
-    - cron: "45 2 * * 0"
+    - cron: "45 2 * * Mon"
 
   # allow running manually
   workflow_dispatch:

--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   schedule:
     # run every working day (Monday-Friday) at 1:42AM UTC
-    - cron: "42 1 * * 0-4"
+    - cron: "42 1 * * Mon-Fri"
 
   # allow running manually
   workflow_dispatch:


### PR DESCRIPTION
## Problem

Installing the GitHub Actions extension (github.vscode-github-actions) in VS Code put an annotation to our action schedules that revealed we were off by one day in the Weblate actions (Sun-Thu instead of the intended Mon-Fri)

The action logs confirmed my finding.

## Solution

Fix that.

After fixing the numbers I checked the docs and realized that names are allowed too :)

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onschedule
- https://www.man7.org/linux/man-pages/man5/crontab.5.html

## Testing

Did not run any Action, but the editor extension considers it correct syntax (and flags incorrect syntax when I misspell a weekday)

## Screenshots

No

## Documentation

Trivial fix in dev tooling, no docs