### PR TITLE
Fix TW MicroOS Software Selection

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 13 14:47:11 UTC 2026 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Moved sudo-policy-wheel-auth-self from mandatory patterns to
+  mandatory packages for TW MicroOS (bsc#1261991) 
+
+-------------------------------------------------------------------
 Fri Apr  2 13:11:03 UTC 2026 - Jiri Srain <jsrain@suse.com>
 
 - Install by default the enhanced_base pattern for immutable mode

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -148,7 +148,6 @@ software:
     - microos_defaults
     - microos_hardware
     - microos_selinux
-    - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_patterns: []
   user_patterns:
     - container_runtime
@@ -157,6 +156,7 @@ software:
   mandatory_packages:
     - NetworkManager
     - openSUSE-repos-MicroOS
+    - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
   optional_packages: []
   base_product: MicroOS
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1261991


## Problem

Agama complains about "Invalid Software Selection", and the user can't fix it:

> Could not select pattern 'sudo-policy-wheel-auth-self' for installation.


## Cause

It's listed in the product definition as a mandatory _pattern_, but it's a _package_.

## Fix

Moved it from _mandatory patterns_ to _mandatory packages_ in the product definition.


## Other Products?

This is the only product that is affected; in all others, it's correctly listed under _mandatory packages_, not _mandatory patterns_.


## Test

Hope and pray and put our faith in Santiago to test it manually :smiley: 