### PR TITLE
Change the save dir for user-defined scripts.

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Apr 10 08:02:40 UTC 2026 - Lidong Zhong <lidong.zhong@suse.com>
+
+- Run scripts from /var/lib/agama/scripts (bsc#1261787).
+
+-------------------------------------------------------------------
 Thu Apr  9 06:53:34 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix OpenAPI specification for PATCH /config (gh#agama-project/agama#3368).

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -22,7 +22,7 @@
 
 # This script runs the user-defined Agama init scripts.
 
-: "${SCRIPTS_DIR:=/var/log/agama-installation/scripts/init}"
+: "${SCRIPTS_DIR:=/var/lib/agama/scripts/init}"
 
 systemctl disable agama-scripts.service
 

--- a/service/lib/agama/storage/umounter.rb
+++ b/service/lib/agama/storage/umounter.rb
@@ -114,6 +114,7 @@ module Agama
 
         def run
           FileUtils.mkdir_p(logs_dir, mode: 0o700)
+          FileUtils.mkdir_p(var_dir, mode: 0o700)
           collect_logs
           copy_scripts
         end
@@ -123,13 +124,19 @@ module Agama
         def copy_scripts
           return unless Dir.exist?(SCRIPTS_DIR)
 
-          FileUtils.cp_r(SCRIPTS_DIR, logs_dir)
+          FileUtils.cp_r(SCRIPTS_DIR, var_dir)
         end
 
         def collect_logs
           path = File.join(logs_dir, "logs")
           Yast::Execute.locally(
             "agama", "logs", "store", "--destination", path
+          )
+        end
+
+        def var_dir
+          @var_dir ||= File.join(
+            Yast::Installation.destdir, "var", "lib", "agama"
           )
         end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 10 08:03:07 UTC 2026 - Lidong Zhong <lidong.zhong@suse.com>
+
+- Use /var/lib/agama/scripts to save the scripts in the target
+  system (bsc#1261787).
+
+-------------------------------------------------------------------
 Wed Apr  8 09:28:31 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix for diskless installation making a proposal when

--- a/service/test/agama/storage/umounter_test.rb
+++ b/service/test/agama/storage/umounter_test.rb
@@ -54,7 +54,7 @@ describe Agama::Storage::Umounter do
 
   describe described_class::CopyLogsStep do
     let(:logger) { Logger.new($stdout, level: :warn) }
-    let(:scripts_dir) { File.join(tmp_dir, "run", "agama", "scripts") }
+    let(:init_scripts_dir) { File.join(tmp_dir, "run", "agama", "scripts", "init") }
     let(:tmp_dir) { Dir.mktmpdir }
 
     subject { described_class.new(logger) }
@@ -72,14 +72,16 @@ describe Agama::Storage::Umounter do
 
     context "when scripts artifacts exist" do
       before do
-        FileUtils.mkdir_p(scripts_dir)
-        FileUtils.touch(File.join(scripts_dir, "test.sh"))
+        FileUtils.mkdir_p(init_scripts_dir)
+        FileUtils.touch(File.join(init_scripts_dir, "test.sh"))
       end
 
       it "copies the artifacts to the installed system" do
         subject.run
-        expect(File).to exist(File.join(tmp_dir, "mnt", "var", "log", "agama-installation",
-          "scripts"))
+        files = Dir.glob(File.join(tmp_dir, "**", "*"))
+        puts files
+        expect(File).to exist(File.join(tmp_dir, "mnt", "var", "lib", "agama",
+          "scripts", "init", "test.sh"))
       end
     end
   end


### PR DESCRIPTION

## Problem

The scripts cannot be executed from /var/log/agama-installation on a hardened system.

- [*bsc1261787*](https://bugzilla.suse.com/show_bug.cgi?id=1261787)
- https://github.com/agama-project/agama/pull/3371


## Solution

change /var/log/agama-installation to /var/lib/agama/


## Testing

- Adapted the unit test.