### PR TITLE
Added a dracut module for configuring HNV bonding (POC)

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
@@ -7,7 +7,7 @@ ConditionPathExists=/proc/device-tree
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/parse-hcnmgr.sh
+ExecStart=/bin/sh -c "/usr/bin/parse-hcnmgr.sh"
 RemainAfterExit=yes
 
 [Install]

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hybrid Cloud Network Manager
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=dracut-initqueue.service nm-initrd.service
+ConditionPathExists=/proc/device-tree
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/parse-hcnmgr.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=initrd.target

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
@@ -8,6 +8,8 @@ ConditionPathExists=/proc/device-tree
 [Service]
 Type=oneshot
 ExecStart=/bin/sh -c "/usr/bin/parse-hcnmgr.sh"
+SyslogIdentifier=hcngmr-initrd
+StandardOutput=journal+console
 RemainAfterExit=yes
 
 [Install]

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
@@ -1,13 +1,14 @@
 [Unit]
 Description=Hybrid Cloud Network Manager
 DefaultDependencies=no
-After=systemd-udev-settle.service
+Wants=nm-initrd.service systemd-udev-trigger.service
+After=systemd-udev-trigger.service
 Before=dracut-initqueue.service nm-initrd.service
 ConditionPathExists=/proc/device-tree
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/parse-hcnmgr.sh
+ExecStart=/bin/sh -c "/usr/bin/parse-hcnmgr.sh"
 SyslogIdentifier=hcnmgr-initrd
 StandardOutput=journal+console
 StandardError=journal+console

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Hybrid Cloud Network Manager
 DefaultDependencies=no
-Wants=nm-initrd.service systemd-udev-trigger.service
+Wants=systemd-udev-trigger.service
 After=systemd-udev-trigger.service
-Before=dracut-initqueue.service nm-initrd.service
+Before=dracut-initqueue.service nm-initrd.service NetworkManager-initrd.service
 ConditionPathExists=/proc/device-tree
 
 [Service]

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/hcnmgr-initrd.service
@@ -7,9 +7,10 @@ ConditionPathExists=/proc/device-tree
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "/usr/bin/parse-hcnmgr.sh"
-SyslogIdentifier=hcngmr-initrd
+ExecStart=/usr/bin/parse-hcnmgr.sh
+SyslogIdentifier=hcnmgr-initrd
 StandardOutput=journal+console
