### PR TITLE
fix(web): Improve ProductSelection form behavior

### DIFF
--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -323,7 +323,12 @@ const ProductForm = ({ products, currentProduct, isSubmitted, onSubmit }: Produc
   };
 
   return (
-    <Form id="productSelectionForm" onSubmit={onFormSubmission}>
+    <Form
+      id="productSelectionForm"
+      onSubmit={onFormSubmission}
+      // @ts-expect-error: https://www.codegenes.net/blog/error-when-using-inert-attribute-with-typescript/
+      inert={isSubmitted ? "" : undefined}
+    >
       <FormGroup
         role="radiogroup"
         label={sprintf(
@@ -368,13 +373,14 @@ const ProductForm = ({ products, currentProduct, isSubmitted, onSubmit }: Produc
               isDisabled={isSelectionDisabled}
               isLoading={isSubmitted}
               variant={isSubmitted ? "secondary" : "primary"}
+              style={{ maxInlineSize: "30dvw", overflow: "hidden", textWrap: "balance" }}
             >
               <ProductFormSubmitLabel
                 currentProduct={currentProduct}
                 selectedProduct={selectedProduct}
               />
             </Page.Submit>
-            {currentProduct && (
+            {currentProduct && !isSubmitted && (
               <Link to={ROOT.overview} size="lg" variant="link">
                 {_("Cancel")}
               </Link>


### PR DESCRIPTION
  * Disable form after submission to prevent further changes, reducing confusion (as selections won’t affect anything post-submission).
  * Hide the "Cancel" button after form submission to streamline the UI.
  * Limit the width of the "Submit" button to prevent it from expanding due to long product names.
