### PR TITLE
Support to configure the bootloader type to use

### DIFF
--- a/products.d/kalpa.yaml
+++ b/products.d/kalpa.yaml
@@ -103,15 +103,6 @@ software:
   optional_packages: []
   base_product: Kalpa
 
-security:
-  lsm: selinux
-  available_lsms:
-    selinux:
-      patterns:
-        - microos_selinux
-    none:
-      patterns: null
-
 storage:
   space_policy: delete
   volumes:

--- a/products.d/leap_161.yaml
+++ b/products.d/leap_161.yaml
@@ -99,18 +99,6 @@ software:
   optional_packages: []
   base_product: Leap
 
-security:
-  lsm: selinux
-  available_lsms:
-    apparmor:
-      patterns:
-        - apparmor
-    selinux:
-      patterns:
-        - selinux
-    none:
-      patterns: null
-
 storage:
   space_policy: delete
   volumes:

--- a/products.d/leap_micro_62.yaml
+++ b/products.d/leap_micro_62.yaml
@@ -59,15 +59,6 @@ software:
   optional_packages: []
   base_product: Leap-Micro
 
-security:
-  lsm: selinux
-  available_lsms:
-    selinux:
-      patterns:
-        - selinux
-    none:
-      patterns: null
-
 storage:
   space_policy: delete
   volumes:

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -160,15 +160,6 @@ software:
   optional_packages: []
   base_product: MicroOS
 
-security:
-  lsm: selinux
-  available_lsms:
-    selinux:
-      patterns:
-        - microos_selinux
-    none:
-      patterns: null
-
 storage:
   space_policy: delete
   volumes:

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -213,15 +213,6 @@ software:
   optional_packages: []
   base_product: SLES
 
-security:
-  lsm: selinux
-  available_lsms:
-    selinux:
-      patterns:
-        - selinux
-    none:
-      patterns: null
-
 modes:
   - id: standard
     # ------------------------------------------------------------------------------

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -193,15 +193,6 @@ software:
   optional_packages: []
   base_product: SLES_SAP
 
-security:
-  lsm: selinux
-  available_lsms:
-    selinux:
-      patterns:
-        - selinux
-    none:
-      patterns: null
-
 modes:
   - id: standard
     # ------------------------------------------------------------------------------

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -113,18 +113,6 @@ software:
   optional_packages: []
   base_product: openSUSE
 
-security:
-  lsm: apparmor
-  available_lsms:
-    apparmor:
-      patterns:
-        - apparmor
-    selinux:
-      patterns:
-        - selinux
-    none:
-      patterns: null
-
 storage:
   boot_strategy: BLS
   space_policy: delete

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -150,6 +150,9 @@ software:
   optional_packages: []
   base_product: openSUSE
 
+boot:
+  default_efi_bootloader: "systemd-boot"
+
 storage:
   boot_strategy: BLS
   space_policy: delete

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -150,18 +150,6 @@ software:
   optional_packages: []
   base_product: openSUSE
 
-security:
-  lsm: selinux
-  available_lsms:
-    apparmor:
-      patterns:
-        - apparmor
-    selinux:
-      patterns:
-        - selinux
-    none:
-      patterns: null
-
 storage:
   boot_strategy: BLS
   space_policy: delete

--- a/rust/agama-utils/src/products.rs
+++ b/rust/agama-utils/src/products.rs
@@ -212,6 +212,8 @@ pub struct ProductTemplate {
     #[serde(default)]
     pub storage: StorageSpec,
     #[serde(default)]
+    pub boot: BootSpec,
+    #[serde(default)]
     pub modes: Vec<ProductModeSpec>,
 }
 
@@ -255,6 +257,7 @@ impl ProductTemplate {
             license: self.license.clone(),
             software,
             storage,
+            boot: self.boot.clone(),
         })
     }
 
@@ -289,6 +292,7 @@ pub struct ProductSpec {
     pub license: Option<String>,
     pub software: SoftwareSpec,
     pub storage: StorageSpec,
+    pub boot: BootSpec,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Merge)]
@@ -396,6 +400,13 @@ pub struct StorageSpec {
     #[serde(default)]
     #[merge(strategy = merge::vec::append)]
     pub volume_templates: Vec<VolumeSpec>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Merge)]