+StandardError=journal+console
 RemainAfterExit=yes
 
 [Install]

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -4,7 +4,7 @@
 check() {
   # Only support ppc64/ppc64le
   local _arch
-  _arch=$(uname -m)
+  _arch=${DRACUT_ARCH:-$(uname -m)}
   [ "$_arch" = "ppc64" ] || [ "$_arch" = "ppc64le" ] || return 1
   require_binaries hexdump ofpathname pseries_platform || return 1
   return 0
@@ -12,7 +12,7 @@ check() {
 
 # called by dracut
 depends() {
-  echo "network"
+  echo "systemd network-manager"
 }
 
 # called by dracut
@@ -23,6 +23,6 @@ install() {
     inst_simple "$moddir/hcnmgr-initrd.service" "${systemdsystemunitdir}/hcnmgr-initrd.service"
     $SYSTEMCTL -q --root "$initdir" enable hcnmgr-initrd.service
   else
-    inst_hook initqueue 01 "$moddir/parse-hcnmgr.sh"
+    inst_hook initqueue/settled 91 "$moddir/parse-hcnmgr.sh"
   fi
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -19,11 +19,7 @@ depends() {
 # called by dracut
 install() {
   inst_multiple awk sort wc tr sed
-  if dracut_module_included "systemd"; then
-    inst_simple "$moddir/parse-hcnmgr.sh" "/usr/bin/parse-hcnmgr.sh"
-    inst_simple "$moddir/hcnmgr-initrd.service" "${systemdsystemunitdir}/hcnmgr-initrd.service"
-    $SYSTEMCTL -q --root "$initdir" enable hcnmgr-initrd.service
-  else
-    inst_hook initqueue/settled 91 "$moddir/parse-hcnmgr.sh"
-  fi
+  inst_simple "$moddir/parse-hcnmgr.sh" "/usr/bin/parse-hcnmgr.sh"
+  inst_simple "$moddir/hcnmgr-initrd.service" "${systemdsystemunitdir}/hcnmgr-initrd.service"
+  $SYSTEMCTL -q --root "$initdir" enable hcnmgr-initrd.service
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -6,7 +6,7 @@ check() {
   local _arch
   _arch=$(uname -m)
   [ "$_arch" = "ppc64" ] || [ "$_arch" = "ppc64le" ] || return 1
-  require_binaries hexdump ofpathname || return 1
+  require_binaries hexdump ofpathname pseries_platform || return 1
   return 0
 }
 
@@ -17,7 +17,7 @@ depends() {
 
 # called by dracut
 install() {
-  inst_multiple hexdump ofpathname
+  inst_multiple hexdump ofpathname pseries_platform
   #    inst_hook initqueue/settled 30 "$moddir/parse-hcnmgr.sh"
   inst_hook cmdline 30 "$moddir/parse-hcnmgr.sh"
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -17,7 +17,13 @@ depends() {
 
 # called by dracut
 install() {
-  inst_multiple hcnmgr hexdump ofpathname pseries_platform
-  #    inst_hook initqueue/settled 30 "$moddir/parse-hcnmgr.sh"
-  inst_hook initqueue/settled 30 "$moddir/parse-hcnmgr.sh"
+  inst_multiple hcnmgr hexdump ofpathname pseries_platform awk sort wc tr sed grep cat
+  if dracut_module_included "systemd"; then
+    inst_simple "$moddir/parse-hcnmgr.sh" "/usr/bin/parse-hcnmgr.sh"
+    inst_simple "$moddir/hcnmgr-initrd.service" "${systemdsystemunitdir}/hcnmgr-initrd.service"
+    mkdir -p "${initdir}${systemdsystemunitdir}/initrd.target.wants"
+    ln_s "../hcnmgr-initrd.service" "${systemdsystemunitdir}/initrd.target.wants/hcnmgr-initrd.service"
+  else
+    inst_hook initqueue 01 "$moddir/parse-hcnmgr.sh"
+  fi
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -17,7 +17,7 @@ depends() {
 
 # called by dracut
 install() {
-  inst_multiple hexdump ofpathname pseries_platform
+  inst_multiple hcnmgr hexdump ofpathname pseries_platform
   #    inst_hook initqueue/settled 30 "$moddir/parse-hcnmgr.sh"
-  inst_hook cmdline 30 "$moddir/parse-hcnmgr.sh"
+  inst_hook initqueue/settled 30 "$moddir/parse-hcnmgr.sh"
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+  # Only support ppc64/ppc64le
+  local _arch
+  _arch=$(uname -m)
+  [ "$_arch" = "ppc64" ] || [ "$_arch" = "ppc64le" ] || return 1
+  require_binaries hexdump ofpathname || return 1
+  return 0
+}
+
+# called by dracut
+depends() {
+  echo "network"
+}
+
+# called by dracut
+install() {
+  inst_multiple hexdump ofpathname
+  #    inst_hook initqueue/settled 30 "$moddir/parse-hcnmgr.sh"
+  inst_hook cmdline 30 "$moddir/parse-hcnmgr.sh"
+}

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -6,6 +6,7 @@ check() {
   local _arch
   _arch=${DRACUT_ARCH:-$(uname -m)}
   [ "$_arch" = "ppc64" ] || [ "$_arch" = "ppc64le" ] || return 1
+  # pseries_platform is required by ofpathname
   require_binaries hexdump ofpathname pseries_platform || return 1
   return 0
 }
@@ -17,7 +18,7 @@ depends() {
 
 # called by dracut
 install() {
-  inst_multiple hcnmgr hexdump ofpathname pseries_platform awk sort wc tr sed grep cat
+  inst_multiple awk sort wc tr sed
   if dracut_module_included "systemd"; then
     inst_simple "$moddir/parse-hcnmgr.sh" "/usr/bin/parse-hcnmgr.sh"
     inst_simple "$moddir/hcnmgr-initrd.service" "${systemdsystemunitdir}/hcnmgr-initrd.service"

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/module-setup.sh
@@ -21,8 +21,7 @@ install() {
   if dracut_module_included "systemd"; then
     inst_simple "$moddir/parse-hcnmgr.sh" "/usr/bin/parse-hcnmgr.sh"
     inst_simple "$moddir/hcnmgr-initrd.service" "${systemdsystemunitdir}/hcnmgr-initrd.service"
-    mkdir -p "${initdir}${systemdsystemunitdir}/initrd.target.wants"
-    ln_s "../hcnmgr-initrd.service" "${systemdsystemunitdir}/initrd.target.wants/hcnmgr-initrd.service"
+    $SYSTEMCTL -q --root "$initdir" enable hcnmgr-initrd.service
   else
     inst_hook initqueue 01 "$moddir/parse-hcnmgr.sh"
   fi

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -1,20 +1,23 @@
 #!/bin/sh
 
-type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
+. /lib/dracut-lib.sh
 
 info "parse-hcnmgr: starting"
 
+# xdump4: reads 4-byte big-endian integer from file and returns hex string
 xdump4() {
-  hexdump -n 4 -ve '/1 "%02x"' "$1"
+    [ -f "$1" ] || return 1
+    hexdump -n 4 -ve '/1 "%02x"' "$1"
 }
 
+# get_mac: reads MAC address from local-mac-address file in device-tree
 get_mac() {
-  local _dev=$1
-  local _mac
-  if [ -f "$_dev/local-mac-address" ]; then
-    _mac=$(hexdump -ve '/1 "%02x:"' "$_dev/local-mac-address")
-    echo "${_mac%:}"
-  fi
+    local _dev=$1
+    local _mac
+    if [ -f "$_dev/local-mac-address" ]; then
+        _mac=$(hexdump -ve '/1 "%02x:"' "$_dev/local-mac-address")
+        echo "${_mac%:}"
+    fi
 }
 
 #
@@ -26,260 +29,234 @@ get_mac() {
 # $1 path to device-tree device
 #
 get_dev_hcn() {
-  local _dev=$1
-  local _hcnid
-  local _devname
-  local _mode
-  local _mac
-  local _wait=12
+    local _dev=$1
+    local _hcnid
+    local _devname
+    local _mode
+    local _mac
+    local _wait=180
+    local _ofpath
 
-  _hcnid=$(xdump4 "$_dev"/ibm,hcn-id)
-  if [ -z "$_hcnid" ]; then
-    return 1
-  fi
+    _hcnid=$(xdump4 "$_dev"/ibm,hcn-id)
+    [ -z "$_hcnid" ] && return 1
 
-  _mode=$(tr -d '\0' <"$_dev"/ibm,hcn-mode 2>/dev/null)
+    _mode=$(tr -d '\0' < "$_dev"/ibm,hcn-mode 2> /dev/null)
 
-  # Get the device name. After migration, it may take some time for
-  # sysfs interface up or OFPATHENAME command to translate to device name.
-  # Let's retry a few times.
-  while [ $_wait -ne 0 ]; do
-    local _ofpath=$(echo "$_dev" | sed -e "s/^\/proc\/device-tree//")
-    if _devname=$(ofpathname -l "$_ofpath" 2>/dev/null); then
-      if [ -e "/sys/class/net/$_devname" ]; then
-        info "ofpathname waiting for /sys/class/net device $_devname ready"
-        _mac=$(get_mac "$_dev")
-        break
-      fi
+    # Get the device name. After migration, it may take some time for
+    # sysfs interface up or OFPATHENAME command to translate to device name.
+    # Let's retry a few times.
+    while [ "$_wait" -gt 0 ]; do
+        _ofpath=${_dev#/proc/device-tree}
+        if _devname=$(ofpathname -l "$_ofpath" 2> /dev/null); then
+            if [ -e "/sys/class/net/$_devname" ]; then
+                info "ofpathname waiting for /sys/class/net device $_devname ready"
+                _mac=$(get_mac "$_dev")
+                break
+            fi
+        fi
+
+        info "ofpathname return $?, devname is $_devname, and the retry counter $_wait"
+        sleep 1
+        _wait=$((_wait - 1))
+    done
+
+    if [ -z "$_devname" ]; then
+        warn "get_dev_hcn: couldn't get dev name for $_dev"
+        return 1
     fi
 
-    info "ofpathname return $?, devname is $_devname, and the retry counter $_wait"
-    sleep 15
-    _wait=$((_wait - 1))
-  done
-
-  if [ -z "$_devname" ]; then
-    warn "get_dev_hcn: couldn't get dev name for $_dev"
-    return 1
-  fi
-
-  # Output the bond mapping: bondname devname mac mode
-  echo "bond$_hcnid $_devname ${_mac:-none} ${_mode:-none}"
-  return 0
+    # Output the bond mapping: bondname devname mac mode
+    echo "bond$_hcnid $_devname ${_mac:-none} ${_mode:-none}"
+    return 0
 }
 
 # Collect all mappings
 MAPPINGS=""
 if [ -d /proc/device-tree ]; then
-  # PCI devices (SR-IOV)
-  for pci_dev in /proc/device-tree/pci*; do
-    [ -d "$pci_dev" ] || continue
-    for dev in "$pci_dev"/ethernet*; do
-      [ -d "$dev" ] || continue
-      if [ -e "$dev"/ibm,hcn-id ]; then
-        res=$(get_dev_hcn "$dev")
-        if [ -n "$res" ]; then
-          MAPPINGS="$MAPPINGS $res"
+    # PCI devices (SR-IOV) and vdevices (VNIC and Virtual Ethernet)
+    for dev in /proc/device-tree/pci*/ethernet* \
+        /proc/device-tree/vdevice/vnic* \
+        /proc/device-tree/vdevice/l-lan*; do
+        [ -d "$dev" ] || continue
+        if [ -e "$dev/ibm,hcn-id" ]; then
+            res=$(get_dev_hcn "$dev")
+            [ -n "$res" ] && MAPPINGS="${MAPPINGS:+$MAPPINGS }$res"
         fi
-      fi
     done
-  done
-
-  # vdevices (VNIC and Virtual Ethernet)
-  if [ -d /proc/device-tree/vdevice ]; then
-    for dev in /proc/device-tree/vdevice/vnic* /proc/device-tree/vdevice/l-lan*; do
-      [ -d "$dev" ] || continue
-      if [ -e "$dev"/ibm,hcn-id ]; then
-        res=$(get_dev_hcn "$dev")
-        if [ -n "$res" ]; then
-          MAPPINGS="$MAPPINGS $res"
-        fi
-      fi
-    done
-  fi
 fi
 
-if [ -z "$MAPPINGS" ]; then
-  info "parse-hcnmgr: no mappings found"
-  # Use return if sourced (like in a dracut hook), or exit if executed directly
-  [ "$0" = "/init" ] || [ "$0" = "/lib/dracut/dracut-initqueue.sh" ] && return 0 || exit 0
-fi
+if [ -n "$MAPPINGS" ]; then
+    info "parse-hcnmgr: mappings found: $MAPPINGS"
 
-info "parse-hcnmgr: mappings found:$MAPPINGS"
+    HCN_IP=$(getargs hcn.ip -d hvn.ip)
+    HCN_ROUTE=$(getargs hcn.route -d hvn.route)
 
-# We might not have CMDLINE variable exported if it's an older dracut, so let's check
-if [ -z "$CMDLINE" ]; then
-  [ -r /proc/cmdline ] && CMDLINE=$(cat /proc/cmdline)
-fi
+    info "parse-hcnmgr: HCN_IP=$HCN_IP HCN_ROUTE=$HCN_ROUTE"
 
-HCN_IP=$(getargs hcn.ip)
-[ -z "$HCN_IP" ] && HCN_IP=$(getargs hvn.ip)
+    NEW_ARGS=""
+    MOD_CMDLINE=$(getcmdline)
+    CHANGED=0
 
-HCN_ROUTE=$(getargs hcn.route)
-[ -z "$HCN_ROUTE" ] && HCN_ROUTE=$(getargs hvn.route)
+    # Unique bond names
+    BOND_NAMES=$(for m in $MAPPINGS; do echo "$m"; done | awk '{print $1}' | sort -u)
 
-info "parse-hcnmgr: HCN_IP=$HCN_IP HCN_ROUTE=$HCN_ROUTE"
+    for BONDNAME in $BOND_NAMES; do
+        SLAVE_NAMES=""
+        SLAVE_MACS=""
+        PRIMARY=""
+        SLAVES=""
 
-NEW_ARGS=""
-MOD_CMDLINE="$CMDLINE"
-CHANGED=0
+        # Extract slaves for this bond
+        # MAPPINGS is space-separated quadruplets: bondname devname mac mode
+        # shellcheck disable=SC2086
+        set -- $MAPPINGS
+        while [ $# -ge 4 ]; do
+            if [ "$1" = "$BONDNAME" ]; then
+                _s_name=$2
+                _s_mac=$3
+                _s_mode=$4
 
-# Unique bond names
-BOND_NAMES=$(echo "$MAPPINGS" | awk '{print $1}' | sort -u)
+                SLAVE_NAMES="${SLAVE_NAMES:+$SLAVE_NAMES }$_s_name"
+                [ "$_s_mac" != "none" ] && SLAVE_MACS="${SLAVE_MACS:+$SLAVE_MACS }$_s_mac"
+                [ "$_s_mode" = "primary" ] && PRIMARY=$_s_name
 
-for BONDNAME in $BOND_NAMES; do
-  SLAVES=""
-  SLAVE_NAMES=""
-  SLAVE_MACS=""
-  PRIMARY=""
+                if [ -z "$SLAVES" ]; then
+                    SLAVES=$_s_name
+                else
+                    SLAVES="$SLAVES,$_s_name"
+                fi
+            fi
+            shift 4
+        done
 
-  # Extract slaves for this bond
-  set -- $MAPPINGS
-  while [ $# -ge 4 ]; do
-    if [ "$1" = "$BONDNAME" ]; then
-      _s_name=$2
-      _s_mac=$3
-      _s_mode=$4
+        # Add bond definition
+        BOND_OPTS="mode=1,miimon=100,fail_over_mac=2"
+        [ -n "$PRIMARY" ] && BOND_OPTS="$BOND_OPTS,primary=$PRIMARY"
 
-      SLAVE_NAMES="$SLAVE_NAMES $_s_name"
-      [ "$_s_mac" != "none" ] && SLAVE_MACS="$SLAVE_MACS $_s_mac"
-      [ "$_s_mode" = "primary" ] && PRIMARY="$_s_name"
+        NEW_ARGS="$NEW_ARGS bond=$BONDNAME:$SLAVES:$BOND_OPTS"
 
-      if [ -z "$SLAVES" ]; then
-        SLAVES="$_s_name"
-      else
-        SLAVES="$SLAVES,$_s_name"
-      fi
-    fi
-    shift 4
-  done
+        if [ -n "$HCN_IP" ]; then
+            MATCHED=0
+            CURRENT_HCN_IP=$HCN_IP
 
-  # Add bond definition
-  BOND_OPTS="mode=1,miimon=100,fail_over_mac=2"
-  [ -n "$PRIMARY" ] && BOND_OPTS="$BOND_OPTS,primary=$PRIMARY"
+            # Check if HCN_IP matches any slave of THIS bond (name or MAC)
+            for s in $SLAVE_NAMES $SLAVE_MACS; do
+                [ -z "$s" ] && continue
+                s_dash=$(echo "$s" | tr ':' '-')
+                if [ "$HCN_IP" = "$s" ] || [ "$HCN_IP" = "$s_dash" ]; then
+                    CURRENT_HCN_IP=$BONDNAME
+                    MATCHED=1
+                    break
+                elif strstr "$HCN_IP" ":$s:" || str_ends "$HCN_IP" ":$s"; then
+                    CURRENT_HCN_IP=$(echo "$HCN_IP" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
+                    MATCHED=1
+                    break
+                elif strstr "$HCN_IP" ":$s_dash:" || str_ends "$HCN_IP" ":$s_dash"; then
+                    CURRENT_HCN_IP=$(echo "$HCN_IP" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
+                    MATCHED=1
+                    break
+                fi
+            done
 
-  NEW_ARGS="$NEW_ARGS bond=$BONDNAME:$SLAVES:$BOND_OPTS"
+            if [ $MATCHED -eq 1 ]; then
+                NEW_ARGS="$NEW_ARGS ip=$CURRENT_HCN_IP"
+                CHANGED=1
+            else
+                # Fallback if it doesn't match any specific bond but is just an IP
+                if ! strstr "$HCN_IP" ":bond"; then
+                    COLONS=$(echo "$HCN_IP" | tr -dc ':' | wc -c)
+                    if [ "$COLONS" -eq 0 ]; then
+                        NEW_ARGS="$NEW_ARGS ip=$HCN_IP:::::$BONDNAME:none"
+                        CHANGED=1
+                    fi
+                fi
+            fi
+        fi
 
-  if [ -n "$HCN_IP" ]; then
-    MATCHED=0
-    CURRENT_HCN_IP="$HCN_IP"
+        if [ -n "$HCN_ROUTE" ]; then
+            MATCHED=0
+            CURRENT_HCN_ROUTE=$HCN_ROUTE
 
-    # Check if HCN_IP matches any slave of THIS bond (name or MAC)
-    for s in $SLAVE_NAMES $SLAVE_MACS; do
-      [ -z "$s" ] && continue
-      s_dash=$(echo "$s" | tr ':' '-')
-      if [ "$HCN_IP" = "$s" ] || [ "$HCN_IP" = "$s_dash" ]; then
-        CURRENT_HCN_IP="$BONDNAME"
-        MATCHED=1
-        break
-      elif echo "$HCN_IP" | grep -q ":$s\(:\|$\)"; then
-        CURRENT_HCN_IP=$(echo "$HCN_IP" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
-        MATCHED=1
-        break
-      elif echo "$HCN_IP" | grep -q ":$s_dash\(:\|$\)"; then
-        CURRENT_HCN_IP=$(echo "$HCN_IP" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
-        MATCHED=1
-        break
-      fi
+            # Check if HCN_ROUTE matches any slave of THIS bond (name or MAC)
+            for s in $SLAVE_NAMES $SLAVE_MACS; do
+                [ -z "$s" ] && continue
+                s_dash=$(echo "$s" | tr ':' '-')
+                if [ "$HCN_ROUTE" = "$s" ] || [ "$HCN_ROUTE" = "$s_dash" ]; then
+                    CURRENT_HCN_ROUTE=$BONDNAME
+                    MATCHED=1
+                    break
+                elif strstr "$HCN_ROUTE" ":$s:" || str_ends "$HCN_ROUTE" ":$s"; then
+                    CURRENT_HCN_ROUTE=$(echo "$HCN_ROUTE" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
+                    MATCHED=1
+                    break
+                elif strstr "$HCN_ROUTE" ":$s_dash:" || str_ends "$HCN_ROUTE" ":$s_dash"; then
+                    CURRENT_HCN_ROUTE=$(echo "$HCN_ROUTE" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
+                    MATCHED=1
+                    break
+                fi
+            done
+
+            if [ $MATCHED -eq 1 ]; then
+                NEW_ARGS="$NEW_ARGS rd.route=$CURRENT_HCN_ROUTE"
+                CHANGED=1
+            else
+                # Fallback if it doesn't match any specific bond but is just a route spec without interface
+                if ! strstr "$HCN_ROUTE" ":bond"; then
+                    COLONS=$(echo "$HCN_ROUTE" | tr -dc ':' | wc -c)
+                    if [ "$COLONS" -eq 0 ]; then
+                        NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE::$BONDNAME"
+                        CHANGED=1
+                    elif [ "$COLONS" -eq 1 ]; then
+                        NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE:$BONDNAME"
+                        CHANGED=1
+                    fi
+                fi
+            fi
+        fi
+
+        # Replace slaves in existing ip= and rd.route= arguments
+        for slave in $SLAVE_NAMES; do
+            if strstr "$MOD_CMDLINE" "$slave"; then
+                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
+                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
+                CHANGED=1
+            fi
+        done
+        for mac in $SLAVE_MACS; do
+            mac_dash=$(echo "$mac" | tr ':' '-')
+            if strstr "$MOD_CMDLINE" "$mac"; then
+                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
+                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
+                CHANGED=1
+            fi
+            if strstr "$MOD_CMDLINE" "$mac_dash"; then
+                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
+                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
+                CHANGED=1
+            fi
+        done
     done
 
-    if [ $MATCHED -eq 1 ]; then
-      NEW_ARGS="$NEW_ARGS ip=$CURRENT_HCN_IP"
-      CHANGED=1
-    else
-      # Fallback if it doesn't match any specific bond but is just an IP
-      if ! echo "$HCN_IP" | grep -q ":bond[0-9]"; then
-        COLONS=$(echo "$HCN_IP" | tr -dc ':' | wc -c)
-        if [ "$COLONS" -eq 0 ]; then
-          NEW_ARGS="$NEW_ARGS ip=$HCN_IP:::::$BONDNAME:none"
-          CHANGED=1
-        fi
-      fi
+    if [ "$CHANGED" -eq 1 ] || [ -n "$NEW_ARGS" ]; then
+        info "parse-hcnmgr: writing /etc/cmdline.d/99-hcnmgr.conf with $NEW_ARGS"
+        # Write to cmdline.d
+        mkdir -p /etc/cmdline.d
+        echo "$NEW_ARGS" > /etc/cmdline.d/99-hcnmgr.conf
+
+        # Call nm-initrd-generator
+        for generator in /usr/lib/NetworkManager/nm-initrd-generator \
+            /usr/libexec/nm-initrd-generator \
+            /usr/lib/nm-initrd-generator; do
+            if [ -x "$generator" ]; then
+                info "parse-hcnmgr: calling $generator"
+                # shellcheck disable=SC2086
+                "$generator" -- $MOD_CMDLINE $NEW_ARGS
+                mkdir -p /run/NetworkManager/initrd
+                : > /run/NetworkManager/initrd/neednet
+                break
+            fi
+        done
     fi
-  fi
-
-  if [ -n "$HCN_ROUTE" ]; then
-    MATCHED=0
-    CURRENT_HCN_ROUTE="$HCN_ROUTE"
-
-    # Check if HCN_ROUTE matches any slave of THIS bond (name or MAC)
-    for s in $SLAVE_NAMES $SLAVE_MACS; do
-      [ -z "$s" ] && continue
-      s_dash=$(echo "$s" | tr ':' '-')
-      if [ "$HCN_ROUTE" = "$s" ] || [ "$HCN_ROUTE" = "$s_dash" ]; then
-        CURRENT_HCN_ROUTE="$BONDNAME"
-        MATCHED=1
-        break
-      elif echo "$HCN_ROUTE" | grep -q ":$s\(:\|$\)"; then
-        CURRENT_HCN_ROUTE=$(echo "$HCN_ROUTE" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
-        MATCHED=1
-        break
-      elif echo "$HCN_ROUTE" | grep -q ":$s_dash\(:\|$\)"; then
-        CURRENT_HCN_ROUTE=$(echo "$HCN_ROUTE" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
-        MATCHED=1
-        break
-      fi
-    done
-
-    if [ $MATCHED -eq 1 ]; then
-      NEW_ARGS="$NEW_ARGS rd.route=$CURRENT_HCN_ROUTE"
-      CHANGED=1
-    else
-      # Fallback if it doesn't match any specific bond but is just a route spec without interface
-      if ! echo "$HCN_ROUTE" | grep -q ":bond[0-9]"; then
-        COLONS=$(echo "$HCN_ROUTE" | tr -dc ':' | wc -c)
-        if [ "$COLONS" -eq 0 ]; then
-          NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE::$BONDNAME"
-          CHANGED=1
-        elif [ "$COLONS" -eq 1 ]; then
-          NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE:$BONDNAME"
-          CHANGED=1
-        fi
-      fi
-    fi
-  fi
-
-  # Replace slaves in existing ip= and rd.route= arguments
-  for slave in $SLAVE_NAMES; do
-    if echo "$MOD_CMDLINE" | grep -q "$slave"; then
-      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
-      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
-      CHANGED=1
-    fi
-  done
-  for mac in $SLAVE_MACS; do
-    mac_dash=$(echo "$mac" | tr ':' '-')
-    if echo "$MOD_CMDLINE" | grep -q "$mac"; then
-      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
-      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
-      CHANGED=1
-    fi
-    if echo "$MOD_CMDLINE" | grep -q "$mac_dash"; then
-      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
-      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
-      CHANGED=1
-    fi
-  done
-done
-
-if [ $CHANGED -eq 1 ] || [ -n "$NEW_ARGS" ]; then
-  info "parse-hcnmgr: writing /etc/cmdline.d/99-hcnmgr.conf with $NEW_ARGS"
-  # Write to cmdline.d
-  mkdir -p /etc/cmdline.d
-  echo "$NEW_ARGS" >/etc/cmdline.d/99-hcnmgr.conf
-
-  # Update global CMDLINE
-  export CMDLINE="$MOD_CMDLINE $NEW_ARGS"
-
-  # Call nm-initrd-generator
-  for generator in /usr/lib/NetworkManager/nm-initrd-generator /usr/libexec/nm-initrd-generator; do
-    if [ -x "$generator" ]; then
-      info "parse-hcnmgr: calling $generator"
-      $generator -- $CMDLINE
-      mkdir -p /run/NetworkManager/initrd
-      : >/run/NetworkManager/initrd/neednet
-      break
-    fi
-  done
-
+else
+    info "parse-hcnmgr: no mappings found"
 fi

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -17,31 +17,61 @@ get_mac() {
   fi
 }
 
+#
+# function get_dev_hcn
+#	Given device path, Search for device-tree, get HCNID,
+#	device name, and mode to configure/delete/query device
+#	or active-backup bonding
+#
+# $1 path to device-tree device
+#
 get_dev_hcn() {
   local _dev=$1
   local _hcnid
   local _devname
+  local _mode
   local _mac
+  local _wait=12
 
   _hcnid=$(xdump4 "$_dev"/ibm,hcn-id)
   if [ -z "$_hcnid" ]; then
     return 1
   fi
 
-  # Get the device name using ofpathname
-  _devname=$(ofpathname -l "$(echo "$_dev" | sed -e "s/\/proc\/device-tree//")" 2>/dev/null)
-  _mac=$(get_mac "$_dev")
+  _mode=$(tr -d '\0' <"$_dev"/ibm,hcn-mode 2>/dev/null)
 
-  if [ -n "$_devname" ]; then
-    echo "bond$_hcnid $_devname $_mac"
-    return 0
+  # Get the device name. After migration, it may take some time for
+  # sysfs interface up or OFPATHENAME command to translate to device name.
+  # Let's retry a few times.
+  while [ $_wait -ne 0 ]; do
+    local _ofpath=$(echo "$_dev" | sed -e "s/^\/proc\/device-tree//")
+    if _devname=$(ofpathname -l "$_ofpath" 2>/dev/null); then
+      if [ -e "/sys/class/net/$_devname" ]; then
+        info "ofpathname waiting for /sys/class/net device $_devname ready"
+        _mac=$(get_mac "$_dev")
+        break
+      fi
+    fi
+
+    info "ofpathname return $?, devname is $_devname, and the retry counter $_wait"
+    sleep 15
+    _wait=$((_wait - 1))
+  done
+
+  if [ -z "$_devname" ]; then
+    warn "get_dev_hcn: couldn't get dev name for $_dev"
+    return 1
   fi
-  return 1
+
+  # Output the bond mapping: bondname devname mac mode
+  echo "bond$_hcnid $_devname ${_mac:-none} ${_mode:-none}"
+  return 0
 }
 
 # Collect all mappings
 MAPPINGS=""
 if [ -d /proc/device-tree ]; then
+  # PCI devices (SR-IOV)
   for pci_dev in /proc/device-tree/pci*; do
     [ -d "$pci_dev" ] || continue
     for dev in "$pci_dev"/ethernet*; do
@@ -54,6 +84,19 @@ if [ -d /proc/device-tree ]; then
       fi
     done
   done
+
+  # vdevices (VNIC and Virtual Ethernet)
+  if [ -d /proc/device-tree/vdevice ]; then
+    for dev in /proc/device-tree/vdevice/vnic* /proc/device-tree/vdevice/l-lan*; do
+      [ -d "$dev" ] || continue
+      if [ -e "$dev"/ibm,hcn-id ]; then
+        res=$(get_dev_hcn "$dev")
+        if [ -n "$res" ]; then
+          MAPPINGS="$MAPPINGS $res"
+        fi
+      fi
+    done
+  fi
 fi
 
 if [ -z "$MAPPINGS" ]; then
@@ -88,24 +131,34 @@ for BONDNAME in $BOND_NAMES; do
   SLAVES=""
   SLAVE_NAMES=""
   SLAVE_MACS=""
+  PRIMARY=""
 
   # Extract slaves for this bond
   set -- $MAPPINGS
-  while [ $# -ge 3 ]; do
+  while [ $# -ge 4 ]; do
     if [ "$1" = "$BONDNAME" ]; then
-      SLAVE_NAMES="$SLAVE_NAMES $2"
-      [ -n "$3" ] && SLAVE_MACS="$SLAVE_MACS $3"
+      _s_name=$2
+      _s_mac=$3
+      _s_mode=$4
+
+      SLAVE_NAMES="$SLAVE_NAMES $_s_name"
+      [ "$_s_mac" != "none" ] && SLAVE_MACS="$SLAVE_MACS $_s_mac"
+      [ "$_s_mode" = "primary" ] && PRIMARY="$_s_name"
+
       if [ -z "$SLAVES" ]; then
-        SLAVES="$2"
+        SLAVES="$_s_name"
       else
-        SLAVES="$SLAVES,$2"
+        SLAVES="$SLAVES,$_s_name"
       fi
     fi
-    shift 3
+    shift 4
   done
 
   # Add bond definition
-  NEW_ARGS="$NEW_ARGS bond=$BONDNAME:$SLAVES:mode=1,miimon=100,fail_over_mac=2"
+  BOND_OPTS="mode=1,miimon=100,fail_over_mac=2"
+  [ -n "$PRIMARY" ] && BOND_OPTS="$BOND_OPTS,primary=$PRIMARY"
+
+  NEW_ARGS="$NEW_ARGS bond=$BONDNAME:$SLAVES:$BOND_OPTS"
 
   if [ -n "$HNV_IP" ]; then
     MATCHED=0
@@ -212,6 +265,7 @@ done
 if [ $CHANGED -eq 1 ] || [ -n "$NEW_ARGS" ]; then
   info "parse-hcnmgr: writing /etc/cmdline.d/99-hcnmgr.conf with $NEW_ARGS"
   # Write to cmdline.d
+  mkdir -p /etc/cmdline.d
   echo "$NEW_ARGS" >/etc/cmdline.d/99-hcnmgr.conf
 
   # Update global CMDLINE

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -94,8 +94,6 @@ if [ -n "$MAPPINGS" ]; then
     info "parse-hcnmgr: HCN_IP=$HCN_IP HCN_ROUTE=$HCN_ROUTE"
 
     NEW_ARGS=""
-    MOD_CMDLINE=$(getcmdline)
-    CHANGED=0
 
     # Unique bond names
     BOND_NAMES=$(for m in $MAPPINGS; do echo "$m"; done | awk '{print $1}' | sort -u)
@@ -160,14 +158,12 @@ if [ -n "$MAPPINGS" ]; then
 
             if [ $MATCHED -eq 1 ]; then
                 NEW_ARGS="$NEW_ARGS ip=$CURRENT_HCN_IP"
-                CHANGED=1
             else
                 # Fallback if it doesn't match any specific bond but is just an IP
                 if ! strstr "$HCN_IP" ":bond"; then
                     COLONS=$(echo "$HCN_IP" | tr -dc ':' | wc -c)
                     if [ "$COLONS" -eq 0 ]; then
                         NEW_ARGS="$NEW_ARGS ip=$HCN_IP:::::$BONDNAME:none"
-                        CHANGED=1
                     fi
                 fi
             fi
@@ -198,46 +194,21 @@ if [ -n "$MAPPINGS" ]; then
 
             if [ $MATCHED -eq 1 ]; then
                 NEW_ARGS="$NEW_ARGS rd.route=$CURRENT_HCN_ROUTE"
-                CHANGED=1
             else
                 # Fallback if it doesn't match any specific bond but is just a route spec without interface
                 if ! strstr "$HCN_ROUTE" ":bond"; then
                     COLONS=$(echo "$HCN_ROUTE" | tr -dc ':' | wc -c)
                     if [ "$COLONS" -eq 0 ]; then
                         NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE::$BONDNAME"
-                        CHANGED=1
                     elif [ "$COLONS" -eq 1 ]; then
                         NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE:$BONDNAME"
-                        CHANGED=1
                     fi
                 fi
             fi
         fi
-
-        # Replace slaves in existing ip= and rd.route= arguments
-        for slave in $SLAVE_NAMES; do
-            if strstr "$MOD_CMDLINE" "$slave"; then
-                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
-                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
-                CHANGED=1
-            fi
-        done
-        for mac in $SLAVE_MACS; do
-            mac_dash=$(echo "$mac" | tr ':' '-')
-            if strstr "$MOD_CMDLINE" "$mac"; then
-                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
-                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
-                CHANGED=1
-            fi
-            if strstr "$MOD_CMDLINE" "$mac_dash"; then
-                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
-                MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
-                CHANGED=1
-            fi
-        done
     done
 
-    if [ "$CHANGED" -eq 1 ] || [ -n "$NEW_ARGS" ]; then
+    if [ -n "$NEW_ARGS" ]; then
         info "parse-hcnmgr: writing /etc/cmdline.d/99-hcnmgr.conf with $NEW_ARGS"
         # Write to cmdline.d
         mkdir -p /etc/cmdline.d
@@ -250,7 +221,7 @@ if [ -n "$MAPPINGS" ]; then
             if [ -x "$generator" ]; then
                 info "parse-hcnmgr: calling $generator"
                 # shellcheck disable=SC2086
-                "$generator" -- $MOD_CMDLINE $NEW_ARGS
+                "$generator" -- $NEW_ARGS
                 mkdir -p /run/NetworkManager/initrd
                 : > /run/NetworkManager/initrd/neednet
                 break

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -55,7 +55,8 @@ if [ -d /proc/device-tree ]; then
 fi
 
 if [ -z "$MAPPINGS" ]; then
-  return 0
+  # Use return if sourced (like in a dracut hook), or exit if executed directly
+  [ "$0" = "/init" ] || [ "$0" = "/lib/dracut/dracut-initqueue.sh" ] && return 0 || exit 0
 fi
 
 # We might not have CMDLINE variable exported if it's an older dracut, so let's check

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -1,81 +1,171 @@
 #!/bin/sh
 
+type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
 xdump4() {
-    hexdump -n 4 -ve '/1 "%02x"' "$1"
+  hexdump -n 4 -ve '/1 "%02x"' "$1"
+}
+
+get_mac() {
+  local _dev=$1
+  local _mac
+  if [ -f "$_dev/local-mac-address" ]; then
+    _mac=$(hexdump -ve '/1 "%02x:"' "$_dev/local-mac-address")
+    echo "${_mac%:}"
+  fi
 }
 
 get_dev_hcn() {
-    local dev=$1
-    local HCNID
-    local DEVNAME
-    
-    HCNID=$(xdump4 "$dev"/ibm,hcn-id)
-    if [ -z "$HCNID" ]; then
-        return 1
-    fi
-    
-    # Get the device name using ofpathname
-    DEVNAME=$(ofpathname -l "$(echo "$dev" | sed -e "s/\/proc\/device-tree//")" 2>/dev/null)
-    if [ -n "$DEVNAME" ]; then
-        echo "bond$HCNID $DEVNAME"
-        return 0
-    fi
+  local _dev=$1
+  local _hcnid
+  local _devname
+  local _mac
+
+  _hcnid=$(xdump4 "$_dev"/ibm,hcn-id)
+  if [ -z "$_hcnid" ]; then
     return 1
+  fi
+
+  # Get the device name using ofpathname
+  _devname=$(ofpathname -l "$(echo "$_dev" | sed -e "s/\/proc\/device-tree//")" 2>/dev/null)
+  _mac=$(get_mac "$_dev")
+
+  if [ -n "$_devname" ]; then
+    echo "bond$_hcnid $_devname $_mac"
+    return 0
+  fi
+  return 1
 }
 
 # Collect all mappings
 MAPPINGS=""
 if [ -d /proc/device-tree ]; then
-    for pci_dev in /proc/device-tree/pci*; do
-        [ -d "$pci_dev" ] || continue
-        for dev in "$pci_dev"/ethernet*; do
-            [ -d "$dev" ] || continue
-            if [ -e "$dev"/ibm,hcn-id ]; then
-                res=$(get_dev_hcn "$dev")
-                if [ -n "$res" ]; then
-                    MAPPINGS="$MAPPINGS $res"
-                fi
-            fi
-        done
+  for pci_dev in /proc/device-tree/pci*; do
+    [ -d "$pci_dev" ] || continue
+    for dev in "$pci_dev"/ethernet*; do
+      [ -d "$dev" ] || continue
+      if [ -e "$dev"/ibm,hcn-id ]; then
+        res=$(get_dev_hcn "$dev")
+        if [ -n "$res" ]; then
+          MAPPINGS="$MAPPINGS $res"
+        fi
+      fi
     done
+  done
 fi
 
 if [ -z "$MAPPINGS" ]; then
-    return 0
+  return 0
 fi
 
 # We might not have CMDLINE variable exported if it's an older dracut, so let's check
 if [ -z "$CMDLINE" ]; then
-    CMDLINE=$(cat /proc/cmdline)
+  [ -r /proc/cmdline ] && CMDLINE=$(cat /proc/cmdline)
 fi
 
-NEW_CMDLINE="$CMDLINE"
-REPLACED=0
+HNV_IP=$(getargs hnv.ip)
+[ -z "$HNV_IP" ] && HNV_IP=$(getargs hvn.ip)
 
-set -- $MAPPINGS
-while [ $# -ge 2 ]; do
-    BONDNAME="$1"
-    DEVNAME="$2"
-    shift 2
-    
-    # Check if DEVNAME is in the cmdline
-    if echo "$NEW_CMDLINE" | grep -q "$DEVNAME"; then
-        # Replace DEVNAME with BONDNAME for ip=... arguments
-        NEW_CMDLINE=$(echo "$NEW_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$DEVNAME\([: ]\|$\)/\1$BONDNAME\2/g")
-        
-        # Check if replacement occurred to add bond options
-        if [ "$NEW_CMDLINE" != "$CMDLINE" ] || [ $REPLACED -eq 1 ]; then
-            # We don't want to add multiple bond= arguments for the same bond, 
-            # but Dracut can handle it, or we just append it once.
-            if ! echo "$NEW_CMDLINE" | grep -q "bond=$BONDNAME:"; then
-                NEW_CMDLINE="$NEW_CMDLINE bond=$BONDNAME:$DEVNAME:mode=1,miimon=100,fail_over_mac=2"
-            fi
-            REPLACED=1
-        fi
+NEW_ARGS=""
+MOD_CMDLINE="$CMDLINE"
+CHANGED=0
+
+# Unique bond names
+BOND_NAMES=$(echo "$MAPPINGS" | awk '{print $1}' | sort -u)
+
+for BONDNAME in $BOND_NAMES; do
+  SLAVES=""
+  SLAVE_NAMES=""
+  SLAVE_MACS=""
+
+  # Extract slaves for this bond
+  set -- $MAPPINGS
+  while [ $# -ge 3 ]; do
+    if [ "$1" = "$BONDNAME" ]; then
+      SLAVE_NAMES="$SLAVE_NAMES $2"
+      [ -n "$3" ] && SLAVE_MACS="$SLAVE_MACS $3"
+      if [ -z "$SLAVES" ]; then
+        SLAVES="$2"
+      else
+        SLAVES="$SLAVES,$2"
+      fi
     fi
+    shift 3
+  done
+
+  # Add bond definition
+  NEW_ARGS="$NEW_ARGS bond=$BONDNAME:$SLAVES:mode=1,miimon=100,fail_over_mac=2"
+
+  if [ -n "$HNV_IP" ]; then
+    MATCHED=0
+    CURRENT_HNV_IP="$HNV_IP"
+
+    # Check if HNV_IP matches any slave of THIS bond (name or MAC)
+    for s in $SLAVE_NAMES $SLAVE_MACS; do
+      [ -z "$s" ] && continue
+      s_dash=$(echo "$s" | tr ':' '-')
+      if [ "$HNV_IP" = "$s" ] || [ "$HNV_IP" = "$s_dash" ]; then
+        CURRENT_HNV_IP="$BONDNAME"
+        MATCHED=1
+        break
+      elif echo "$HNV_IP" | grep -q ":$s\(:\|$\)"; then
+        CURRENT_HNV_IP=$(echo "$HNV_IP" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
+        MATCHED=1
+        break
+      elif echo "$HNV_IP" | grep -q ":$s_dash\(:\|$\)"; then
+        CURRENT_HNV_IP=$(echo "$HNV_IP" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
+        MATCHED=1
+        break
+      fi
+    done
+
+    if [ $MATCHED -eq 1 ]; then
+      NEW_ARGS="$NEW_ARGS ip=$CURRENT_HNV_IP"
+      CHANGED=1
+    else
+      # Fallback if it doesn't match any specific bond but is just an IP
+      if ! echo "$HNV_IP" | grep -q ":bond[0-9]"; then
+        COLONS=$(echo "$HNV_IP" | tr -dc ':' | wc -c)
+        if [ "$COLONS" -eq 0 ]; then
+          NEW_ARGS="$NEW_ARGS ip=$HNV_IP:::::$BONDNAME:none"
+          CHANGED=1
+        fi
+      fi
+    fi
+  fi
+
+  # Replace slaves in existing ip= arguments
+  for slave in $SLAVE_NAMES; do
+    if echo "$MOD_CMDLINE" | grep -q "$slave"; then
+      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
+      CHANGED=1
+    fi
+  done
+  for mac in $SLAVE_MACS; do
+    mac_dash=$(echo "$mac" | tr ':' '-')
+    if echo "$MOD_CMDLINE" | grep -q "$mac"; then
+      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
+      CHANGED=1
+    fi
+    if echo "$MOD_CMDLINE" | grep -q "$mac_dash"; then
+      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
+      CHANGED=1
+    fi
+  done
 done
 
-if [ $REPLACED -eq 1 ]; then
-    export CMDLINE="$NEW_CMDLINE"
-    echo "$NEW_CMDLINE" > /etc/cmdline.d/99-hcnmgr.conf
+if [ $CHANGED -eq 1 ] || [ -n "$NEW_ARGS" ]; then
+  # Write to cmdline.d
+  echo "$NEW_ARGS" >/etc/cmdline.d/99-hcnmgr.conf
+
+  # Update global CMDLINE
+  export CMDLINE="$MOD_CMDLINE $NEW_ARGS"
+
+  # Call nm-initrd-generator
+  for generator in /usr/lib/NetworkManager/nm-initrd-generator /usr/libexec/nm-initrd-generator; do
+    if [ -x "$generator" ]; then
+      $generator -- $CMDLINE
+      break
+    fi
+  done
 fi

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+xdump4() {
+    hexdump -n 4 -ve '/1 "%02x"' "$1"
+}
+
+get_dev_hcn() {
+    local dev=$1
+    local HCNID
+    local DEVNAME
+    
+    HCNID=$(xdump4 "$dev"/ibm,hcn-id)
+    if [ -z "$HCNID" ]; then
+        return 1
+    fi
+    
+    # Get the device name using ofpathname
+    DEVNAME=$(ofpathname -l "$(echo "$dev" | sed -e "s/\/proc\/device-tree//")" 2>/dev/null)
+    if [ -n "$DEVNAME" ]; then
+        echo "bond$HCNID $DEVNAME"
+        return 0
+    fi
+    return 1
+}
+
+# Collect all mappings
+MAPPINGS=""
+if [ -d /proc/device-tree ]; then
+    for pci_dev in /proc/device-tree/pci*; do
+        [ -d "$pci_dev" ] || continue
+        for dev in "$pci_dev"/ethernet*; do
+            [ -d "$dev" ] || continue
+            if [ -e "$dev"/ibm,hcn-id ]; then
+                res=$(get_dev_hcn "$dev")
+                if [ -n "$res" ]; then
+                    MAPPINGS="$MAPPINGS $res"
+                fi
+            fi
+        done
+    done
+fi
+
+if [ -z "$MAPPINGS" ]; then
+    return 0
+fi
+
+# We might not have CMDLINE variable exported if it's an older dracut, so let's check
+if [ -z "$CMDLINE" ]; then
+    CMDLINE=$(cat /proc/cmdline)
+fi
+
+NEW_CMDLINE="$CMDLINE"
+REPLACED=0
+
+set -- $MAPPINGS
+while [ $# -ge 2 ]; do
+    BONDNAME="$1"
+    DEVNAME="$2"
+    shift 2
+    
+    # Check if DEVNAME is in the cmdline
+    if echo "$NEW_CMDLINE" | grep -q "$DEVNAME"; then
+        # Replace DEVNAME with BONDNAME for ip=... arguments
+        NEW_CMDLINE=$(echo "$NEW_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$DEVNAME\([: ]\|$\)/\1$BONDNAME\2/g")
+        
+        # Check if replacement occurred to add bond options
+        if [ "$NEW_CMDLINE" != "$CMDLINE" ] || [ $REPLACED -eq 1 ]; then
+            # We don't want to add multiple bond= arguments for the same bond, 
+            # but Dracut can handle it, or we just append it once.
+            if ! echo "$NEW_CMDLINE" | grep -q "bond=$BONDNAME:"; then
+                NEW_CMDLINE="$NEW_CMDLINE bond=$BONDNAME:$DEVNAME:mode=1,miimon=100,fail_over_mac=2"
+            fi
+            REPLACED=1
+        fi
+    fi
+done
+
+if [ $REPLACED -eq 1 ]; then
+    export CMDLINE="$NEW_CMDLINE"
+    echo "$NEW_CMDLINE" > /etc/cmdline.d/99-hcnmgr.conf
+fi

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -67,6 +67,9 @@ fi
 HNV_IP=$(getargs hnv.ip)
 [ -z "$HNV_IP" ] && HNV_IP=$(getargs hvn.ip)
 
+HNV_ROUTE=$(getargs hnv.route)
+[ -z "$HNV_ROUTE" ] && HNV_ROUTE=$(getargs hvn.route)
+
 NEW_ARGS=""
 MOD_CMDLINE="$CMDLINE"
 CHANGED=0
@@ -135,10 +138,52 @@ for BONDNAME in $BOND_NAMES; do
     fi
   fi
 
-  # Replace slaves in existing ip= arguments
+  if [ -n "$HNV_ROUTE" ]; then
+    MATCHED=0
+    CURRENT_HNV_ROUTE="$HNV_ROUTE"
+
+    # Check if HNV_ROUTE matches any slave of THIS bond (name or MAC)
+    for s in $SLAVE_NAMES $SLAVE_MACS; do
+      [ -z "$s" ] && continue
+      s_dash=$(echo "$s" | tr ':' '-')
+      if [ "$HNV_ROUTE" = "$s" ] || [ "$HNV_ROUTE" = "$s_dash" ]; then
+        CURRENT_HNV_ROUTE="$BONDNAME"
+        MATCHED=1
+        break
+      elif echo "$HNV_ROUTE" | grep -q ":$s\(:\|$\)"; then
+        CURRENT_HNV_ROUTE=$(echo "$HNV_ROUTE" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
+        MATCHED=1
+        break
+      elif echo "$HNV_ROUTE" | grep -q ":$s_dash\(:\|$\)"; then
+        CURRENT_HNV_ROUTE=$(echo "$HNV_ROUTE" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
+        MATCHED=1
+        break
+      fi
+    done
+
+    if [ $MATCHED -eq 1 ]; then
+      NEW_ARGS="$NEW_ARGS rd.route=$CURRENT_HNV_ROUTE"
+      CHANGED=1
+    else
+      # Fallback if it doesn't match any specific bond but is just a route spec without interface
+      if ! echo "$HNV_ROUTE" | grep -q ":bond[0-9]"; then
+        COLONS=$(echo "$HNV_ROUTE" | tr -dc ':' | wc -c)
+        if [ "$COLONS" -eq 0 ]; then
+          NEW_ARGS="$NEW_ARGS rd.route=$HNV_ROUTE::$BONDNAME"
+          CHANGED=1
+        elif [ "$COLONS" -eq 1 ]; then
+          NEW_ARGS="$NEW_ARGS rd.route=$HNV_ROUTE:$BONDNAME"
+          CHANGED=1
+        fi
+      fi
+    fi
+  fi
+
+  # Replace slaves in existing ip= and rd.route= arguments
   for slave in $SLAVE_NAMES; do
     if echo "$MOD_CMDLINE" | grep -q "$slave"; then
       MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
+      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$slave\([: ]\|$\)/\1$BONDNAME\2/g")
       CHANGED=1
     fi
   done
@@ -146,10 +191,12 @@ for BONDNAME in $BOND_NAMES; do
     mac_dash=$(echo "$mac" | tr ':' '-')
     if echo "$MOD_CMDLINE" | grep -q "$mac"; then
       MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
+      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac\([: ]\|$\)/\1$BONDNAME\2/g")
       CHANGED=1
     fi
     if echo "$MOD_CMDLINE" | grep -q "$mac_dash"; then
       MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(ip=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
+      MOD_CMDLINE=$(echo "$MOD_CMDLINE" | sed "s/\(rd.route=[^ ]*[:=]\)$mac_dash\([: ]\|$\)/\1$BONDNAME\2/g")
       CHANGED=1
     fi
   done

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -2,6 +2,8 @@
 
 type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
+info "parse-hcnmgr: starting"
+
 xdump4() {
   hexdump -n 4 -ve '/1 "%02x"' "$1"
 }
@@ -55,9 +57,12 @@ if [ -d /proc/device-tree ]; then
 fi
 
 if [ -z "$MAPPINGS" ]; then
+  info "parse-hcnmgr: no mappings found"
   # Use return if sourced (like in a dracut hook), or exit if executed directly
   [ "$0" = "/init" ] || [ "$0" = "/lib/dracut/dracut-initqueue.sh" ] && return 0 || exit 0
 fi
+
+info "parse-hcnmgr: mappings found:$MAPPINGS"
 
 # We might not have CMDLINE variable exported if it's an older dracut, so let's check
 if [ -z "$CMDLINE" ]; then
@@ -69,6 +74,8 @@ HNV_IP=$(getargs hnv.ip)
 
 HNV_ROUTE=$(getargs hnv.route)
 [ -z "$HNV_ROUTE" ] && HNV_ROUTE=$(getargs hvn.route)
+
+info "parse-hcnmgr: HNV_IP=$HNV_IP HNV_ROUTE=$HNV_ROUTE"
 
 NEW_ARGS=""
 MOD_CMDLINE="$CMDLINE"
@@ -203,6 +210,7 @@ for BONDNAME in $BOND_NAMES; do
 done
 
 if [ $CHANGED -eq 1 ] || [ -n "$NEW_ARGS" ]; then
+  info "parse-hcnmgr: writing /etc/cmdline.d/99-hcnmgr.conf with $NEW_ARGS"
   # Write to cmdline.d
   echo "$NEW_ARGS" >/etc/cmdline.d/99-hcnmgr.conf
 
@@ -212,7 +220,9 @@ if [ $CHANGED -eq 1 ] || [ -n "$NEW_ARGS" ]; then
   # Call nm-initrd-generator
   for generator in /usr/lib/NetworkManager/nm-initrd-generator /usr/libexec/nm-initrd-generator; do
     if [ -x "$generator" ]; then
+      info "parse-hcnmgr: calling $generator"
       $generator -- $CMDLINE
+      mkdir -p /run/NetworkManager/initrd
       : >/run/NetworkManager/initrd/neednet
       break
     fi

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -213,7 +213,9 @@ if [ $CHANGED -eq 1 ] || [ -n "$NEW_ARGS" ]; then
   for generator in /usr/lib/NetworkManager/nm-initrd-generator /usr/libexec/nm-initrd-generator; do
     if [ -x "$generator" ]; then
       $generator -- $CMDLINE
+      : >/run/NetworkManager/initrd/neednet
       break
     fi
   done
+
 fi

--- a/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99hcnmgr/parse-hcnmgr.sh
@@ -112,13 +112,13 @@ if [ -z "$CMDLINE" ]; then
   [ -r /proc/cmdline ] && CMDLINE=$(cat /proc/cmdline)
 fi
 
-HNV_IP=$(getargs hnv.ip)
-[ -z "$HNV_IP" ] && HNV_IP=$(getargs hvn.ip)
+HCN_IP=$(getargs hcn.ip)
+[ -z "$HCN_IP" ] && HCN_IP=$(getargs hvn.ip)
 
-HNV_ROUTE=$(getargs hnv.route)
-[ -z "$HNV_ROUTE" ] && HNV_ROUTE=$(getargs hvn.route)
+HCN_ROUTE=$(getargs hcn.route)
+[ -z "$HCN_ROUTE" ] && HCN_ROUTE=$(getargs hvn.route)
 
-info "parse-hcnmgr: HNV_IP=$HNV_IP HNV_ROUTE=$HNV_ROUTE"
+info "parse-hcnmgr: HCN_IP=$HCN_IP HCN_ROUTE=$HCN_ROUTE"
 
 NEW_ARGS=""
 MOD_CMDLINE="$CMDLINE"
@@ -160,79 +160,79 @@ for BONDNAME in $BOND_NAMES; do
 
   NEW_ARGS="$NEW_ARGS bond=$BONDNAME:$SLAVES:$BOND_OPTS"
 
-  if [ -n "$HNV_IP" ]; then
+  if [ -n "$HCN_IP" ]; then
     MATCHED=0
-    CURRENT_HNV_IP="$HNV_IP"
+    CURRENT_HCN_IP="$HCN_IP"
 
-    # Check if HNV_IP matches any slave of THIS bond (name or MAC)
+    # Check if HCN_IP matches any slave of THIS bond (name or MAC)
     for s in $SLAVE_NAMES $SLAVE_MACS; do
       [ -z "$s" ] && continue
       s_dash=$(echo "$s" | tr ':' '-')
-      if [ "$HNV_IP" = "$s" ] || [ "$HNV_IP" = "$s_dash" ]; then
-        CURRENT_HNV_IP="$BONDNAME"
+      if [ "$HCN_IP" = "$s" ] || [ "$HCN_IP" = "$s_dash" ]; then
+        CURRENT_HCN_IP="$BONDNAME"
         MATCHED=1
         break
-      elif echo "$HNV_IP" | grep -q ":$s\(:\|$\)"; then
-        CURRENT_HNV_IP=$(echo "$HNV_IP" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
+      elif echo "$HCN_IP" | grep -q ":$s\(:\|$\)"; then
+        CURRENT_HCN_IP=$(echo "$HCN_IP" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
         MATCHED=1
         break
-      elif echo "$HNV_IP" | grep -q ":$s_dash\(:\|$\)"; then
-        CURRENT_HNV_IP=$(echo "$HNV_IP" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
+      elif echo "$HCN_IP" | grep -q ":$s_dash\(:\|$\)"; then
+        CURRENT_HCN_IP=$(echo "$HCN_IP" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
         MATCHED=1
         break
       fi
     done
 
     if [ $MATCHED -eq 1 ]; then
-      NEW_ARGS="$NEW_ARGS ip=$CURRENT_HNV_IP"
+      NEW_ARGS="$NEW_ARGS ip=$CURRENT_HCN_IP"
       CHANGED=1
     else
       # Fallback if it doesn't match any specific bond but is just an IP
-      if ! echo "$HNV_IP" | grep -q ":bond[0-9]"; then
-        COLONS=$(echo "$HNV_IP" | tr -dc ':' | wc -c)
+      if ! echo "$HCN_IP" | grep -q ":bond[0-9]"; then
+        COLONS=$(echo "$HCN_IP" | tr -dc ':' | wc -c)
         if [ "$COLONS" -eq 0 ]; then
-          NEW_ARGS="$NEW_ARGS ip=$HNV_IP:::::$BONDNAME:none"
+          NEW_ARGS="$NEW_ARGS ip=$HCN_IP:::::$BONDNAME:none"
           CHANGED=1
         fi
       fi
     fi
   fi
 
-  if [ -n "$HNV_ROUTE" ]; then
+  if [ -n "$HCN_ROUTE" ]; then
     MATCHED=0
-    CURRENT_HNV_ROUTE="$HNV_ROUTE"
+    CURRENT_HCN_ROUTE="$HCN_ROUTE"
 
-    # Check if HNV_ROUTE matches any slave of THIS bond (name or MAC)
+    # Check if HCN_ROUTE matches any slave of THIS bond (name or MAC)
     for s in $SLAVE_NAMES $SLAVE_MACS; do
       [ -z "$s" ] && continue
       s_dash=$(echo "$s" | tr ':' '-')
-      if [ "$HNV_ROUTE" = "$s" ] || [ "$HNV_ROUTE" = "$s_dash" ]; then
-        CURRENT_HNV_ROUTE="$BONDNAME"
+      if [ "$HCN_ROUTE" = "$s" ] || [ "$HCN_ROUTE" = "$s_dash" ]; then
+        CURRENT_HCN_ROUTE="$BONDNAME"
         MATCHED=1
         break
-      elif echo "$HNV_ROUTE" | grep -q ":$s\(:\|$\)"; then
-        CURRENT_HNV_ROUTE=$(echo "$HNV_ROUTE" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
+      elif echo "$HCN_ROUTE" | grep -q ":$s\(:\|$\)"; then
+        CURRENT_HCN_ROUTE=$(echo "$HCN_ROUTE" | sed "s/:$s\(:\|$\)/:$BONDNAME\1/")
         MATCHED=1
         break
-      elif echo "$HNV_ROUTE" | grep -q ":$s_dash\(:\|$\)"; then
-        CURRENT_HNV_ROUTE=$(echo "$HNV_ROUTE" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
+      elif echo "$HCN_ROUTE" | grep -q ":$s_dash\(:\|$\)"; then
+        CURRENT_HCN_ROUTE=$(echo "$HCN_ROUTE" | sed "s/:$s_dash\(:\|$\)/:$BONDNAME\1/")
         MATCHED=1
         break
       fi
     done
 
     if [ $MATCHED -eq 1 ]; then
-      NEW_ARGS="$NEW_ARGS rd.route=$CURRENT_HNV_ROUTE"
+      NEW_ARGS="$NEW_ARGS rd.route=$CURRENT_HCN_ROUTE"
       CHANGED=1
     else
       # Fallback if it doesn't match any specific bond but is just a route spec without interface
-      if ! echo "$HNV_ROUTE" | grep -q ":bond[0-9]"; then
-        COLONS=$(echo "$HNV_ROUTE" | tr -dc ':' | wc -c)
+      if ! echo "$HCN_ROUTE" | grep -q ":bond[0-9]"; then
+        COLONS=$(echo "$HCN_ROUTE" | tr -dc ':' | wc -c)
         if [ "$COLONS" -eq 0 ]; then
-          NEW_ARGS="$NEW_ARGS rd.route=$HNV_ROUTE::$BONDNAME"
+          NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE::$BONDNAME"
           CHANGED=1
         elif [ "$COLONS" -eq 1 ]; then
-          NEW_ARGS="$NEW_ARGS rd.route=$HNV_ROUTE:$BONDNAME"
+          NEW_ARGS="$NEW_ARGS rd.route=$HCN_ROUTE:$BONDNAME"
           CHANGED=1
         fi
       fi

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -15,7 +15,7 @@ suseSetupProduct
 # save the current build data, the %VARIABLES% are replaced by the OBS
 # kiwi_metainfo_helper service before starting the build
 mkdir -p /var/log/build
-cat << EOF > /var/log/build/info
+cat <<EOF >/var/log/build/info
 Build date:    $(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%F %T %Z")
 Build number:  Build%RELEASE%
 Image profile: $kiwi_profiles
@@ -25,7 +25,7 @@ Source URL:    %SOURCEURL%
 EOF
 
 # for reproducible builds:
-echo -n > /var/log/alternatives.log
+echo -n >/var/log/alternatives.log
 sed -i 's/# AutoInstalled generated.*/# AutoInstalled generated in kiwi reproducible build/' /var/lib/zypp/AutoInstalled # drop timestamp
 rm -f /var/tmp/rpm-tmp.*
 
@@ -49,15 +49,18 @@ if stat -t /usr/lib/rpm/gnupg/keys/*.asc 2>/dev/null 1>/dev/null; then
   rpm --import /usr/lib/rpm/gnupg/keys/*.asc
 fi
 
-if [ $(rpm -q --provides libzypp | grep -q 'libzypp(econf)'; echo $?) -eq 0 ]; then
-# A new enough version of libzypp is in use which supports UAPI configuration. Configure a drop-in conf
-cat <<EOF > /etc/zypp/zypp.conf.d/90-agama.conf
+if [ $(
+  rpm -q --provides libzypp | grep -q 'libzypp(econf)'
+  echo $?
+) -eq 0 ]; then
+  # A new enough version of libzypp is in use which supports UAPI configuration. Configure a drop-in conf
+  cat <<EOF >/etc/zypp/zypp.conf.d/90-agama.conf
 [main]
 download.connect_timeout = 20
 EOF
 else
-# decrease the libzypp timeout to 20 seconds (the default is 60 seconds)
-sed -i -e "s/^\s*#\s*download.connect_timeout\s*=\s*.*$/download.connect_timeout = 20/" /etc/zypp/zypp.conf
+  # decrease the libzypp timeout to 20 seconds (the default is 60 seconds)
+  sed -i -e "s/^\s*#\s*download.connect_timeout\s*=\s*.*$/download.connect_timeout = 20/" /etc/zypp/zypp.conf
 fi
 
 # activate services
@@ -117,18 +120,18 @@ sed -i 's:# event_activation = 1:event_activation = 0:' /etc/lvm/lvm.conf
 touch /etc/udev/rules.d/64-md-raid-assembly.rules
 
 # the "eurlatgr" is the default font for the English locale
-echo -e "\nFONT=eurlatgr.psfu" >> /etc/vconsole.conf
+echo -e "\nFONT=eurlatgr.psfu" >>/etc/vconsole.conf
 
 # configure self-update in SLES
 if [[ "$kiwi_profiles" == *SLE* ]]; then
   echo "Configuring the installer self-update..."
   # read the self-update configuration variables
   . /usr/lib/live-self-update/conf.sh
-  mkdir -p  "$CONFIG_DIR"
+  mkdir -p "$CONFIG_DIR"
   # the default registration server (SCC) if RMT is not set
-  echo "https://scc.suse.com" > "$CONFIG_DEFAULT_REG_SERVER_FILE"
+  echo "https://scc.suse.com" >"$CONFIG_DEFAULT_REG_SERVER_FILE"
   # fallback URL when contacting SCC/RMT fails or no self-update is returned
-  echo 'https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/$os_release_version_id/$arch/product/' > "$CONFIG_FALLBACK_FILE"
+  echo 'https://installer-updates.suse.com/SUSE/Products/SLE-INSTALLER/$os_release_version_id/$arch/product/' >"$CONFIG_FALLBACK_FILE"
 fi
 
 ### setup dracut for live system
@@ -142,20 +145,19 @@ mkdir /etc/cmdline.d
 echo "root=live:LABEL=$label" >/etc/cmdline.d/10-liveroot.conf
 echo "root_disk=live:LABEL=$label" >>/etc/cmdline.d/10-liveroot.conf
 echo 'install_items+=" /etc/cmdline.d/10-liveroot.conf "' >/etc/dracut.conf.d/10-liveroot-file.conf
-echo 'add_dracutmodules+=" dracut-menu agama-cmdline agama-dud live-self-update initrd-nmtui "' >>/etc/dracut.conf.d/10-liveroot-file.conf
+echo 'add_dracutmodules+=" dracut-menu agama-cmdline agama-dud live-self-update hcnmgr initrd-nmtui "' >>/etc/dracut.conf.d/10-liveroot-file.conf
 
 # decrease the kernel logging on the console, use a dracut module to do it early in the boot process
-echo 'add_dracutmodules+=" agama-logging "' > /etc/dracut.conf.d/10-agama-logging.conf
+echo 'add_dracutmodules+=" agama-logging "' >/etc/dracut.conf.d/10-agama-logging.conf
 
 # add the ipmi drivers to the initrd (bsc#1237354)
 extra_drivers=(acpi_ipmi ipmi_devintf ipmi_poweroff ipmi_si ipmi_ssif ipmi_watchdog)
 
-for driver in "${extra_drivers[@]}"
-do
+for driver in "${extra_drivers[@]}"; do
   # check if the driver is present (allow a suffix like .zstd or .xz for optionally compressed drivers)
   if find /lib/modules -type f -name "$driver.ko*" -print0 | grep -qz .; then
     echo "Adding $driver driver to initrd..."
-    echo "add_drivers+=\" $driver \"" >> /etc/dracut.conf.d/10-extra-drivers.conf
+    echo "add_drivers+=\" $driver \"" >>/etc/dracut.conf.d/10-extra-drivers.conf
   else
     echo "Skipping driver $driver, not found in the system"
   fi
@@ -242,12 +244,12 @@ ls -1 -d /usr/lib/locale/*.utf8 | sed -e "s#/usr/lib/locale/##" -e "s#utf8#UTF-8
 # build list of ignore options for "ls" with supported languages like "-I cs -I cs_CZ ..."
 # languages.json is like: { "ca-ES": "Català", "de-DE": "Deutsch", ...}
 # jq prints ca-ES\nde-DE\n...
-readarray -t IGNORE_OPTS < <(jq -r keys[] < /usr/share/agama/web_ui/languages.json | sed -e "s/\(.*\)-\(.*\)/-I\n\\1\n-I\n\1_\2/")
+readarray -t IGNORE_OPTS < <(jq -r keys[] </usr/share/agama/web_ui/languages.json | sed -e "s/\(.*\)-\(.*\)/-I\n\\1\n-I\n\1_\2/")
 # additionally keep the en_US translations
 ls -1 "${IGNORE_OPTS[@]}" -I en_US /usr/share/locale/ | xargs -I% sh -c "echo 'Removing translations %...' && rm -rf /usr/share/locale/%"
 
 # delete locale definitions for unsupported languages (explicitly keep the C and en_US locales)
-readarray -t IGNORE_OPTS < <(jq -r keys[] < /usr/share/agama/web_ui/languages.json | sed -e "s/-/_/" -e "s/$/.utf8/" -e "s/^/-I\n/")
+readarray -t IGNORE_OPTS < <(jq -r keys[] </usr/share/agama/web_ui/languages.json | sed -e "s/-/_/" -e "s/$/.utf8/" -e "s/^/-I\n/")
 ls -1 "${IGNORE_OPTS[@]}" -I "en_US.utf8" -I "C.utf8" /usr/lib/locale/ | xargs -I% sh -c "echo 'Removing locale %...' && rm -rf /usr/lib/locale/%"
 
 # delete unused translations (MO files)
@@ -297,7 +299,7 @@ rm -f /usr/lib64/firefox/libmozavcodec.so
 
 # uninstall libyui-qt and libqt (pulled in by the YaST dependencies),
 # not present in SLES, do not fail if not installed
-if rpm -q --whatprovides libyui-qt libyui-qt-pkg > /dev/null; then
+if rpm -q --whatprovides libyui-qt libyui-qt-pkg >/dev/null; then
   rpm -q --whatprovides libyui-qt libyui-qt-pkg | xargs rpm -e --nodeps
 fi
 rpm -qa | grep ^libQt | xargs --no-run-if-empty rpm -e --nodeps
@@ -331,13 +333,13 @@ du -h -s /lib/modules /lib/firmware
 #
 
 # Stronger compression for the initrd
-echo 'compress="xz -9 --check=crc32 --memlimit-compress=50%"' >> /etc/dracut.conf.d/less-storage.conf
+echo 'compress="xz -9 --check=crc32 --memlimit-compress=50%"' >>/etc/dracut.conf.d/less-storage.conf
 
 # Kernel modules (+ firmware) for X13s
 if [ "$(arch)" == "aarch64" ]; then
-	echo 'add_drivers+=" clk-rpmh dispcc-sc8280xp gcc-sc8280xp gpucc-sc8280xp nvmem_qcom-spmi-sdam qcom_hwspinlock qcom_q6v5 qcom_q6v5_pas qnoc-sc8280xp pmic_glink pmic_glink_altmode smp2p spmi-pmic-arb leds-qcom-lpg "'  > /etc/dracut.conf.d/x13s_modules.conf
-	echo 'add_drivers+=" nvme phy_qcom_qmp_pcie pcie-qcom-ep i2c_hid_of i2c_qcom_geni leds-qcom-lpg pwm_bl qrtr pmic_glink_altmode gpio_sbu_mux phy_qcom_qmp_combo panel-edp msm phy_qcom_edp "' >> /etc/dracut.conf.d/x13s_modules.conf
-	echo 'install_items+=" /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcadsp8280.mbn.xz /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qccdsp8280.mbn.xz "' >> /etc/dracut.conf.d/x13s_modules.conf
+  echo 'add_drivers+=" clk-rpmh dispcc-sc8280xp gcc-sc8280xp gpucc-sc8280xp nvmem_qcom-spmi-sdam qcom_hwspinlock qcom_q6v5 qcom_q6v5_pas qnoc-sc8280xp pmic_glink pmic_glink_altmode smp2p spmi-pmic-arb leds-qcom-lpg "' >/etc/dracut.conf.d/x13s_modules.conf
+  echo 'add_drivers+=" nvme phy_qcom_qmp_pcie pcie-qcom-ep i2c_hid_of i2c_qcom_geni leds-qcom-lpg pwm_bl qrtr pmic_glink_altmode gpio_sbu_mux phy_qcom_qmp_combo panel-edp msm phy_qcom_edp "' >>/etc/dracut.conf.d/x13s_modules.conf
+  echo 'install_items+=" /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcadsp8280.mbn.xz /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qccdsp8280.mbn.xz "' >>/etc/dracut.conf.d/x13s_modules.conf
 fi
 
 # Decompress kernel modules, better for squashfs (boo#1192457)


### PR DESCRIPTION
This PR introduces a Proof of Concept (POC) dracut module named 99hcnmgr. Its primary purpose is to configure Hybrid Network Virtualization (HNV) bonding on IBM Power (ppc64/ppc64le) systems early in the boot process for the Agama installer. This ensures network connectivity is established for fetching installation media and enabling remote management.

## Problem

**HNV** bonding on IBM Power systems involves combining a high-performance **SR-IOV interface** with a virtual Ethernet interface for failover and virtualization benefits.

Current implementation: The process relies on the `hcnmgr -s` script (part of powerpc-utils), triggered by the `hcn-init.service`. It reads configuration data from `/proc/device-tree` and utilizes the kernel command line `ip=` to generate NetworkManager connections replacing the **SR-IOV device name** by the new bond created using the `hcnid`.

The goal is to enable Hybrid Network Virtualization (HNV) bonding within the Agama installer. This configuration must be established early in the boot process, before the installer environment initializes, to ensure network connectivity is available for the installation media and remote management.


## Solution

Key Features Implemented:
   * Hardware Discovery: The module scans /proc/device-tree for PCI ethernet devices, identifying those that belong to a Hybrid Connector Network by looking for the ibm,hcn-id property.
   * Automatic Bonding: Network interfaces that share the same hcn-id are automatically grouped into a single bond interface (typically named bond<N>). These bonds are pre-configured with
     mode=1 (Active-Backup), miimon=100, and fail_over_mac=2.
   * Command Line Translation: It automatically translates network configurations by replacing references to physical interface names or MAC addresses in standard ip= arguments with the
     newly created bond interface name.
   * Persistence: The generated network configuration is saved to /etc/cmdline.d/99-hcnmgr.conf within the initrd environment.
   * NetworkManager Integration: After generating the command line arguments, the module triggers nm-initrd-generator to ensure NetworkManager correctly initializes the bonded interfaces during the boot sequence.

  Dracut Kernel Arguments

  To utilize this module, it processes specific kernel arguments to configure the HNV bonds:


   * `hnv.ip=...` (or hvn.ip=...): Used to associate IP configurations directly with the discovered bond interfaces.
   * `hnv.route=...` (or hvn.route=...): Used to define routing configurations associated with the HNV bonds.
  
### Examples

  1. Simple Static IP Assignment
  If you only provide an IP address, the module automatically associates it with the discovered bond (e.g., bond0).
   * Argument: hcn.ip=192.168.122.100
   * Resulting config: ip=192.168.122.100:::::bond0:none


  2. DHCP Configuration
  You can also request DHCP for the bonded interface.
   * Argument: hcn.ip=dhcp
   * Resulting config: ip=dhcp:::::bond0:none


  3. Full Dracut Specification (using Interface Name)
  If your deployment scripts already use physical interface names (like eth0), the module will "intercept" them. If eth0 is identified as a slave of an HNV bond, the module replaces it with
  the bond name.
   * Argument: hcn.ip=192.168.100.50::192.168.100.1:255.255.255.0:agama:eth0:none
   * Resulting config: ip=192.168.100.50::192.168.100.1:255.255.255.0:agama:bond0:none


  4. Full Dracut Specification (using MAC Address)
  Similarly, if you identify interfaces by MAC address, the module performs the translation to the bond name.
   * Argument: hcn.ip=10.0.0.15::10.0.0.1:255.255.255.0:installer:52:54:00:11:22:33:none
   * Resulting config: ip=10.0.0.15::10.0.0.1:255.255.255.0:installer:bond0:none
  (Note: Both colon-separated `52:54:00:11:22:33` and dash-separated `52-54-00-11-22-33` formats are supported.)


  5. Routing Configuration
  The module also handles routing via hvn.route (or hcn.route), translating slave interfaces to the bond.
   * Argument: hcn.route=10.1.0.0/16:192.168.100.1:eth0
   * Resulting config: rd.route=10.1.0.0/16:192.168.100.1:bond0


  Summary of Kernel Arguments

| Argument | Description |
| --- | --- |
| hvn.ip= | IP configuration for HNV bonds (supports standard dracut ip= syntax). |
| hcn.ip= | Alias for hvn.ip. |
| hvn.route= | Route configuration for HNV bonds (supports rd.route syntax). |
| hcn.route= | Alias for hvn.route. |

  
  These arguments ensure that even if the underlying physical topology changes (e.g., due to partition migration on IBM Power), the installer can consistently address the network via the logical bond interface.


