### PR TITLE
Do not log the registration code in the RegistrationState

### DIFF
--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -240,6 +240,8 @@ impl Service {
             SoftwareState::build_from(&product, &state.config, &state.system, &self.selection)
         };
 
+        tracing::info!("Wanted software state: {new_state:?}");
+
         self.update_selinux(&new_state);
 
         let model = self.model.clone();


### PR DESCRIPTION
## Problem

- The hot fix in https://github.com/agama-project/agama/pull/3167 is too aggressive, to avoid logging the registration code it removes the logged message completely. That might make debugging more complicated in some cases.

## Solution

- Implement the `fmt::Debug` trait for the `RegistrationState` structure so it replaces the configured registration code if present with "[FILTERED]" string so the code is not logged.

## Testing

- Added a new unit test
- Example output:
> RegistrationState { product: "SLES", version: "16.1", code: Some("[FILTERED]"), email: None, url: None, addons: [] }
