### PR TITLE
Add options for pervasive encryption

### DIFF
--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -907,7 +907,19 @@
           "additionalProperties": false,
           "required": ["password"],
           "properties": {
-            "password": { "$ref": "#/$defs/encryptionPassword" }
+            "password": { "$ref": "#/$defs/encryptionPassword" },
+            "apqns": {
+              "description": "List of APQNs used to generate secure keys.",
+              "type": "array",
+              "items": {
+                "examples": ["01.0001", "01.0002"],
+                "type": "string"
+              }
+            },
+            "keyType": {
+              "description": "Type of the generated secure key.",
+              "enum": ["EP11-AES", "CCA-AESCIPHER"]
+            }
           }
         }
       }

--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -918,7 +918,7 @@
             },
             "keyType": {
               "description": "Type of the generated secure key.",
-              "enum": ["EP11-AES", "CCA-AESCIPHER"]
+              "enum": ["EP11-AES", "CCA-AESCIPHER", "CCA-AESDATA"]
             }
           }
         }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 17 10:29:38 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Add support for pervasive encryption options in storage
+  configuration schema (gh#agama-project/agama#3384).
+
+-------------------------------------------------------------------
 Wed Apr 15 07:25:18 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Copy the Agama systemd network link files for renaming devices

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/encryption.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/encryption.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -110,8 +110,10 @@ module Agama
             pervasive_json = encryption_json[:pervasiveLuks2]
 
             {
-              method:   Y2Storage::EncryptionMethod::PERVASIVE_LUKS2,
-              password: convert_password(pervasive_json)
+              method:             Y2Storage::EncryptionMethod::PERVASIVE_LUKS2,
+              password:           convert_password(pervasive_json),
+              apqns:              pervasive_json[:apqns] || [],
+              pervasive_key_type: pervasive_json[:keyType]
             }
           end
 

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/encryption_properties.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/encryption_properties.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -75,7 +75,9 @@ module Agama
           # @return [Hash]
           def pervasive_luks2_properties_conversions
             {
-              password: config.password
+              password: config.password,
+              apqns:    config.apqns,
+              keyType:  config.pervasive_key_type
             }
           end
 

--- a/service/lib/agama/storage/configs/encryption.rb
+++ b/service/lib/agama/storage/configs/encryption.rb
@@ -69,7 +69,7 @@ module Agama
 
         # Type of the generated secure key (only for pervasive encryption).
         #
-        # @return [String, nil] "EP11-AES" or "CCA-AESCIPHER".
+        # @return [String, nil] Accepted key types: "EP11-AES", "CCA-AESCIPHER", "CCA-AESCIPHER".
         attr_accessor :pervasive_key_type
 
         def initialize

--- a/service/lib/agama/storage/configs/encryption.rb
+++ b/service/lib/agama/storage/configs/encryption.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -30,7 +30,8 @@ module Agama
         include Yast2::Equatable
         include Y2Storage::SecretAttributes
 
-        eql_attr :eql_method, :password, :eql_pbkd_function, :label, :cipher, :key_size
+        eql_attr :eql_method, :password, :eql_pbkd_function, :label, :cipher, :key_size, :apqns,
+          :pervasive_key_type
 
         # @return [Y2Storage::EncryptionMethod::Base, nil]
         attr_accessor :method
@@ -60,6 +61,20 @@ module Agama
         # @return [Integer, nil] If nil, the default key size will be used. If an integer
         #     value is used, it has to be a multiple of 8
         attr_accessor :key_size
+
+        # List of APQNs used for generating secure keys (only for pervasive encryption).
+        #
+        # @return [Array<String>]
+        attr_accessor :apqns
+
+        # Type of the generated secure key (only for pervasive encryption).
+        #
+        # @return [String, nil] "EP11-AES" or "CCA-AESCIPHER".
+        attr_accessor :pervasive_key_type
+
+        def initialize
+          @apqns = []
+        end
 
         # Whether the password is missing.
         #

--- a/service/lib/agama/storage/configs/encryption.rb
+++ b/service/lib/agama/storage/configs/encryption.rb
@@ -69,7 +69,8 @@ module Agama
 
         # Type of the generated secure key (only for pervasive encryption).
         #
-        # @return [String, nil] Accepted key types: "EP11-AES", "CCA-AESCIPHER", "CCA-AESCIPHER".
+        # @return [String, nil] Accepted key types: "EP11-AES", "CCA-AESCIPHER", "CCA-AESCIPHER". If
+        #   nil, a default one is used according to the APQNs.
         attr_accessor :pervasive_key_type
 
         def initialize

--- a/service/lib/y2storage/proposal/agama_device_planner.rb
+++ b/service/lib/y2storage/proposal/agama_device_planner.rb
@@ -142,8 +142,21 @@ module Y2Storage
         planned.encryption_label = config.label
         planned.encryption_cipher = config.cipher
         planned.encryption_key_size = config.key_size
-        planned.encryption_pervasive_apqns = config.apqns || []
+        configure_pervasive_encryption(planned, config)
+      end
+
+      # @param planned [Planned::Disk, Planned::Partition, Planned::LvmLv]
+      # @param config [Agama::Storage::Configs::Encryption]
+      def configure_pervasive_encryption(planned, config)
         planned.encryption_pervasive_key_type = config.pervasive_key_type
+
+        # TODO: report APQN issues (e.g., not found, incompatible types, different master key,
+        #   offline).
+
+        apqns = config.apqns || []
+        planned.encryption_pervasive_apqns = Y2Storage::EncryptionProcesses::Apqn
+          .all
+          .select { |a| apqns.include?(a.name) }
       end
 
       # @param planned [Planned::Partition, Planned::LvmLv]

--- a/service/lib/y2storage/proposal/agama_device_planner.rb
+++ b/service/lib/y2storage/proposal/agama_device_planner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -142,6 +142,8 @@ module Y2Storage
         planned.encryption_label = config.label
         planned.encryption_cipher = config.cipher
         planned.encryption_key_size = config.key_size
+        planned.encryption_pervasive_apqns = config.apqns || []
+        planned.encryption_pervasive_key_type = config.pervasive_key_type
       end
 
       # @param planned [Planned::Partition, Planned::LvmLv]

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 17 10:29:38 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Add support for configuring pervasive encryption APQNs and key
+  type (gh#agama-project/agama#3384).
+
+-------------------------------------------------------------------
 Tue Apr 14 17:36:56 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 20

--- a/service/test/agama/storage/config_conversions/from_json_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/examples.rb
@@ -181,6 +181,8 @@ shared_examples "with encryption" do
       expect(encryption.pbkd_function).to eq(Y2Storage::PbkdFunction::ARGON2I)
       expect(encryption.cipher).to eq("twofish")
       expect(encryption.label).to eq("test")
+      expect(encryption.apqns).to be_empty
+      expect(encryption.pervasive_key_type).to be_nil
     end
 
     context "if 'encryption' only specifies 'password'" do
@@ -205,11 +207,37 @@ shared_examples "with encryption" do
       end
     end
 
+    context "if 'encryption' is 'luks1'" do
+      let(:encryption) do
+        {
+          luks1: {
+            password: "12345"
+          }
+        }
+      end
+
+      it "sets #encryption to the expected value" do
+        config = subject.convert
+        encryption = config.encryption
+        expect(encryption).to be_a(Agama::Storage::Configs::Encryption)
+        expect(encryption.method).to eq(Y2Storage::EncryptionMethod::LUKS1)
+        expect(encryption.password).to eq("12345")
+        expect(encryption.key_size).to be_nil
+        expect(encryption.pbkd_function).to be_nil
+        expect(encryption.cipher).to be_nil
+        expect(encryption.label).to be_nil
+        expect(encryption.apqns).to be_empty
+        expect(encryption.pervasive_key_type).to be_nil
+      end
+    end
+
     context "if 'encryption' is 'pervasiveLuks2'" do
       let(:encryption) do
         {
           pervasiveLuks2: {
-            password: "12345"
+            password: "12345",
+            apqns:    ["01.0001", "01.0002"],
+            keyType:  "CCA-AESCIPHER"
           }
         }
       end
@@ -220,6 +248,8 @@ shared_examples "with encryption" do
         expect(encryption).to be_a(Agama::Storage::Configs::Encryption)
         expect(encryption.method).to eq(Y2Storage::EncryptionMethod::PERVASIVE_LUKS2)
         expect(encryption.password).to eq("12345")
+        expect(encryption.apqns).to contain_exactly("01.0001", "01.0002")
+        expect(encryption.pervasive_key_type).to eq("CCA-AESCIPHER")
         expect(encryption.key_size).to be_nil
         expect(encryption.pbkd_function).to be_nil
         expect(encryption.cipher).to be_nil
@@ -227,7 +257,7 @@ shared_examples "with encryption" do
       end
     end
 
-    context "if 'encryption' is 'tmpFde'" do
+    context "if 'encryption' is 'tpmFde'" do
       let(:encryption) do
         {
           tpmFde: {
@@ -246,6 +276,8 @@ shared_examples "with encryption" do
         expect(encryption.pbkd_function).to be_nil
         expect(encryption.cipher).to be_nil
         expect(encryption.label).to be_nil
+        expect(encryption.apqns).to be_empty
+        expect(encryption.pervasive_key_type).to be_nil
       end
     end
   end

--- a/service/test/agama/storage/config_conversions/to_json_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -196,7 +196,9 @@ shared_examples "with encryption" do
       let(:encryption) do
         {
           pervasiveLuks2: {
-            password: "12345"
+            password: "12345",
+            apqns:    ["01.0001", "01.0002"],
+            keyType:  "CCA-AESCIPHER"
           }
         }
       end
@@ -208,7 +210,9 @@ shared_examples "with encryption" do
         expect(encryption_json).to eq(
           {
             pervasiveLuks2: {
-              password: "12345"
+              password: "12345",
+              apqns:    ["01.0001", "01.0002"],
+              keyType:  "CCA-AESCIPHER"
             }
           }
         )

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -410,13 +410,18 @@ describe Y2Storage::AgamaProposal do
       context "if the encryption settings contains pervasive method" do
         before do
           allow(Y2Storage::EncryptionProcesses::SecureKey).to receive(:all).and_return([])
+          allow(Y2Storage::EncryptionProcesses::Apqn).to receive(:all).and_return(apqns)
         end
+
+        let(:apqns) { [apqn1, apqn2] }
+        let(:apqn1) { Y2Storage::EncryptionProcesses::Apqn.new("01.0001", "", "", "") }
+        let(:apqn2) { Y2Storage::EncryptionProcesses::Apqn.new("01.0002", "", "", "") }
 
         let(:home_encryption) do
           Agama::Storage::Configs::Encryption.new.tap do |enc|
             enc.method = Y2Storage::EncryptionMethod::PERVASIVE_LUKS2
             enc.password = "notSecreT"
-            enc.apqns = ["01.0001", "01.0002"]
+            enc.apqns = ["01.0001", "01.0002", "01.0003"]
             enc.pervasive_key_type = "CCA-AESCIPHER"
           end
         end
@@ -431,10 +436,9 @@ describe Y2Storage::AgamaProposal do
             method:   Y2Storage::EncryptionMethod::PERVASIVE_LUKS2,
             password: "notSecreT"
           )
-          expect(partition.encryption.encryption_process).to have_attributes(
-            apqns:    ["01.0001", "01.0002"],
-            key_type: "CCA-AESCIPHER"
-          )
+          expect(partition.encryption.encryption_process.apqns.map(&:name))
+            .to contain_exactly("01.0001", "01.0002")
+          expect(partition.encryption.encryption_process.key_type).to eq("CCA-AESCIPHER")
         end
       end
 

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -403,6 +403,37 @@ describe Y2Storage::AgamaProposal do
             # libstorage-ng uses bytes instead of bits to represent the key size, contrary to
             # all LUKS documentation and to cryptsetup
             key_size: 64
+          )
+        end
+      end
+
+      context "if the encryption settings contains pervasive method" do
+        before do
+          allow(Y2Storage::EncryptionProcesses::SecureKey).to receive(:all).and_return([])
+        end
+
+        let(:home_encryption) do
+          Agama::Storage::Configs::Encryption.new.tap do |enc|
+            enc.method = Y2Storage::EncryptionMethod::PERVASIVE_LUKS2
+            enc.password = "notSecreT"
+            enc.apqns = ["01.0001", "01.0002"]
+            enc.pervasive_key_type = "CCA-AESCIPHER"
+          end
+        end
+
+        it "proposes the right encryption layer" do
+          proposal.propose
+          partition = proposal.devices.partitions.find do |part|
+            part.blk_filesystem&.mount_path == "/home"
+          end
+          expect(partition.encrypted?).to eq true
+          expect(partition.encryption).to have_attributes(
+            method:   Y2Storage::EncryptionMethod::PERVASIVE_LUKS2,
+            password: "notSecreT"
+          )
+          expect(partition.encryption.encryption_process).to have_attributes(
+            apqns:    ["01.0001", "01.0002"],
+            key_type: "CCA-AESCIPHER"
           )
         end
       end


### PR DESCRIPTION
Extends the storage JSON configuration to support pervasive encryption options (APQNs and key type). Updates the schema, adds JSON conversions for encryption properties, and adapts the encryption planner to properly assign APQN objects and key type to planned encrypted devices.

Example:

~~~json
{
  "storage": {
    "drives": [
      {
        "partitions": [
          {
            "filesystem": {
              "path": "/home"
            },
            "encryption": {
              "pervasiveLuks2": {
                "password": "notsecret",
                "apqns": ["01.0017", "02.0017"],
                "keyType": "CCA-AESCIPHER"
              }
            }
          }
        ]
      }
    ]
  }
~~~

Tested manually in a s390 installation.

Follow-up:

Checks for the selected APQNs will be addressed later in a separate card. Right now, the installation will fail (with a popup) in the commit phase if there is something wrong with the selected APQNs. The required checks are:
  
* APQN not found.
* Whether the APQN is online.
* Whether all the selected APQNs have the same master key (CCA vs EP11). 
* Whether the selected key type is valid according to the selected APQNs.

As a reference:

* AutoYaST filters out and logs an error for the following APQNs from the profile: not found, offline, missing master key. On the other hand, it does not check that all the APQNs use the same master key or whether the selected key type is compatible with the mode of the APQNs (https://github.com/yast/yast-storage-ng/pull/1402).
* The YasT Expert Partitioner is well prepared to only allow selecting APQNs configured with the same master key (https://github.com/yast/yast-storage-ng/pull/1399).
