### PR TITLE
setup-services.sh - fixed modifying the webserver path

### DIFF
--- a/setup-services.sh
+++ b/setup-services.sh
@@ -212,13 +212,7 @@ EOS
 (
   cd $MYDIR/rust/share
   for SVC in agama*.service; do
-    # the web server uses a wrapper script from a different directory
-    if [ "$SVC" = "agama-web-server.service" ]; then
-      TARGET=rust/share
-    else
-      TARGET=rust/target/debug
-    fi
-    sudosed "s@\(ExecStart\)=/usr/bin/@\1=$MYDIR/$TARGET/@" \
+    sudosed "s@/usr/bin/agama@$MYDIR/rust/target/debug/agama@g" \
       $SVC /usr/lib/systemd/system/$SVC
   done
 )


### PR DESCRIPTION
## Problem

- The `setup-services.sh` script was not updated in https://github.com/agama-project/agama/pull/3336

## Solution

- Update the script to match the current configuration