### PR TITLE
Remove "FIXME" from translations

### DIFF
--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -68,7 +68,8 @@ export default function ConfigEditor() {
 
   return (
     <>
-      <DataList aria-label={_("[FIXME]")} isCompact className="storage-structure">
+      {/* FIXME add arial label */}
+      <DataList aria-label="" isCompact className="storage-structure">
         {volumeGroups.map((vg, i) => {
           return <VolumeGroupEditor key={`vg-${i}`} vg={vg} />;
         })}


### PR DESCRIPTION
## Problem

- The Weblate translations contain the "[FIXME]" text

## Solution

- As a quick fix to not confuse translators remove the string
- Later add some real label