### PR TITLE
Merge the mode translations back to the product YAML files

### DIFF
--- a/.github/workflows/product_translations/merge_po
+++ b/.github/workflows/product_translations/merge_po
@@ -14,7 +14,7 @@ const fs = require("fs");
 const process = require("process");
 const path = require("path");
 
-const { parseDocument } = require("yaml");
+const { parseDocument, isCollection } = require("yaml");
 const { globSync } = require("glob");
 const gettextParser = require("gettext-parser");
 
@@ -48,8 +48,8 @@ class Translation {
     // sort the files so the translations in the YAML files are also sorted
     const files = globSync(dir + "/*.po").sort();
 
-    files.forEach(f => {
-      console.log(`Reading ${path.basename(f)}`);
+    files.forEach((f) => {
+      console.log(`Reading ${f}`);
 
       const locale = path.basename(f, ".po");
       const input = fs.readFileSync(f, "utf-8");
@@ -58,7 +58,7 @@ class Translation {
       // translations for the default (empty) context
       const translations = po.translations[""];
 
-      Object.values(translations).forEach(t => {
+      Object.values(translations).forEach((t) => {
         if (t.msgid !== "") {
           ret.push(new Translation(t.msgid, t.msgstr[0], locale));
         }
@@ -95,8 +95,8 @@ class YamlProduct {
   static read(dir) {
     const ret = [];
     const files = globSync(dir + "/*.y{a,}ml");
-    return files.map(f => {
-      console.log(`Reading ${path.basename(f)}`);
+    return files.map((f) => {
+      console.log(`Reading ${f}`);
       return new YamlProduct(f);
     });
   }
@@ -109,22 +109,51 @@ class YamlProduct {
     const description = this.document.get("description");
     const newTranslations = {};
 
-    translations.forEach(t => {
+    translations.forEach((t) => {
       if (t.msgid === description && t.msgstr?.length > 0) {
         newTranslations[t.locale] = t.msgstr;
       }
     });
 
     // add or update the translations depending on whether they already exist
-    if (!this.document.has("translations")) {
-       this.document.add({key: "translations", value: { description: newTranslations}});
-    } else {
-      const trans = this.document.get("translations");
-      if (!trans) {
-        this.document.set("translations", { description: newTranslations});
-      } else {
-        trans.set("description", newTranslations);
-      }
+    if (Object.keys(newTranslations).length > 0) {
+      this.document.setIn(["translations", "description"], newTranslations);
+    }
+
+    const modes = this.document.get("modes");
+    if (modes && isCollection(modes)) {
+      modes.items.forEach((mode) => {
+        const modeId = mode.get("id");
+        const modeName = mode.get("name");
+        const modeDescription = mode.get("description");
+
+        const nameTranslations = {};
+        const descTranslations = {};
+
+        translations.forEach((t) => {
+          if (t.msgstr?.length > 0) {
+            if (t.msgid === modeName) {
+              nameTranslations[t.locale] = t.msgstr;
+            }
+            if (t.msgid === modeDescription) {
+              descTranslations[t.locale] = t.msgstr;
+            }
+          }
+        });
+
+        if (Object.keys(nameTranslations).length > 0) {
+          this.document.setIn(
+            ["translations", "mode", modeId, "name"],
+            nameTranslations,
+          );
+        }
+        if (Object.keys(descTranslations).length > 0) {
+          this.document.setIn(
+            ["translations", "mode", modeId, "description"],
+            descTranslations,
+          );
+        }
+      });
     }
   }
 
@@ -141,7 +170,7 @@ class YamlProduct {
    * overwritten.
    */
   save() {
-    console.log(`Writing ${path.basename(this.file)}`);
+    console.log(`Writing ${this.file}`);
     fs.writeFileSync(this.file, this.dump(), "utf-8");
   }
 }
@@ -160,7 +189,7 @@ const translations = Translation.read(translations_dir);
 const products = YamlProduct.read(products_dir);
 
 // inject the translations to the products and save the changes
-products.forEach(p => {
+products.forEach((p) => {
   p.addTranslations(translations);
   p.save();
 });

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -151,6 +151,11 @@ security:
 
 modes:
   - id: standard
+    # ------------------------------------------------------------------------------
+    # WARNING: When changing the mode name or description delete the translations
+    # located at the translations/mode/<id> key above to avoid using obsolete
+    # translations!!
+    # ------------------------------------------------------------------------------
     name: Standard
     description: Standard system
 
@@ -249,6 +254,11 @@ modes:
               - vfat
 
   - id: immutable
+    # ------------------------------------------------------------------------------
+    # WARNING: When changing the mode name or description delete the translations
+    # located at the translations/mode/<id> key above to avoid using obsolete
+    # translations!!
+    # ------------------------------------------------------------------------------
     name: Immutable
     description: Immutable system with atomic updates
 


### PR DESCRIPTION
## Problem

- We need to merge the translations from Weblate back to the YAML product files


## Solution

- Add support for mode translations
- The translations are inserted into key `translations.mode.<id>.name|description`, see the example below
- 
## Testing

- Tested manually
- There are already some few translations, after running the updated script the product YAML file is changed like this:
```diff
diff --git a/products.d/sles_161.yaml b/products.d/sles_161.yaml
index 409eb9ffe..0d66ec9c8 100644
--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -93,6 +93,25 @@ translations:
       服务器系统，旨在确保企业业务持续运作。作为安全和可适应的操作系统，它适用于本地、云端或边缘计算平台的关键业务工作负载，运行在需要长期支持、容许创新的基础设施之上。
     zh_TW: 一個開放、可靠、符合標準且具未來適應性的 Linux
       伺服器系統，能確保企業業務的持續運作。它是一個安全且具備適應力的作業系統，適用於受到長期支援、具備創新彈性並用於在內部、雲端與邊緣環境中執行關鍵業務工作負載的基礎架構。
+  mode:
+    standard:
+      name:
+        cs: Standardní
+        id: Standar
+        ja: 標準
+      description:
+        cs: Standardní systém
+        id: Sistem standar
+        ja: 標準システム
+    immutable:
+      name:
+        cs: Neměnitelný
+        id: Immutable
+        ja: 不変型
+      description:
+        cs: Neměnitelný systém s atomickými aktualizacemi
+        id: Sistem immutable dengan pembaruan atomik
+        ja: 不可分な更新機能を持つ不変型システム
 software:
   installation_repositories: []
   installation_labels:

```
 
