### PR TITLE
[SLE-16.0] Autoload the installation profile from the medium root (jsc#PED-16010)

### DIFF
--- a/rust/agama-autoinstall/src/auto_loader.rs
+++ b/rust/agama-autoinstall/src/auto_loader.rs
@@ -23,10 +23,16 @@ use agama_lib::http::BaseHTTPClient;
 use anyhow::anyhow;
 
 /// List of pre-defined locations for profiles.
-const PREDEFINED_LOCATIONS: [&str; 6] = [
+const PREDEFINED_LOCATIONS: [&str; 9] = [
+    // OEM drive (pre-installed systems)
     "label://OEMDRV/autoinst.jsonnet",
     "label://OEMDRV/autoinst.json",
     "label://OEMDRV/autoinst.xml",
+    // root of the installation medium
+    "file:///run/initramfs/live/autoinst.jsonnet",
+    "file:///run/initramfs/live/autoinst.json",
+    "file:///run/initramfs/live/autoinst.xml",
+    // root filesystem (squashfs image)
     "file:///autoinst.jsonnet",
     "file:///autoinst.json",
     "file:///autoinst.xml",

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 14 13:51:47 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Automatically try loading the autoinstallation profile from the
+  root of the installation medium (jsc#PED-16010)
+
+-------------------------------------------------------------------
 Fri Apr 10 06:21:35 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Run scripts from /var/lib/agama/scripts (bsc#1261787).


### PR DESCRIPTION
## Problem

- The https://jira.suse.com/browse/PED-16010 is requested also for 16.0

## Solution

- Backport #3366 to SLE-16.0
- Only the list of predefined places has been updated, the logging was not changed to have a minimal patch for 16.0

## Testing

- Tested manually with a patched ISO image

```console
# journalctl -u agama-autoinstall.service
Apr 14 16:30:30 agama systemd[1]: Started Agama automatic profile runner.
Apr 14 16:30:30 agama agama-autoinstall[5443]: Could not load the configuration from label://OEMDRV/autoinst.jsonnet
Apr 14 16:30:30 agama agama-autoinstall[5443]: Could not load the configuration from label://OEMDRV/autoinst.json
Apr 14 16:30:33 agama agama-autoinstall[5443]: Could not load the configuration from label://OEMDRV/autoinst.xml
Apr 14 16:30:33 agama agama-autoinstall[5443]: Could not load the configuration from file:///run/initramfs/live/autoinst.jsonnet
Apr 14 16:30:42 agama agama-autoinstall[5443]: Configuration loaded from file:///run/initramfs/live/autoinst.json
Apr 14 16:30:42 agama agama-autoinstall[5443]: Skipping the auto-installation on user's request (inst.install=0)
Apr 14 16:30:42 agama systemd[1]: agama-autoinstall.service: Deactivated successfully.
Apr 14 16:30:42 agama systemd[1]: agama-autoinstall.service: Consumed 1.125s CPU time, 18.2M memory peak.
```

The `/autoinst.json` from the ISO was found and successfully loaded.

## Notes

- The openAPI CI job fails as it uses the old Ubuntu based definition which does not work anymore, just ignore the failure. Later we should update the CI definitions.