### PR TITLE
Make our GH Actions source YML files more readable by factoring out strings

### DIFF
--- a/.github/workflows/obs-service-shared.yml
+++ b/.github/workflows/obs-service-shared.yml
@@ -11,10 +11,14 @@ on:
       OBS_PASSWORD:
         required: true
 
+env:
+  obs_project: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+
 jobs:
   update_service:
     # do not run in forks which do not set the OBS_PROJECTS and OBS_USER variables,
     # or the mapping for the current branch is missing
+    # (BTW, jobs.FOO.if cannot see env.*)
     if: vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER
 
     runs-on: ubuntu-latest
@@ -65,11 +69,11 @@ jobs:
           OBS_USER:     ${{ vars.OBS_USER }}
           OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
 
-      - name: Commit the rubygem-agama-yast package to ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+      - name: Commit the rubygem-agama-yast package to ${{ env.obs_project }}
         run: rake osc:commit
         working-directory: ./service
         env:
           # do not build the package with "osc", it takes long time
           # and does not provide much value
           SKIP_OSC_BUILD: 1
-          OBS_PROJECT: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+          OBS_PROJECT: ${{ env.obs_project }}

--- a/.github/workflows/obs-staging-debug.yml
+++ b/.github/workflows/obs-staging-debug.yml
@@ -30,10 +30,6 @@ jobs:
           echo 'vars.OBS_PROJECTS: ${{ vars.OBS_PROJECTS }}'
           echo 'parsed vars.OBS_PROJECTS: ${{ fromJson(vars.OBS_PROJECTS) }}'
           echo 'github.ref_name: ${{ github.ref_name }}'
-          echo 'Target OBS project:      ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}'
-          echo 'Target OBS project(env): ${{ env.obs_project }}'
+          echo 'Target OBS project: ${{ env.obs_project }}'
           echo 'Submit condition: ${{ vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER }}'
-          echo 'Submit would start: ${{ !contains(fromJSON('[false, 0, -0, "", null]'), vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER) }}'
-          echo 'Submit would start2:${{ !!(vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER) }}'
-          echo 'Boolean expr test: !!0 "${{ !!0 }}", !!null "${{ !!null }}"'
-
+          echo 'Submit would start: ${{ !!(vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER) }}'

--- a/.github/workflows/obs-staging-debug.yml
+++ b/.github/workflows/obs-staging-debug.yml
@@ -14,6 +14,9 @@ on:
   # allow running manually
   workflow_dispatch:
 
+env:
+  obs_project: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+
 jobs:
   test:
 
@@ -27,7 +30,10 @@ jobs:
           echo 'vars.OBS_PROJECTS: ${{ vars.OBS_PROJECTS }}'
           echo 'parsed vars.OBS_PROJECTS: ${{ fromJson(vars.OBS_PROJECTS) }}'
           echo 'github.ref_name: ${{ github.ref_name }}'
-          echo 'Target OBS project: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}'
-          echo 'Submit condition: ${{ vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER }}'
-          echo 'Submit would start: ${{ !contains(fromJSON('[false, 0, -0, "", null]'), vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER) }}'
+          echo 'Target OBS project:      ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}'
+          echo 'Target OBS project(env): ${{ env.obs_project }}'
+          echo 'Submit condition: ${{ vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER }}'
+          echo 'Submit would start: ${{ !contains(fromJSON('[false, 0, -0, "", null]'), vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER) }}'
+          echo 'Submit would start2:${{ !!(vars.OBS_PROJECTS && env.obs_project && vars.OBS_USER) }}'
+          echo 'Boolean expr test: !!0 "${{ !!0 }}", !!null "${{ !!null }}"'
 

--- a/.github/workflows/obs-staging-live.yml
+++ b/.github/workflows/obs-staging-live.yml
@@ -12,10 +12,14 @@ on:
   # allow running manually
   workflow_dispatch:
 
+env:
+  obs_project: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+
 jobs:
   update_obs_package:
     # do not run in forks which do not set the OBS_PROJECTS variable,
     # or the mapping for the current branch is missing
+    # (BTW, jobs.FOO.if cannot see env.*)
     if: vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER
 
     runs-on: ubuntu-latest
