### PR TITLE
Run the Action for updating the POT file after any change

### DIFF
--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -5,9 +5,36 @@ permissions:
   contents: write
 
 on:
-  schedule:
-    # run every working day (Monday-Friday) at 1:42AM UTC
-    - cron: "42 1 * * Mon-Fri"
+  push:
+    branches:
+      # run on every change in master, the action actually checks if there is
+      # any change in the translations, if there is no change it does not upload
+      # the files to Weblate so it should be OK to run it quite often
+      - master
+
+    paths:
+      # run only if any file which can contain translatable strings is modified,
+      # changing documentation, unit tests, configuration files, etc... cannot
+      # change translations so do not run it in that case
+
+      # any change in the web Typescript files
+      - web/**.ts
+      - web/**.tsx
+      # except tests
+      - "!web/**.test.*"
+
+      # any change in the Ruby service files
+      - service/**.rb
+      # except tests
+      - "!service/test/**"
+
+      # any change in the Rust server files, the unit tests are embedded so we
+      # cannot skip it when only tests are updated
+      - rust/**.rs
+
+      # any change in the product files
+      - products.d/**.yaml
+      - products.d/**.yml
 
   # allow running manually
   workflow_dispatch:


### PR DESCRIPTION
## Problem

- The Weblate server quite often reports conflicts in the translations. When a conflict is detected then the translation repository is locked and the translators cannot do any changes. The reason is to avoid translating possibly outdated texts and causing even more conflicts and also to avoid wasting translator's time .
- The conflicts need to be resolved manually which is a bit annoying.
- Originally I wanted to avoid spamming the Weblate with too often changes so the translations were sent from Agama to Weblate only once a day. But that seems to cause conflicts quite often as the Agama sources might change in the meantime.

## Solution

- Run the POT update action after every change (merge) in the `master` branch
- To minimize the amount of runs run the action only when a source file is modified. When changing only documentation, unit tests, configuration files, etc... we can skip this action.
- Moreover the action itself checks if there is any change in the translations and if not then it does not update Weblate, this also decreases the traffic.

## Notes

- Let's see how this helps, we can tweak it later again if needed

