### PR TITLE
agama-web-server: keep working even if IPv6 is not available

### DIFF
--- a/rust/share/agama-web-server.service
+++ b/rust/share/agama-web-server.service
@@ -9,7 +9,7 @@ BindsTo=agama.service
 EnvironmentFile=-/run/agama/environment.conf
 Environment="AGAMA_LOG=debug,zbus=info"
 Type=notify
-ExecStart=/usr/bin/agama-web-server serve --address :::80 --address2 :::443
+ExecStart=/usr/bin/agama-web-server serve --address :::80,0.0.0.0:80 --address2 :::443,0.0.0.0:443
 PIDFile=/run/agama/web.pid
 User=root
 TimeoutStopSec=5


### PR DESCRIPTION
## Problem

The Agama installer does not start if IPv6 is disabled on the kernel command line with 'ipv6.disable=1'.

- https://bugzilla.suse.com/show_bug.cgi?id=1257251

## Solution

If `:::$PORT` does not work, try on `0.0.0.0:$PORT`

It works but the code is hacky.

## Testing

Tested manually in a VM booted with `ipv6.disable=1`

## Screenshots

*If the fix affects the UI attach some screenshots here.*

## Documentation

*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
*other times they need advertisement and explanation.*

*Look for relevant sections and adjust:*
- The `*.changes` files. For ALL affected packages.
- The description parts of the [JSON schema][profile.schema.json]
- Is the CLI affected? See [cli.md][] for a complete overview,
  change the `///` comments (rust doc)
  and update the .md with `cargo xtask markdown`
- <https://agama-project.github.io/> ([source][gh.io])
- Run: `git ls-files '*.md'`

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md
[profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
[gh.io]: https://github.com/agama-project/agama-project.github.io/
