### PR TITLE
Do not crash when users setup fails

### DIFF
--- a/rust/agama-users/src/service.rs
+++ b/rust/agama-users/src/service.rs
@@ -222,7 +222,9 @@ impl MessageHandler<message::GetProposal> for Service {
 impl MessageHandler<message::Install> for Service {
     async fn handle(&mut self, _message: message::Install) -> Result<(), Error> {
         if let Some(proposal) = self.get_proposal() {
-            self.model.install(&proposal)?;
+            if let Err(error) = self.model.install(&proposal) {
+                tracing::error!("Failed to write users configuration: {error}");
+            }
         } else {
             tracing::error!("Missing authentication configuration");
         };


### PR DESCRIPTION
Just log the error when setting up the users in the installed system fails. It happens, for instance, if the root password is empty.
