### PR TITLE
Use /var/lib/agama/scripts to save scripts

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Apr 10 06:21:35 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Run scripts from /var/lib/agama/scripts (bsc#1261787).
+
+-------------------------------------------------------------------
 Tue Mar 24 10:57:02 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Add the zFCP controller internal id to the device when some

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -22,7 +22,7 @@
 
 # This script runs the user-defined Agama init scripts.
 
-: "${SCRIPTS_DIR:=/var/log/agama-installation/scripts/init}"
+: "${SCRIPTS_DIR:=/var/lib/agama/scripts/init}"
 
 systemctl disable agama-scripts.service
 

--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -256,6 +256,7 @@ module Agama
 
         def run
           FileUtils.mkdir_p(logs_dir, mode: 0o700)
+          FileUtils.mkdir_p(var_dir, mode: 0o700)
           collect_logs
           copy_scripts
         end
@@ -265,7 +266,7 @@ module Agama
         def copy_scripts
           return unless Dir.exist?(SCRIPTS_DIR)
 
-          FileUtils.cp_r(SCRIPTS_DIR, logs_dir)
+          FileUtils.cp_r(SCRIPTS_DIR, var_dir)
         end
 
         def collect_logs
@@ -278,6 +279,12 @@ module Agama
         def logs_dir
           @logs_dir ||= File.join(
             Yast::Installation.destdir, "var", "log", "agama-installation"
+          )
+        end
+
+        def var_dir
+          @var_dir ||= File.join(
+            Yast::Installation.destdir, "var", "lib", "agama"
           )
         end
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 10 06:20:39 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use /var/lib/agama/scripts to save the scripts in the target
+  system (bsc#1261787).
+
+-------------------------------------------------------------------
 Tue Mar 24 07:13:47 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Increase the Net::HTTP read_timeout to 300 seconds to mitigates

--- a/service/test/agama/storage/finisher_test.rb
+++ b/service/test/agama/storage/finisher_test.rb
@@ -156,7 +156,7 @@ end
 
 describe Agama::Storage::Finisher::CopyLogsStep do
   let(:logger) { Logger.new($stdout, level: :warn) }
-  let(:scripts_dir) { File.join(tmp_dir, "run", "agama", "scripts") }
+  let(:init_scripts_dir) { File.join(tmp_dir, "run", "agama", "scripts", "init") }
   let(:tmp_dir) { Dir.mktmpdir }
 
   subject { Agama::Storage::Finisher::CopyLogsStep.new(logger) }
@@ -174,14 +174,16 @@ describe Agama::Storage::Finisher::CopyLogsStep do
 
   context "when scripts artifacts exist" do
     before do
-      FileUtils.mkdir_p(scripts_dir)
-      FileUtils.touch(File.join(scripts_dir, "test.sh"))
+      FileUtils.mkdir_p(init_scripts_dir)
+      FileUtils.touch(File.join(init_scripts_dir, "test.sh"))
     end
 
     it "copies the artifacts to the installed system" do
       subject.run
-      expect(File).to exist(File.join(tmp_dir, "mnt", "var", "log", "agama-installation",
-        "scripts"))
+      files = Dir.glob(File.join(tmp_dir, "**", "*"))
+      puts files
+      expect(File).to exist(File.join(tmp_dir, "mnt", "var", "lib", "agama",
+        "scripts", "init", "test.sh"))
     end
   end
 end

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -534,8 +534,7 @@ describe Agama::Storage::Manager do
 
       it "copies the artifacts to the installed system" do
         storage.finish
-        expect(File).to exist(File.join(tmp_dir, "mnt", "var", "log", "agama-installation",
-          "scripts"))
+        expect(File).to exist(File.join(tmp_dir, "mnt", "var", "lib", "agama", "scripts"))
       end
     end
   end


### PR DESCRIPTION
## Problem


* The scripts cannot be executed from /var/log/agama-installation on a hardened system.

- [bsc#1261787](https://bugzilla.suse.com/show_bug.cgi?id=1261787).

## Solution

Use `/var/lib/agama/scripts`.

## Testing

- Adapted the unit test.
- Tested manually.