### PR TITLE
refactor(web): migrate SoftwarePatternsSelection to TanStack Form

### DIFF
--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -28,12 +28,31 @@ import testingPatterns from "./patterns.test.json";
 import testingProposal from "./proposal.test.json";
 import SoftwarePatternsSelection from "./SoftwarePatternsSelection";
 
+const patternsWithPreselected = [
+  ...testingPatterns,
+  {
+    name: "preselected_pattern",
+    category: "Base Technologies",
+    icon: "./pattern-base",
+    description: "A pattern preselected by the product",
+    summary: "Preselected Pattern",
+    order: "1225",
+    preselected: true,
+  },
+];
+
 jest.mock("~/hooks/model/system/software", () => ({
-  useSystem: () => ({ patterns: testingPatterns }),
+  useSystem: () => ({ patterns: patternsWithPreselected }),
 }));
 
 jest.mock("~/hooks/model/proposal/software", () => ({
-  useProposal: () => ({ patterns: testingProposal.patterns }),
+  useProposal: () => ({
+    patterns: {
+      ...testingProposal.patterns,
+      preselected_pattern: "auto",
+      kde: "removed",
+    },
+  }),
 }));
 
 jest.mock("~/api", () => ({
@@ -94,29 +113,156 @@ describe("SoftwarePatternsSelection", () => {
     expect(serverCheckbox).not.toBeChecked();
   });
 
-  it("allows changing the selection", async () => {
-    const { user } = installerRender(<SoftwarePatternsSelection />);
-    const y2BasisPattern = testingPatterns.find((p) => p.name === "yast2_basis");
-
-    const basisCheckbox = await screen.findByRole("checkbox", {
-      name: `Unselect ${y2BasisPattern.summary}`,
+  describe("when submitting the form", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
     });
 
-    expect(basisCheckbox).toBeChecked();
+    it("removes patterns that were initially selected (AUTO) and are now unchecked", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+      const y2BasisPattern = testingPatterns.find((p) => p.name === "yast2_basis");
 
-    await user.click(basisCheckbox);
-    expect(basisCheckbox).not.toBeChecked();
+      const basisCheckbox = await screen.findByRole("checkbox", {
+        name: `Unselect ${y2BasisPattern.summary}`,
+      });
+      expect(basisCheckbox).toBeChecked();
 
-    const acceptButton = await screen.findByRole("button", { name: /accept/i });
-    await user.click(acceptButton);
+      await user.click(basisCheckbox);
+      expect(basisCheckbox).not.toBeChecked();
 
-    expect(patchConfig).toHaveBeenCalledWith({
-      software: {
-        patterns: {
-          add: expect.any(Array),
-          remove: expect.arrayContaining(["yast2_basis"]),
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.not.arrayContaining(["yast2_basis"]),
+            remove: expect.arrayContaining(["yast2_basis"]),
+          },
         },
-      },
+      });
+    });
+
+    it("removes patterns that were initially selected (USER) and are now unchecked", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+      const gnomePattern = testingPatterns.find((p) => p.name === "gnome");
+
+      const gnomeCheckbox = await screen.findByRole("checkbox", {
+        name: `Unselect ${gnomePattern.summary}`,
+      });
+      expect(gnomeCheckbox).toBeChecked();
+
+      await user.click(gnomeCheckbox);
+      expect(gnomeCheckbox).not.toBeChecked();
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.not.arrayContaining(["gnome"]),
+            remove: expect.arrayContaining(["gnome"]),
+          },
+        },
+      });
+    });
+
+    it("adds newly selected patterns", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+      const kdePattern = testingPatterns.find((p) => p.name === "kde");
+
+      const kdeCheckbox = await screen.findByRole("checkbox", {
+        name: `Select ${kdePattern.summary}`,
+      });
+      expect(kdeCheckbox).not.toBeChecked();
+
+      await user.click(kdeCheckbox);
+      expect(kdeCheckbox).toBeChecked();
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.arrayContaining(["kde"]),
+            remove: expect.not.arrayContaining(["kde"]),
+          },
+        },
+      });
+    });
+
+    it("keeps initially selected patterns in add list when they remain selected", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.arrayContaining(["gnome", "yast2_basis", "yast2_desktop"]),
+            remove: expect.any(Array),
+          },
+        },
+      });
+    });
+
+    it("does not include unselected patterns that remain unselected", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.not.arrayContaining(["kde", "xfce", "yast2_server"]),
+            remove: expect.not.arrayContaining(["kde", "xfce", "yast2_server"]),
+          },
+        },
+      });
+    });
+
+    it("removes preselected patterns when unchecked", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const preselectedCheckbox = await screen.findByRole("checkbox", {
+        name: /Preselected Pattern/,
+      });
+      expect(preselectedCheckbox).toBeChecked();
+
+      await user.click(preselectedCheckbox);
+      expect(preselectedCheckbox).not.toBeChecked();
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.not.arrayContaining(["preselected_pattern"]),
+            remove: expect.arrayContaining(["preselected_pattern"]),
+          },
+        },
+      });
+    });
+
+    it("keeps REMOVED patterns in remove list when they remain unchecked", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            add: expect.any(Array),
+            remove: expect.arrayContaining(["kde"]),
+          },
+        },
+      });
     });
   });
 });

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -193,7 +193,7 @@ describe("SoftwarePatternsSelection", () => {
       });
     });
 
