### PR TITLE
Installer: configure libzypp through drop-in config snippet when supported

### DIFF
--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -49,8 +49,16 @@ if stat -t /usr/lib/rpm/gnupg/keys/*.asc 2>/dev/null 1>/dev/null; then
   rpm --import /usr/lib/rpm/gnupg/keys/*.asc
 fi
 
+if [ $(rpm -q --provides libzypp | grep -q 'libzypp(econf)'; echo $?) -eq 0 ]; then
+# A new enough version of libzypp is in use which supports UAPI configuration. Configure a drop-in conf
+cat <<EOF > /etc/zypp/zypp.conf.d/90-agama.conf
+[main]
+download.connect_timeout = 20
+EOF
+else
 # decrease the libzypp timeout to 20 seconds (the default is 60 seconds)
 sed -i -e "s/^\s*#\s*download.connect_timeout\s*=\s*.*$/download.connect_timeout = 20/" /etc/zypp/zypp.conf
+fi
 
 # activate services
 systemctl enable sshd.service


### PR DESCRIPTION

## Problem

Libypp, from version 17.38.0 on, supports UAPI style configuration.

- Build fail against new libzypp version: https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:K/agama-installer:openSUSE/images/x86_64


## Solution

Change the build of the live image to no lonber patch /etc/zypp/zypp.conf,
which does not exist in this case anymore (distro default moved to /usr/etc),
but rather create a drop-in configuration in /etc/zypp/zypp.conf.d.
If the image is built against a libzypp not yet supporting UAPI conf, continue
with patching zypp.conf directly

