### PR TITLE
Upgrade axum to version 0.8.9

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "openssl",
  "pam",
  "pin-project",
- "rand 0.9.2",
+ "rand",
  "sd-notify",
  "serde",
  "serde_json",
@@ -830,15 +830,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -851,15 +851,14 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -868,19 +867,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -889,34 +886,32 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
  "cookie",
- "fastrand",
+ "futures-core",
  "futures-util",
  "headers",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
- "serde",
- "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3062,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -3156,23 +3151,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.4.0",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -3871,33 +3849,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3907,16 +3864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -4569,12 +4517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,18 +4905,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -4985,6 +4915,18 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5181,24 +5123,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -5209,10 +5133,26 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1.16"
 async-trait = "0.1.83"
-axum = { version = "0.7.7", features = ["ws", "macros"] }
+axum = { version = "0.8.9", features = ["ws", "macros"] }
 serde_json = "1.0.128"
 tower-http = { version = "0.6.2", features = [
     "compression-br",
@@ -36,7 +36,7 @@ tower = { version = "0.5.2", features = ["util"] }
 utoipa = { version = "5.2.0", features = ["axum_extras", "uuid"] }
 config = "0.15.11"
 rand = "0.9.1"
-axum-extra = { version = "0.9.4", features = ["cookie", "typed-header"] }
+axum-extra = { version = "0.12.6", features = ["cookie", "typed-header"] }
 # pam 0.8.0 (2023-11) plus an unreleased commit from 2023-12
 # that switches from users to uzers, fixing CVE-2025-5791
 pam = { git = "https://github.com/1wilkens/pam.git", rev = "daf26ae" }

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -207,7 +207,7 @@ fn https_redirect() -> Router {
     Router::new()
         // the wildcard path below does not match an empty path, we need to match it explicitly
         .route_service("/", redirect_service)
-        .route_service("/*path", redirect_service)
+        .route_service("/{*path}", redirect_service)
 }
 
 /// handle the HTTPS connection

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -129,13 +129,13 @@ pub fn server_with_state(state: ServerState) -> Result<Router, ServiceError> {
             "/questions",
             get(get_questions).post(ask_question).patch(update_question),
         )
-        .route("/licenses/:id", get(get_license))
+        .route("/licenses/{id}", get(get_license))
         .route(
             "/private/storage_model",
             get(get_storage_model).put(set_storage_model),
         )
         .route("/private/solve_storage_model", get(solve_storage_model))
-        .route("/private/resolvables/:id", put(set_resolvables))
+        .route("/private/resolvables/{id}", put(set_resolvables))
         .route("/private/download_logs", get(download_logs))
         .route("/private/password_check", post(check_password))
         .with_state(state))
@@ -418,7 +418,7 @@ struct LicenseQuery {
 /// the license in English.
 #[utoipa::path(
     get,
-    path = "/licenses/:id",
+    path = "/licenses/{id}",
     context_path = "/api/software",
     params(LicenseQuery),
     responses(
@@ -550,7 +550,7 @@ async fn solve_storage_model(
 
 #[utoipa::path(
     put,
-    path = "/resolvables/:id",
+    path = "/resolvables/{id}",
     context_path = "/api/v2",
     responses(
         (status = 200, description = "The resolvables list was updated.")

--- a/rust/agama-server/src/web/auth.rs
+++ b/rust/agama-server/src/web/auth.rs
@@ -22,7 +22,6 @@
 
 use super::state::ServiceState;
 use agama_lib::auth::{AuthToken, AuthTokenError, TokenClaims};
-use async_trait::async_trait;
 use axum::{
     extract::FromRequestParts,
     http::{request, StatusCode},
@@ -60,7 +59,6 @@ impl IntoResponse for AuthError {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<ServiceState> for TokenClaims {
     type Rejection = AuthError;
 

--- a/rust/agama-server/src/web/service.rs
+++ b/rust/agama-server/src/web/service.rs
@@ -91,7 +91,7 @@ impl MainServiceBuilder {
     /// * `service`: Service to mount on the given `path`.
     pub fn add_service<T>(self, path: &str, service: T) -> Self
     where
-        T: Service<Request, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -121,9 +121,9 @@ impl MainServiceBuilder {
         let serve = ServeDir::new(self.public_dir).precompressed_gzip();
 
         Router::new()
-            .nest_service("/", serve)
             .route("/login", get(login_from_query))
             .nest("/api", api_router)
+            .fallback_service(serve)
             .layer(
                 TraceLayer::new_for_http()
                     .on_request(|request: &Request<Body>, span: &Span| {

--- a/rust/agama-server/src/web/ws.rs
+++ b/rust/agama-server/src/web/ws.rs
@@ -63,7 +63,7 @@ async fn handle_socket(mut socket: WebSocket, events: event::Sender, _client_id:
                             continue;
                         };
 
-                        if socket.send(Message::Text(json)).await.is_err() {
+                        if socket.send(Message::Text(json.into())).await.is_err() {
                             // Failed to send the message, client probably disconnected.
                             break;
                         }


### PR DESCRIPTION
## Problem

We are using a rather old axum version. Version 0.8 [was released](https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0) more than one year ago, so it is time to move forward.

## Solution

Ask Claude to update to the latest version.

- Updated dependency versions in rust/agama-server/Cargo.toml
- Removed #[async_trait] from FromRequestParts implementation (axum 0.8 uses [RPITIT](https://rustc-dev-guide.rust-lang.org/return-position-impl-trait-in-trait.html))
- Changed path parameter syntax from :id to {id} in route definitions
- Replaced nest_service("/", serve) with fallback_service(serve)
- Fixed WebSocket message to use .into() for Utf8Bytes conversion

## Testing

- Tested manually

## Follow-up

It is possible that we can rid of [async_trait](https://crates.io/crates/async-trait) once we have updated our dependencies.