### PR TITLE
products: add Beta tag to the SLES and SLES4SAP product names.

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 11 14:53:05 UTC 2026 - Eugenio Paolantonio <eugenio.paolantonio@suse.com>
+
+- Add Beta tag to the SLES and SLES4SAP product names
+  (gh#agama-project/agama#3151)
+
+-------------------------------------------------------------------
 Wed Feb 11 13:58:01 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add standard and immutable modes to SLES for SAP (bsc#1258042).

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -1,5 +1,5 @@
 id: SLES
-name: SUSE Linux Enterprise Server 16.1
+name: SUSE Linux Enterprise Server 16.1 Beta
 registration: true
 version: "16.1"
 license: "license.final"

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -1,5 +1,5 @@
 id: SLES_SAP
-name: SUSE Linux Enterprise Server for SAP applications 16.1
+name: SUSE Linux Enterprise Server for SAP applications 16.1 Beta
 archs: x86_64,ppc
 registration: true
 version: "16.1"


### PR DESCRIPTION
Adds the Beta tag to the product names.

Note, with the newest EULAs (#3150) the "beta" EULAs are not used. So we will not switch licenses for 16.1 Beta like we did for 16.0.