@@ -44,8 +48,8 @@ jobs:
           OBS_USER:     ${{ vars.OBS_USER }}
           OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
 
-      - name: Checkout ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }} agama-installer
-        run: osc co -o dist ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }} agama-installer
+      - name: Checkout ${{ env.obs_project }} agama-installer
+        run: osc co -o dist ${{ env.obs_project }} agama-installer
         working-directory: ./live
 
       - name: Build sources
@@ -60,6 +64,6 @@ jobs:
         run: osc diff && osc status
         working-directory: ./live/dist
 
-      - name: Commit agama-installer to ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+      - name: Commit agama-installer to ${{ env.obs_project }}
         run: osc commit -m "Updated to Agama $GITHUB_SHA"
         working-directory: ./live/dist

--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -79,9 +79,11 @@ jobs:
       - name: Update service revision
         # only when a tag has been pushed, or "release" branch updated
         if: inputs.service_file != ''
-        run: |-
+        run: |
           echo "Updating revision to \"${{ github.ref_name }}\""
-          sed -i -e 's#<param name="revision">.*</param>#<param name="revision">${{ github.ref_name }}</param>#' ${{ inputs.service_file }}
+          BEG='<param name="revision">'
+          END='</param>'
+          sed -i -e "s#${BEG}.*${END}#${BEG}${{ github.ref_name }}${END}#" ${{ inputs.service_file }}
 
       - name: Copy optional service file
         # patch the URL in the file so it works also from forks, forks also by
@@ -89,8 +91,13 @@ jobs:
         # no tag is present
         if: inputs.service_file != ''
         run: |
-          sed -e 's#<param name="url">.*</param>#<param name="url">https://github.com/${{ github.repository }}.git</param>#' ${{ inputs.service_file }} > ./${{ env.obs_project }}/${{ inputs.package_name }}/_service
-          if [ -z "$(git tag -l)" ]; then sed -i -e 's#<param name="versionformat">.*</param>##' ./${{ env.obs_project }}/${{ inputs.package_name }}/_service; fi
+          OUT_SERVICE=./${{ env.obs_project }}/${{ inputs.package_name }}/_service
+          BEG='<param name="url">'
+          END='</param>'
+          SED_EXPR="s#${BEG}.*${END}#${BEG}https://github.com/${{ github.repository }}.git${END}#"
+          sed -e "${SED_EXPR}" ${{ inputs.service_file }} > $OUT_SERVICE
+          BEG='<param name="versionformat">'
+          if [ -z "$(git tag -l)" ]; then sed -i -e "s#${BEG}.*${END}##" $OUT_SERVICE; fi
 
       - name: Run services
         run: |
@@ -106,6 +113,8 @@ jobs:
         working-directory: ./${{ env.obs_project }}/${{ inputs.package_name }}
 
       - name: Commit ${{ inputs.package_name }} to ${{ env.obs_project }}
-        run: |-
-          osc commit -m "Updated to $(sed -e '/^version:/!d' -e 's/version: *\(.*\)/\1/' agama.obsinfo) ($(sed -e '/^commit:/!d' -e 's/commit: *\(.*\)/\1/' agama.obsinfo))"
+        run: |
+          VERSION="$(sed -e '/^version:/!d' -e 's/version: *\(.*\)/\1/' agama.obsinfo)"
+          COMMIT="$(sed  -e '/^commit:/!d'  -e 's/commit: *\(.*\)/\1/'  agama.obsinfo)"
+          osc commit -m "Updated to ${VERSION} (${COMMIT})"
         working-directory: ./${{ env.obs_project }}/${{ inputs.package_name }}

--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -27,10 +27,14 @@ on:
         required: false
         type: string
 
+env:
+  obs_project: ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+
 jobs:
   update_obs_package:
     # do not run in forks which do not set the OBS_PROJECTS and OBS_USER variables,
     # or the mapping for the current branch is missing
+    # (BTW, jobs.FOO.if cannot see env.*)
     if: vars.OBS_PROJECTS && fromJson(vars.OBS_PROJECTS)[github.ref_name] && vars.OBS_USER
 
     runs-on: ubuntu-latest
@@ -66,8 +70,8 @@ jobs:
           OBS_USER:     ${{ vars.OBS_USER }}
           OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
 
