### PR TITLE
Fixed opening the SSH firewall port

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb  2 11:56:24 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed opening the SSH firewall port when the firewall is not
+  installed because of the set "onlyRequires" flag in the software
+  configuration (bsc#1257212)
+
+-------------------------------------------------------------------
 Mon Feb  2 08:13:10 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Implement modification of kernel parameters when SELinux pattern


### PR DESCRIPTION
## Problem

- The firewall configuration is not handled properly when the firewall is not installed. That can happen when the "onlyRequires" flag is set in the software configuration.
- I overlooked that the command is running in the `chroot` wrapper, the code actually tested the failure for missing `chroot` command instead.

## Solution

- The `chroot` command returns exit status 127 when the command to run does not exist. If that value is returned then ignore the error.

