### PR TITLE
live: Enable the YAML syntax highlighting in vim

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -213,7 +213,7 @@ rm /var/log/zypper.log /var/log/zypp/history
 # reduce the "vim-data" content, this package is huge (37MB unpacked!), keep
 # only support for JSON (for "agama config edit"), YAML (the product definition
 # files) and Ruby (fixing/debugging the Ruby service)
-rpm -ql vim-data | grep -v -e '/ruby.vim$' -e '/json.vim$' -e '/yaml.vim$' -e colors | xargs rm 2>/dev/null || true
+rpm -ql vim-data | grep -v -e '/ruby.vim$' -e '/json.vim$' -e '/yaml.vim$' -e '/bash.vim$' -e colors | xargs rm 2>/dev/null || true
 
 du -h -s /usr/{share,lib}/locale/
 


### PR DESCRIPTION
## Problem

- When tweaking the Agama product files in the Live ISO the syntax highlighting for YAML files is not active.

## Solution

- Keep the vim YAML syntax files in the ISO

## Testing

- Tested manually in a locally built ISO

## Screenshots

<img width="802" height="506" alt="agama-yaml-syntax" src="https://github.com/user-attachments/assets/3294fa12-4bc3-4855-a7eb-3c6fae758f35" />