-      - name: Checkout ${{ inputs.package_name }} from ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
-        run: osc co ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }} ${{ inputs.package_name }}
+      - name: Checkout ${{ inputs.package_name }} from ${{ env.obs_project }}
+        run: osc co ${{ env.obs_project }} ${{ inputs.package_name }}
 
       - name: Configure git
         run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -85,8 +89,8 @@ jobs:
         # no tag is present
         if: inputs.service_file != ''
         run: |
-          sed -e 's#<param name="url">.*</param>#<param name="url">https://github.com/${{ github.repository }}.git</param>#' ${{ inputs.service_file }} > ./${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}/${{ inputs.package_name }}/_service
-          if [ -z "$(git tag -l)" ]; then sed -i -e 's#<param name="versionformat">.*</param>##' ./${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}/${{ inputs.package_name }}/_service; fi
+          sed -e 's#<param name="url">.*</param>#<param name="url">https://github.com/${{ github.repository }}.git</param>#' ${{ inputs.service_file }} > ./${{ env.obs_project }}/${{ inputs.package_name }}/_service
+          if [ -z "$(git tag -l)" ]; then sed -i -e 's#<param name="versionformat">.*</param>##' ./${{ env.obs_project }}/${{ inputs.package_name }}/_service; fi
 
       - name: Run services
         run: |
@@ -95,13 +99,13 @@ jobs:
           # downloaded NPM package tarballs and they are accidentally added to the
           # OBS package, so delete any TGZ files present
           rm -vf *.tgz
-        working-directory: ./${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}/${{ inputs.package_name }}
+        working-directory: ./${{ env.obs_project }}/${{ inputs.package_name }}
 
       - name: Check status
         run: osc addremove && osc diff && osc status
-        working-directory: ./${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}/${{ inputs.package_name }}
+        working-directory: ./${{ env.obs_project }}/${{ inputs.package_name }}
 
-      - name: Commit ${{ inputs.package_name }} to ${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}
+      - name: Commit ${{ inputs.package_name }} to ${{ env.obs_project }}
         run: |-
           osc commit -m "Updated to $(sed -e '/^version:/!d' -e 's/version: *\(.*\)/\1/' agama.obsinfo) ($(sed -e '/^commit:/!d' -e 's/commit: *\(.*\)/\1/' agama.obsinfo))"
-        working-directory: ./${{ fromJson(vars.OBS_PROJECTS)[github.ref_name] }}/${{ inputs.package_name }}
+        working-directory: ./${{ env.obs_project }}/${{ inputs.package_name }}

--- a/devel/branch2obs.sh
+++ b/devel/branch2obs.sh
@@ -236,14 +236,14 @@ workflows=(obs-staging-live.yml obs-staging-products.yml obs-staging-rust.yml ob
 if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
   for workflow in "${workflows[@]}"; do
     echo "Starting GitHub Action $workflow..."
-    gh workflow run "$workflow" --ref "$BRANCH"
+    gh -R "$repo_slug" workflow run "$workflow" --ref "$BRANCH"
   done
 else
   echo "After creating the remote branch trigger the submission actions on the web"
   echo "or run these commands:"
   echo
   for workflow in "${workflows[@]}"; do
-    echo "    gh workflow run \"$workflow\" --ref \"$BRANCH\""
+    echo "    gh -R \"$repo_slug\" workflow run \"$workflow\" --ref \"$BRANCH\""
   done
 fi
 


### PR DESCRIPTION
## Problem

I read our GitHub Actions that autosubmit Agama to OBS and find them hard to read:

- The expression for the target OBS project is repeated
- Shell commands are squashed to a single line

## Solution

- Declare `env.obs_project`
- Use shell variables to break up the monster lines to tame ones

## Testing

- [x] Tested manually: ran `devel/branch2obs.sh` so that the submission actions run
    - [x] Fixed a quoting error in this PR
    - [x] Fixed a bug in branch2obs when you have multiple remotes

## Screenshots

No, but here is a [Workflow run](https://github.com/agama-project/agama/actions/runs/23494790385/job/68372677885) to demonstrate that the `env` expressions indeed work, even in boolean contexts.

## Documentation

- No new functionality
- Mentioned reference docs links in the commits
