### PR TITLE
Move SAP related patterns into Standard mode

### DIFF
--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -137,7 +137,6 @@ software:
   optional_patterns: [] # no optional pattern shared
   user_patterns:
     - cockpit
-    - sles_sap_minimal_sap
     - fips
     - name: selinux
       selected: true
@@ -189,6 +188,8 @@ modes:
     software:
       mandatory_patterns:
         - enhanced_base
+      user_patterns:
+        - sles_sap_minimal_sap
 
     storage:
       space_policy: delete

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -86,12 +86,10 @@ software:
   mandatory_patterns:
     - base
     - bootloader
-    - sles_sap_base_sap_server
   optional_patterns: [] # no optional pattern shared
   user_patterns:
     # First all patterns from file sles_160.yaml
     - cockpit
-    - sles_sap_minimal_sap
     - fips
     - name: selinux
       selected: true
@@ -113,16 +111,6 @@ software:
     - devel_kernel
     - oracle_server
     - print_server
-    # Second, all patterns for SAP only
-    - sles_sap_DB
-    - sles_sap_HADB
-    - sles_sap_APP
-    - sles_sap_HAAPP
-    - sles_sap_trento_server
-    - sles_sap_trento_agent
-    - sles_sap_automation
-    - sles_sap_monitoring
-    - sles_sap_gui
   mandatory_packages:
     - NetworkManager
     # bsc#1241224, bsc#1224868 avoid probe DHCP over all ethernet devices and ignore carrier
@@ -153,6 +141,18 @@ modes:
     software:
       mandatory_patterns:
         - enhanced_base
+        - sles_sap_base_sap_server
+      user_patterns:
+        - sles_sap_DB
+        - sles_sap_HADB
+        - sles_sap_APP
+        - sles_sap_HAAPP
+        - sles_sap_trento_server
+        - sles_sap_trento_agent
+        - sles_sap_automation
+        - sles_sap_monitoring
+        - sles_sap_gui
+        - sles_sap_addons
 
     storage:
       space_policy: delete


### PR DESCRIPTION
Move the SAP related patterns for plain SLES and for SLES for SAP into the new Standard mode. They are not yet scheduled for Immutable mode. Related to bsc#1258042
