### PR TITLE
POC: Try boot partitions with desired and min sizes

### DIFF
--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -134,11 +134,40 @@ module Y2Storage
 
       configure_ptable_types(devicegraph)
       devicegraph = clean_graph(devicegraph)
-      complete_planned(devicegraph)
       return if issues?
 
-      result = create_devices(devicegraph)
+      result = create_devices_with_boot(devicegraph)
       result.devicegraph
+    end
+
+    # Creates the devices doing several attempts, each one for a different set of boot partitions
+    #
+    # @raise [NoDiskSpaceError] if there is no enough space to perform the installation
+    # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
+    def create_devices_with_boot(devicegraph)
+      initial_devicegraph = devicegraph.dup
+      possible_boot_sets = Proposal::BootPlanner.new(devicegraph, config, bootloader_config)
+        .plans(planned_devices.mountable_devices)
+
+      result = nil
+      while !result && possible_boot_sets.any? do
+        begin
+          boot_devices = possible_boot_sets.pop
+          planned_with_boot = planned_devices.prepend(boot_devices)
+          # Although this can affect the planned devices in the collection, that is not a problem
+          # because the different "boot plans" are almost equal (only the sizes change) so there is
+          # no difference in shadowing.
+          remove_shadowed_subvols(planned_with_boot)
+          result = create_devices(devicegraph, planned_with_boot)
+          @planned_devices = planned_with_boot
+        rescue NoDiskSpaceError
+          raise if possible_boot_sets.empty?
+
+          devicegraph = initial_devicegraph.dup
+        end
+      end
+
+      result
     end
 
     # Fills the list of planned devices, excluding partitions from the boot requirements checker
@@ -173,26 +202,6 @@ module Y2Storage
       end
     end
 
-    # Modifies the list of planned devices, removing shadowed subvolumes and adding any planned
-    # partition needed for booting the new target system
-    #
-    # @param devicegraph [Devicegraph]
-    def complete_planned(devicegraph)
-      if config.boot.configure?
-        @planned_devices = planned_devices.prepend(boot_partitions(devicegraph))
-      end
-
-      remove_shadowed_subvols(planned_devices)
-    end
-
-    # @see #complete_planned
-    #
-    # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
-    def boot_partitions(devicegraph)
-      planner = Proposal::BootPlanner.new(devicegraph, config, bootloader_config)
-      planner.partitions(planned_devices.mountable_devices)
-    end
-
     # Removes partition tables from candidate devices with empty partition table
     #
     # @param devicegraph [Devicegraph] the graph gets modified
@@ -222,9 +231,9 @@ module Y2Storage
     # Creates the planned devices on a given devicegraph
     #
     # @param devicegraph [Devicegraph] the graph gets modified
-    def create_devices(devicegraph)
+    def create_devices(devicegraph, all_devices)
       devices_creator = Proposal::AgamaDevicesCreator.new(devicegraph, issues_list)
-      result = devices_creator.populated_devicegraph(planned_devices, space_maker)
+      result = devices_creator.populated_devicegraph(all_devices, space_maker)
     end
 
     # Name of the boot device.

--- a/service/lib/y2storage/proposal/boot_planner.rb
+++ b/service/lib/y2storage/proposal/boot_planner.rb
@@ -46,15 +46,20 @@ module Y2Storage
         @bootloader_config = bootloader_config
       end
 
-      # Partitions needed in order to be able to boot the system
+      # Candidate sets of partitions needed in order to be able to boot the system
       #
       # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
       #
       # @param planned_devices [Array<Planned::Device>] devices that are already planned to be
       #   added to the starting devicegraph.
-      # @return [Array<Planned::Partition>]
-      def partitions(planned_devices)
-        strategy(planned_devices).needed_partitions(:min)
+      # @return [Array<Array<Planned::Partition>>]
+      def plans(planned_devices)
+        return [[]] unless config.boot.configure?
+
+        strategy = strategy(planned_devices)
+        [:desired, :min].map do |target|
+          strategy.needed_partitions(target)
+        end
       rescue BootRequirementsStrategies::Error => e
         raise NotBootableError, e.message
       end


### PR DESCRIPTION
## Useless proof of concept

The logic to define boot-related partitions in yast2-storage-ng defines three sizes for each partition: min, desired and max.

When using that in Agama, desired is ignored and only min and max are taken into account. That's something we always wanted to re-evaluate (together with several other aspects related to proposing boot partitions).

This shows a possible implementation in which several different sets of boot-related partitions are calculated and tried. In this case, it makes a first attempt using the desired sizes as starting point and, if that fails, a second attempt using the min size as starting point.

Although there is some room for improvement, the implementation is fully functional... but kind of useless.

In the process of testing the result I realized there is no practical difference. The distance between min, desired and max is so small (especially in comparison with the rest of partitions to create) that both attempts always produce the same result.

- If the disk is big enough, the max size is always reached. That's the most common case (I would say more than 99% of the scenarios) because the boot-related partitions are tiny compared to the partitions of the operating system and because, as mentioned, the distance between min, desired and max is really small.
- In super-small disks where the desired size cannot be reached, trying first with desired and then with min makes no difference, you will end up using the min size anyways.

So I'm creating (and directly closing) this pull request only for documentation purposes and to be taken as inspiration/starting point if we decide in the future to try a different approach for booting. The general principle of trying several different boot setups can still be useful.