-    it("keeps initially selected patterns in add list when they remain selected", async () => {
+    it("only adds USER-selected patterns when form is pristine", async () => {
       const { user } = installerRender(<SoftwarePatternsSelection />);
 
       const acceptButton = screen.getByRole("button", { name: "Accept" });
@@ -202,8 +202,10 @@ describe("SoftwarePatternsSelection", () => {
       expect(patchConfig).toHaveBeenCalledWith({
         software: {
           patterns: {
-            add: expect.arrayContaining(["gnome", "yast2_basis", "yast2_desktop"]),
-            remove: expect.any(Array),
+            // Only USER-selected patterns (not AUTO)
+            add: ["gnome"],
+            // AUTO patterns stay AUTO (not converted to USER)
+            remove: expect.arrayContaining(["kde"]),
           },
         },
       });
@@ -259,6 +261,35 @@ describe("SoftwarePatternsSelection", () => {
         software: {
           patterns: {
             add: expect.any(Array),
+            remove: expect.arrayContaining(["kde"]),
+          },
+        },
+      });
+    });
+
+    it("adds AUTO-selected patterns when user touches them (uncheck/recheck)", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+      const y2BasisPattern = testingPatterns.find((p) => p.name === "yast2_basis");
+
+      const basisCheckbox = await screen.findByRole("checkbox", {
+        name: `Unselect ${y2BasisPattern.summary}`,
+      });
+      expect(basisCheckbox).toBeChecked();
+
+      // Uncheck then recheck (makes it dirty)
+      await user.click(basisCheckbox);
+      expect(basisCheckbox).not.toBeChecked();
+      await user.click(basisCheckbox);
+      expect(basisCheckbox).toBeChecked();
+
+      const acceptButton = screen.getByRole("button", { name: "Accept" });
+      await user.click(acceptButton);
+
+      expect(patchConfig).toHaveBeenCalledWith({
+        software: {
+          patterns: {
+            // Now yast2_basis is added because user touched it (dirty)
+            add: expect.arrayContaining(["gnome", "yast2_basis"]),
             remove: expect.arrayContaining(["kde"]),
           },
         },

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -23,10 +23,10 @@
 import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
+import { patchConfig } from "~/api";
 import testingPatterns from "./patterns.test.json";
 import testingProposal from "./proposal.test.json";
 import SoftwarePatternsSelection from "./SoftwarePatternsSelection";
-import { patchConfig } from "~/api";
 
 jest.mock("~/hooks/model/system/software", () => ({
   useSystem: () => ({ patterns: testingPatterns }),
@@ -101,9 +101,22 @@ describe("SoftwarePatternsSelection", () => {
     const basisCheckbox = await screen.findByRole("checkbox", {
       name: `Unselect ${y2BasisPattern.summary}`,
     });
+
     expect(basisCheckbox).toBeChecked();
 
     await user.click(basisCheckbox);
-    expect(patchConfig).toHaveBeenCalled();
+    expect(basisCheckbox).not.toBeChecked();
+
+    const acceptButton = await screen.findByRole("button", { name: /accept/i });
+    await user.click(acceptButton);
+
+    expect(patchConfig).toHaveBeenCalledWith({
+      software: {
+        patterns: {
+          add: expect.any(Array),
+          remove: expect.arrayContaining(["yast2_basis"]),
+        },
+      },
+    });
   });
 });

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -193,26 +193,25 @@ describe("SoftwarePatternsSelection", () => {
       });
     });
 
-    it("only adds USER-selected patterns when form is pristine", async () => {
+    it("skips API call when form is pristine (nothing changed)", async () => {
       const { user } = installerRender(<SoftwarePatternsSelection />);
 
       const acceptButton = screen.getByRole("button", { name: "Accept" });
       await user.click(acceptButton);
 
-      expect(patchConfig).toHaveBeenCalledWith({
-        software: {
-          patterns: {
-            // Only USER-selected patterns (not AUTO)
-            add: ["gnome"],
-            // AUTO patterns stay AUTO (not converted to USER)
-            remove: expect.arrayContaining(["kde"]),
-          },
-        },
-      });
+      // Form is pristine, no API call should be made
+      expect(patchConfig).not.toHaveBeenCalled();
     });
 
-    it("does not include unselected patterns that remain unselected", async () => {
+    it("only adds touched patterns when user makes changes", async () => {
       const { user } = installerRender(<SoftwarePatternsSelection />);
+      const kdePattern = testingPatterns.find((p) => p.name === "kde");
+
+      // Touch one pattern (select kde)
+      const kdeCheckbox = await screen.findByRole("checkbox", {
+        name: `Select ${kdePattern.summary}`,
+      });
+      await user.click(kdeCheckbox);
 
       const acceptButton = screen.getByRole("button", { name: "Accept" });
       await user.click(acceptButton);
@@ -220,8 +219,10 @@ describe("SoftwarePatternsSelection", () => {
       expect(patchConfig).toHaveBeenCalledWith({
         software: {
           patterns: {
-            add: expect.not.arrayContaining(["kde", "xfce", "yast2_server"]),
-            remove: expect.not.arrayContaining(["kde", "xfce", "yast2_server"]),
+            // Only touched patterns (kde) and USER patterns (gnome)
+            add: expect.arrayContaining(["kde", "gnome"]),
+            // Unselected patterns that remain unselected are not included
+            remove: expect.not.arrayContaining(["xfce", "yast2_server"]),
           },
         },
       });
@@ -253,6 +254,14 @@ describe("SoftwarePatternsSelection", () => {
 
     it("keeps REMOVED patterns in remove list when they remain unchecked", async () => {
       const { user } = installerRender(<SoftwarePatternsSelection />);
+      const gnomePattern = testingPatterns.find((p) => p.name === "gnome");
+
+      // Make a change to make form dirty (toggle gnome off then on)
+      const gnomeCheckbox = await screen.findByRole("checkbox", {
+        name: `Unselect ${gnomePattern.summary}`,
+      });
+      await user.click(gnomeCheckbox);
+      await user.click(gnomeCheckbox);
 
       const acceptButton = screen.getByRole("button", { name: "Accept" });
       await user.click(acceptButton);
@@ -260,7 +269,8 @@ describe("SoftwarePatternsSelection", () => {
       expect(patchConfig).toHaveBeenCalledWith({
         software: {
           patterns: {
-            add: expect.any(Array),
+            add: expect.arrayContaining(["gnome"]),
+            // kde was REMOVED and remains unchecked
             remove: expect.arrayContaining(["kde"]),
           },
         },

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -50,11 +50,10 @@ import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from
 
 /**
  * Form options for pattern selection.
+ * Each pattern is a boolean field (pattern name -> selected state).
  */
 const softwarePatternsFormOptions = formOptions({
-  defaultValues: {
-    selectedPatterns: [] as string[],
-  },
+  defaultValues: {} as Record<string, boolean>,
 });
 
 const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the filter.")}</b>;
@@ -69,34 +68,43 @@ function SoftwarePatternsSelection() {
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
 
-  // Extract initially selected patterns (USER or AUTO)
-  const initialSelection = patterns
-    .filter((p) => isPatternSelected(selection, p.name))
-    .map((p) => p.name);
+  // Build initial form values: each pattern name -> selected boolean
+  const initialValues = patterns.reduce(
+    (acc, pattern) => {
+      acc[pattern.name] = isPatternSelected(selection, pattern.name);
+      return acc;
+    },
+    {} as Record<string, boolean>,
+  );
 
   const form = useAppForm({
     ...softwarePatternsFormOptions,
-    defaultValues: {
-      selectedPatterns: initialSelection,
-    },
-    onSubmit: async ({ value: formValues }) => {
-      const initiallySelected = new Set(initialSelection);
-      const currentlySelected = new Set(formValues.selectedPatterns);
-      const preselected = new Set(patterns.filter((p) => p.preselected).map((p) => p.name));
+    defaultValues: initialValues,
+    onSubmit: async ({ value: formValues, formApi }) => {
+      // Add: selected patterns that user touched OR were already USER-selected
+      const add = patterns
+        .filter((p) => {
+          const isSelected = formValues[p.name];
+          if (!isSelected) return false;
 
-      // All currently selected patterns (API expects full list, not delta)
-      const add = formValues.selectedPatterns;
+          const isDirty = formApi.getFieldMeta(p.name)?.isDirty;
+          const wasUserSelected = selection[p.name] === SelectedBy.USER;
 
-      // Patterns to remove: unchecked patterns that were previously selected, preselected, or explicitly removed
+          // Add if user touched it OR it was already USER-selected
+          return isDirty || wasUserSelected;
+        })
+        .map((p) => p.name);
+
+      // Remove: unchecked patterns that were previously selected, preselected, or explicitly removed
       const remove = patterns
         .filter((p) => {
-          if (currentlySelected.has(p.name)) return false;
+          const isSelected = formValues[p.name];
+          if (isSelected) return false;
 
-          const wasInitiallySelected = initiallySelected.has(p.name);
-          const wasPreselected = preselected.has(p.name);
+          const wasInitiallySelected = initialValues[p.name];
           const wasExplicitlyRemoved = selection[p.name] === SelectedBy.REMOVED;
 
-          return wasInitiallySelected || wasPreselected || wasExplicitlyRemoved;
+          return wasInitiallySelected || p.preselected || wasExplicitlyRemoved;
         })
         .map((p) => p.name);
 
@@ -134,63 +142,59 @@ function SoftwarePatternsSelection() {
               resultsCount={visiblePatterns.length}
             />
             <Page.Section title="Patterns">
-              <form.Subscribe selector={(s) => s.values.selectedPatterns}>
-                {(selectedPatterns) => {
-                  const selectedSet = new Set(selectedPatterns);
-                  const selector = sortGroupNames(groups).map((groupName) => (
-                    <section key={groupName}>
-                      <Content component="h3">{groupName}</Content>
-                      <DataList isCompact aria-label={groupName}>
-                        {groups[groupName].map((option) => {
-                          const titleId = `${option.name}-title`;
-                          const descId = `${option.name}-desc`;
-                          const selected = selectedSet.has(option.name);
-                          const nextActionId = `${option.name}-next-action`;
+              <Stack hasGutter>
+                {sortGroupNames(groups).map((groupName) => (
+                  <section key={groupName}>
+                    <Content component="h3">{groupName}</Content>
+                    <DataList isCompact aria-label={groupName}>
+                      {groups[groupName].map((option) => {
+                        const titleId = `${option.name}-title`;
+                        const descId = `${option.name}-desc`;
+                        const nextActionId = `${option.name}-next-action`;
 
-                          return (
-                            <DataListItem key={option.name}>
-                              <DataListItemRow>
-                                <DataListCheck
-                                  onChange={(_, value) => {
-                                    const updated = value
-                                      ? [...selectedPatterns, option.name]
-                                      : selectedPatterns.filter((name) => name !== option.name);
-                                    form.setFieldValue("selectedPatterns", updated);
-                                  }}
-                                  aria-labelledby={[nextActionId, titleId].join(" ")}
-                                  isChecked={selected}
-                                />
-                                <DataListItemCells
-                                  dataListCells={[
-                                    <DataListCell key="summary">
-                                      <Stack hasGutter>
-                                        <div>
-                                          <b id={titleId}>{option.summary}</b>{" "}
-                                          {selection[option.name] === SelectedBy.AUTO && (
-                                            <Label color="blue" isCompact>
-                                              {_("auto selected")}
-                                            </Label>
-                                          )}
-                                          <span id={nextActionId} className={a11yStyles.hidden}>
-                                            {selected ? _("Unselect") : _("Select")}
-                                          </span>
-                                        </div>
-                                        <div id={descId}>{option.description}</div>
-                                      </Stack>
-                                    </DataListCell>,
-                                  ]}
-                                />
-                              </DataListItemRow>
-                            </DataListItem>
-                          );
-                        })}
-                      </DataList>
-                    </section>
-                  ));
-
-                  return selector.length > 0 ? <Stack hasGutter>{selector}</Stack> : <NoMatches />;
-                }}
-              </form.Subscribe>
+                        return (
+                          <DataListItem key={option.name}>
+                            <form.Subscribe selector={(s) => s.values[option.name]}>
+                              {(selected) => (
+                                <DataListItemRow>
+                                  <DataListCheck
+                                    onChange={(_, value) => {
+                                      form.setFieldValue(option.name, value);
+                                    }}
+                                    aria-labelledby={[nextActionId, titleId].join(" ")}
+                                    isChecked={selected}
+                                  />
+                                  <DataListItemCells
+                                    dataListCells={[
+                                      <DataListCell key="summary">
+                                        <Stack hasGutter>
+                                          <div>
+                                            <b id={titleId}>{option.summary}</b>{" "}
+                                            {selection[option.name] === SelectedBy.AUTO && (
+                                              <Label color="blue" isCompact>
+                                                {_("auto selected")}
+                                              </Label>
+                                            )}
+                                            <span id={nextActionId} className={a11yStyles.hidden}>
+                                              {selected ? _("Unselect") : _("Select")}
+                                            </span>
+                                          </div>
+                                          <div id={descId}>{option.description}</div>
+                                        </Stack>
+                                      </DataListCell>,
+                                    ]}
+                                  />
+                                </DataListItemRow>
+                              )}
+                            </form.Subscribe>
+                          </DataListItem>
+                        );
+                      })}
+                    </DataList>
+                  </section>
+                ))}
+              </Stack>
+              {visiblePatterns.length === 0 && <NoMatches />}
             </Page.Section>
 
             <ActionGroup>

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -32,7 +32,11 @@ import {
   SearchInput,
   Stack,
   Content,
+  ActionGroup,
+  Form,
 } from "@patternfly/react-core";
+import { formOptions } from "@tanstack/react-form";
+import { useNavigate } from "react-router";
 import { Page } from "~/components/core";
 import { _ } from "~/i18n";
 import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
@@ -42,11 +46,21 @@ import { SelectedBy } from "~/model/proposal/software";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { patchConfig } from "~/api";
 import { SOFTWARE } from "~/routes/paths";
+import { useAppForm } from "~/hooks/form";
 
 /**
  * PatternGroups mapping "group name" => list of patterns
  */
 type PatternsGroups = { [key: string]: Pattern[] };
+
+/**
+ * Form options for pattern selection.
+ */
+const softwarePatternsFormOptions = formOptions({
+  defaultValues: {
+    selectedPatterns: [] as string[],
+  },
+});
 
 /**
  * Group the patterns with the same group name
@@ -106,37 +120,43 @@ const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the f
  * Pattern selector component
  */
 function SoftwarePatternsSelection(): React.ReactNode {
+  const navigate = useNavigate();
   const { patterns } = useSystem();
   const proposal = useProposal();
   const selection = proposal?.patterns || [];
   const [searchValue, setSearchValue] = useState("");
 
-  const onToggle = (name: string, selected: boolean) => {
-    const add = patterns
-      .filter((p) => selection[p.name] === SelectedBy.USER && p.name !== name)
-      .map((p) => p.name);
-    const remove = patterns
-      .filter((p) => selection[p.name] === SelectedBy.REMOVED && p.name !== name)
-      .map((p) => p.name);
+  // Extract initially selected patterns (USER or AUTO)
+  const initialSelection = patterns
+    .filter((p) => [SelectedBy.USER, SelectedBy.AUTO].includes(selection[p.name]))
+    .map((p) => p.name);
 
-    if (selected) {
-      add.push(name);
-    } else {
-      // add the pattern to the "remove" list only if it was autoselected by dependencies, otherwise
-      // it was selected by user and it is enough to remove it from the "add" list above
-      // with exception of product preselected pattern which also needs to be added
-      const preselected = patterns.find((p) => p.name === name && p.preselected);
+  const form = useAppForm({
+    ...softwarePatternsFormOptions,
+    defaultValues: {
+      selectedPatterns: initialSelection,
+    },
+    onSubmit: async ({ value: formValues }) => {
+      const selectedSet = new Set(formValues.selectedPatterns);
 
-      if (selection[name] === SelectedBy.AUTO || preselected) {
-        remove.push(name);
-      }
-    }
+      // All selected patterns become USER-selected
+      const add = formValues.selectedPatterns;
 
-    patchConfig({ software: { patterns: { add, remove } } });
-  };
+      // Patterns that were previously selected (AUTO or USER) or preselected but now unchecked
+      const remove = patterns
+        .filter((p) => {
+          const wasSelected = [SelectedBy.USER, SelectedBy.AUTO].includes(selection[p.name]);
+          const isPreselected = p.preselected;
+          const isNowUnselected = !selectedSet.has(p.name);
 
-  // FIXME: use loading indicator when busy, we cannot know if it will be
-  // quickly or not in advance.
+          return isNowUnselected && (wasSelected || isPreselected);
+        })
+        .map((p) => p.name);
+
+      await patchConfig({ software: { patterns: { add, remove } } });
+      navigate(SOFTWARE.root);
+    },
+  });
 
   // initial empty screen, the patterns are loaded very quickly, no need for any progress
   const visiblePatterns = filterPatterns(patterns, searchValue);
@@ -144,84 +164,95 @@ function SoftwarePatternsSelection(): React.ReactNode {
 
   const groups = groupPatterns(visiblePatterns);
 
-  // FIXME: use a switch instead of a checkbox since these patterns are going to
-  // be selected/deselected immediately.
-  // TODO: extract to a DataListSelector component or so.
-  const selector = sortGroups(groups).map((groupName) => {
-    const selectedIds = groups[groupName]
-      .filter((p) => [SelectedBy.USER, SelectedBy.AUTO].includes(selection[p.name]))
-      .map((p) => p.name);
-
-    return (
-      <section key={groupName}>
-        <Content component="h3">{groupName}</Content>
-        <DataList isCompact aria-label={groupName}>
-          {groups[groupName].map((option) => {
-            const titleId = `${option.name}-title`;
-            const descId = `${option.name}-desc`;
-            const selected = selectedIds.includes(option.name);
-            const nextActionId = `${option.name}-next-action`;
-
-            return (
-              <DataListItem key={option.name}>
-                <DataListItemRow>
-                  <DataListCheck
-                    onChange={(_, value) => onToggle(option.name, value)}
-                    aria-labelledby={[nextActionId, titleId].join(" ")}
-                    isChecked={selected}
-                  />
-                  <DataListItemCells
-                    dataListCells={[
-                      <DataListCell key="summary">
-                        <Stack hasGutter>
-                          <div>
-                            <b id={titleId}>{option.summary}</b>{" "}
-                            {selection[option.name] === SelectedBy.AUTO && (
-                              <Label color="blue" isCompact>
-                                {_("auto selected")}
-                              </Label>
-                            )}
-                            <span id={nextActionId} className={a11yStyles.hidden}>
-                              {selected ? _("Unselect") : _("Select")}
-                            </span>
-                          </div>
-                          <div id={descId}>{option.description}</div>
-                        </Stack>
-                      </DataListCell>,
-                    ]}
-                  />
-                </DataListItemRow>
-              </DataListItem>
-            );
-          })}
-        </DataList>
-      </section>
-    );
-  });
-
   return (
     <Page
       breadcrumbs={[{ label: _("Software"), path: SOFTWARE.root }, { label: "Patterns selection" }]}
       progress={{ scope: "software" }}
     >
       <Page.Content>
-        <SearchInput
-          // TRANSLATORS: search field placeholder text
-          placeholder={_("Filter by pattern title or description")}
-          aria-label={_("Filter by pattern title or description")}
-          value={searchValue}
-          onChange={(_event, value) => setSearchValue(value)}
-          onClear={() => setSearchValue("")}
-          resultsCount={visiblePatterns.length}
-        />
-        <Page.Section title="Patterns">
-          {selector.length > 0 ? <Stack hasGutter>{selector}</Stack> : <NoMatches />}
-        </Page.Section>
-      </Page.Content>
+        <form.AppForm>
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              form.handleSubmit();
+            }}
+          >
+            <SearchInput
+              // TRANSLATORS: search field placeholder text
+              placeholder={_("Filter by pattern title or description")}
+              aria-label={_("Filter by pattern title or description")}
+              value={searchValue}
+              onChange={(_event, value) => setSearchValue(value)}
+              onClear={() => setSearchValue("")}
+              resultsCount={visiblePatterns.length}
+            />
+            <Page.Section title="Patterns">
+              <form.Subscribe selector={(s) => s.values.selectedPatterns}>
+                {(selectedPatterns) => {
+                  const selectedSet = new Set(selectedPatterns);
+                  const selector = sortGroups(groups).map((groupName) => (
+                    <section key={groupName}>
+                      <Content component="h3">{groupName}</Content>
+                      <DataList isCompact aria-label={groupName}>
+                        {groups[groupName].map((option) => {
+                          const titleId = `${option.name}-title`;
+                          const descId = `${option.name}-desc`;
+                          const selected = selectedSet.has(option.name);
+                          const nextActionId = `${option.name}-next-action`;
 
-      <Page.Actions>
-        <Page.Cancel variant="secondary">{_("Close")}</Page.Cancel>
-      </Page.Actions>
+                          return (
+                            <DataListItem key={option.name}>
+                              <DataListItemRow>
+                                <DataListCheck
+                                  onChange={(_, value) => {
+                                    const updated = value
+                                      ? [...selectedPatterns, option.name]
+                                      : selectedPatterns.filter((name) => name !== option.name);
+                                    form.setFieldValue("selectedPatterns", updated);
+                                  }}
+                                  aria-labelledby={[nextActionId, titleId].join(" ")}
+                                  isChecked={selected}
+                                />
+                                <DataListItemCells
+                                  dataListCells={[
+                                    <DataListCell key="summary">
+                                      <Stack hasGutter>
+                                        <div>
+                                          <b id={titleId}>{option.summary}</b>{" "}
+                                          {selection[option.name] === SelectedBy.AUTO && (
+                                            <Label color="blue" isCompact>
+                                              {_("auto selected")}
+                                            </Label>
+                                          )}
+                                          <span id={nextActionId} className={a11yStyles.hidden}>
+                                            {selected ? _("Unselect") : _("Select")}
+                                          </span>
+                                        </div>
+                                        <div id={descId}>{option.description}</div>
+                                      </Stack>
+                                    </DataListCell>,
+                                  ]}
+                                />
+                              </DataListItemRow>
+                            </DataListItem>
+                          );
+                        })}
+                      </DataList>
+                    </section>
+                  ));
+
+                  return selector.length > 0 ? <Stack hasGutter>{selector}</Stack> : <NoMatches />;
+                }}
+              </form.Subscribe>
+            </Page.Section>
+
+            <ActionGroup>
+              <form.SubmitButton />
+              <form.CancelButton />
+            </ActionGroup>
+          </Form>
+        </form.AppForm>
+      </Page.Content>
     </Page>
   );
 }

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -81,6 +81,12 @@ function SoftwarePatternsSelection() {
     ...softwarePatternsFormOptions,
     defaultValues: initialValues,
     onSubmit: async ({ value: formValues, formApi }) => {
+      // Skip API call if form is pristine (nothing changed)
+      if (!formApi.state.isDirty) {
+        navigate(SOFTWARE.root);
+        return;
+      }
+
       // Add: selected patterns that user touched OR were already USER-selected
       const add = patterns
         .filter((p) => {

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -45,7 +45,7 @@ import { SelectedBy } from "~/model/proposal/software";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { patchConfig } from "~/api";
 import { SOFTWARE } from "~/routes/paths";
-import { useAppForm } from "~/hooks/form";
+import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
 
 /**
@@ -77,16 +77,10 @@ function SoftwarePatternsSelection() {
     {} as Record<string, boolean>,
   );
 
-  const form = useAppForm({
+  const form = usePristineSafeForm({
     ...softwarePatternsFormOptions,
     defaultValues: initialValues,
     onSubmit: async ({ value: formValues, formApi }) => {
-      // Skip API call if form is pristine (nothing changed)
-      if (!formApi.state.isDirty) {
-        navigate(SOFTWARE.root);
-        return;
-      }
-
       // Add: selected patterns that user touched OR were already USER-selected
       const add = patterns
         .filter((p) => {
@@ -115,8 +109,8 @@ function SoftwarePatternsSelection() {
         .map((p) => p.name);
 
       await patchConfig({ software: { patterns: { add, remove } } });
-      navigate(SOFTWARE.root);
     },
+    onSubmitComplete: () => navigate(SOFTWARE.root),
   });
 
   // initial empty screen, the patterns are loaded very quickly, no need for any progress

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -41,17 +41,12 @@ import { Page } from "~/components/core";
 import { _ } from "~/i18n";
 import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 import { useSystem } from "~/hooks/model/system/software";
-import { Pattern } from "~/model/system/software";
 import { SelectedBy } from "~/model/proposal/software";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { patchConfig } from "~/api";
 import { SOFTWARE } from "~/routes/paths";
 import { useAppForm } from "~/hooks/form";
-
-/**
- * PatternGroups mapping "group name" => list of patterns
- */
-type PatternsGroups = { [key: string]: Pattern[] };
+import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
 
 /**
  * Form options for pattern selection.
@@ -62,58 +57,6 @@ const softwarePatternsFormOptions = formOptions({
   },
 });
 
-/**
- * Group the patterns with the same group name
- */
-function groupPatterns(patterns: Pattern[]): PatternsGroups {
-  const groups = {};
-
-  patterns.forEach((pattern) => {
-    if (groups[pattern.category]) {
-      groups[pattern.category].push(pattern);
-    } else {
-      groups[pattern.category] = [pattern];
-    }
-  });
-
-  // sort patterns by the "order" value
-  Object.keys(groups).forEach((group) => {
-    groups[group].sort((p1, p2) => {
-      if (p1.order === p2.order) {
-        // there should be no patterns with the same name
-        return p1.name < p2.name ? -1 : 1;
-      } else {
-        return p1.order - p2.order;
-      }
-    });
-  });
-
-  return groups;
-}
-
-/**
- * Sort pattern group names
- */
-function sortGroups(groups: PatternsGroups): string[] {
-  return Object.keys(groups).sort((g1, g2) => {
-    const order1 = groups[g1][0].order;
-    const order2 = groups[g2][0].order;
-    return order1 - order2;
-  });
-}
-
-const filterPatterns = (patterns: Pattern[] = [], searchValue = ""): Pattern[] => {
-  if (searchValue.trim() === "") return patterns;
-
-  // case insensitive search
-  const searchData = searchValue.toUpperCase();
-  return patterns.filter(
-    (p) =>
-      p.name.toUpperCase().indexOf(searchData) !== -1 ||
-      p.description.toUpperCase().indexOf(searchData) !== -1,
-  );
-};
-
 const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the filter.")}</b>;
 
 /**
@@ -123,12 +66,12 @@ function SoftwarePatternsSelection(): React.ReactNode {
   const navigate = useNavigate();
   const { patterns } = useSystem();
   const proposal = useProposal();
-  const selection = proposal?.patterns || [];
+  const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
 
   // Extract initially selected patterns (USER or AUTO)
   const initialSelection = patterns
-    .filter((p) => [SelectedBy.USER, SelectedBy.AUTO].includes(selection[p.name]))
+    .filter((p) => isPatternSelected(selection, p.name))
     .map((p) => p.name);
 
   const form = useAppForm({
@@ -145,11 +88,10 @@ function SoftwarePatternsSelection(): React.ReactNode {
       // Patterns that were previously selected (AUTO or USER) or preselected but now unchecked
       const remove = patterns
         .filter((p) => {
-          const wasSelected = [SelectedBy.USER, SelectedBy.AUTO].includes(selection[p.name]);
-          const isPreselected = p.preselected;
+          const wasSelected = isPatternSelected(selection, p.name);
           const isNowUnselected = !selectedSet.has(p.name);
 
-          return isNowUnselected && (wasSelected || isPreselected);
+          return isNowUnselected && (wasSelected || p.preselected);
         })
         .map((p) => p.name);
 
@@ -190,7 +132,7 @@ function SoftwarePatternsSelection(): React.ReactNode {
               <form.Subscribe selector={(s) => s.values.selectedPatterns}>
                 {(selectedPatterns) => {
                   const selectedSet = new Set(selectedPatterns);
-                  const selector = sortGroups(groups).map((groupName) => (
+                  const selector = sortGroupNames(groups).map((groupName) => (
                     <section key={groupName}>
                       <Content component="h3">{groupName}</Content>
                       <DataList isCompact aria-label={groupName}>

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -62,7 +62,7 @@ const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the f
 /**
  * Pattern selector component
  */
-function SoftwarePatternsSelection(): React.ReactNode {
+function SoftwarePatternsSelection() {
   const navigate = useNavigate();
   const { patterns } = useSystem();
   const proposal = useProposal();
@@ -80,18 +80,23 @@ function SoftwarePatternsSelection(): React.ReactNode {
       selectedPatterns: initialSelection,
     },
     onSubmit: async ({ value: formValues }) => {
-      const selectedSet = new Set(formValues.selectedPatterns);
+      const initiallySelected = new Set(initialSelection);
+      const currentlySelected = new Set(formValues.selectedPatterns);
+      const preselected = new Set(patterns.filter((p) => p.preselected).map((p) => p.name));
 
-      // All selected patterns become USER-selected
+      // All currently selected patterns (API expects full list, not delta)
       const add = formValues.selectedPatterns;
 
-      // Patterns that were previously selected (AUTO or USER) or preselected but now unchecked
+      // Patterns to remove: unchecked patterns that were previously selected, preselected, or explicitly removed
       const remove = patterns
         .filter((p) => {
-          const wasSelected = isPatternSelected(selection, p.name);
-          const isNowUnselected = !selectedSet.has(p.name);
+          if (currentlySelected.has(p.name)) return false;
 
-          return isNowUnselected && (wasSelected || p.preselected);
+          const wasInitiallySelected = initiallySelected.has(p.name);
+          const wasPreselected = preselected.has(p.name);
+          const wasExplicitlyRemoved = selection[p.name] === SelectedBy.REMOVED;
+
+          return wasInitiallySelected || wasPreselected || wasExplicitlyRemoved;
         })
         .map((p) => p.name);
 

--- a/web/src/hooks/form.test.tsx
+++ b/web/src/hooks/form.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender } from "~/test-utils";
+import { usePristineSafeForm } from "./form";
+
+// Dummy form component for testing usePristineSafeForm behavior
+function TestForm({
+  onSubmitAsync = jest.fn(),
+  onSubmit = jest.fn(),
+  onSubmitComplete = jest.fn(),
+}) {
+  const form = usePristineSafeForm({
+    defaultValues: { name: "", email: "" },
+    validators: {
+      onSubmitAsync: async ({ value }) => {
+        onSubmitAsync(value);
+      },
+    },
+    onSubmit: async ({ value }) => {
+      onSubmit(value);
+    },
+    onSubmitComplete,
+  });
+
+  return (
+    <form.AppForm>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          form.handleSubmit();
+        }}
+      >
+        <form.Field name="name">
+          {(field) => (
+            <label>
+              Name
+              <input
+                value={field.state.value as string}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+            </label>
+          )}
+        </form.Field>
+        <button type="submit">Submit</button>
+      </form>
+    </form.AppForm>
+  );
+}
+
+describe("usePristineSafeForm", () => {
+  it("skips validation and onSubmit when form is pristine, but calls onSubmitComplete", async () => {
+    const onSubmitAsync = jest.fn();
+    const onSubmit = jest.fn();
+    const onSubmitComplete = jest.fn();
+
+    const { user } = installerRender(
+      <TestForm
+        onSubmitAsync={onSubmitAsync}
+        onSubmit={onSubmit}
+        onSubmitComplete={onSubmitComplete}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", { name: "Submit" });
+    await user.click(submitButton);
+
+    expect(onSubmitAsync).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onSubmitComplete).toHaveBeenCalled();
+  });
+
+  it("calls validation, onSubmit, and onSubmitComplete when form is dirty", async () => {
+    const onSubmitAsync = jest.fn();
+    const onSubmit = jest.fn();
+    const onSubmitComplete = jest.fn();
+
+    const { user } = installerRender(
+      <TestForm
+        onSubmitAsync={onSubmitAsync}
+        onSubmit={onSubmit}
+        onSubmitComplete={onSubmitComplete}
+      />,
+    );
+
+    const nameInput = screen.getByRole("textbox", { name: "Name" });
+    await user.type(nameInput, "John");
+
+    const submitButton = screen.getByRole("button", { name: "Submit" });
+    await user.click(submitButton);
+
+    expect(onSubmitAsync).toHaveBeenCalledWith({ name: "John", email: "" });
+    expect(onSubmit).toHaveBeenCalledWith({ name: "John", email: "" });
+    expect(onSubmitComplete).toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/form.ts
+++ b/web/src/hooks/form.ts
@@ -47,6 +47,58 @@ const { useAppForm, withForm } = createFormHook({
 });
 
 /**
+ * Form hook built on top of useAppForm that skips business logic when pristine.
+ *
+ * Optimizes form submission by checking if the form has changes before executing
+ * validation and business logic. Always executes onSubmitComplete regardless of
+ * pristine state, making it ideal for forms that need guaranteed completion logic
+ * (e.g., navigation, cleanup, modal dismissal).
+ *
+ * Behavior:
+ * - When pristine: skips validators.onSubmitAsync and onSubmit business logic
+ * - When dirty: executes all validators and handlers normally
+ * - Always: executes onSubmitComplete
+ *
+ * Use this pattern to separate concerns:
+ * - validators.onSubmitAsync: validation logic (skipped when pristine)
+ * - onSubmit: business logic like data persistence (skipped when pristine)
+ * - onSubmitComplete: completion logic like navigation (always executed)
+ *
+ * @example
+ * const form = usePristineSafeForm({
+ *   defaultValues: { patterns: {} },
+ *   validators: {
+ *     onSubmitAsync: async ({ value }) => validatePatterns(value),
+ *   },
+ *   onSubmit: async ({ value }) => {
+ *     await patchConfig(value);
+ *   },
+ *   onSubmitComplete: () => navigate(SOFTWARE.root),
+ * });
+ */
+function usePristineSafeForm(options) {
+  const { validators, onSubmit, onSubmitComplete, ...rest } = options;
+
+  return useAppForm({
+    ...rest,
+    validators: {
+      ...validators,
+      onSubmitAsync: async (ctx) => {
+        if (ctx.formApi.state.isDirty) {
+          return validators?.onSubmitAsync?.(ctx);
+        }
+      },
+    },
+    onSubmit: async (ctx) => {
+      if (ctx.formApi.state.isDirty) {
+        await onSubmit?.(ctx);
+      }
+      onSubmitComplete?.();
+    },
+  });
+}
+
+/**
  * Merges runtime-derived values into a `formOptions` object's `defaultValues`.
  *
  * Use this when some defaults depend on runtime data (e.g. values from a hook)
@@ -70,4 +122,11 @@ function mergeFormDefaults<T extends { defaultValues: Record<string, unknown> }>
   return { ...opts, defaultValues: { ...opts.defaultValues, ...runtimeDefaults } };
 }
 
-export { useAppForm, withForm, mergeFormDefaults, useFieldContext, useFormContext };
+export {
+  useAppForm,
+  usePristineSafeForm,
+  withForm,
+  mergeFormDefaults,
+  useFieldContext,
+  useFormContext,
+};

--- a/web/src/hooks/form.ts
+++ b/web/src/hooks/form.ts
@@ -47,6 +47,26 @@ const { useAppForm, withForm } = createFormHook({
 });
 
 /**
+ * Options accepted by useAppForm, derived via `Parameters` to stay in sync with
+ * TanStack Form's API automatically.
+ */
+type AppFormOptions = Parameters<typeof useAppForm>[0];
+
+/**
+ * Specific options for {@link usePristineSafeForm}, not part of useAppForm.
+ */
+type PristineSafeFormOwnOptions = {
+  /** Called after every submission, whether the form was dirty or pristine. */
+  onSubmitComplete?: () => void;
+};
+
+/**
+ * Options accepted by {@link usePristineSafeForm}, built on top of
+ * {@link AppFormOptions} and {@link PristineSafeFormOwnOptions}.
+ */
+type PristineSafeFormOptions = AppFormOptions & PristineSafeFormOwnOptions;
+
+/**
  * Form hook built on top of useAppForm that skips business logic when pristine.
  *
  * Optimizes form submission by checking if the form has changes before executing
@@ -64,6 +84,20 @@ const { useAppForm, withForm } = createFormHook({
  * - onSubmit: business logic like data persistence (skipped when pristine)
  * - onSubmitComplete: completion logic like navigation (always executed)
  *
+ * TypeScript does not support exact object types natively (see link below).
+ * Because this hook destructures known keys and forwards the rest to useAppForm
+ * via `...rest`, unknown properties would be silently passed through to
+ * useAppForm without complaint, potentially causing subtle bugs. A plain `T
+ * extends PristineSafeFormOptions` would not catch this: TypeScript infers T
+ * from the call site and includes the extra keys in T's shape. The intersection
+ * with `Record<Exclude<keyof T, keyof PristineSafeFormOptions>, never>` forces
+ * any key in T not present in PristineSafeFormOptions to be typed as `never`.
+ * Passing an unknown property then produces a type error ("Type X is not
+ * assignable to type never"), while keeping T generic ensures the return type
+ * is fully inferred from the options passed in.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/12936
+ *
  * @example
  * const form = usePristineSafeForm({
  *   defaultValues: { patterns: {} },
@@ -76,16 +110,20 @@ const { useAppForm, withForm } = createFormHook({
  *   onSubmitComplete: () => navigate(SOFTWARE.root),
  * });
  */
-function usePristineSafeForm(options) {
-  const { validators, onSubmit, onSubmitComplete, ...rest } = options;
+function usePristineSafeForm<T extends PristineSafeFormOptions>(
+  options: T & Record<Exclude<keyof T, keyof PristineSafeFormOptions>, never>,
+) {
+  const { onSubmitComplete, ...useAppFormOptions } = options as PristineSafeFormOptions;
+  const { validators, onSubmit, ...rest } = useAppFormOptions as AppFormOptions;
 
   return useAppForm({
     ...rest,
     validators: {
       ...validators,
       onSubmitAsync: async (ctx) => {
-        if (ctx.formApi.state.isDirty) {
-          return validators?.onSubmitAsync?.(ctx);
+        const { onSubmitAsync } = validators ?? {};
+        if (ctx.formApi.state.isDirty && typeof onSubmitAsync === "function") {
+          return onSubmitAsync(ctx);
         }
       },
     },

--- a/web/src/utils/software.test.ts
+++ b/web/src/utils/software.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import type { Pattern } from "~/model/system/software";
+import type { PatternsSelection } from "~/model/proposal/software";
+import { SelectedBy } from "~/model/proposal/software";
+import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "./software";
+
+describe("groupPatterns", () => {
+  const patterns: Pattern[] = [
+    {
+      name: "pattern1",
+      category: "Base",
+      summary: "Pattern 1",
+      description: "Description 1",
+      order: 2,
+      icon: "icon1",
+      preselected: false,
+    },
+    {
+      name: "pattern2",
+      category: "Desktop",
+      summary: "Pattern 2",
+      description: "Description 2",
+      order: 1,
+      icon: "icon2",
+      preselected: false,
+    },
+    {
+      name: "pattern3",
+      category: "Base",
+      summary: "Pattern 3",
+      description: "Description 3",
+      order: 2,
+      icon: "icon3",
+      preselected: false,
+    },
+    {
+      name: "pattern4",
+      category: "Base",
+      summary: "Pattern 4",
+      description: "Description 4",
+      order: 1,
+      icon: "icon4",
+      preselected: false,
+    },
+  ];
+
+  it("groups patterns by category", () => {
+    const result = groupPatterns(patterns);
+
+    expect(Object.keys(result)).toEqual(expect.arrayContaining(["Base", "Desktop"]));
+    expect(result.Base).toHaveLength(3);
+    expect(result.Desktop).toHaveLength(1);
+  });
+
+  it("sorts patterns within each group by order, then by name", () => {
+    const result = groupPatterns(patterns);
+
+    expect(result.Base[0].name).toBe("pattern4");
+    expect(result.Base[1].name).toBe("pattern1");
+    expect(result.Base[2].name).toBe("pattern3");
+  });
+});
+
+describe("sortGroupNames", () => {
+  it("sorts group names based on the order of their first pattern", () => {
+    const groups = {
+      Desktop: [{ order: 10 } as Pattern],
+      Base: [{ order: 5 } as Pattern],
+      Server: [{ order: 15 } as Pattern],
+    };
+
+    const result = sortGroupNames(groups);
+
+    expect(result).toEqual(["Base", "Desktop", "Server"]);
+  });
+});
+
+describe("filterPatterns", () => {
+  const patterns: Pattern[] = [
+    {
+      name: "multimedia",
+      category: "Desktop",
+      summary: "Multimedia",
+      description: "Audio and video tools",
+      order: 1,
+      icon: "icon1",
+      preselected: false,
+    },
+    {
+      name: "office",
+      category: "Desktop",
+      summary: "Office Software",
+      description: "Productivity applications",
+      order: 2,
+      icon: "icon2",
+      preselected: false,
+    },
+    {
+      name: "development",
+      category: "Base",
+      summary: "Development Tools",
+      description: "Compilers and multimedia libraries",
+      order: 3,
+      icon: "icon3",
+      preselected: false,
+    },
+  ];
+
+  it("returns all patterns when search value is empty", () => {
+    expect(filterPatterns(patterns, "")).toEqual(patterns);
+    expect(filterPatterns(patterns, "   ")).toEqual(patterns);
+  });
+
+  it("filters patterns by name (case-insensitive)", () => {
+    const result = filterPatterns(patterns, "office");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("office");
+  });
+
+  it("filters patterns by description (case-insensitive)", () => {
+    const result = filterPatterns(patterns, "multimedia");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.name)).toEqual(
+      expect.arrayContaining(["multimedia", "development"]),
+    );
+  });
+
+  it("performs case-insensitive search", () => {
+    const result = filterPatterns(patterns, "OFFICE");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("office");
+  });
+
+  it("returns empty array when no patterns match", () => {
+    const result = filterPatterns(patterns, "nonexistent");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("isPatternSelected", () => {
+  const selection: PatternsSelection = {
+    pattern1: SelectedBy.USER,
+    pattern2: SelectedBy.AUTO,
+    pattern3: SelectedBy.NONE,
+    pattern4: SelectedBy.REMOVED,
+  };
+
+  it("returns true for USER-selected patterns", () => {
+    expect(isPatternSelected(selection, "pattern1")).toBe(true);
+  });
+
+  it("returns true for AUTO-selected patterns", () => {
+    expect(isPatternSelected(selection, "pattern2")).toBe(true);
+  });
+
+  it("returns false for NONE patterns", () => {
+    expect(isPatternSelected(selection, "pattern3")).toBe(false);
+  });
+
+  it("returns false for REMOVED patterns", () => {
+    expect(isPatternSelected(selection, "pattern4")).toBe(false);
+  });
+
+  it("returns false for unknown patterns", () => {
+    expect(isPatternSelected(selection, "unknown")).toBe(false);
+  });
+});

--- a/web/src/utils/software.ts
+++ b/web/src/utils/software.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { group, sort } from "radashi";
+import type { Pattern } from "~/model/system/software";
+import type { PatternsSelection } from "~/model/proposal/software";
+import { SelectedBy } from "~/model/proposal/software";
+
+/**
+ * PatternGroups mapping "group name" => list of patterns
+ */
+export type PatternsGroups = { [key: string]: Pattern[] };
+
+/**
+ * Groups patterns by category and sorts them by order within each group.
+ *
+ * @param patterns - Array of patterns to group
+ * @returns Object mapping category names to sorted pattern arrays
+ */
+export function groupPatterns(patterns: Pattern[]): PatternsGroups {
+  const groups = group(patterns, (p) => p.category);
+
+  // Sort patterns within each group by order, then by name
+  Object.keys(groups).forEach((category) => {
+    groups[category].sort((p1, p2) => {
+      if (p1.order !== p2.order) return p1.order - p2.order;
+      return p1.name.localeCompare(p2.name);
+    });
+  });
+
+  return groups;
+}
+
+/**
+ * Sorts group names based on the order of their first pattern.
+ *
+ * @param groups - Pattern groups to sort
+ * @returns Array of sorted group names
+ */
+export function sortGroupNames(groups: PatternsGroups): string[] {
+  return sort(Object.keys(groups), (groupName) => groups[groupName][0].order);
+}
+
+/**
+ * Filters patterns by search value (case-insensitive).
+ * Searches in both pattern name and description.
+ *
+ * @param patterns - Array of patterns to filter
+ * @param searchValue - Search string to filter by
+ * @returns Filtered array of patterns
+ */
+export function filterPatterns(patterns: Pattern[], searchValue = ""): Pattern[] {
+  if (searchValue.trim() === "") return patterns;
+
+  const searchData = searchValue.toUpperCase();
+  return patterns.filter(
+    (p) =>
+      p.name.toUpperCase().includes(searchData) || p.description.toUpperCase().includes(searchData),
+  );
+}
+
+/**
+ * Checks if a pattern is selected (either by USER or AUTO).
+ *
+ * @param selection - Pattern selection state
+ * @param patternName - Name of the pattern to check
+ * @returns True if the pattern is selected by USER or AUTO
+ */
+export function isPatternSelected(selection: PatternsSelection, patternName: string): boolean {
+  return [SelectedBy.USER, SelectedBy.AUTO].includes(selection[patternName]);
+}


### PR DESCRIPTION
## Summary
This PR transforms `SoftwarePatternsSelection` from a **page of checkboxes** into a **real, declarative form driven by TanStack Form**, making it consistent with how other areas of the app manage settings. Users can now interact with multiple patterns and submit changes explicitly with **Accept** or discard them with **Cancel**, rather than triggering backend updates on every toggle.

This is the first step in a broader **Software area revamp**, laying the foundation for future improvements in UX consistency and visibility of selected patterns.

Key benefits:
- **Consistent UX**: Behaves like other forms, avoiding surprises and making interaction predictable.
- **Reliable submission**: Only patterns that users actually touched are included in the backend update.
- **Maintainable code**: TanStack Form simplifies state management, validation, and submission logic.


## Why
Before this change, the software patterns selection was a list of checkboxes acting like switches: **every toggle immediately called the backend**, triggering a software progress overlay and **blocking user interaction until the request completed**. This made user interaction slow and frustrating.

With this migration:
- Users can make multiple selections and submit once.
- The form tracks which patterns were touched, so only intentional changes are applied.
- The UI now behaves consistently with other forms in the app, supporting proper validation, submission, and completion logic.

Under the hood, each pattern is a separate form field, enabling precise tracking and ensuring correct behavior on save.

## Under the Hood
This PR also brings improvements for developers and the broader Software area:
- **Reusable `usePristineSafeForm` hook**: Detects untouched forms and skips unnecessary business logic, available for other forms across the app.
- **Extracted utilities (`utils/software.ts`)**: Grouping, sorting, filtering, and selection-check helpers are now reusable and testable.
- **Improved test coverage**: Covers form behavior, touched fields, submission logic, and edge cases.
- **Clearer submission logic**: Add/remove operations now compute against initial form state rather than mixing API state and UI state.

Together, these changes make the form **safer, more predictable, and easier to maintain**, while providing tools that will benefit future work in the Software area.

## UX consideration

Before submission, users don’t immediately see which auto-selected patterns resulted from their selections. However, this is not exactly a regression: in the previous form, users might also not have realized some auto-selected patterns were added, especially if they were out of the visible viewport and the user navigated away to the installation summary instead of going back to the software page and been able to realize there were more stuff than they selected.

With the new form, users will be redirected to the main software page, where auto-selected patterns are expected to be _highlighted_ in a future iteration. This improvement is planned as part of the ongoing Software area revamp. Once implemented, the overall experience will be improved and predictable.

## Screencasts

### Before

[screen-recording-2026-04-16T07-59-53.webm](https://github.com/user-attachments/assets/0f1fd774-ed45-4ee8-92d4-4c355b5606c6)

### After


[screen-recording-2026-04-16T08-00-28.webm](https://github.com/user-attachments/assets/b1dca04a-daa1-46df-a012-74912341c489)
