### PR TITLE
Add desktop selection option

### DIFF
--- a/products.d/leap_161.yaml
+++ b/products.d/leap_161.yaml
@@ -53,6 +53,7 @@ translations:
       SUSE Linux Enterprise Server.
     zh_CN: 基于 SUSE Linux Enterprise Server 构建的社区发行版的最新版本。
     zh_TW: 根據最新 SUSE Linux Enterprise Server 打造的最新社群版發行版本。
+desktop_selection: suggested
 software:
   installation_repositories:
     - url: https://download.opensuse.org/distribution/leap/16.1/repo/oss/$basearch

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -167,6 +167,7 @@ translations:
         ru: Неизменяемая система с атомарными обновлениями
         sv: Oföränderligt system med atomiska uppdateringar
         uk: Незмінна система з атомарними оновленнями
+desktop_selection: optional
 software:
   installation_repositories: []
   installation_labels:

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -149,6 +149,7 @@ translations:
         ru: Неизменяемая система с атомарными обновлениями
         sv: Oföränderligt system med atomiska uppdateringar
         uk: Незмінна система з атомарними оновленнями
+desktop_selection: optional
 software:
   installation_repositories: []
   installation_labels:

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -85,6 +85,7 @@ translations:
       之间，旨在让用户无需在“稳定版”和新版软件包之间抉择。
     zh_TW: 一個具實驗性質且稍慢的 openSUSE 滾動發行版本，其更新頻率低於 Tumbleweed、高於 Leap，讓使用者無需在 "穩定性"
       與新套件之間做出選擇。
+desktop_selection: suggested
 software:
   installation_repositories:
     - url: https://download.opensuse.org/slowroll/repo/oss/

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -91,6 +91,7 @@ translations:
     zh_CN: openSUSE 的纯滚动发布版本，持续包含所有最新“稳定”版本的软件，而不依赖于严格的定时发布周期。该版本为追求最新稳定软件的用户而生。
     zh_TW: openSUSE 的純滾動發行版本，包含所有軟體的最新 "穩定"
       版本，而不是依賴於僵化的定期發行週期。這個專案是為了那些希望使用最新穩定軟體的使用者而設計。
+desktop_selection: suggested
 software:
   installation_repositories:
     - url: https://download.opensuse.org/tumbleweed/repo/oss/

--- a/rust/agama-server/src/web/docs/config.rs
+++ b/rust/agama-server/src/web/docs/config.rs
@@ -118,6 +118,7 @@ impl ApiDocBuilder for ConfigApiDocBuilder {
             .schema_from::<agama_utils::api::manager::Product>()
             .schema_from::<agama_utils::api::manager::ProductMode>()
             .schema_from::<agama_utils::api::manager::HardwareInfo>()
+            .schema_from::<agama_utils::api::manager::system_info::DesktopSelection>()
             .schema_from::<agama_locale_data::KeymapId>()
             .schema_from::<agama_locale_data::LocaleId>()
             .schema_from::<agama_locale_data::TimezoneId>()

--- a/rust/agama-utils/src/api/manager.rs
+++ b/rust/agama-utils/src/api/manager.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -21,5 +21,5 @@
 mod license;
 pub use license::{InvalidLanguageCode, LanguageTag, License, LicenseContent};
 
-mod system_info;
+pub mod system_info;
 pub use system_info::{HardwareInfo, Product, ProductMode, SystemInfo};

--- a/rust/agama-utils/src/api/manager/system_info.rs
+++ b/rust/agama-utils/src/api/manager/system_info.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -49,12 +49,23 @@ pub struct Product {
     pub registration: bool,
     /// License ID
     pub license: Option<String>,
+    /// Desktop selection mode
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub desktop_selection: Option<DesktopSelection>,
     /// Translations
     #[serde(skip_serializing_if = "Option::is_none")]
     pub translations: Option<Translations>,
     /// Product modes
     #[serde(default)]
     pub modes: Vec<ProductMode>,
+}
+
+/// Desktop selection mode for a product
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum DesktopSelection {
+    Optional,
+    Suggested,
 }
 
 #[derive(Clone, Default, Debug, Serialize, utoipa::ToSchema)]

--- a/rust/agama-utils/src/products.rs
+++ b/rust/agama-utils/src/products.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -44,7 +44,7 @@
 use crate::{
     api::{
         l10n::Translations,
-        manager::{Product, ProductMode},
+        manager::{system_info, Product, ProductMode},
     },
     arch::Arch,
 };
@@ -166,6 +166,12 @@ impl Registry {
                         description: m.description.clone(),
                     })
                     .collect();
+
+                let desktop_selection = p.desktop_selection.as_ref().map(|ds| match ds {
+                    DesktopSelection::Optional => system_info::DesktopSelection::Optional,
+                    DesktopSelection::Suggested => system_info::DesktopSelection::Suggested,
+                });
+
                 Product {
                     id: p.id.clone(),
                     name: p.name.clone(),
@@ -173,6 +179,7 @@ impl Registry {
                     icon: p.icon.clone(),
                     registration: p.registration,
                     license: p.license.clone(),
+                    desktop_selection,
                     translations: Some(p.translations.clone()),
                     modes,
                 }
@@ -207,6 +214,8 @@ pub struct ProductTemplate {
     pub registration: bool,
     pub version: Option<String>,
     pub license: Option<String>,
+    #[serde(default)]
+    pub desktop_selection: Option<DesktopSelection>,
     #[serde(default)]
     pub software: SoftwareSpec,
     #[serde(default)]
@@ -253,6 +262,7 @@ impl ProductTemplate {
             registration: self.registration,
             version: self.version.clone(),
             license: self.license.clone(),
+            desktop_selection: self.desktop_selection.clone(),
             software,
             storage,
         })
@@ -287,8 +297,17 @@ pub struct ProductSpec {
     pub registration: bool,
     pub version: Option<String>,
     pub license: Option<String>,
+    #[serde(default)]
+    pub desktop_selection: Option<DesktopSelection>,
     pub software: SoftwareSpec,
     pub storage: StorageSpec,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DesktopSelection {
+    Optional,
+    Suggested,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Merge)]


### PR DESCRIPTION
Extend the yaml configuration of the product with the `desktop_selection` option. 

Possible values:

* `optional`: Suitable for server-oriented products. No warnings or alerts if a DE is not selected.
* `suggested`: The product suggests a DE. The UI will display an info alert in the summary and a confirmation prompt if none are selected.

This is the first step to implement the desktop selection feature. For more details see https://github.com/agama-project/agama/discussions/3335.

**Note for reviewers**: The target of this PR is a feature branch. Changelog entries will be added later.