### PR TITLE
Added an action to connect a device to the network backend

### DIFF
--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -811,6 +811,10 @@ impl MessageHandler<message::RunAction> for Service {
             Action::Install => {
                 self.tasks.cast(tasks::message::Install)?;
             }
+            Action::ConnectNetworkDevice(device_name) => {
+                checks::check_stage(&self.progress, Stage::Configuring).await?;
+                self.network.connect_device(&device_name).await?;
+            }
             Action::Finish(method) => {
                 checks::check_stage(&self.progress, Stage::Finished).await?;
                 let action = FinishAction::new(method);

--- a/rust/agama-network/src/action.rs
+++ b/rust/agama-network/src/action.rs
@@ -94,6 +94,8 @@ pub enum Action {
     RefreshScan(Responder<Result<(), NetworkAdapterError>>),
     /// Remove the connection with the given Uuid.
     RemoveConnection(String, Responder<Result<(), NetworkStateError>>),
+    /// Connect a network device.
+    ConnectDevice(String, Responder<Result<(), NetworkStateError>>),
     /// Apply the current configuration.
     Apply(Responder<Result<(), NetworkAdapterError>>),
 }

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -343,6 +343,30 @@ impl NetworkState {
         Ok(())
     }
 
+    /// Connects the device with the given name.
+    ///
+    /// It sets the connection associated with the device to UP. If there is no connection,
+    /// it creates a new one and sets it to UP.
+    pub fn connect_device(&mut self, name: &str) -> Result<(), NetworkStateError> {
+        let device = self
+            .get_device(name)
+            .ok_or_else(|| NetworkStateError::UnknownDevice(name.to_string()))?;
+
+        let device_type = device.type_;
+        let connection = self.connections.iter_mut().find(|c| {
+            c.interface.as_deref() == Some(name) || (c.interface.is_none() && c.id == name)
+        });
+
+        if let Some(conn) = connection {
+            conn.set_up();
+        } else {
+            let mut conn = Connection::new(name.to_string(), device_type);
+            conn.set_up();
+            self.add_connection(conn)?;
+        }
+        Ok(())
+    }
+
     /// Sets a controller's ports.
     ///
     /// If the connection is not a controller, returns an error.
@@ -458,6 +482,49 @@ mod tests {
         let mut state = NetworkState::default();
         let error = state.remove_connection("unknown".as_ref()).unwrap_err();
         assert!(matches!(error, NetworkStateError::UnknownConnection(_)));
+    }
+
+    #[test]
+    fn test_connect_device_unknown() {
+        let mut state = NetworkState::default();
+        let error = state.connect_device("unknown").unwrap_err();
+        assert!(matches!(error, NetworkStateError::UnknownDevice(_)));
+    }
+
+    #[test]
+    fn test_connect_device_new_connection() {
+        let mut state = NetworkState::default();
+        let device = Device {
+            name: "eth0".to_string(),
+            type_: DeviceType::Ethernet,
+            ..Default::default()
+        };
+        state.add_device(device).unwrap();
+        state.connect_device("eth0").unwrap();
+
+        let conn = state.get_connection("eth0").unwrap();
+        assert!(conn.is_up());
+        assert_eq!(conn.config, ConnectionConfig::Ethernet);
+    }
+
+    #[test]
+    fn test_connect_device_existing_connection() {
+        let mut state = NetworkState::default();
+        let device = Device {
+            name: "eth0".to_string(),
+            type_: DeviceType::Ethernet,
+            ..Default::default()
+        };
+        state.add_device(device).unwrap();
+
+        let mut conn = Connection::new("eth0".to_string(), DeviceType::Ethernet);
+        conn.set_down();
+        state.add_connection(conn).unwrap();
+
+        state.connect_device("eth0").unwrap();
+
+        let conn = state.get_connection("eth0").unwrap();
+        assert!(conn.is_up());
     }
 
     #[test]

--- a/rust/agama-network/src/service.rs
+++ b/rust/agama-network/src/service.rs
@@ -246,6 +246,17 @@ impl NetworkSystemClient {
         Ok(result?)
     }
 
+    /// Connects the network device with the given name.
+    ///
+    /// * `name`: Device name.
+    pub async fn connect_device(&self, name: &str) -> Result<(), NetworkSystemError> {
+        let (tx, rx) = oneshot::channel();
+        self.actions
+            .send(Action::ConnectDevice(name.to_string(), tx))?;
+        let result = rx.await?;
+        Ok(result?)
+    }
+
     pub async fn set_ports(
         &self,
         uuid: Uuid,
@@ -446,6 +457,10 @@ impl Service {
 
                 tx.send(result).unwrap();
             }
+            Action::ConnectDevice(name, tx) => {
+                let result = self.connect_device_action(name).await;
+                tx.send(result).unwrap();
+            }
             Action::Apply(tx) => {
                 let result = self.apply().await;
                 tx.send(result).unwrap();
@@ -471,6 +486,16 @@ impl Service {
         let conn = Connection::new(name, ty);
         // TODO: handle tree handling problems
         self.state.add_connection(conn.clone())?;
+        Ok(())
+    }
+
+    async fn connect_device_action(&mut self, name: String) -> Result<(), NetworkStateError> {
+        self.state.connect_device(&name)?;
+
+        self.apply()
+            .await
+            .map_err(|e| NetworkStateError::IoError(e.to_string()))?;
+
         Ok(())
     }
 

--- a/rust/agama-utils/src/api/action.rs
+++ b/rust/agama-utils/src/api/action.rs
@@ -37,6 +37,8 @@ pub enum Action {
     ConfigureL10n(l10n::SystemConfig),
     #[serde(rename = "install")]
     Install,
+    #[serde(rename = "connectNetworkDevice")]
+    ConnectNetworkDevice(String),
     #[serde(rename = "finish")]
     Finish(FinishMethod),
 }


### PR DESCRIPTION
## Problem

We are working in a revamp of the network UI. And one of the things we are providing is an action for connection devices. It should create a new connection if the device does not  have any one available.

## Solution

Provide the option for connecting a device in the backend.


## Testing

- *Added a new unit test*
- *Tested manually*