+pub struct BootSpec {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[merge(strategy = merge::option::overwrite_none)]
+    pub default_efi_bootloader: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -532,6 +543,12 @@ mod test {
         assert_eq!(
             preselected,
             Some(&UserPattern::Preselected(expected_pattern))
+        );
+
+        let boot = &tw.boot;
+        assert_eq!(
+            boot.default_efi_bootloader.as_ref().unwrap(),
+            "systemd-boot"
         );
     }
 

--- a/rust/test/share/products.d/tumbleweed.yaml
+++ b/rust/test/share/products.d/tumbleweed.yaml
@@ -222,3 +222,6 @@ storage:
           - ext4
           - xfs
           - vfat
+
+boot:
+  default_efi_bootloader: "systemd-boot"

--- a/service/lib/agama/config.rb
+++ b/service/lib/agama/config.rb
@@ -68,13 +68,6 @@ module Agama
       data.dig("storage", "lvm") || false
     end
 
-    # Boot strategy for the product
-    #
-    # @return [String, nil]
-    def boot_strategy
-      data.dig("storage", "boot_strategy")
-    end
-
   private
 
     def mandatory_path?(path)

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -36,7 +36,9 @@ module Agama
   module DBus
     module Storage
       # D-Bus object to manage storage installation
-      class Manager < BaseObject
+      class Manager < BaseObject # rubocop:disable Metrics/ClassLength
+        # The class is long due to declarations (D-BUS, JSON and progress reporting).
+
         extend Yast::I18n
         include Yast::I18n
         include WithIssues
@@ -226,10 +228,16 @@ module Agama
         def configure_bootloader(serialized_config)
           logger.info("Setting bootloader config: #{serialized_config}")
           config_json = JSON.parse(serialized_config, symbolize_names: true)
+          reconfigure_storage = manager.configured_for_bootloader?(config_json)
           manager.update_bootloader_config(config_json)
+
           # after loading config try to apply it, so proper packages can be requested
           # TODO: generate also new issue from configuration
-          calculate_bootloader
+          if reconfigure_storage
+            configure_with_current
+          else
+            calculate_bootloader
+          end
           0
         end
 

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -185,13 +185,13 @@ module Agama
         # Implementation for the API method #Install.
         def install
           start_progress(3, _("Preparing bootloader proposal"))
-          manager.bootloader.configure
+          manager.configure_bootloader
 
           next_progress_step(_("Preparing the storage devices"))
           manager.install
 
           next_progress_step(_("Writing bootloader sysconfig"))
-          manager.bootloader.install
+          manager.install_bootloader
 
           finish_progress
         end
@@ -226,7 +226,7 @@ module Agama
         def configure_bootloader(serialized_config)
           logger.info("Setting bootloader config: #{serialized_config}")
           config_json = JSON.parse(serialized_config, symbolize_names: true)
-          manager.bootloader.config.load_json(config_json)
+          manager.update_bootloader_config(config_json)
           # after loading config try to apply it, so proper packages can be requested
           # TODO: generate also new issue from configuration
           calculate_bootloader
@@ -333,7 +333,7 @@ module Agama
         # Performs the bootloader configuration applying the current config.
         def calculate_bootloader
           logger.info("Configuring bootloader")
-          manager.bootloader.configure
+          manager.configure_bootloader
           update_serialized_bootloader_config
         end
 
@@ -455,7 +455,7 @@ module Agama
         #
         # @return [String]
         def serialize_bootloader_config
-          JSON.pretty_generate(manager.bootloader.config.to_json)
+          JSON.pretty_generate(manager.bootloader_config.to_json)
         end
 
         # Representation of the null JSON.

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -225,7 +225,8 @@ module Agama
         # @return [Integer] 0 success; 1 error
         def configure_bootloader(serialized_config)
           logger.info("Setting bootloader config: #{serialized_config}")
-          manager.bootloader.config.load_json(serialized_config)
+          config_json = JSON.parse(serialized_config, symbolize_names: true)
+          manager.bootloader.config.load_json(config_json)
           # after loading config try to apply it, so proper packages can be requested
           # TODO: generate also new issue from configuration
           calculate_bootloader
@@ -454,7 +455,7 @@ module Agama
         #
         # @return [String]
         def serialize_bootloader_config
-          manager.bootloader.config.to_json
+          JSON.pretty_generate(manager.bootloader.config.to_json)
         end
 
         # Representation of the null JSON.

--- a/service/lib/agama/storage/bootloader.rb
+++ b/service/lib/agama/storage/bootloader.rb
@@ -20,11 +20,11 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "json"
 require "bootloader/bootloader_factory"
 require "bootloader/os_prober"
 
 require "agama/http/clients"
+require "agama/storage/bootloader_config"
 
 Yast.import "BootStorage"
 
@@ -32,104 +32,12 @@ module Agama
   module Storage
     # Represents bootloader specific functionality
     class Bootloader
-      # Represents bootloader settings
-      class Config
-        # Whether bootloader should update persistent RAM.
-        # If kept as nil then default will be used.
-        #
-        # @return [Boolean]
-        attr_accessor :update_nvram
-
-        # Whether bootloader should stop on boot menu.
-        #
-        # @return [Boolean]
-        attr_accessor :stop_on_boot_menu
-
-        # Bootloader timeout.
-        #
-        # Only positive numbers are supported and stop_on_boot_menu has precedence.
-        #
-        # @return [Integer]
-        attr_accessor :timeout
-
-        # Bootloader extra kernel parameters beside ones that is proposed.
-        #
-        # @return [String]
-        attr_accessor :extra_kernel_params
-
-        # Bootloader extra kernel parameters needed for other parts of agama
-        #
-        # @return [Hash<String, String>]
-        attr_accessor :scoped_kernel_params
-
-        # Keys to export to JSON.
-        #
-        # As both previous keys are conflicting, remember which one to set or none. It can be empty
-        # and it means export nothing.
-        #
-        # @return [Array<Symbol>]
-        attr_accessor :keys_to_export
-
-        def initialize
-          @keys_to_export = []
-          @stop_on_boot_menu = false # false means use proposal, which has timeout
-          @timeout = 10 # just some reasonable timeout, we do not send it anywhere
-          @update_nvram = nil
-          @extra_kernel_params = ""
-          @scoped_kernel_params = {}
-        end
-
-        # Serializes the config to JSON.
-        #
-        # @return [String]
-        def to_json(*_args)
-          result = {}
-
-          # our json use camel case
-          result[:stopOnBootMenu] = stop_on_boot_menu if keys_to_export.include?(:stop_on_boot_menu)
-          result[:timeout] = timeout if keys_to_export.include?(:timeout)
-          result[:updateNvram] = update_nvram if keys_to_export.include?(:update_nvram)
-          if keys_to_export.include?(:extra_kernel_params)
-            result[:extraKernelParams] =
-              @extra_kernel_params
-          end
-
-          result.to_json
-        end
-
-        # Loads the config from a JSON string.
-        #
-        # @param serialized_config [String]
-        # @return [Config] self
-        def load_json(serialized_config)
-          hsh = JSON.parse(serialized_config, symbolize_names: true)
-          update_attribute(hsh, :timeout, :timeout, conflicts: :stop_on_boot_menu)
-          update_attribute(hsh, :stopOnBootMenu, :stop_on_boot_menu, conflicts: :timeout)
-          update_attribute(hsh, :extraKernelParams, :extra_kernel_params)
-          update_attribute(hsh, :updateNvram, :update_nvram)
-
-          self.scoped_kernel_params = hsh[:kernelArgs]
-
-          self
-        end
-
-      private
-
-        def update_attribute(hsh, json_key, attr_key, conflicts: nil)
-          return unless hsh.key?(json_key)
-
-          public_send("#{attr_key}=", hsh[json_key])
-          keys_to_export.delete(conflicts) if conflicts
-          keys_to_export.push(attr_key) unless keys_to_export.include?(attr_key)
-        end
-      end
-
-      # @return [Config]
+      # @return [BootloaderConfig]
       attr_reader :config
 
       # @param logger [Logger]
       def initialize(logger)
-        @config = Config.new
+        @config = BootloaderConfig.new
         @logger = logger
       end
 

--- a/service/lib/agama/storage/bootloader.rb
+++ b/service/lib/agama/storage/bootloader.rb
@@ -45,17 +45,16 @@ module Agama
       #
       # It proposes the bootloader configuration based on the current system and storage
       # configuration. It also applies the user configuration and installs the needed packages.
-      def configure
+      #
+      # @param product_config [Agama::Config]
+      def configure(product_config)
         # TODO: get value from product ( probably for TW and maybe Leap?)
         ::Bootloader::OsProber.package_available = false
         # reset disk to always read the recent storage configuration
         ::Yast::BootStorage.reset_disks
         # reset bootloader factory cache as we want here to reapply config from scratch
         ::Bootloader::BootloaderFactory.clear_cache
-        # propose values first. Propose bootloader from factory and do not use
-        # current as agama has /etc/sysconfig/bootloader with efi, so it
-        # will lead to wrong one.
-        bootloader = ::Bootloader::BootloaderFactory.proposed
+        bootloader = bootloader_object(product_config)
         ::Bootloader::BootloaderFactory.current = bootloader
         bootloader.propose
         # then also apply changes to that proposal
@@ -169,6 +168,25 @@ module Agama
         else
           @logger.error "unexpected value for stop_on_boot_menu #{@config.stop_on_boot_menu}"
         end
+      end
+
+      # Bootloader object from yast2-bootloader to use during configuration
+      #
+      # @param product_config [Agama::Config]
+      def bootloader_object(product_config)
+        ::Bootloader::BootloaderFactory.bootloader_by_name(bootloader_name(product_config))
+      end
+
+      # Name of the bootloader at ::Bootloader::BootloaderFactory
+      #
+      # @param product_config [Agama::Config]
+      # @return [String]
+      def bootloader_name(product_config)
+        solved = @config.copy
+        BootloaderConfigSolver.new(product_config).solve(solved)
+        return "grub2-efi" if solved.type.is?(:grub2) && ::Bootloader::Systeminfo.efi?
+
+        solved.type.to_s
       end
     end
   end

--- a/service/lib/agama/storage/bootloader_config.rb
+++ b/service/lib/agama/storage/bootloader_config.rb
@@ -19,10 +19,19 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/copyable"
+
 module Agama
   module Storage
     # Representation of the bootloader settings, also affecting the storage proposal
     class BootloaderConfig
+      include Copyable
+
+      # Type of bootloader to install
+      #
+      # @return [BootloaderType, nil] if nil, the type is decided by Agama
+      attr_accessor :type
+
       # Whether bootloader should update persistent RAM.
       # If kept as nil then default will be used.
       #

--- a/service/lib/agama/storage/bootloader_config.rb
+++ b/service/lib/agama/storage/bootloader_config.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024-2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "json"
+
+module Agama
+  module Storage
+    # Representation of the bootloader settings, also affecting the storage proposal
+    class BootloaderConfig
+      # Whether bootloader should update persistent RAM.
+      # If kept as nil then default will be used.
+      #
+      # @return [Boolean]
+      attr_accessor :update_nvram
+
+      # Whether bootloader should stop on boot menu.
+      #
+      # @return [Boolean]
+      attr_accessor :stop_on_boot_menu
+
+      # Bootloader timeout.
+      #
+      # Only positive numbers are supported and stop_on_boot_menu has precedence.
+      #
+      # @return [Integer]
+      attr_accessor :timeout
+
+      # Bootloader extra kernel parameters beside ones that is proposed.
+      #
+      # @return [String]
+      attr_accessor :extra_kernel_params
+
+      # Bootloader extra kernel parameters needed for other parts of agama
+      #
+      # @return [Hash<String, String>]
+      attr_accessor :scoped_kernel_params
+
+      # Keys to export to JSON.
+      #
+      # As both previous keys are conflicting, remember which one to set or none. It can be empty
+      # and it means export nothing.
+      #
+      # @return [Array<Symbol>]
+      attr_accessor :keys_to_export
+
+      def initialize
+        @keys_to_export = []
+        @stop_on_boot_menu = false # false means use proposal, which has timeout
+        @timeout = 10 # just some reasonable timeout, we do not send it anywhere
+        @update_nvram = nil
+        @extra_kernel_params = ""
+        @scoped_kernel_params = {}
+      end
+
+      # Serializes the config to JSON.
+      #
+      # @return [String]
+      def to_json(*_args)
+        result = {}
+
+        # our json use camel case
+        result[:stopOnBootMenu] = stop_on_boot_menu if keys_to_export.include?(:stop_on_boot_menu)
+        result[:timeout] = timeout if keys_to_export.include?(:timeout)
+        result[:updateNvram] = update_nvram if keys_to_export.include?(:update_nvram)
+        if keys_to_export.include?(:extra_kernel_params)
+          result[:extraKernelParams] =
+            @extra_kernel_params
+        end
+
+        result.to_json
+      end
+
+      # Loads the config from a JSON string.
+      #
+      # @param serialized_config [String]
+      # @return [Config] self
+      def load_json(serialized_config)
+        hsh = JSON.parse(serialized_config, symbolize_names: true)
+        update_attribute(hsh, :timeout, :timeout, conflicts: :stop_on_boot_menu)
+        update_attribute(hsh, :stopOnBootMenu, :stop_on_boot_menu, conflicts: :timeout)
+        update_attribute(hsh, :extraKernelParams, :extra_kernel_params)
+        update_attribute(hsh, :updateNvram, :update_nvram)
+
+        self.scoped_kernel_params = hsh[:kernelArgs]
+
+        self
+      end
+
+    private
+
+      def update_attribute(hsh, json_key, attr_key, conflicts: nil)
+        return unless hsh.key?(json_key)
+
+        public_send("#{attr_key}=", hsh[json_key])
+        keys_to_export.delete(conflicts) if conflicts
+        keys_to_export.push(attr_key) unless keys_to_export.include?(attr_key)
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/bootloader_config.rb
+++ b/service/lib/agama/storage/bootloader_config.rb
@@ -19,8 +19,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "json"
-
 module Agama
   module Storage
     # Representation of the bootloader settings, also affecting the storage proposal
@@ -70,9 +68,9 @@ module Agama
         @scoped_kernel_params = {}
       end
 
-      # Serializes the config to JSON.
+      # Converts the config to a JSON hash.
       #
-      # @return [String]
+      # @return [Hash]
       def to_json(*_args)
         result = {}
 
@@ -81,19 +79,17 @@ module Agama
         result[:timeout] = timeout if keys_to_export.include?(:timeout)
         result[:updateNvram] = update_nvram if keys_to_export.include?(:update_nvram)
         if keys_to_export.include?(:extra_kernel_params)
-          result[:extraKernelParams] =
-            @extra_kernel_params
+          result[:extraKernelParams] = @extra_kernel_params
         end
 
-        result.to_json
+        result
       end
 
-      # Loads the config from a JSON string.
+      # Loads the configuration from a hash according to the JSON schema.
       #
-      # @param serialized_config [String]
+      # @param hsh [Hash]
       # @return [Config] self
-      def load_json(serialized_config)
-        hsh = JSON.parse(serialized_config, symbolize_names: true)
+      def load_json(hsh)
         update_attribute(hsh, :timeout, :timeout, conflicts: :stop_on_boot_menu)
         update_attribute(hsh, :stopOnBootMenu, :stop_on_boot_menu, conflicts: :timeout)
         update_attribute(hsh, :extraKernelParams, :extra_kernel_params)

--- a/service/lib/agama/storage/bootloader_config_solver.rb
+++ b/service/lib/agama/storage/bootloader_config_solver.rb
@@ -19,7 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "bootloader_type"
+require "agama/storage/bootloader_type"
 require "yast"
 require "bootloader/systeminfo"
 

--- a/service/lib/agama/storage/bootloader_config_solver.rb
+++ b/service/lib/agama/storage/bootloader_config_solver.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "bootloader_type"
+require "yast"
+require "bootloader/systeminfo"
+
+module Agama
+  module Storage
+    # Class for solving a bootloader storage config.
+    #
+    # Solving a config means to assign proper values according to the product and the system.
+    # That is analogous to the equivalent process described for the storage config at
+    # doc/storage_proposal_from_profile.md.
+    class BootloaderConfigSolver
+      # @param product_config [Agama::Config] configuration of the product to install
+      def initialize(product_config)
+        @product_config = product_config
+      end
+
+      # Solves the config according to the product and the system.
+      #
+      # @note The config object is modified.
+      #
+      # @param config [BootloaderConfig]
+      def solve(config)
+        return if config.type
+
+        config.type =
+          if bls?
+            product_bls_type || DEFAULT_BLS_TYPE
+          else
+            DEFAULT_TYPE
+          end
+      end
+
+    private
+
+      # @return [Agama::Config]
+      attr_reader :product_config
+
+      # Default bootloader type for most scenarios
+      DEFAULT_TYPE = BootloaderType::GRUB2
+      private_constant :DEFAULT_TYPE
+
+      # Default bootloader type for systems in which a BLS-compliant bootloader is supported
+      # TODO: change this to SYSTEMD_BOOT when we have sorted everthing out (encryption with TPM,
+      # dual-booting, etc.).
+      DEFAULT_BLS_TYPE = BootloaderType::GRUB2
+      private_constant :DEFAULT_BLS_TYPE
+
+      # Archs in which a BLS-compliant bootloader is supported
+      BLS_ARCHS = [:x86_64, :i386, :aarch64, :arm, :riscv64].freeze
+      private_constant :BLS_ARCHS
+
+      # @return [BootloaderType, nil]
+      def product_bls_type
+        BootloaderType.find(product_config.data.dig("boot", "default_efi_bootloader"))
+      end
+
+      # Whether the usage of a BLS-compliant bootloader is supported
+      #
+      # @return [Boolean]
+      def bls?
+        return false unless ::Bootloader::Systeminfo.efi?
+
+        BLS_ARCHS.any? { |a| Yast::Arch.public_send(a) }
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/bootloader_type.rb
+++ b/service/lib/agama/storage/bootloader_type.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module Storage
+    # Enum-like class to represent the possible bootloader types at BootloaderConfig
+    class BootloaderType
+      # Constructor, to be used internally by the class
+      #
+      # @param value [String] see {#value}
+      def initialize(value)
+        @value = value
+      end
+
+      # Instance of the function to be always returned by the class
+      GRUB2 = new("grub2")
+      # Instance of the function to be always returned by the class
+      SYSTEMD_BOOT = new("systemd-boot")
+      # Instance of the function to be always returned by the class
+      GRUB2_BLS = new("grub2-bls")
+      # Instance of the function to be always returned by the class
+      NONE = new("none")
+
+      # All possible instances
+      ALL = [GRUB2, SYSTEMD_BOOT, GRUB2_BLS, NONE].freeze
+      private_constant :ALL
+
+      # List of all possible types
+      def self.all
+        ALL.dup
+      end
+
+      # Finds a type by its value
+      #
+      # @param value [#to_s]
+      # @return [BootloaderType, nil] nil if such value does not exist
+      def self.find(value)
+        ALL.find { |type| type.value == value.to_s }
+      end
+
+      # @return [String] value to represent the type in the config
+      attr_reader :value
+
+      alias_method :to_s, :value
+
+      # @return [Symbol]
+      def to_sym
+        value.to_sym
+      end
+
+      # Checks whether the object corresponds to any of the given enum values.
+      #
+      # By default, this will be the base comparison used in the case statements.
+      #
+      # @param names [#to_sym]
+      # @return [Boolean]
+      def is?(*names)
+        names.any? { |n| n.to_sym == to_sym }
+      end
+
+      # @return [Boolean]
+      def ==(other)
+        other.class == self.class && other.value == value
+      end
+
+      alias_method :eql?, :==
+
+      # @return [Boolean]
+      def ===(other)
+        other.instance_of?(self.class) && is?(other)
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -192,6 +192,34 @@ module Agama
         probing_issues + [candidate_devices_issue].compact
       end
 
+      # Current bootloader configuration
+      #
+      # @return [BootloaderConfig]
+      def bootloader_config
+        bootloader.config
+      end
+
+      # Updates the bootloader configuration
+      #
+      # @param config_json [Hash]
+      def update_bootloader_config(config_json)
+        bootloader.config.load_json(config_json)
+      end
+
+      # Configures the bootloader
+      #
+      # @see Bootloader#configure
+      def configure_bootloader
+        bootloader.configure(product_config)
+      end
+
+      # Installs the bootloader
+      #
+      # @see Bootloader#install
+      def install_bootloader
+        bootloader.install
+      end
+
     private
 
       PROPOSAL_ID = "storage_proposal"

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -60,7 +60,6 @@ module Agama
         @logger = logger || Logger.new($stdout)
         @bootloader = Bootloader.new(logger)
         @issues = []
-        @yast_no_bls_boot = ENV["YAST_NO_BLS_BOOT"]
         update_product_config(Agama::Config.new)
       end
 
@@ -70,7 +69,6 @@ module Agama
       def update_product_config(product_config)
         @product_config = product_config
         proposal.product_config = product_config
-        configure_no_bls_bootloader
       end
 
       def activated?
@@ -95,7 +93,8 @@ module Agama
         Y2Storage::StorageManager.instance.probed?
       end
 
-      # Whether the current proposal was already calculated for the given product and config.
+      # Whether the current proposal was already calculated for the given product and config
+      # (assuming the bootloader config has not changed).
       #
       # @param product_config_json [Hash]
       # @param config_json [Hash]
@@ -103,6 +102,18 @@ module Agama
       # @return [Boolean]
       def configured?(product_config_json, config_json)
         product_config.data == product_config_json && self.config_json == config_json
+      end
+
+      # Whether the current proposal was already calculated for the given bootloader config
+      # (assuming the product and storage config have not changed).
+      #
+      # @param boot_config_json [Hash]
+      # @return [Boolean]
+      def configured_for_bootloader?(boot_config_json)
+        # Check only the bootloader type since we know the rest of the bootloader configuration is
+        # irrelevant (ie. does not influence the calculation of the storage setup).
+        # Although formally it is a bit wrong since the manager should not know those details.
+        bootloader_config.type == boot_config_json[:type]
       end
 
       # Probes the devices.
@@ -157,7 +168,9 @@ module Agama
       #
       # @return [Storage::Proposal]
       def proposal
-        @proposal ||= Proposal.new(product_config, logger: logger)
+        @proposal ||= Proposal.new(
+          product_config, bootloader_config: bootloader_config, logger: logger
+        )
       end
 
       # iSCSI manager
@@ -203,7 +216,7 @@ module Agama
       #
       # @param config_json [Hash]
       def update_bootloader_config(config_json)
-        bootloader.config.load_json(config_json)
+        bootloader_config.load_json(config_json)
       end
 
       # Configures the bootloader
@@ -227,17 +240,6 @@ module Agama
 
       # @return [Logger]
       attr_reader :logger
-
-      # Underlying yast-storage-ng has own mechanism for proposing boot strategies.
-      # However, we don't always want to use BLS when it proposes so. Currently
-      # we want to use BLS only for Tumbleweed / Slowroll
-      def configure_no_bls_bootloader
-        # Keep original value of the env variable or set it if needed.
-        value = product_config.boot_strategy&.casecmp("BLS") ? @yast_no_bls_boot : "1"
-        ENV["YAST_NO_BLS_BOOT"] = value
-        # Avoiding problems with cached values
-        Y2Storage::StorageEnv.instance.reset_cache
-      end
 
       # Whether iSCSI is needed in the target system.
       #

--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -26,6 +26,7 @@ require "agama/storage/config_conversions"
 require "agama/storage/config_json_generator"
 require "agama/storage/config_solver"
 require "agama/storage/model_support_checker"
+require "agama/storage/bootloader_config"
 require "agama/storage/proposal_strategies"
 require "agama/storage/issue_classes"
 require "agama/storage/system"
@@ -42,12 +43,17 @@ module Agama
       # @return [Agama::Config]
       attr_accessor :product_config
 
+      # @return [Agama::Storage::BootloaderConfig]
+      attr_accessor :bootloader_config
+
       # @param product_config [Agama::Config] Agama config
+      # @param bootloader_config [BootloaderConfig] Bootloader config
       # @param logger [Logger]
-      def initialize(product_config, logger: nil)
+      def initialize(product_config, bootloader_config: nil, logger: nil)
         textdomain "agama"
 
         @product_config = product_config
+        @bootloader_config = bootloader_config || BootloaderConfig.new
         @logger = logger || Logger.new($stdout)
       end
 
@@ -150,7 +156,9 @@ module Agama
         logger.info("Calculating proposal with agama strategy: #{config.inspect}")
         reset
         @source_config = config.copy
-        @strategy = ProposalStrategies::Agama.new(product_config, storage_system, config, logger)
+        @strategy = ProposalStrategies::Agama.new(
+          product_config, storage_system, config, bootloader_config.copy, logger
+        )
         calculate
       end
 

--- a/service/lib/agama/storage/proposal.rb
+++ b/service/lib/agama/storage/proposal.rb
@@ -173,7 +173,7 @@ module Agama
         # Ensures keys are strings.
         partitioning = JSON.parse(partitioning.to_json)
         @strategy = ProposalStrategies::Autoyast
-          .new(product_config, storage_system, partitioning, logger)
+          .new(product_config, storage_system, partitioning, bootloader_config.copy, logger)
         calculate
       end
 

--- a/service/lib/agama/storage/proposal_strategies/agama.rb
+++ b/service/lib/agama/storage/proposal_strategies/agama.rb
@@ -37,11 +37,12 @@ module Agama
         # @param storage_system [Storage::System]
         # @param config [Agama::Storage::Config]
         # @param logger [Logger]
-        def initialize(product_config, storage_system, config, logger)
+        def initialize(product_config, storage_system, config, bootloader_config, logger)
           textdomain "agama"
 
           super(product_config, storage_system, logger)
           @config = config
+          @bootloader_config = bootloader_config
         end
 
         # @see Base#calculate
@@ -71,8 +72,9 @@ module Agama
           Y2Storage::AgamaProposal.new(
             config,
             storage_system,
-            product_config: product_config,
-            issues_list:    []
+            product_config:    product_config,
+            bootloader_config: @bootloader_config,
+            issues_list:       []
           )
         end
       end

--- a/service/lib/agama/storage/proposal_strategies/autoyast.rb
+++ b/service/lib/agama/storage/proposal_strategies/autoyast.rb
@@ -22,6 +22,7 @@
 require "agama/storage/proposal_strategies/base"
 require "agama/storage/proposal_settings"
 require "agama/storage/proposal_settings_reader"
+require "agama/storage/bootloader_config_solver"
 
 module Agama
   module Storage
@@ -33,12 +34,14 @@ module Agama
         # @param product_config [Config] Product config
         # @param storage_system [Storage::System]
         # @param partitioning [Array<Hash>]
+        # @param bootloader_config [Agama::Storage::BootloaderConfig]
         # @param logger [Logger]
-        def initialize(product_config, storage_system, partitioning, logger)
+        def initialize(product_config, storage_system, partitioning, bootloader_config, logger)
           textdomain "agama"
 
           super(product_config, storage_system, logger)
           @partitioning = partitioning
+          @bootloader_config = bootloader_config
         end
 
         # Settings used for calculating the proposal.
@@ -50,6 +53,7 @@ module Agama
         # @see Base#calculate
         def calculate
           @ay_issues = ::Installation::AutoinstIssues::List.new
+          disable_bls_bootloader
           proposal = Y2Storage::AutoinstProposal.new(
             partitioning:      partitioning,
             proposal_settings: proposal_settings,
@@ -104,6 +108,22 @@ module Agama
         # Agama issue equivalent to the given AutoYaST issue
         def agama_issue(ay_issue)
           Issue.new(ay_issue.message)
+        end
+
+        # The underlying yast-storage-ng contains its own logic to infer which boot loader will
+        # be used when deciding the strategy to calculate boot partitions. This method tries to
+        # influence that logic in order to get a proposal that is aligned with the rest of the
+        # Agama settings.
+        #
+        # TODO: there is no way to actually enable a BLS-based bootloader if the product is
+        # configured in YaST to never use that kind of bootloaders. The plan is to re-evaluate the
+        # changes needed in Y2Storage::BootRequirementsChecker in the short future.
+        def disable_bls_bootloader
+          BootloaderConfigSolver.new(product_config).solve(@bootloader_config)
+          value = @bootloader_config.type == BootloaderType::GRUB2 ? "1" : "0"
+          ENV["YAST_NO_BLS_BOOT"] = value
+          # Avoiding problems with cached values
+          Y2Storage::StorageEnv.instance.reset_cache
         end
       end
     end

--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -21,12 +21,15 @@
 
 require "agama/storage/config_checker"
 require "agama/storage/config_solver"
+require "agama/storage/bootloader_config"
+require "agama/storage/bootloader_config_solver"
 require "yast"
 require "y2storage/exceptions"
 require "y2storage/planned"
 require "y2storage/proposal"
 require "y2storage/proposal/agama_devices_creator"
 require "y2storage/proposal/agama_devices_planner"
+require "y2storage/proposal/boot_planner"
 require "y2storage/proposal/space_settings_builder"
 require "y2storage/proposal/planned_devices_handler"
 
@@ -61,11 +64,14 @@ module Y2Storage
     # @param storage_system [Agama::Storage::System]
     # @param product_config [Agama::Config, nil]
     # @param issues_list [Array<Agama::Issue>, nil] Stores issues found during the process.
-    def initialize(config, storage_system, product_config: nil, issues_list: nil)
+    def initialize(
+      config, storage_system, product_config: nil, bootloader_config: nil, issues_list: nil
+    )
       super(devicegraph: storage_system.devicegraph, disk_analyzer: storage_system.analyzer)
       @config = config
       @storage_system = storage_system
       @product_config = product_config || Agama::Config.new
+      @bootloader_config = bootloader_config || Agama::Storage::BootloaderConfig.new
       @issues_list = issues_list || []
     end
 
@@ -80,6 +86,9 @@ module Y2Storage
     # @return [Proposal::AgamaSpaceMaker]
     attr_reader :space_maker
 
+    # @return [Agama::Storage::BootloaderConfig]
+    attr_reader :bootloader_config
+
     # Whether there is any issue.
     #
     # @return [Boolean]
@@ -91,6 +100,8 @@ module Y2Storage
     #
     # @raise [NoDiskSpaceError] if there is no enough space to perform the installation
     def calculate_proposal
+      Agama::Storage::BootloaderConfigSolver.new(product_config).solve(bootloader_config)
+
       Agama::Storage::ConfigSolver
         .new(product_config, storage_system)
         .solve(config)
@@ -175,16 +186,11 @@ module Y2Storage
     end
 
     # @see #complete_planned
+    #
+    # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
     def boot_partitions(devicegraph)
-      checker = BootRequirementsChecker.new(
-        devicegraph,
-        planned_devices: planned_devices.mountable_devices,
-        boot_disk_name:  boot_device_name
-      )
-      # NOTE: Should we try with :desired first?
-      checker.needed_partitions(:min)
-    rescue BootRequirementsChecker::Error => e
-      raise NotBootableError, e.message
+      planner = Proposal::BootPlanner.new(devicegraph, config, bootloader_config)
+      planner.partitions(planned_devices.mountable_devices)
     end
 
     # Removes partition tables from candidate devices with empty partition table

--- a/service/lib/y2storage/proposal/boot_planner.rb
+++ b/service/lib/y2storage/proposal/boot_planner.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/boot_requirements_strategies"
+require "y2storage/storage_manager"
+
+module Y2Storage
+  module Proposal
+    # Class to calculate the partitions that will be needed to boot the system in the Agama
+    # proposal, according to the Agama settings
+    #
+    # TODO: Currently this class overlaps some of its reponsibilities (and even logic!) with
+    # Y2Storage::BootRequirementsChecker. We need to re-evaluate that before merging everything
+    # to the master branch of Agama. It would likely make sense to make BootRequirementsChecker
+    # more configurable instead of directly using its strategies in this class.
+    class BootPlanner
+      include Yast::Logger
+
+      # Constructor
+      #
+      # @param devicegraph [Devicegraph]
+      # @param config [Agama::Storage::Config]
+      # @param bootloader_config [Agama::Storage::BootloaderConfig]
+      def initialize(devicegraph, config, bootloader_config)
+        @devicegraph = devicegraph
+        @config = config
+        @bootloader_config = bootloader_config
+      end
+
+      # Partitions needed in order to be able to boot the system
+      #
+      # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
+      #
+      # @param planned_devices [Array<Planned::Device>] devices that are already planned to be
+      #   added to the starting devicegraph.
+      # @return [Array<Planned::Partition>]
+      def partitions(planned_devices)
+        strategy(planned_devices).needed_partitions(:min)
+      rescue BootRequirementsStrategies::Error => e
+        raise NotBootableError, e.message
+      end
+
+    protected
+
+      # @return [Devicegraph] starting situation.
+      attr_reader :devicegraph
+
+      # @return [Agama::Storage::Config]
+      attr_reader :config
+
+      # @return [Agama::Storage::BootloaderConfig]
+      attr_reader :bootloader_config
+
+      # Name of the boot device.
+      #
+      # @return [String, nil]
+      def boot_device_name
+        config.boot_device&.found_device&.name
+      end
+
+      # @see #partitions
+      def strategy(planned_devices)
+        strategy_class.new(devicegraph, planned_devices, boot_device_name)
+      end
+
+      # @see #grub2_strategy_class
+      def arch
+        @arch ||= StorageManager.instance.arch
+      end
+
+      # @see #strategy
+      #
+      # @return [BootRequirementsStrategies::Base]
+      def strategy_class
+        @strategy_class ||=
+          case bootloader_config.type
+          when Agama::Storage::BootloaderType::NONE
+            BootRequirementsStrategies::NfsRoot
+          when Agama::Storage::BootloaderType::GRUB2
+            grub2_strategy_class
+          else
+            BootRequirementsStrategies::BLS
+          end
+      end
+
+      # @see #strategy
+      #
+      # @return [BootRequirementsStrategies::Base]
+      def grub2_strategy_class
+        if raspberry_pi?
+          BootRequirementsStrategies::Raspi
+        elsif arch.efiboot?
+          BootRequirementsStrategies::UEFI
+        elsif arch.s390?
+          BootRequirementsStrategies::ZIPL
+        elsif arch.ppc?
+          BootRequirementsStrategies::PReP
+        else
+          # Fallback to Legacy as default
+          BootRequirementsStrategies::Legacy
+        end
+      end
+
+      # @see #raspberry_pi?
+      VENDOR_MODEL_PATH = "/proc/device-tree/model"
+      private_constant :VENDOR_MODEL_PATH
+
+      # Whether this is a Raspberry Pi. See fate#323484
+      #
+      # @return [Boolean]
+      def raspberry_pi?
+        return false unless File.exist?(VENDOR_MODEL_PATH)
+
+        File.read(VENDOR_MODEL_PATH).match?(/Raspberry Pi/i)
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/autoyast_proposal_test.rb
+++ b/service/test/agama/storage/autoyast_proposal_test.rb
@@ -38,8 +38,6 @@ describe Agama::Storage::Proposal do
   before do
     mock_storage(devicegraph: scenario)
     allow(Y2Storage::Arch).to receive(:new).and_return(arch)
-    # This environment is enforced by Agama
-    allow(Y2Storage::StorageEnv.instance).to receive(:no_bls_bootloader).and_return true
   end
 
   let(:scenario) { "windows-linux-pc.yml" }
@@ -143,6 +141,32 @@ describe Agama::Storage::Proposal do
         it "registers no issues" do
           subject.calculate_autoyast(partitioning)
           expect(subject.issues).to be_empty
+        end
+
+        context "in an EFI system with grub2 as the product's default EFI bootloader" do
+          it "proposes the expected EFI partition" do
+            subject.calculate_autoyast(partitioning)
+
+            efi = staging.find_by_name("/dev/sda").partitions.min_by(&:number)
+            expect(efi.size).to eq 512.MiB
+          end
+        end
+
+        # TODO: Actually this also depends on the value of "preferred_bootloader" at
+        # Yast::ProductFeatures, but let's assume all distributions has the same value
+        # than Tumbleweed currently uses.
+        context "in an EFI system with systemd-boot as the product's default EFI bootloader" do
+          before do
+            config.data["boot"] ||= {}
+            config.data["boot"]["default_efi_bootloader"] = "systemd-boot"
+          end
+
+          it "proposes the expected EFI partition" do
+            subject.calculate_autoyast(partitioning)
+
+            efi = staging.find_by_name("/dev/sda").partitions.min_by(&:number)
+            expect(efi.size).to eq 1.GiB
+          end
         end
       end
 

--- a/service/test/agama/storage/bootloader_config_solver_test.rb
+++ b/service/test/agama/storage/bootloader_config_solver_test.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+
+require "agama/storage/bootloader_config_solver"
+require "agama/storage/bootloader_config"
+require "agama/storage/bootloader_type"
+require "agama/config"
+
+describe Agama::Storage::BootloaderConfigSolver do
+  subject(:solver) { described_class.new(product_config) }
+
+  let(:product_config) { instance_double(Agama::Config, data: product_data) }
+  let(:product_data) { {} }
+  let(:bootloader_config) { Agama::Storage::BootloaderConfig.new }
+
+  describe "#solve" do
+    context "when the config already has a type set" do
+      before do
+        bootloader_config.type = Agama::Storage::BootloaderType::SYSTEMD_BOOT
+      end
+
+      it "does not modify the type" do
+        solver.solve(bootloader_config)
+        expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+      end
+    end
+
+    context "when the config does not have a type set" do
+      context "on a non-EFI system" do
+        before do
+          allow(Bootloader::Systeminfo).to receive(:efi?).and_return(false)
+        end
+
+        it "sets the type to GRUB2" do
+          solver.solve(bootloader_config)
+          expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+        end
+      end
+
+      context "on an EFI system" do
+        before do
+          allow(Bootloader::Systeminfo).to receive(:efi?).and_return(true)
+        end
+
+        context "on a non-BLS architecture" do
+          before do
+            allow(Yast::Arch).to receive(:x86_64).and_return(false)
+            allow(Yast::Arch).to receive(:i386).and_return(false)
+            allow(Yast::Arch).to receive(:aarch64).and_return(false)
+            allow(Yast::Arch).to receive(:arm).and_return(false)
+            allow(Yast::Arch).to receive(:riscv64).and_return(false)
+          end
+
+          it "sets the type to GRUB2" do
+            solver.solve(bootloader_config)
+            expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+          end
+        end
+
+        context "on a BLS-supported architecture (x86_64)" do
+          before do
+            allow(Yast::Arch).to receive(:x86_64).and_return(true)
+            allow(Yast::Arch).to receive(:i386).and_return(false)
+            allow(Yast::Arch).to receive(:aarch64).and_return(false)
+            allow(Yast::Arch).to receive(:arm).and_return(false)
+            allow(Yast::Arch).to receive(:riscv64).and_return(false)
+          end
+
+          context "when the product does not specify a default EFI bootloader" do
+            let(:product_data) { {} }
+
+            it "sets the type to GRUB2 (default BLS type)" do
+              solver.solve(bootloader_config)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+            end
+          end
+
+          context "when the product specifies a default EFI bootloader" do
+            let(:product_data) { { "boot" => { "default_efi_bootloader" => "systemd-boot" } } }
+
+            it "sets the type to the product-specified bootloader" do
+              solver.solve(bootloader_config)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+            end
+          end
+
+          context "when the product specifies grub2-bls as default EFI bootloader" do
+            let(:product_data) { { "boot" => { "default_efi_bootloader" => "grub2-bls" } } }
+
+            it "sets the type to GRUB2_BLS" do
+              solver.solve(bootloader_config)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2_BLS)
+            end
+          end
+
+          context "when the product specifies an invalid bootloader type" do
+            let(:product_data) { { "boot" => { "default_efi_bootloader" => "invalid" } } }
+
+            it "falls back to GRUB2 (default BLS type)" do
+              solver.solve(bootloader_config)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+            end
+          end
+        end
+
+        context "on a BLS-supported architecture (aarch64)" do
+          before do
+            allow(Yast::Arch).to receive(:x86_64).and_return(false)
+            allow(Yast::Arch).to receive(:i386).and_return(false)
+            allow(Yast::Arch).to receive(:aarch64).and_return(true)
+            allow(Yast::Arch).to receive(:arm).and_return(false)
+            allow(Yast::Arch).to receive(:riscv64).and_return(false)
+          end
+
+          context "when the product does not specify a default EFI bootloader" do
+            let(:product_data) { {} }
+
+            it "sets the type to GRUB2 (default BLS type)" do
+              solver.solve(bootloader_config)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+            end
+          end
+
+          context "when the product specifies systemd-boot" do
+            let(:product_data) { { "boot" => { "default_efi_bootloader" => "systemd-boot" } } }
+
+            it "sets the type to SYSTEMD_BOOT" do
+              solver.solve(bootloader_config)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+            end
+          end
+        end
+
+        context "on a BLS-supported architecture (riscv64)" do
+          before do
+            allow(Yast::Arch).to receive(:x86_64).and_return(false)
+            allow(Yast::Arch).to receive(:i386).and_return(false)
+            allow(Yast::Arch).to receive(:aarch64).and_return(false)
+            allow(Yast::Arch).to receive(:arm).and_return(false)
+            allow(Yast::Arch).to receive(:riscv64).and_return(true)
+          end
+
+          it "sets the type to GRUB2 when product doesn't specify" do
+            solver.solve(bootloader_config)
+            expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/test/agama/storage/bootloader_config_test.rb
+++ b/service/test/agama/storage/bootloader_config_test.rb
@@ -28,11 +28,11 @@ describe Agama::Storage::BootloaderConfig do
 
   describe "#to_json" do
     before do
-      config.load_json({ "stopOnBootMenu" => true }.to_json)
+      config.load_json({ stopOnBootMenu: true })
     end
 
     it "serializes its content with keys as camelCase" do
-      expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
+      expect(config.to_json).to eq({ stopOnBootMenu: true })
     end
 
     it "can serialize in a way that #load_json can restore it" do
@@ -44,22 +44,22 @@ describe Agama::Storage::BootloaderConfig do
     end
 
     it "exports only what was previously set" do
-      expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
-      config.load_json({ "timeout" => 10, "extraKernelParams" => "verbose" }.to_json)
-      expect(config.to_json).to eq "{\"timeout\":10,\"extraKernelParams\":\"verbose\"}"
+      expect(config.to_json).to eq({ stopOnBootMenu: true })
+      config.load_json({ timeout: 10, extraKernelParams: "verbose" })
+      expect(config.to_json).to eq({ timeout: 10, extraKernelParams: "verbose" })
     end
   end
 
   describe "#load_json" do
     it "loads config from given json" do
-      content = "{\"stopOnBootMenu\":true,\"updateNvram\":true}"
+      content = { stopOnBootMenu: true, updateNvram: true }
       config.load_json(content)
       expect(config.stop_on_boot_menu).to eq true
       expect(config.update_nvram).to eq true
     end
 
     it "remembers which keys are set" do
-      content = "{\"timeout\":10}"
+      content = { timeout: 10 }
       config.load_json(content)
       expect(config.keys_to_export).to eq([:timeout])
     end

--- a/service/test/agama/storage/bootloader_config_test.rb
+++ b/service/test/agama/storage/bootloader_config_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+
+require "agama/storage/bootloader_config"
+
+describe Agama::Storage::BootloaderConfig do
+  subject(:config) { described_class.new }
+
+  describe "#to_json" do
+    before do
+      config.load_json({ "stopOnBootMenu" => true }.to_json)
+    end
+
+    it "serializes its content with keys as camelCase" do
+      expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
+    end
+
+    it "can serialize in a way that #load_json can restore it" do
+      config.stop_on_boot_menu = false
+      json = config.to_json
+      config.stop_on_boot_menu = true
+      config.load_json(json)
+      expect(config.stop_on_boot_menu).to eq false
+    end
+
+    it "exports only what was previously set" do
+      expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
+      config.load_json({ "timeout" => 10, "extraKernelParams" => "verbose" }.to_json)
+      expect(config.to_json).to eq "{\"timeout\":10,\"extraKernelParams\":\"verbose\"}"
+    end
+  end
+
+  describe "#load_json" do
+    it "loads config from given json" do
+      content = "{\"stopOnBootMenu\":true,\"updateNvram\":true}"
+      config.load_json(content)
+      expect(config.stop_on_boot_menu).to eq true
+      expect(config.update_nvram).to eq true
+    end
+
+    it "remembers which keys are set" do
+      content = "{\"timeout\":10}"
+      config.load_json(content)
+      expect(config.keys_to_export).to eq([:timeout])
+    end
+  end
+end

--- a/service/test/agama/storage/bootloader_test.rb
+++ b/service/test/agama/storage/bootloader_test.rb
@@ -25,49 +25,6 @@ require "agama/storage/bootloader"
 require "bootloader/grub2"
 require "bootloader/systemdboot"
 
-describe Agama::Storage::Bootloader::Config do
-  subject(:config) { described_class.new }
-
-  describe "#to_json" do
-    before do
-      config.load_json({ "stopOnBootMenu" => true }.to_json)
-    end
-
-    it "serializes its content with keys as camelCase" do
-      expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
-    end
-
-    it "can serialize in a way that #load_json can restore it" do
-      config.stop_on_boot_menu = false
-      json = config.to_json
-      config.stop_on_boot_menu = true
-      config.load_json(json)
-      expect(config.stop_on_boot_menu).to eq false
-    end
-
-    it "exports only what was previously set" do
-      expect(config.to_json).to eq "{\"stopOnBootMenu\":true}"
-      config.load_json({ "timeout" => 10, "extraKernelParams" => "verbose" }.to_json)
-      expect(config.to_json).to eq "{\"timeout\":10,\"extraKernelParams\":\"verbose\"}"
-    end
-  end
-
-  describe "#load_json" do
-    it "loads config from given json" do
-      content = "{\"stopOnBootMenu\":true,\"updateNvram\":true}"
-      config.load_json(content)
-      expect(config.stop_on_boot_menu).to eq true
-      expect(config.update_nvram).to eq true
-    end
-
-    it "remembers which keys are set" do
-      content = "{\"timeout\":10}"
-      config.load_json(content)
-      expect(config.keys_to_export).to eq([:timeout])
-    end
-  end
-end
-
 describe Agama::Storage::Bootloader do
   let(:logger) { Logger.new($stdout, level: :warn) }
   let(:agama_bootloader) { described_class.new(logger) }

--- a/service/test/agama/storage/bootloader_test.rb
+++ b/service/test/agama/storage/bootloader_test.rb
@@ -22,12 +22,169 @@
 require_relative "../../test_helper"
 
 require "agama/storage/bootloader"
+require "agama/storage/bootloader_type"
+require "agama/config"
 require "bootloader/grub2"
 require "bootloader/systemdboot"
 
 describe Agama::Storage::Bootloader do
   let(:logger) { Logger.new($stdout, level: :warn) }
   let(:agama_bootloader) { described_class.new(logger) }
+  let(:product_config) { instance_double(Agama::Config, data: product_data) }
+  let(:product_data) { {} }
+  let(:bootloader_obj) { instance_double(::Bootloader::Grub2, name: "grub2", propose: nil) }
+  let(:http_client) { instance_double(Agama::HTTP::Clients::Main) }
+
+  before do
+    allow(Yast::BootStorage).to receive(:reset_disks)
+    allow(::Bootloader::OsProber).to receive(:package_available=)
+    allow(::Bootloader::BootloaderFactory).to receive(:clear_cache)
+    allow(::Bootloader::BootloaderFactory).to receive(:current=)
+    allow(::Bootloader::BootloaderFactory).to receive(:current).and_return(bootloader_obj)
+    allow(bootloader_obj).to receive(:packages).and_return([])
+    allow(Agama::HTTP::Clients::Main).to receive(:new).and_return(http_client)
+    allow(http_client).to receive(:set_resolvables)
+  end
+
+  describe "#configure" do
+    context "when bootloader type is not set" do
+      context "on an EFI system" do
+        before do
+          allow(::Bootloader::Systeminfo).to receive(:efi?).and_return(true)
+          allow(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .and_return(bootloader_obj)
+        end
+
+        context "with x86_64 architecture" do
+          before do
+            allow(Yast::Arch).to receive(:x86_64).and_return(true)
+            allow(Yast::Arch).to receive(:i386).and_return(false)
+            allow(Yast::Arch).to receive(:aarch64).and_return(false)
+            allow(Yast::Arch).to receive(:arm).and_return(false)
+            allow(Yast::Arch).to receive(:riscv64).and_return(false)
+          end
+
+          it "calls bootloader_by_name with 'grub2-efi'" do
+            expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+              .with("grub2-efi")
+              .and_return(bootloader_obj)
+
+            agama_bootloader.configure(product_config)
+          end
+
+          context "when product specifies systemd-boot" do
+            let(:product_data) { { "boot" => { "default_efi_bootloader" => "systemd-boot" } } }
+
+            it "calls bootloader_by_name with 'systemd-boot'" do
+              expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+                .with("systemd-boot")
+                .and_return(bootloader_obj)
+
+              agama_bootloader.configure(product_config)
+            end
+          end
+
+          context "when product specifies grub2-bls" do
+            let(:product_data) { { "boot" => { "default_efi_bootloader" => "grub2-bls" } } }
+
+            it "calls bootloader_by_name with 'grub2-bls'" do
+              expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+                .with("grub2-bls")
+                .and_return(bootloader_obj)
+
+              agama_bootloader.configure(product_config)
+            end
+          end
+        end
+      end
+
+      context "on a non-EFI system" do
+        before do
+          allow(::Bootloader::Systeminfo).to receive(:efi?).and_return(false)
+          allow(Yast::Arch).to receive(:x86_64).and_return(true)
+          allow(Yast::Arch).to receive(:i386).and_return(false)
+          allow(Yast::Arch).to receive(:aarch64).and_return(false)
+          allow(Yast::Arch).to receive(:arm).and_return(false)
+          allow(Yast::Arch).to receive(:riscv64).and_return(false)
+          allow(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .and_return(bootloader_obj)
+        end
+
+        it "calls bootloader_by_name with 'grub2'" do
+          expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .with("grub2")
+            .and_return(bootloader_obj)
+
+          agama_bootloader.configure(product_config)
+        end
+      end
+    end
+
+    context "when bootloader type is explicitly set" do
+      before do
+        allow(::Bootloader::Systeminfo).to receive(:efi?).and_return(true)
+        allow(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+          .and_return(bootloader_obj)
+      end
+
+      context "to systemd-boot" do
+        before do
+          agama_bootloader.config.type = Agama::Storage::BootloaderType::SYSTEMD_BOOT
+        end
+
+        it "calls bootloader_by_name with 'systemd-boot'" do
+          expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .with("systemd-boot")
+            .and_return(bootloader_obj)
+
+          agama_bootloader.configure(product_config)
+        end
+      end
+
+      context "to grub2 on EFI" do
+        before do
+          agama_bootloader.config.type = Agama::Storage::BootloaderType::GRUB2
+        end
+
+        it "calls bootloader_by_name with 'grub2-efi'" do
+          expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .with("grub2-efi")
+            .and_return(bootloader_obj)
+
+          agama_bootloader.configure(product_config)
+        end
+      end
+
+      context "to grub2 on non-EFI" do
+        before do
+          allow(::Bootloader::Systeminfo).to receive(:efi?).and_return(false)
+          agama_bootloader.config.type = Agama::Storage::BootloaderType::GRUB2
+        end
+
+        it "calls bootloader_by_name with 'grub2'" do
+          expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .with("grub2")
+            .and_return(bootloader_obj)
+
+          agama_bootloader.configure(product_config)
+        end
+      end
+
+      context "to none" do
+        before do
+          agama_bootloader.config.type = Agama::Storage::BootloaderType::NONE
+        end
+
+        it "calls bootloader_by_name with 'none'" do
+          expect(::Bootloader::BootloaderFactory).to receive(:bootloader_by_name)
+            .with("none")
+            .and_return(bootloader_obj)
+
+          agama_bootloader.configure(product_config)
+        end
+      end
+    end
+  end
 
   describe "#write_extra_kernel_params" do
     let(:extra_params) { "splash=silent quiet" }

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -238,39 +238,6 @@ describe Agama::Storage::Manager do
       expect(storage.product_config).to eq(config)
       expect(storage.proposal.product_config).to eq(config)
     end
-
-    context "if the product does not require bls boot explicitly" do
-      before do
-        allow(ENV).to receive(:[]=)
-      end
-
-      let(:config) { Agama::Config.new({}) }
-
-      it "sets env YAST_NO_BLS_BOOT to yes " do
-        expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "1")
-        storage.update_product_config(config)
-      end
-    end
-
-    context "if the product requires bls boot explicitly" do
-      before do
-        allow(ENV).to receive(:[]=)
-        allow(ENV).to receive(:[]).with("YAST_NO_BLS_BOOT").and_return("0")
-      end
-
-      let(:config) do
-        Agama::Config.new({
-          "storage" => {
-            "boot_strategy" => "BLS"
-          }
-        })
-      end
-
-      it "keeps initial env YAST_NO_BLS_BOOT" do
-        expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "0")
-        storage.update_product_config(config)
-      end
-    end
   end
 
   describe "#configured?" do

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -232,6 +232,74 @@ describe Y2Storage::AgamaProposal do
       end
     end
 
+    context "on an EFI system" do
+      let(:config) { default_config }
+
+      before do
+        allow_any_instance_of(Y2Storage::Arch).to receive(:efiboot?).and_return(true)
+        allow(Yast::Arch).to receive(:x86_64).and_return(true)
+        allow(Yast::Arch).to receive(:i386).and_return(false)
+        allow(Yast::Arch).to receive(:aarch64).and_return(false)
+        allow(Yast::Arch).to receive(:arm).and_return(false)
+        allow(Yast::Arch).to receive(:riscv64).and_return(false)
+        # Bypass the global mock
+        allow(Y2Storage::BootRequirementsStrategies::Analyzer)
+          .to receive(:bls_bootloader_proposed?).and_call_original
+      end
+
+      context "when the product configures systemd-boot as default EFI bootloader" do
+        let(:product_data) do
+          super().merge(
+            "boot" => {
+              "default_efi_bootloader" => "systemd-boot"
+            }
+          )
+        end
+
+        it "proposes the corresponding boot partitions" do
+          proposal.propose
+          efi_partition = proposal.devices.partitions.find do |part|
+            part.filesystem&.mount_path == "/boot/efi"
+          end
+
+          expect(efi_partition).to_not be_nil
+          expect(efi_partition.size).to eq(1.GiB)
+        end
+      end
+
+      context "when the product configures grub2 as default EFI bootloader" do
+        let(:product_data) do
+          super().merge(
+            "boot" => {
+              "default_efi_bootloader" => "grub2"
+            }
+          )
+        end
+
+        it "proposes the corresponding boot partitions" do
+          proposal.propose
+          efi_partition = proposal.devices.partitions.find do |part|
+            part.filesystem&.mount_path == "/boot/efi"
+          end
+
+          expect(efi_partition).to_not be_nil
+          expect(efi_partition.size).to eq(512.MiB)
+        end
+      end
+
+      context "when the product does not specify a default EFI bootloader" do
+        it "proposes the corresponding boot partitions for the default case" do
+          proposal.propose
+          efi_partition = proposal.devices.partitions.find do |part|
+            part.filesystem&.mount_path == "/boot/efi"
+          end
+
+          expect(efi_partition).to_not be_nil
+          expect(efi_partition.size).to eq(512.MiB)
+        end
+      end
+    end
+
     context "when only 'default' partitions is specified" do
       let(:scenario) { "empty-hd-50GiB.yaml" }
 


### PR DESCRIPTION
## Problem

Quite some logic has been introduced lately in yast2-bootloader and in yast2-storage-ng to decide which bootloader to install in every case (Grub2, systemd-boot, grub2-bls, etc.).

That logic is duplicated in both YaST components but, unfortunately, it is not identical.

Moreover, that logic is based on the system architecture and in some YaST-specific configurations like `Yast::ProductFeatures.preferred_bootloader`. Although initially a `YAST_NO_BLS_BOOT` environment variable was introduced as a mechanism to avoid the YaST changes to affect Agama, that is not longer working after several changes in that area.

## Solution

This introduces a reasonable mechanism to select the bootloader type to use in Agama.

The setting is handled internally in the Agama configuration but not exposed in JSON yet. For now, products can define the default bootloader for EFI environments.

Both yast2-bootloader and yast2-storage-ng will now honor the setting, which value is now handled with a single centralized mechanism.

## Notes

This is a pull request against a feature branch. It introduces new classes like `Y2Storage::Proposal::BootPlanner` or `Agama::Storage::BootloaderType` that would need to be re-evaluated. Before merging the feature branch into master, it will maybe make sense to consolidate some of those with yast2-storage-ng.