### PR TITLE
feat(web): revamp software selection page with improved UX

### DIFF
--- a/web/src/components/core/Text.test.tsx
+++ b/web/src/components/core/Text.test.tsx
@@ -55,6 +55,11 @@ describe("Text", () => {
     expect(screen.getByText("Installer")).toHaveClass(a11yStyles.screenReader);
   });
 
+  it("sets aria-hidden when srHidden is true", () => {
+    plainRender(<Text srHidden>Installer</Text>);
+    expect(screen.getByText("Installer")).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("applies screenReader class when srOn is 'default'", () => {
     plainRender(<Text srOn="default">Installer</Text>);
     expect(screen.getByText("Installer")).toHaveClass(a11yStyles.screenReader);

--- a/web/src/components/core/Text.tsx
+++ b/web/src/components/core/Text.tsx
@@ -41,6 +41,12 @@ type TextProps = React.HTMLProps<HTMLSpanElement> &
      */
     srOnly?: boolean;
     /**
+     * Whether the text should be hidden from screen readers while remaining visible.
+     * Useful for pairing with `srOnly` content: show a short label visually while
+     * providing a more descriptive alternative for screen reader users.
+     */
+    srHidden?: boolean;
+    /**
      * Makes text only accessible to screen readers at a specific breakpoint.
      * Ignored if `srOnly` is true.
      */
@@ -65,15 +71,16 @@ type TextProps = React.HTMLProps<HTMLSpanElement> &
 
 /**
  * Simple text wrapper that optionally applies bold styling and
- * screen-reader-only visibility.
+ * screen-reader visibility controls.
  *
- * Accessibility behavior is controlled by `srOnly` and `srOn`, with `srOnly`
- * taking precedence.
+ * Accessibility behavior is controlled by `srOnly`, `srHidden`, and `srOn`,
+ * with `srOnly` taking precedence over `srOn`.
  */
 export default function Text({
   component = "span",
   isBold = false,
   srOnly = false,
+  srHidden = false,
   srOn,
   children,
   textStyle,
@@ -85,6 +92,7 @@ export default function Text({
   return (
     <Wrapper
       {...props}
+      aria-hidden={srHidden || undefined}
       className={[
         className,
         isString(textStyle) && textStyles[textStyle],

--- a/web/src/components/overview/SoftwareSummary.test.tsx
+++ b/web/src/components/overview/SoftwareSummary.test.tsx
@@ -149,6 +149,7 @@ describe("SoftwareSummary", () => {
           summary: "GNOME Desktop Environment (Wayland)",
           order: 1010,
           preselected: false,
+          desktop: true,
         },
       ]);
 
@@ -167,6 +168,7 @@ describe("SoftwareSummary", () => {
           summary: "GNOME Desktop Environment (Wayland)",
           order: 1010,
           preselected: false,
+          desktop: true,
         },
         {
           name: "yast2_basis",
@@ -176,6 +178,7 @@ describe("SoftwareSummary", () => {
           summary: "YaST Base Utilities",
           order: 1220,
           preselected: false,
+          desktop: false,
         },
       ]);
       rerender(<SoftwareSummary />);

--- a/web/src/components/software/AutoSelectedLabel.tsx
+++ b/web/src/components/software/AutoSelectedLabel.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Label } from "@patternfly/react-core";
+import { _ } from "~/i18n";
+
+/**
+ * Label indicating a pattern was automatically selected as a dependency.
+ */
+export default function AutoSelectedLabel(): React.ReactNode {
+  return (
+    <Label color="blue" isCompact>
+      {/* TRANSLATORS: label shown for patterns automatically selected as dependencies */}
+      {_("auto selected")}
+    </Label>
+  );
+}

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -71,6 +71,20 @@ describe("SoftwarePage", () => {
     screen.getByRole("link", { name: "Change selection" });
   });
 
+  it("does not render patterns marked as removed", () => {
+    const proposalWithRemovedPattern = {
+      ...testingProposal,
+      patterns: {
+        ...testingProposal.patterns,
+        multimedia: "removed",
+      },
+    };
+    mockProposal.mockReturnValue(proposalWithRemovedPattern);
+
+    installerRender(<SoftwarePage />);
+    expect(screen.queryByText("Multimedia")).toBeNull();
+  });
+
   describe("when there is no proposal yet", () => {
     beforeEach(() => {
       mockProposal.mockReturnValue(null);

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -80,6 +80,25 @@ describe("SoftwarePage", () => {
     screen.getByRole("link", { name: "Change desktop" });
   });
 
+  it("shows auto selected label for automatically selected patterns", () => {
+    installerRender(<SoftwarePage />);
+    const yasTBaseUtilities = screen.getByText("YaST Base Utilities").closest("li");
+    const yasTDesktopUtilities = screen.getByText("YaST Desktop Utilities").closest("li");
+    const officeSoftware = screen.getByText("Office Software").closest("li");
+    const multimedia = screen.getByText("Multimedia").closest("li");
+
+    expect(yasTBaseUtilities).toHaveTextContent("auto selected");
+    expect(yasTDesktopUtilities).toHaveTextContent("auto selected");
+    expect(officeSoftware).toHaveTextContent("auto selected");
+    expect(multimedia).toHaveTextContent("auto selected");
+  });
+
+  it("does not show auto selected label for user-selected patterns", () => {
+    installerRender(<SoftwarePage />);
+    const gnomeDesktop = screen.getByText("GNOME Desktop Environment (Wayland)").closest("li");
+    expect(gnomeDesktop).not.toHaveTextContent("auto selected");
+  });
+
   it("does not render patterns marked as removed", () => {
     const proposalWithRemovedPattern = {
       ...testingProposal,

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -113,13 +113,13 @@ describe("SoftwarePage", () => {
 
   it("shows auto selected label for automatically selected patterns", () => {
     installerRender(<SoftwarePage />);
-    const yasTBaseUtilities = screen.getByText("YaST Base Utilities").closest("li");
-    const yasTDesktopUtilities = screen.getByText("YaST Desktop Utilities").closest("li");
+    const baseUtilities = screen.getByText("YaST Base Utilities").closest("li");
+    const desktopUtilities = screen.getByText("YaST Desktop Utilities").closest("li");
     const officeSoftware = screen.getByText("Office Software").closest("li");
     const multimedia = screen.getByText("Multimedia").closest("li");
 
-    expect(yasTBaseUtilities).toHaveTextContent("auto selected");
-    expect(yasTDesktopUtilities).toHaveTextContent("auto selected");
+    expect(baseUtilities).toHaveTextContent("auto selected");
+    expect(desktopUtilities).toHaveTextContent("auto selected");
     expect(officeSoftware).toHaveTextContent("auto selected");
     expect(multimedia).toHaveTextContent("auto selected");
   });

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -67,9 +67,22 @@ describe("SoftwarePage", () => {
     expect(screen.queryByText("YaST Server Utilities")).toBeNull();
   });
 
-  it("renders the summary", () => {
+  it("renders the summary including the selection context", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText(/About 4.60 GiB space required/);
+    screen.getByText(/Required space with current selection/);
+    screen.getByText("4.60 GiB");
+  });
+
+  it("renders the summary without selection context when nothing is selected", () => {
+    const proposalWithNoPatterns = {
+      ...testingProposal,
+      patterns: Object.fromEntries(Object.keys(testingProposal.patterns).map((k) => [k, "none"])),
+    };
+    mockProposal.mockReturnValue(proposalWithNoPatterns);
+
+    installerRender(<SoftwarePage />);
+    screen.getByText(/Required space:/);
+    expect(screen.queryByText(/with current selection/)).toBeNull();
   });
 
   it("renders buttons for navigating to patterns selection", () => {

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -49,26 +49,33 @@ describe("SoftwarePage", () => {
     mockProposal.mockReturnValue(testingProposal);
   });
 
+  it("renders selected desktop", () => {
+    installerRender(<SoftwarePage />);
+    screen.getByText("Selected desktop");
+    screen.getAllByText(/GNOME/);
+    expect(screen.queryByText(/KDE/)).toBeNull();
+    expect(screen.queryByText(/XFCE/)).toBeNull();
+  });
+
   it("renders a list of selected patterns", () => {
     installerRender(<SoftwarePage />);
-    screen.getAllByText(/GNOME/);
+    screen.getByText("Selected patterns");
     screen.getByText("YaST Base Utilities");
     screen.getByText("YaST Desktop Utilities");
     screen.getByText("Multimedia");
     screen.getAllByText(/Office software/);
-    expect(screen.queryByText(/KDE/)).toBeNull();
-    expect(screen.queryByText(/XFCE/)).toBeNull();
     expect(screen.queryByText("YaST Server Utilities")).toBeNull();
   });
 
   it("renders the summary", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText(/5 selected patterns, total size needed: 4.60 GiB/);
+    screen.getByText(/About 4.60 GiB space needed with the current selection \(4 patterns and 1 desktops\)/);
   });
 
-  it("renders a button for navigating to patterns selection", () => {
+  it("renders buttons for navigating to patterns selection", () => {
     installerRender(<SoftwarePage />);
-    screen.getByRole("link", { name: "Change selection" });
+    screen.getByRole("link", { name: "Change patterns" });
+    screen.getByRole("link", { name: "Change desktop" });
   });
 
   it("does not render patterns marked as removed", () => {

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -113,6 +113,41 @@ describe("SoftwarePage", () => {
     expect(screen.queryByText("Multimedia")).toBeNull();
   });
 
+  it("shows empty state when no desktop is selected", () => {
+    const proposalWithNoDesktop = {
+      ...testingProposal,
+      patterns: {
+        ...testingProposal.patterns,
+        gnome: "none",
+      },
+    };
+    mockProposal.mockReturnValue(proposalWithNoDesktop);
+
+    installerRender(<SoftwarePage />);
+    screen.getByText("None selected");
+    screen.getByText("Choose a desktop environment.");
+    screen.getByRole("link", { name: "Select desktop" });
+  });
+
+  it("shows empty state when no patterns are selected", () => {
+    const proposalWithNoPatterns = {
+      ...testingProposal,
+      patterns: {
+        gnome: "user",
+        yast2_basis: "none",
+        yast2_desktop: "none",
+        multimedia: "none",
+        office: "none",
+      },
+    };
+    mockProposal.mockReturnValue(proposalWithNoPatterns);
+
+    installerRender(<SoftwarePage />);
+    screen.getByText("None selected");
+    screen.getByText("The product does not provide additional patterns.");
+    screen.getByRole("link", { name: "Select patterns" });
+  });
+
   describe("when there is no proposal yet", () => {
     beforeEach(() => {
       mockProposal.mockReturnValue(null);

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -49,17 +49,17 @@ describe("SoftwarePage", () => {
     mockProposal.mockReturnValue(testingProposal);
   });
 
-  it("renders selected desktop", () => {
+  it("renders the Desktops section with the selected desktop", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText("Desktop");
+    screen.getByText("Desktops");
     screen.getByText("GNOME Desktop Environment (Wayland)");
     expect(screen.queryByText("KDE Applications and Plasma 5 Desktop")).toBeNull();
     expect(screen.queryByText("XFCE Desktop Environment")).toBeNull();
   });
 
-  it("renders a list of selected patterns", () => {
+  it("renders the Additional patterns section with selected patterns", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText("Patterns");
+    screen.getByText("Additional patterns");
     screen.getByText("YaST Base Utilities");
     screen.getByText("YaST Desktop Utilities");
     screen.getByText("Multimedia");
@@ -69,15 +69,33 @@ describe("SoftwarePage", () => {
 
   it("renders the summary", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText(
-      /About 4.60 GiB space needed with the current selection \(4 patterns and 1 desktops\)/,
-    );
+    screen.getByText(/About 4.60 GiB space required/);
   });
 
   it("renders buttons for navigating to patterns selection", () => {
     installerRender(<SoftwarePage />);
     screen.getByRole("link", { name: "Change patterns" });
+    // 1 desktop selected — singular form
     screen.getByRole("link", { name: "Change desktop" });
+  });
+
+  it("shows selection counter when patterns are selected", () => {
+    installerRender(<SoftwarePage />);
+    // 1 desktop selected out of 4 available
+    screen.getByText(/1 of 4 selected/);
+    // 4 other patterns selected out of 5 available
+    screen.getByText(/4 of 5 selected/);
+  });
+
+  it("hides selection counter when no patterns are selected", () => {
+    const proposalWithNoDesktop = {
+      ...testingProposal,
+      patterns: { ...testingProposal.patterns, gnome: "none" },
+    };
+    mockProposal.mockReturnValue(proposalWithNoDesktop);
+
+    installerRender(<SoftwarePage />);
+    expect(screen.queryByText(/0 of 4 selected/)).toBeNull();
   });
 
   it("shows auto selected label for automatically selected patterns", () => {
@@ -102,10 +120,7 @@ describe("SoftwarePage", () => {
   it("does not render patterns marked as removed", () => {
     const proposalWithRemovedPattern = {
       ...testingProposal,
-      patterns: {
-        ...testingProposal.patterns,
-        multimedia: "removed",
-      },
+      patterns: { ...testingProposal.patterns, multimedia: "removed" },
     };
     mockProposal.mockReturnValue(proposalWithRemovedPattern);
 
@@ -116,20 +131,17 @@ describe("SoftwarePage", () => {
   it("shows empty state when no desktop is selected", () => {
     const proposalWithNoDesktop = {
       ...testingProposal,
-      patterns: {
-        ...testingProposal.patterns,
-        gnome: "none",
-      },
+      patterns: { ...testingProposal.patterns, gnome: "none" },
     };
     mockProposal.mockReturnValue(proposalWithNoDesktop);
 
     installerRender(<SoftwarePage />);
     screen.getByText("None selected");
-    screen.getByText("Choose a desktop environment.");
-    screen.getByRole("link", { name: "Select desktop" });
+    screen.getByText("Select a desktop environment to get a graphical interface.");
+    screen.getByRole("link", { name: "Select a desktop" });
   });
 
-  it("shows empty state when no patterns are selected", () => {
+  it("shows empty state when no additional patterns are selected", () => {
     const proposalWithNoPatterns = {
       ...testingProposal,
       patterns: {
@@ -144,8 +156,19 @@ describe("SoftwarePage", () => {
 
     installerRender(<SoftwarePage />);
     screen.getByText("None selected");
-    screen.getByText("The product does not provide additional patterns.");
+    screen.getByText("Select one or more to extend the system.");
     screen.getByRole("link", { name: "Select patterns" });
+  });
+
+  it("uses plural button label when multiple desktops are selected", () => {
+    const proposalWithMultipleDesktops = {
+      ...testingProposal,
+      patterns: { ...testingProposal.patterns, kde: "user" },
+    };
+    mockProposal.mockReturnValue(proposalWithMultipleDesktops);
+
+    installerRender(<SoftwarePage />);
+    screen.getByRole("link", { name: "Change desktops" });
   });
 
   describe("when there is no proposal yet", () => {
@@ -153,7 +176,7 @@ describe("SoftwarePage", () => {
       mockProposal.mockReturnValue(null);
     });
 
-    it("renders an informative messsage", () => {
+    it("renders an informative message", () => {
       installerRender(<SoftwarePage />);
       screen.getByText("No information available yet");
     });

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -51,25 +51,27 @@ describe("SoftwarePage", () => {
 
   it("renders selected desktop", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText("Selected desktop");
-    screen.getAllByText(/GNOME/);
-    expect(screen.queryByText(/KDE/)).toBeNull();
-    expect(screen.queryByText(/XFCE/)).toBeNull();
+    screen.getByText("Desktop");
+    screen.getByText("GNOME Desktop Environment (Wayland)");
+    expect(screen.queryByText("KDE Applications and Plasma 5 Desktop")).toBeNull();
+    expect(screen.queryByText("XFCE Desktop Environment")).toBeNull();
   });
 
   it("renders a list of selected patterns", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText("Selected patterns");
+    screen.getByText("Patterns");
     screen.getByText("YaST Base Utilities");
     screen.getByText("YaST Desktop Utilities");
     screen.getByText("Multimedia");
-    screen.getAllByText(/Office software/);
+    screen.getByText("Office Software");
     expect(screen.queryByText("YaST Server Utilities")).toBeNull();
   });
 
   it("renders the summary", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText(/About 4.60 GiB space needed with the current selection \(4 patterns and 1 desktops\)/);
+    screen.getByText(
+      /About 4.60 GiB space needed with the current selection \(4 patterns and 1 desktops\)/,
+    );
   });
 
   it("renders buttons for navigating to patterns selection", () => {

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -61,9 +61,9 @@ describe("SoftwarePage", () => {
     expect(screen.queryByText("YaST Server Utilities")).toBeNull();
   });
 
-  it("renders amount of size selected product and patterns will need", () => {
+  it("renders the summary", () => {
     installerRender(<SoftwarePage />);
-    screen.getByText("Installation will take 4.60 GiB.");
+    screen.getByText(/5 selected patterns, total size needed: 4.60 GiB/);
   });
 
   it("renders a button for navigating to patterns selection", () => {

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -36,6 +36,7 @@ import {
   List,
   ListItem,
 } from "@patternfly/react-core";
+import Interpolate from "~/components/core/Interpolate";
 import IssuesAlert from "~/components/core/IssuesAlert";
 import Link from "~/components/core/Link";
 import NestedContent from "~/components/core/NestedContent";
@@ -80,6 +81,63 @@ const NothingSelected = ({
 );
 
 /**
+ * A single pattern entry with its name, optional auto-selected label, and an
+ * expandable description.
+ *
+ * Uses a controlled ExpandableSection with `toggleContent` (ReactNode) rather
+ * than `toggleTextCollapsed`/`toggleTextExpanded` (string-only) so the toggle
+ * button can carry both a visible label and a screen-reader-only label that
+ * includes the pattern name for context when navigating by button.
+ *
+ * TODO: revert to uncontrolled once
+ * https://github.com/patternfly/patternfly-react/pull/12063 lands, which will
+ * allow `toggleContent` to accept a function receiving `isExpanded`.
+ */
+const PatternListItem = ({
+  pattern,
+  selection,
+}: {
+  pattern: Pattern;
+  selection: PatternsSelection;
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  const toggleContent = isExpanded ? (
+    <>
+      <Text srHidden>{_("Read less")}</Text>
+      {/* TRANSLATORS: accessible label for the collapse button; %s is the pattern name */}
+      <Text srOnly>{sprintf(_("Read less about %s"), pattern.summary)}</Text>
+    </>
+  ) : (
+    <>
+      <Text srHidden>{_("Read more")}</Text>
+      {/* TRANSLATORS: accessible label for the expand button; %s is the pattern name */}
+      <Text srOnly>{sprintf(_("Read more about %s"), pattern.summary)}</Text>
+    </>
+  );
+
+  return (
+    <ListItem>
+      <Text>
+        <Text isBold>{pattern.summary} </Text>
+        {selection[pattern.name] === SelectedBy.AUTO && <AutoSelectedLabel />}
+      </Text>
+      <NestedContent margin="mxXs">
+        <ExpandableSection
+          variant="truncate"
+          truncateMaxLines={2}
+          isExpanded={isExpanded}
+          onToggle={(_event, value) => setIsExpanded(value)}
+          toggleContent={toggleContent}
+        >
+          <SubtleContent>{pattern.description}</SubtleContent>
+        </ExpandableSection>
+      </NestedContent>
+    </ListItem>
+  );
+};
+
+/**
  * List of selected patterns.
  */
 const SelectedPatternsList = ({
@@ -100,24 +158,7 @@ const SelectedPatternsList = ({
       <NestedContent margin="mxSm">
         <List isPlain>
           {patterns.map((pattern) => (
-            <ListItem key={pattern.name}>
-              <Text>
-                <Text isBold>{pattern.summary} </Text>
-                {selection[pattern.name] === SelectedBy.AUTO && <AutoSelectedLabel />}
-              </Text>
-              <NestedContent margin="mxXs">
-                <ExpandableSection
-                  variant="truncate"
-                  truncateMaxLines={2}
-                  // TRANSLATORS: button to expand truncated pattern description
-                  toggleTextCollapsed={_("Read more")}
-                  // TRANSLATORS: button to collapse expanded pattern description
-                  toggleTextExpanded={_("Read less")}
-                >
-                  <SubtleContent>{pattern.description}</SubtleContent>
-                </ExpandableSection>
-              </NestedContent>
-            </ListItem>
+            <PatternListItem key={pattern.name} pattern={pattern} selection={selection} />
           ))}
         </List>
       </NestedContent>
@@ -130,13 +171,26 @@ const SelectedPatternsList = ({
  *
  * Renders nothing when no size information is available.
  */
-const SpaceRequirements = ({ usedSize }: { usedSize?: string }) => {
+const SpaceRequirements = ({
+  usedSize,
+  hasSelection,
+}: {
+  usedSize?: string;
+  hasSelection: boolean;
+}) => {
   if (!usedSize) return;
 
-  // TRANSLATORS: %s is the required disk space
-  const text = sprintf(_("About %s space required"), usedSize);
+  const text = hasSelection
+    ? // TRANSLATORS: %s is the required disk space. Keep the [brackets]: they mark the value to be displayed in bold.
+      sprintf(_("Required space with current selection: [%s]"), usedSize)
+    : // TRANSLATORS: %s is the required disk space. Keep the [brackets]: they mark the value to be displayed in bold.
+      sprintf(_("Required space: [%s]"), usedSize);
 
-  return <Text textStyle="fontSizeMd">{text}</Text>;
+  return (
+    <Text textStyle="fontSizeMd">
+      <Interpolate sentence={text}>{(size) => <Text isBold>{size}</Text>}</Interpolate>
+    </Text>
+  );
 };
 
 type SoftwareSectionProps = {
@@ -236,7 +290,7 @@ const SoftwarePageContent = () => {
   return (
     <Page.Content>
       <Content>
-        <SpaceRequirements usedSize={usedSize} />
+        <SpaceRequirements usedSize={usedSize} hasSelection={selectedPatterns.length > 0} />
       </Content>
       <IssuesAlert issues={issues} />
       {isEmpty(proposal.patterns) ? (

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -50,7 +50,7 @@ import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useSystem } from "~/hooks/model/system/software";
-import { isPatternSelected } from "~/utils/software";
+import { isDesktopPattern, isPatternSelected } from "~/utils/software";
 import { SOFTWARE as PATHS } from "~/routes/paths";
 import { N_, _ } from "~/i18n";
 
@@ -311,10 +311,7 @@ const PageContent = () => {
     : undefined;
 
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
-  const [desktops, otherPatterns] = fork(
-    selectedPatterns,
-    (p) => p.category === "Graphical Environments",
-  );
+  const [desktops, otherPatterns] = fork(selectedPatterns, isDesktopPattern);
 
   const startProbing = () => {
     setLoading(true);

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -305,7 +305,7 @@ const SoftwarePageContent = () => {
                 "Graphical desktop environments for the system.",
               )}
               buttonText={
-                // TRANSLATORS: button to change the desktop selection; singular when 1 is selected
+                // TRANSLATORS: button to change the desktop selection
                 n_("Change desktop", "Change desktops", desktops.length)
               }
               totalCount={allDesktops.length}

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -21,64 +21,85 @@
  */
 
 import React, { useState } from "react";
+import xbytes from "xbytes";
+import { isEmpty } from "radashi";
+import { sprintf } from "sprintf-js";
 import {
   Alert,
   Button,
+  Content,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   EmptyState,
-  Grid,
-  GridItem,
+  Flex,
   Spinner,
-  Stack,
 } from "@patternfly/react-core";
-import { Link, Page, IssuesAlert } from "~/components/core";
-import UsedSize from "./UsedSize";
+import IssuesAlert from "~/components/core/IssuesAlert";
+import Link from "~/components/core/Link";
+import Page from "~/components/core/Page";
+import Text from "~/components/core/Text";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useSystem } from "~/hooks/model/system/software";
-import { N_, _ } from "~/i18n";
-import { SOFTWARE as PATHS } from "~/routes/paths";
-import xbytes from "xbytes";
-import { PatternsSelection } from "~/model/proposal/software";
-import { Pattern } from "~/model/system/software";
-import { isEmpty } from "radashi";
 import { isPatternSelected } from "~/utils/software";
+import { SOFTWARE as PATHS } from "~/routes/paths";
+import { N_, _ } from "~/i18n";
+
+import type { Pattern } from "~/model/system/software";
 
 /**
  * List of selected patterns.
  */
-const SelectedPatternsList = ({
-  patterns,
-  selection,
-}: {
-  patterns: Pattern[];
-  selection: PatternsSelection;
-}): React.ReactNode => {
-  const selected = patterns.filter((p) => isPatternSelected(selection, p.name));
-
-  if (selected.length === 0) {
+const SelectedPatternsList = ({ patterns }: { patterns: Pattern[] }): React.ReactNode => {
+  if (patterns.length === 0) {
     return <>{_("No additional software was selected.")}</>;
   }
 
   return (
-    <Stack hasGutter>
-      <p>{_("The following software patterns are selected for installation:")}</p>
-      <DescriptionList>
-        {selected.map((pattern) => (
-          <DescriptionListGroup key={pattern.name}>
-            <DescriptionListTerm>{pattern.summary}</DescriptionListTerm>
-            <DescriptionListDescription>{pattern.description}</DescriptionListDescription>
-          </DescriptionListGroup>
-        ))}
-      </DescriptionList>
-    </Stack>
+    <DescriptionList>
+      {patterns.map((pattern) => (
+        <DescriptionListGroup key={pattern.name}>
+          <DescriptionListTerm>{pattern.summary}</DescriptionListTerm>
+          <DescriptionListDescription>{pattern.description}</DescriptionListDescription>
+        </DescriptionListGroup>
+      ))}
+    </DescriptionList>
   );
 };
 
-const SelectedPatterns = ({ patterns, selection }): React.ReactNode => (
+const Summary = ({
+  selectedCount,
+  usedSize,
+}: {
+  selectedCount: number;
+  usedSize?: string;
+}): React.ReactNode => {
+  const summaryText = usedSize
+    ? sprintf(
+        // TRANSLATORS: %1$d is the number of selected patterns, %2$s is the total installation size
+        // (e.g., "5 selected patterns, total size needed: 4.60 GiB")
+        _("%1$d selected patterns, total size needed: %2$s"),
+        selectedCount,
+        usedSize,
+      )
+    : sprintf(
+        // TRANSLATORS: %d is the number of selected patterns
+        _("%d selected patterns"),
+        selectedCount,
+      );
+
+  return (
+    <Flex direction={{ default: "column" }}>
+      <Content isEditorial>
+        <Text>{summaryText}</Text>
+      </Content>
+    </Flex>
+  );
+};
+
+const SelectedPatterns = ({ patterns }: { patterns: Pattern[] }): React.ReactNode => (
   <Page.Section
     title={_("Selected patterns")}
     actions={
@@ -87,7 +108,7 @@ const SelectedPatterns = ({ patterns, selection }): React.ReactNode => (
       </Link>
     }
   >
-    <SelectedPatternsList patterns={patterns} selection={selection} />
+    <SelectedPatternsList patterns={patterns} />
   </Page.Section>
 );
 
@@ -134,7 +155,7 @@ const ReloadSection = ({
   </Alert>
 );
 
-const Content = () => {
+const PageContent = () => {
   const { patterns } = useSystem();
   const proposal = useProposal();
   const issues = useIssues("software");
@@ -146,13 +167,10 @@ const Content = () => {
 
   // FIXME: temporarily disabled, the API end point is not implemented yet
   const repos = []; // useRepositories();
-  const usedSpace = proposal.usedSpace
+  const usedSize = proposal.usedSpace
     ? xbytes(proposal.usedSpace * 1024, { iec: true })
     : undefined;
-
-  // Selected patterns section should fill the full width in big screen too when
-  // there is no information for rendering the Proposal Size section.
-  const selectedPatternsXlSize = usedSpace ? 6 : 12;
+  const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
 
   const startProbing = () => {
     setLoading(true);
@@ -163,28 +181,18 @@ const Content = () => {
 
   return (
     <>
-      <IssuesAlert issues={issues} />
-      <Grid hasGutter>
-        {showReposAlert && (
-          <GridItem sm={12}>
-            <ReloadSection loading={loading} action={startProbing} />
-          </GridItem>
+      <Page.Content>
+        <IssuesAlert issues={issues} />
+        {showReposAlert && <ReloadSection loading={loading} action={startProbing} />}
+        {isEmpty(proposal.patterns) ? (
+          <NoPatterns />
+        ) : (
+          <>
+            <Summary selectedCount={selectedPatterns.length} usedSize={usedSize} />
+            <SelectedPatterns patterns={selectedPatterns} />
+          </>
         )}
-        <GridItem sm={12} xl={selectedPatternsXlSize}>
-          {isEmpty(proposal.patterns) ? (
-            <NoPatterns />
-          ) : (
-            <SelectedPatterns patterns={patterns} selection={proposal.patterns} />
-          )}
-        </GridItem>
-        {usedSpace && (
-          <GridItem sm={12} xl={6}>
-            <Page.Section aria-label={_("Used space")}>
-              <UsedSize size={usedSpace} />
-            </Page.Section>
-          </GridItem>
-        )}
-      </Grid>
+      </Page.Content>
     </>
   );
 };
@@ -195,9 +203,7 @@ const Content = () => {
 function SoftwarePage(): React.ReactNode {
   return (
     <Page breadcrumbs={[{ label: _("Software") }]} progress={{ scope: "software" }}>
-      <Page.Content>
-        <Content />
-      </Page.Content>
+      <PageContent />
     </Page>
   );
 }

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -46,7 +46,7 @@ import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useSystem } from "~/hooks/model/system/software";
-import { isDesktopPattern, isPatternSelected } from "~/utils/software";
+import { isPatternSelected } from "~/utils/software";
 import { SOFTWARE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 
@@ -57,13 +57,21 @@ import { SelectedBy } from "~/model/proposal/software";
 /**
  * Empty state for a software section where nothing has been selected yet.
  */
-const NothingSelected = ({ body, buttonText }: { body: string; buttonText: string }) => (
+const NothingSelected = ({
+  to,
+  body,
+  buttonText,
+}: {
+  to: string;
+  body: string;
+  buttonText: string;
+}) => (
   // TRANSLATORS: empty state title for a software section with nothing selected
   <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
     <EmptyStateBody>{body}</EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>
-        <Link to={PATHS.patternsSelection} isPrimary>
+        <Link to={to} isPrimary>
           {buttonText}
         </Link>
       </EmptyStateActions>
@@ -146,6 +154,8 @@ type SoftwareSectionProps = {
   selection: PatternsSelection;
   /** Content to show when no patterns are selected. */
   emptyContent: React.ReactNode;
+  /** Path to the selection page linked from the section action and empty state. */
+  selectionPath: string;
 };
 
 /**
@@ -163,6 +173,7 @@ const SoftwareSection = ({
   patterns,
   selection,
   emptyContent,
+  selectionPath,
 }: SoftwareSectionProps) => {
   const noneSelected = patterns.length === 0;
   // TRANSLATORS: %1$d is selected count, %2$d is total available count
@@ -179,7 +190,7 @@ const SoftwareSection = ({
       }
       description={description}
       pfCardProps={{ isFullHeight: false }}
-      actions={!noneSelected && <Link to={PATHS.patternsSelection}>{buttonText}</Link>}
+      actions={!noneSelected && <Link to={selectionPath}>{buttonText}</Link>}
     >
       <SelectedPatternsList patterns={patterns} selection={selection} emptyContent={emptyContent} />
     </Page.Section>
@@ -218,9 +229,9 @@ const SoftwarePageContent = () => {
     ? xbytes(proposal.usedSpace * 1024, { iec: true })
     : undefined;
 
-  const [allDesktops, allOtherPatterns] = fork(patterns, isDesktopPattern);
+  const [allDesktops, allOtherPatterns] = fork(patterns, (p) => p.desktop);
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
-  const [desktops, otherPatterns] = fork(selectedPatterns, isDesktopPattern);
+  const [desktops, otherPatterns] = fork(selectedPatterns, (p) => p.desktop);
 
   return (
     <Page.Content>
@@ -246,8 +257,10 @@ const SoftwarePageContent = () => {
               totalCount={allDesktops.length}
               patterns={desktops}
               selection={proposal.patterns}
+              selectionPath={PATHS.desktopSelection}
               emptyContent={
                 <NothingSelected
+                  to={PATHS.desktopSelection}
                   // TRANSLATORS: hint shown when no desktop environment has been chosen
                   body={_("Select a desktop environment to get a graphical interface.")}
                   // TRANSLATORS: button to go to the desktop environment selection page
@@ -268,8 +281,10 @@ const SoftwarePageContent = () => {
               totalCount={allOtherPatterns.length}
               patterns={otherPatterns}
               selection={proposal.patterns}
+              selectionPath={PATHS.patternsSelection}
               emptyContent={
                 <NothingSelected
+                  to={PATHS.patternsSelection}
                   // TRANSLATORS: hint shown when no additional software patterns have been chosen
                   body={_("Select one or more to extend the system.")}
                   // TRANSLATORS: button to go to the pattern selection page

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -28,19 +28,19 @@ import {
   Alert,
   Button,
   Content,
-  DescriptionList,
-  DescriptionListDescription,
-  DescriptionListGroup,
-  DescriptionListTerm,
   EmptyState,
+  ExpandableSection,
   Flex,
   Grid,
   GridItem,
+  List,
+  ListItem,
   Spinner,
 } from "@patternfly/react-core";
 import IssuesAlert from "~/components/core/IssuesAlert";
 import Link from "~/components/core/Link";
 import Page from "~/components/core/Page";
+import SubtleContent from "~/components/core/SubtleContent";
 import Text from "~/components/core/Text";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
@@ -50,6 +50,7 @@ import { SOFTWARE as PATHS } from "~/routes/paths";
 import { N_, _ } from "~/i18n";
 
 import type { Pattern } from "~/model/system/software";
+import { NestedContent } from "../core";
 
 /**
  * List of selected patterns.
@@ -60,14 +61,25 @@ const SelectedPatternsList = ({ patterns }: { patterns: Pattern[] }): React.Reac
   }
 
   return (
-    <DescriptionList>
-      {patterns.map((pattern) => (
-        <DescriptionListGroup key={pattern.name}>
-          <DescriptionListTerm>{pattern.summary}</DescriptionListTerm>
-          <DescriptionListDescription>{pattern.description}</DescriptionListDescription>
-        </DescriptionListGroup>
-      ))}
-    </DescriptionList>
+    <NestedContent margin="mxSm">
+      <List isPlain>
+        {patterns.map((pattern) => (
+          <ListItem key={pattern.name}>
+            <Text isBold>{pattern.summary}</Text>
+            <NestedContent margin="mxXs">
+              <ExpandableSection
+                variant="truncate"
+                truncateMaxLines={2}
+                toggleTextCollapsed={_("Read more")}
+                toggleTextExpanded={_("Read less")}
+              >
+                <SubtleContent>{pattern.description}</SubtleContent>
+              </ExpandableSection>
+            </NestedContent>
+          </ListItem>
+        ))}
+      </List>
+    </NestedContent>
   );
 };
 
@@ -179,7 +191,7 @@ const SoftwareSection = ({
 );
 
 const NoPatterns = (): React.ReactNode => (
-  <Page.Section title={_("Selected patterns")}>
+  <Page.Section title={_("Patterns")}>
     <p>
       {_(
         "This product does not allow to select software patterns during installation. However, you can add additional software once the installation is finished.",
@@ -267,14 +279,14 @@ const PageContent = () => {
             <Grid hasGutter>
               <GridItem lg={6}>
                 <SoftwareSection
-                  title={_("Selected patterns")}
+                  title={_("Patterns")}
                   buttonText={_("Change patterns")}
                   patterns={otherPatterns}
                 />
               </GridItem>
               <GridItem lg={6}>
                 <SoftwareSection
-                  title={_("Selected desktop")}
+                  title={_("Desktop")}
                   buttonText={_("Change desktop")}
                   patterns={desktops}
                 />

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -42,9 +42,10 @@ import { useSystem } from "~/hooks/model/system/software";
 import { N_, _ } from "~/i18n";
 import { SOFTWARE as PATHS } from "~/routes/paths";
 import xbytes from "xbytes";
-import { PatternsSelection, SelectedBy } from "~/model/proposal/software";
+import { PatternsSelection } from "~/model/proposal/software";
 import { Pattern } from "~/model/system/software";
 import { isEmpty } from "radashi";
+import { isPatternSelected } from "~/utils/software";
 
 /**
  * List of selected patterns.
@@ -56,7 +57,7 @@ const SelectedPatternsList = ({
   patterns: Pattern[];
   selection: PatternsSelection;
 }): React.ReactNode => {
-  const selected = patterns.filter((p) => selection[p.name] !== SelectedBy.NONE);
+  const selected = patterns.filter((p) => isPatternSelected(selection, p.name));
 
   if (selected.length === 0) {
     return <>{_("No additional software was selected.")}</>;

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -33,12 +33,14 @@ import {
   Flex,
   Grid,
   GridItem,
+  Label,
   List,
   ListItem,
   Spinner,
 } from "@patternfly/react-core";
 import IssuesAlert from "~/components/core/IssuesAlert";
 import Link from "~/components/core/Link";
+import NestedContent from "~/components/core/NestedContent";
 import Page from "~/components/core/Page";
 import SubtleContent from "~/components/core/SubtleContent";
 import Text from "~/components/core/Text";
@@ -50,12 +52,19 @@ import { SOFTWARE as PATHS } from "~/routes/paths";
 import { N_, _ } from "~/i18n";
 
 import type { Pattern } from "~/model/system/software";
-import { NestedContent } from "../core";
+import type { PatternsSelection } from "~/model/proposal/software";
+import { SelectedBy } from "~/model/proposal/software";
 
 /**
  * List of selected patterns.
  */
-const SelectedPatternsList = ({ patterns }: { patterns: Pattern[] }): React.ReactNode => {
+const SelectedPatternsList = ({
+  patterns,
+  selection,
+}: {
+  patterns: Pattern[];
+  selection: PatternsSelection;
+}): React.ReactNode => {
   if (patterns.length === 0) {
     return <>{_("No additional software was selected.")}</>;
   }
@@ -65,12 +74,22 @@ const SelectedPatternsList = ({ patterns }: { patterns: Pattern[] }): React.Reac
       <List isPlain>
         {patterns.map((pattern) => (
           <ListItem key={pattern.name}>
-            <Text isBold>{pattern.summary}</Text>
+            <Text>
+              <Text isBold>{pattern.summary} </Text>
+              {selection[pattern.name] === SelectedBy.AUTO && (
+                <Label color="blue" isCompact>
+                  {/* TRANSLATORS: label shown for patterns automatically selected as dependencies */}
+                  {_("auto selected")}
+                </Label>
+              )}
+            </Text>
             <NestedContent margin="mxXs">
               <ExpandableSection
                 variant="truncate"
                 truncateMaxLines={2}
+                // TRANSLATORS: button to expand truncated pattern description
                 toggleTextCollapsed={_("Read more")}
+                // TRANSLATORS: button to collapse expanded pattern description
                 toggleTextExpanded={_("Read less")}
               >
                 <SubtleContent>{pattern.description}</SubtleContent>
@@ -172,10 +191,12 @@ const SoftwareSection = ({
   title,
   buttonText,
   patterns,
+  selection,
 }: {
   title: string;
   buttonText: string;
   patterns: Pattern[];
+  selection: PatternsSelection;
 }): React.ReactNode => (
   <Page.Section
     title={title}
@@ -186,7 +207,7 @@ const SoftwareSection = ({
       </Link>
     }
   >
-    <SelectedPatternsList patterns={patterns} />
+    <SelectedPatternsList patterns={patterns} selection={selection} />
   </Page.Section>
 );
 
@@ -282,6 +303,7 @@ const PageContent = () => {
                   title={_("Patterns")}
                   buttonText={_("Change patterns")}
                   patterns={otherPatterns}
+                  selection={proposal.patterns}
                 />
               </GridItem>
               <GridItem lg={6}>
@@ -289,6 +311,7 @@ const PageContent = () => {
                   title={_("Desktop")}
                   buttonText={_("Change desktop")}
                   patterns={desktops}
+                  selection={proposal.patterns}
                 />
               </GridItem>
             </Grid>

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -33,7 +33,6 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   ExpandableSection,
-  Flex,
   Grid,
   GridItem,
   List,
@@ -52,7 +51,7 @@ import { useProposal } from "~/hooks/model/proposal/software";
 import { useSystem } from "~/hooks/model/system/software";
 import { isDesktopPattern, isPatternSelected } from "~/utils/software";
 import { SOFTWARE as PATHS } from "~/routes/paths";
-import { N_, _ } from "~/i18n";
+import { N_, _, n_ } from "~/i18n";
 
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
@@ -62,11 +61,16 @@ import { SelectedBy } from "~/model/proposal/software";
  * Empty state for when no patterns are selected.
  */
 const NoPatternsSelected = (): React.ReactNode => (
+  // TRANSLATORS: empty state title for the additional software section
   <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
-    <EmptyStateBody>{_("The product does not provide additional patterns.")}</EmptyStateBody>
+    <EmptyStateBody>
+      {/* TRANSLATORS: hint shown when no additional software patterns have been chosen */}
+      {_("Select one or more to extend the system.")}
+    </EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>
         <Link to={PATHS.patternsSelection} isPrimary>
+          {/* TRANSLATORS: button to go to the pattern selection page */}
           {_("Select patterns")}
         </Link>
       </EmptyStateActions>
@@ -78,12 +82,17 @@ const NoPatternsSelected = (): React.ReactNode => (
  * Empty state for when no desktop is selected.
  */
 const NoDesktopSelected = (): React.ReactNode => (
+  // TRANSLATORS: empty state title for the desktops section
   <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
-    <EmptyStateBody>{_("Choose a desktop environment.")}</EmptyStateBody>
+    <EmptyStateBody>
+      {/* TRANSLATORS: hint shown when no desktop environment has been chosen */}
+      {_("Select a desktop environment to get a graphical interface.")}
+    </EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>
         <Link to={PATHS.patternsSelection} isPrimary>
-          {_("Select desktop")}
+          {/* TRANSLATORS: button to go to the desktop environment selection page */}
+          {_("Select a desktop")}
         </Link>
       </EmptyStateActions>
     </EmptyStateFooter>
@@ -107,144 +116,76 @@ const SelectedPatternsList = ({
   }
 
   return (
-    <NestedContent margin="mxSm">
-      <List isPlain>
-        {patterns.map((pattern) => (
-          <ListItem key={pattern.name}>
-            <Text>
-              <Text isBold>{pattern.summary} </Text>
-              {selection[pattern.name] === SelectedBy.AUTO && <AutoSelectedLabel />}
-            </Text>
-            <NestedContent margin="mxXs">
-              <ExpandableSection
-                variant="truncate"
-                truncateMaxLines={2}
-                // TRANSLATORS: button to expand truncated pattern description
-                toggleTextCollapsed={_("Read more")}
-                // TRANSLATORS: button to collapse expanded pattern description
-                toggleTextExpanded={_("Read less")}
-              >
-                <SubtleContent>{pattern.description}</SubtleContent>
-              </ExpandableSection>
-            </NestedContent>
-          </ListItem>
-        ))}
-      </List>
+    <NestedContent margin="myMd">
+      <NestedContent margin="mxSm">
+        <List isPlain>
+          {patterns.map((pattern) => (
+            <ListItem key={pattern.name}>
+              <Text>
+                <Text isBold>{pattern.summary} </Text>
+                {selection[pattern.name] === SelectedBy.AUTO && <AutoSelectedLabel />}
+              </Text>
+              <NestedContent margin="mxXs">
+                <ExpandableSection
+                  variant="truncate"
+                  truncateMaxLines={2}
+                  // TRANSLATORS: button to expand truncated pattern description
+                  toggleTextCollapsed={_("Read more")}
+                  // TRANSLATORS: button to collapse expanded pattern description
+                  toggleTextExpanded={_("Read less")}
+                >
+                  <SubtleContent>{pattern.description}</SubtleContent>
+                </ExpandableSection>
+              </NestedContent>
+            </ListItem>
+          ))}
+        </List>
+      </NestedContent>
     </NestedContent>
   );
 };
 
-const SummaryNoSize = ({
-  desktopCount,
-  patternCount,
-}: {
-  desktopCount: number;
-  patternCount: number;
-}): React.ReactNode => {
-  let text = "";
+const Summary = ({ usedSize }: { usedSize?: string }): React.ReactNode => {
+  if (!usedSize) return;
 
-  if (patternCount > 0 && desktopCount > 0) {
-    text = sprintf(
-      // TRANSLATORS: %1$d is pattern count, %2$d is desktop count
-      _("%1$d patterns and %2$d desktop selected"),
-      patternCount,
-      desktopCount,
-    );
-  } else if (patternCount > 0) {
-    text = sprintf(_("%d patterns selected"), patternCount);
-  } else if (desktopCount > 0) {
-    text = sprintf(_("%d desktop selected"), desktopCount);
-  }
+  // TRANSLATORS: %s is the required disk space
+  const text = sprintf(_("About %s space required"), usedSize);
 
-  return (
-    <Flex direction={{ default: "column" }}>
-      <Content isEditorial>
-        <Text>{text}</Text>
-      </Content>
-    </Flex>
-  );
-};
-
-const Summary = ({
-  desktopCount,
-  patternCount,
-  usedSize,
-}: {
-  desktopCount: number;
-  patternCount: number;
-  usedSize?: string;
-}): React.ReactNode => {
-  if (!usedSize) {
-    return <SummaryNoSize desktopCount={desktopCount} patternCount={patternCount} />;
-  }
-
-  let summaryText = "";
-
-  if (patternCount > 0 && desktopCount > 0) {
-    summaryText = sprintf(
-      // TRANSLATORS: %1$s is size, %2$d is pattern count, %3$d is desktop count
-      _("About %1$s space needed with the current selection (%2$d patterns and %3$d desktops)"),
-      usedSize,
-      patternCount,
-      desktopCount,
-    );
-  } else if (patternCount > 0) {
-    summaryText = sprintf(
-      // TRANSLATORS: %1$s is size, %2$d is pattern count
-      _("About %1$s space needed with the current selection (%2$d patterns)"),
-      usedSize,
-      patternCount,
-    );
-  } else if (desktopCount > 0) {
-    summaryText = sprintf(
-      // TRANSLATORS: %1$s is size, %2$d is desktop count
-      _("About %1$s space needed with the current selection (%2$d desktops)"),
-      usedSize,
-      desktopCount,
-    );
-  } else {
-    summaryText = sprintf(
-      // TRANSLATORS: %s is the required space
-      _("About %s space needed"),
-      usedSize,
-    );
-  }
-
-  return (
-    <Flex direction={{ default: "column" }}>
-      <Content isEditorial>
-        <Text>{summaryText}</Text>
-      </Content>
-    </Flex>
-  );
+  return <Text textStyle="fontSizeMd">{text}</Text>;
 };
 
 const SoftwareSection = ({
   title,
+  description,
   buttonText,
+  totalCount,
   patterns,
   selection,
   emptyContent,
 }: {
   title: string;
+  description?: React.ReactNode;
   buttonText: string;
+  totalCount: number;
   patterns: Pattern[];
   selection: PatternsSelection;
   emptyContent: React.ReactNode;
 }): React.ReactNode => {
   const isEmpty = patterns.length === 0;
+  // TRANSLATORS: %1$d is selected count, %2$d is total available count
+  const selected = !isEmpty && sprintf(_("%1$d of %2$d selected"), patterns.length, totalCount);
 
   return (
     <Page.Section
-      title={title}
-      pfCardProps={{ isFullHeight: false }}
-      actions={
-        !isEmpty && (
-          <Link to={PATHS.patternsSelection} isPrimary>
-            {buttonText}
-          </Link>
-        )
+      title={
+        <>
+          {title}{" "}
+          {selected && <Text textStyle={["fontSizeXs", "textColorSubtle"]}>{selected}</Text>}
+        </>
       }
+      description={description}
+      pfCardProps={{ isFullHeight: false }}
+      actions={!isEmpty && <Link to={PATHS.patternsSelection}>{buttonText}</Link>}
     >
       <SelectedPatternsList patterns={patterns} selection={selection} emptyContent={emptyContent} />
     </Page.Section>
@@ -254,8 +195,10 @@ const SoftwareSection = ({
 const NoPatterns = (): React.ReactNode => (
   <Page.Section title={_("Patterns")}>
     <p>
+      {/* TRANSLATORS: shown when the product does not support pattern selection at install time */}
       {_(
-        "This product does not allow to select software patterns during installation. However, you can add additional software once the installation is finished.",
+        "This product does not allow to select software patterns during installation. \
+However, you can add additional software once the installation is finished.",
       )}
     </p>
   </Page.Section>
@@ -301,6 +244,7 @@ const PageContent = () => {
   const [loading, setLoading] = useState(false);
 
   if (!proposal) {
+    // TRANSLATORS: shown while the software proposal is not yet available
     return <EmptyState headingLevel="h2" titleText={_("No information available yet")} />;
   }
 
@@ -310,6 +254,7 @@ const PageContent = () => {
     ? xbytes(proposal.usedSpace * 1024, { iec: true })
     : undefined;
 
+  const [allDesktops, allOtherPatterns] = fork(patterns, isDesktopPattern);
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
   const [desktops, otherPatterns] = fork(selectedPatterns, isDesktopPattern);
 
@@ -321,43 +266,53 @@ const PageContent = () => {
   const showReposAlert = repos.some((r) => !r.loaded);
 
   return (
-    <>
-      <Page.Content>
-        <IssuesAlert issues={issues} />
-        {showReposAlert && <ReloadSection loading={loading} action={startProbing} />}
-        {isEmpty(proposal.patterns) ? (
-          <NoPatterns />
-        ) : (
-          <>
-            <Summary
-              desktopCount={desktops.length}
-              patternCount={otherPatterns.length}
-              usedSize={usedSize}
-            />
-            <Grid hasGutter>
-              <GridItem lg={6}>
-                <SoftwareSection
-                  title={_("Patterns")}
-                  buttonText={_("Change patterns")}
-                  patterns={otherPatterns}
-                  selection={proposal.patterns}
-                  emptyContent={<NoPatternsSelected />}
-                />
-              </GridItem>
-              <GridItem lg={6}>
-                <SoftwareSection
-                  title={_("Desktop")}
-                  buttonText={_("Change desktop")}
-                  patterns={desktops}
-                  selection={proposal.patterns}
-                  emptyContent={<NoDesktopSelected />}
-                />
-              </GridItem>
-            </Grid>
-          </>
-        )}
-      </Page.Content>
-    </>
+    <Page.Content>
+      <Content>
+        <Summary usedSize={usedSize} />
+      </Content>
+      <IssuesAlert issues={issues} />
+      {showReposAlert && <ReloadSection loading={loading} action={startProbing} />}
+      {isEmpty(proposal.patterns) ? (
+        <NoPatterns />
+      ) : (
+        <>
+          <Grid hasGutter>
+            <GridItem lg={6}>
+              <SoftwareSection
+                title={_("Desktops")}
+                description={_(
+                  // TRANSLATORS: description for the Desktops section
+                  "Graphical desktop environments for the system.",
+                )}
+                buttonText={
+                  // TRANSLATORS: button to change the desktop selection; singular when 1 is selected
+                  n_("Change desktop", "Change desktops", desktops.length)
+                }
+                totalCount={allDesktops.length}
+                patterns={desktops}
+                selection={proposal.patterns}
+                emptyContent={<NoDesktopSelected />}
+              />
+            </GridItem>
+            <GridItem lg={6}>
+              <SoftwareSection
+                title={_("Additional patterns")}
+                description={_(
+                  // TRANSLATORS: description for the Additional software section
+                  "Curated sets of packages for common use cases and features to extend the system.",
+                )}
+                // TRANSLATORS: button to change the additional software selection
+                buttonText={_("Change patterns")}
+                totalCount={allOtherPatterns.length}
+                patterns={otherPatterns}
+                selection={proposal.patterns}
+                emptyContent={<NoPatternsSelected />}
+              />
+            </GridItem>
+          </Grid>
+        </>
+      )}
+    </Page.Content>
   );
 };
 

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -22,7 +22,7 @@
 
 import React, { useState } from "react";
 import xbytes from "xbytes";
-import { isEmpty } from "radashi";
+import { fork, isEmpty } from "radashi";
 import { sprintf } from "sprintf-js";
 import {
   Alert,
@@ -34,6 +34,8 @@ import {
   DescriptionListTerm,
   EmptyState,
   Flex,
+  Grid,
+  GridItem,
   Spinner,
 } from "@patternfly/react-core";
 import IssuesAlert from "~/components/core/IssuesAlert";
@@ -69,26 +71,81 @@ const SelectedPatternsList = ({ patterns }: { patterns: Pattern[] }): React.Reac
   );
 };
 
+const SummaryNoSize = ({
+  desktopCount,
+  patternCount,
+}: {
+  desktopCount: number;
+  patternCount: number;
+}): React.ReactNode => {
+  let text = "";
+
+  if (patternCount > 0 && desktopCount > 0) {
+    text = sprintf(
+      // TRANSLATORS: %1$d is pattern count, %2$d is desktop count
+      _("%1$d patterns and %2$d desktop selected"),
+      patternCount,
+      desktopCount,
+    );
+  } else if (patternCount > 0) {
+    text = sprintf(_("%d patterns selected"), patternCount);
+  } else if (desktopCount > 0) {
+    text = sprintf(_("%d desktop selected"), desktopCount);
+  }
+
+  return (
+    <Flex direction={{ default: "column" }}>
+      <Content isEditorial>
+        <Text>{text}</Text>
+      </Content>
+    </Flex>
+  );
+};
+
 const Summary = ({
-  selectedCount,
+  desktopCount,
+  patternCount,
   usedSize,
 }: {
-  selectedCount: number;
+  desktopCount: number;
+  patternCount: number;
   usedSize?: string;
 }): React.ReactNode => {
-  const summaryText = usedSize
-    ? sprintf(
-        // TRANSLATORS: %1$d is the number of selected patterns, %2$s is the total installation size
-        // (e.g., "5 selected patterns, total size needed: 4.60 GiB")
-        _("%1$d selected patterns, total size needed: %2$s"),
-        selectedCount,
-        usedSize,
-      )
-    : sprintf(
-        // TRANSLATORS: %d is the number of selected patterns
-        _("%d selected patterns"),
-        selectedCount,
-      );
+  if (!usedSize) {
+    return <SummaryNoSize desktopCount={desktopCount} patternCount={patternCount} />;
+  }
+
+  let summaryText = "";
+
+  if (patternCount > 0 && desktopCount > 0) {
+    summaryText = sprintf(
+      // TRANSLATORS: %1$s is size, %2$d is pattern count, %3$d is desktop count
+      _("About %1$s space needed with the current selection (%2$d patterns and %3$d desktops)"),
+      usedSize,
+      patternCount,
+      desktopCount,
+    );
+  } else if (patternCount > 0) {
+    summaryText = sprintf(
+      // TRANSLATORS: %1$s is size, %2$d is pattern count
+      _("About %1$s space needed with the current selection (%2$d patterns)"),
+      usedSize,
+      patternCount,
+    );
+  } else if (desktopCount > 0) {
+    summaryText = sprintf(
+      // TRANSLATORS: %1$s is size, %2$d is desktop count
+      _("About %1$s space needed with the current selection (%2$d desktops)"),
+      usedSize,
+      desktopCount,
+    );
+  } else {
+    summaryText = sprintf(
+      // TRANSLATORS: %s is the required space
+      _("About %s space needed"),
+      usedSize,
+    );
+  }
 
   return (
     <Flex direction={{ default: "column" }}>
@@ -99,12 +156,21 @@ const Summary = ({
   );
 };
 
-const SelectedPatterns = ({ patterns }: { patterns: Pattern[] }): React.ReactNode => (
+const SoftwareSection = ({
+  title,
+  buttonText,
+  patterns,
+}: {
+  title: string;
+  buttonText: string;
+  patterns: Pattern[];
+}): React.ReactNode => (
   <Page.Section
-    title={_("Selected patterns")}
+    title={title}
+    pfCardProps={{ isFullHeight: false }}
     actions={
       <Link to={PATHS.patternsSelection} isPrimary>
-        {_("Change selection")}
+        {buttonText}
       </Link>
     }
   >
@@ -170,7 +236,12 @@ const PageContent = () => {
   const usedSize = proposal.usedSpace
     ? xbytes(proposal.usedSpace * 1024, { iec: true })
     : undefined;
+
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
+  const [desktops, otherPatterns] = fork(
+    selectedPatterns,
+    (p) => p.category === "Graphical Environments",
+  );
 
   const startProbing = () => {
     setLoading(true);
@@ -188,8 +259,27 @@ const PageContent = () => {
           <NoPatterns />
         ) : (
           <>
-            <Summary selectedCount={selectedPatterns.length} usedSize={usedSize} />
-            <SelectedPatterns patterns={selectedPatterns} />
+            <Summary
+              desktopCount={desktops.length}
+              patternCount={otherPatterns.length}
+              usedSize={usedSize}
+            />
+            <Grid hasGutter>
+              <GridItem lg={6}>
+                <SoftwareSection
+                  title={_("Selected patterns")}
+                  buttonText={_("Change patterns")}
+                  patterns={otherPatterns}
+                />
+              </GridItem>
+              <GridItem lg={6}>
+                <SoftwareSection
+                  title={_("Selected desktop")}
+                  buttonText={_("Change desktop")}
+                  patterns={desktops}
+                />
+              </GridItem>
+            </Grid>
           </>
         )}
       </Page.Content>

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -57,42 +57,20 @@ import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
 
-/**
- * Empty state for when no patterns are selected.
- */
-const NoPatternsSelected = (): React.ReactNode => (
-  // TRANSLATORS: empty state title for the additional software section
+const NoSelectionEmptyState = ({
+  body,
+  buttonText,
+}: {
+  body: string;
+  buttonText: string;
+}): React.ReactNode => (
+  // TRANSLATORS: empty state title for a software section with nothing selected
   <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
-    <EmptyStateBody>
-      {/* TRANSLATORS: hint shown when no additional software patterns have been chosen */}
-      {_("Select one or more to extend the system.")}
-    </EmptyStateBody>
+    <EmptyStateBody>{body}</EmptyStateBody>
     <EmptyStateFooter>
       <EmptyStateActions>
         <Link to={PATHS.patternsSelection} isPrimary>
-          {/* TRANSLATORS: button to go to the pattern selection page */}
-          {_("Select patterns")}
-        </Link>
-      </EmptyStateActions>
-    </EmptyStateFooter>
-  </EmptyState>
-);
-
-/**
- * Empty state for when no desktop is selected.
- */
-const NoDesktopSelected = (): React.ReactNode => (
-  // TRANSLATORS: empty state title for the desktops section
-  <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
-    <EmptyStateBody>
-      {/* TRANSLATORS: hint shown when no desktop environment has been chosen */}
-      {_("Select a desktop environment to get a graphical interface.")}
-    </EmptyStateBody>
-    <EmptyStateFooter>
-      <EmptyStateActions>
-        <Link to={PATHS.patternsSelection} isPrimary>
-          {/* TRANSLATORS: button to go to the desktop environment selection page */}
-          {_("Select a desktop")}
+          {buttonText}
         </Link>
       </EmptyStateActions>
     </EmptyStateFooter>
@@ -171,9 +149,10 @@ const SoftwareSection = ({
   selection: PatternsSelection;
   emptyContent: React.ReactNode;
 }): React.ReactNode => {
-  const isEmpty = patterns.length === 0;
+  const noneSelected = patterns.length === 0;
   // TRANSLATORS: %1$d is selected count, %2$d is total available count
-  const selected = !isEmpty && sprintf(_("%1$d of %2$d selected"), patterns.length, totalCount);
+  const selected =
+    !noneSelected && sprintf(_("%1$d of %2$d selected"), patterns.length, totalCount);
 
   return (
     <Page.Section
@@ -185,7 +164,7 @@ const SoftwareSection = ({
       }
       description={description}
       pfCardProps={{ isFullHeight: false }}
-      actions={!isEmpty && <Link to={PATHS.patternsSelection}>{buttonText}</Link>}
+      actions={!noneSelected && <Link to={PATHS.patternsSelection}>{buttonText}</Link>}
     >
       <SelectedPatternsList patterns={patterns} selection={selection} emptyContent={emptyContent} />
     </Page.Section>
@@ -275,42 +254,54 @@ const PageContent = () => {
       {isEmpty(proposal.patterns) ? (
         <NoPatterns />
       ) : (
-        <>
-          <Grid hasGutter>
-            <GridItem lg={6}>
-              <SoftwareSection
-                title={_("Desktops")}
-                description={_(
-                  // TRANSLATORS: description for the Desktops section
-                  "Graphical desktop environments for the system.",
-                )}
-                buttonText={
-                  // TRANSLATORS: button to change the desktop selection; singular when 1 is selected
-                  n_("Change desktop", "Change desktops", desktops.length)
-                }
-                totalCount={allDesktops.length}
-                patterns={desktops}
-                selection={proposal.patterns}
-                emptyContent={<NoDesktopSelected />}
-              />
-            </GridItem>
-            <GridItem lg={6}>
-              <SoftwareSection
-                title={_("Additional patterns")}
-                description={_(
-                  // TRANSLATORS: description for the Additional software section
-                  "Curated sets of packages for common use cases and features to extend the system.",
-                )}
-                // TRANSLATORS: button to change the additional software selection
-                buttonText={_("Change patterns")}
-                totalCount={allOtherPatterns.length}
-                patterns={otherPatterns}
-                selection={proposal.patterns}
-                emptyContent={<NoPatternsSelected />}
-              />
-            </GridItem>
-          </Grid>
-        </>
+        <Grid hasGutter>
+          <GridItem lg={6}>
+            <SoftwareSection
+              title={_("Desktops")}
+              description={_(
+                // TRANSLATORS: description for the Desktops section
+                "Graphical desktop environments for the system.",
+              )}
+              buttonText={
+                // TRANSLATORS: button to change the desktop selection; singular when 1 is selected
+                n_("Change desktop", "Change desktops", desktops.length)
+              }
+              totalCount={allDesktops.length}
+              patterns={desktops}
+              selection={proposal.patterns}
+              emptyContent={
+                <NoSelectionEmptyState
+                  // TRANSLATORS: hint shown when no desktop environment has been chosen
+                  body={_("Select a desktop environment to get a graphical interface.")}
+                  // TRANSLATORS: button to go to the desktop environment selection page
+                  buttonText={_("Select a desktop")}
+                />
+              }
+            />
+          </GridItem>
+          <GridItem lg={6}>
+            <SoftwareSection
+              title={_("Additional patterns")}
+              description={_(
+                // TRANSLATORS: description for the Additional software section
+                "Curated sets of packages for common use cases and features to extend the system.",
+              )}
+              // TRANSLATORS: button to change the additional software selection
+              buttonText={_("Change patterns")}
+              totalCount={allOtherPatterns.length}
+              patterns={otherPatterns}
+              selection={proposal.patterns}
+              emptyContent={
+                <NoSelectionEmptyState
+                  // TRANSLATORS: hint shown when no additional software patterns have been chosen
+                  body={_("Select one or more to extend the system.")}
+                  // TRANSLATORS: button to go to the pattern selection page
+                  buttonText={_("Select patterns")}
+                />
+              }
+            />
+          </GridItem>
+        </Grid>
       )}
     </Page.Content>
   );

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -20,13 +20,11 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import xbytes from "xbytes";
 import { fork, isEmpty } from "radashi";
 import { sprintf } from "sprintf-js";
 import {
-  Alert,
-  Button,
   Content,
   EmptyState,
   EmptyStateActions,
@@ -37,7 +35,6 @@ import {
   GridItem,
   List,
   ListItem,
-  Spinner,
 } from "@patternfly/react-core";
 import IssuesAlert from "~/components/core/IssuesAlert";
 import Link from "~/components/core/Link";
@@ -51,7 +48,7 @@ import { useProposal } from "~/hooks/model/proposal/software";
 import { useSystem } from "~/hooks/model/system/software";
 import { isDesktopPattern, isPatternSelected } from "~/utils/software";
 import { SOFTWARE as PATHS } from "~/routes/paths";
-import { N_, _, n_ } from "~/i18n";
+import { _, n_ } from "~/i18n";
 
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
@@ -183,52 +180,16 @@ However, you can add additional software once the installation is finished.",
   </Page.Section>
 );
 
-const errorMsg = N_(
-  /* TRANSLATORS: error details followed by a "Try again" link*/
-  "Some installation repositories could not be loaded. \
-The system cannot be installed without them.",
-);
-
-// error message, allow reloading the repositories again
-const ReloadSection = ({
-  loading,
-  action,
-}: {
-  loading: boolean;
-  action: () => void;
-}): React.ReactNode => (
-  // TRANSLATORS: title for an error message box, at least one repository could not be loaded
-  <Alert variant="danger" isInline title={_("Repository load failed")}>
-    {loading ? (
-      <>
-        {/* TRANSLATORS: progress message */}
-        <Spinner size="md" /> {_("Loading the installation repositories...")}
-      </>
-    ) : (
-      <>
-        {_(errorMsg)}{" "}
-        <Button variant="link" isInline onClick={action}>
-          {/* TRANSLATORS: link for retrying failed repository load */}
-          {_("Try again")}
-        </Button>
-      </>
-    )}
-  </Alert>
-);
-
 const PageContent = () => {
   const { patterns } = useSystem();
   const proposal = useProposal();
   const issues = useIssues("software");
-  const [loading, setLoading] = useState(false);
 
   if (!proposal) {
     // TRANSLATORS: shown while the software proposal is not yet available
     return <EmptyState headingLevel="h2" titleText={_("No information available yet")} />;
   }
 
-  // FIXME: temporarily disabled, the API end point is not implemented yet
-  const repos = []; // useRepositories();
   const usedSize = proposal.usedSpace
     ? xbytes(proposal.usedSpace * 1024, { iec: true })
     : undefined;
@@ -237,20 +198,12 @@ const PageContent = () => {
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
   const [desktops, otherPatterns] = fork(selectedPatterns, isDesktopPattern);
 
-  const startProbing = () => {
-    setLoading(true);
-    // TODO: probe();
-  };
-
-  const showReposAlert = repos.some((r) => !r.loaded);
-
   return (
     <Page.Content>
       <Content>
         <Summary usedSize={usedSize} />
       </Content>
       <IssuesAlert issues={issues} />
-      {showReposAlert && <ReloadSection loading={loading} action={startProbing} />}
       {isEmpty(proposal.patterns) ? (
         <NoPatterns />
       ) : (

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -54,13 +54,10 @@ import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
 
-const NoSelectionEmptyState = ({
-  body,
-  buttonText,
-}: {
-  body: string;
-  buttonText: string;
-}): React.ReactNode => (
+/**
+ * Empty state for a software section where nothing has been selected yet.
+ */
+const NothingSelected = ({ body, buttonText }: { body: string; buttonText: string }) => (
   // TRANSLATORS: empty state title for a software section with nothing selected
   <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
     <EmptyStateBody>{body}</EmptyStateBody>
@@ -85,7 +82,7 @@ const SelectedPatternsList = ({
   patterns: Pattern[];
   selection: PatternsSelection;
   emptyContent: React.ReactNode;
-}): React.ReactNode => {
+}) => {
   if (patterns.length === 0) {
     return emptyContent;
   }
@@ -120,7 +117,12 @@ const SelectedPatternsList = ({
   );
 };
 
-const Summary = ({ usedSize }: { usedSize?: string }): React.ReactNode => {
+/**
+ * Displays the estimated disk space required by the current software selection.
+ *
+ * Renders nothing when no size information is available.
+ */
+const SpaceRequirements = ({ usedSize }: { usedSize?: string }) => {
   if (!usedSize) return;
 
   // TRANSLATORS: %s is the required disk space
@@ -129,6 +131,30 @@ const Summary = ({ usedSize }: { usedSize?: string }): React.ReactNode => {
   return <Text textStyle="fontSizeMd">{text}</Text>;
 };
 
+type SoftwareSectionProps = {
+  /** Section heading. */
+  title: string;
+  /** Optional explanatory text rendered below the heading. */
+  description?: React.ReactNode;
+  /** Label for the link that opens the pattern selection page. */
+  buttonText: string;
+  /** Total number of patterns in this group, selected or not. */
+  totalCount: number;
+  /** Patterns in this group that are currently selected. */
+  patterns: Pattern[];
+  /** Full selection map, used to determine how each pattern was selected. */
+  selection: PatternsSelection;
+  /** Content to show when no patterns are selected. */
+  emptyContent: React.ReactNode;
+};
+
+/**
+ * A page section displaying a group of software patterns with a count of how
+ * many are selected, an optional description, and a link to change the
+ * selection.
+ *
+ * Shows `emptyContent` when no patterns in the group are selected.
+ */
 const SoftwareSection = ({
   title,
   description,
@@ -137,15 +163,7 @@ const SoftwareSection = ({
   patterns,
   selection,
   emptyContent,
-}: {
-  title: string;
-  description?: React.ReactNode;
-  buttonText: string;
-  totalCount: number;
-  patterns: Pattern[];
-  selection: PatternsSelection;
-  emptyContent: React.ReactNode;
-}): React.ReactNode => {
+}: SoftwareSectionProps) => {
   const noneSelected = patterns.length === 0;
   // TRANSLATORS: %1$d is selected count, %2$d is total available count
   const selected =
@@ -168,19 +186,25 @@ const SoftwareSection = ({
   );
 };
 
-const NoPatterns = (): React.ReactNode => (
+/**
+ * Fallback section shown when the product does not support pattern selection.
+ */
+const PatternSelectionUnavailable = () => (
   <Page.Section title={_("Patterns")}>
-    <p>
+    <Content component="p">
       {/* TRANSLATORS: shown when the product does not support pattern selection at install time */}
       {_(
         "This product does not allow to select software patterns during installation. \
 However, you can add additional software once the installation is finished.",
       )}
-    </p>
+    </Content>
   </Page.Section>
 );
 
-const PageContent = () => {
+/**
+ * Main content of the software page.
+ */
+const SoftwarePageContent = () => {
   const { patterns } = useSystem();
   const proposal = useProposal();
   const issues = useIssues("software");
@@ -201,11 +225,11 @@ const PageContent = () => {
   return (
     <Page.Content>
       <Content>
-        <Summary usedSize={usedSize} />
+        <SpaceRequirements usedSize={usedSize} />
       </Content>
       <IssuesAlert issues={issues} />
       {isEmpty(proposal.patterns) ? (
-        <NoPatterns />
+        <PatternSelectionUnavailable />
       ) : (
         <Grid hasGutter>
           <GridItem lg={6}>
@@ -223,7 +247,7 @@ const PageContent = () => {
               patterns={desktops}
               selection={proposal.patterns}
               emptyContent={
-                <NoSelectionEmptyState
+                <NothingSelected
                   // TRANSLATORS: hint shown when no desktop environment has been chosen
                   body={_("Select a desktop environment to get a graphical interface.")}
                   // TRANSLATORS: button to go to the desktop environment selection page
@@ -245,7 +269,7 @@ const PageContent = () => {
               patterns={otherPatterns}
               selection={proposal.patterns}
               emptyContent={
-                <NoSelectionEmptyState
+                <NothingSelected
                   // TRANSLATORS: hint shown when no additional software patterns have been chosen
                   body={_("Select one or more to extend the system.")}
                   // TRANSLATORS: button to go to the pattern selection page
@@ -263,10 +287,10 @@ const PageContent = () => {
 /**
  * Software page component
  */
-function SoftwarePage(): React.ReactNode {
+function SoftwarePage() {
   return (
     <Page breadcrumbs={[{ label: _("Software") }]} progress={{ scope: "software" }}>
-      <PageContent />
+      <SoftwarePageContent />
     </Page>
   );
 }

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -33,7 +33,6 @@ import {
   Flex,
   Grid,
   GridItem,
-  Label,
   List,
   ListItem,
   Spinner,
@@ -44,6 +43,7 @@ import NestedContent from "~/components/core/NestedContent";
 import Page from "~/components/core/Page";
 import SubtleContent from "~/components/core/SubtleContent";
 import Text from "~/components/core/Text";
+import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useSystem } from "~/hooks/model/system/software";
@@ -76,12 +76,7 @@ const SelectedPatternsList = ({
           <ListItem key={pattern.name}>
             <Text>
               <Text isBold>{pattern.summary} </Text>
-              {selection[pattern.name] === SelectedBy.AUTO && (
-                <Label color="blue" isCompact>
-                  {/* TRANSLATORS: label shown for patterns automatically selected as dependencies */}
-                  {_("auto selected")}
-                </Label>
-              )}
+              {selection[pattern.name] === SelectedBy.AUTO && <AutoSelectedLabel />}
             </Text>
             <NestedContent margin="mxXs">
               <ExpandableSection

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -29,6 +29,9 @@ import {
   Button,
   Content,
   EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
   ExpandableSection,
   Flex,
   Grid,
@@ -56,17 +59,51 @@ import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
 
 /**
+ * Empty state for when no patterns are selected.
+ */
+const NoPatternsSelected = (): React.ReactNode => (
+  <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
+    <EmptyStateBody>{_("The product does not provide additional patterns.")}</EmptyStateBody>
+    <EmptyStateFooter>
+      <EmptyStateActions>
+        <Link to={PATHS.patternsSelection} isPrimary>
+          {_("Select patterns")}
+        </Link>
+      </EmptyStateActions>
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+/**
+ * Empty state for when no desktop is selected.
+ */
+const NoDesktopSelected = (): React.ReactNode => (
+  <EmptyState headingLevel="h4" titleText={_("None selected")} variant="sm">
+    <EmptyStateBody>{_("Choose a desktop environment.")}</EmptyStateBody>
+    <EmptyStateFooter>
+      <EmptyStateActions>
+        <Link to={PATHS.patternsSelection} isPrimary>
+          {_("Select desktop")}
+        </Link>
+      </EmptyStateActions>
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+/**
  * List of selected patterns.
  */
 const SelectedPatternsList = ({
   patterns,
   selection,
+  emptyContent,
 }: {
   patterns: Pattern[];
   selection: PatternsSelection;
+  emptyContent: React.ReactNode;
 }): React.ReactNode => {
   if (patterns.length === 0) {
-    return <>{_("No additional software was selected.")}</>;
+    return emptyContent;
   }
 
   return (
@@ -187,24 +224,32 @@ const SoftwareSection = ({
   buttonText,
   patterns,
   selection,
+  emptyContent,
 }: {
   title: string;
   buttonText: string;
   patterns: Pattern[];
   selection: PatternsSelection;
-}): React.ReactNode => (
-  <Page.Section
-    title={title}
-    pfCardProps={{ isFullHeight: false }}
-    actions={
-      <Link to={PATHS.patternsSelection} isPrimary>
-        {buttonText}
-      </Link>
-    }
-  >
-    <SelectedPatternsList patterns={patterns} selection={selection} />
-  </Page.Section>
-);
+  emptyContent: React.ReactNode;
+}): React.ReactNode => {
+  const isEmpty = patterns.length === 0;
+
+  return (
+    <Page.Section
+      title={title}
+      pfCardProps={{ isFullHeight: false }}
+      actions={
+        !isEmpty && (
+          <Link to={PATHS.patternsSelection} isPrimary>
+            {buttonText}
+          </Link>
+        )
+      }
+    >
+      <SelectedPatternsList patterns={patterns} selection={selection} emptyContent={emptyContent} />
+    </Page.Section>
+  );
+};
 
 const NoPatterns = (): React.ReactNode => (
   <Page.Section title={_("Patterns")}>
@@ -299,6 +344,7 @@ const PageContent = () => {
                   buttonText={_("Change patterns")}
                   patterns={otherPatterns}
                   selection={proposal.patterns}
+                  emptyContent={<NoPatternsSelected />}
                 />
               </GridItem>
               <GridItem lg={6}>
@@ -307,6 +353,7 @@ const PageContent = () => {
                   buttonText={_("Change desktop")}
                   patterns={desktops}
                   selection={proposal.patterns}
+                  emptyContent={<NoDesktopSelected />}
                 />
               </GridItem>
             </Grid>

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -343,7 +343,7 @@ describe("SoftwarePatternsSelection scope", () => {
     expect(screen.queryByRole("checkbox", { name: /KDE/ })).not.toBeInTheDocument();
   });
 
-  it("ppreserves REMOVED desktop patterns in remove when submitting with scope 'otherereserves USER-selected desktop patterns (in the 'add' key) when submitting with scope 'other'", async () => {
+  it("preserves REMOVED desktop patterns (in the 'remove' key) when submitting with scope 'other'", async () => {
     const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
 
     // Touch a non-desktop pattern to make the form dirty

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -343,7 +343,7 @@ describe("SoftwarePatternsSelection scope", () => {
     expect(screen.queryByRole("checkbox", { name: /KDE/ })).not.toBeInTheDocument();
   });
 
-  it("preserves USER-selected desktop patterns in add when submitting with scope 'other'", async () => {
+  it("ppreserves REMOVED desktop patterns in remove when submitting with scope 'otherereserves USER-selected desktop patterns (in the 'add' key) when submitting with scope 'other'", async () => {
     const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
 
     // Touch a non-desktop pattern to make the form dirty
@@ -391,7 +391,7 @@ describe("SoftwarePatternsSelection scope", () => {
     });
   });
 
-  it("preserves REMOVED desktop patterns in remove when submitting with scope 'other'", async () => {
+  it("preserves REMOVED desktop patterns (in the 'remove' key) when submitting with scope 'other'", async () => {
     const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
 
     // Touch a non-desktop pattern to make the form dirty

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -56,6 +56,17 @@ jest.mock("~/hooks/model/proposal/software", () => ({
   }),
 }));
 
+jest.mock("~/hooks/model/config", () => ({
+  useExtendedConfig: () => ({
+    software: {
+      patterns: {
+        add: ["gnome"],
+        remove: ["kde"],
+      },
+    },
+  }),
+}));
+
 jest.mock("~/api", () => ({
   patchConfig: jest.fn(),
 }));

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -363,7 +363,13 @@ describe("SoftwarePatternsSelection scope", () => {
     const acceptButton = screen.getByRole("button", { name: "Accept" });
     await user.click(acceptButton);
 
-    const nonDesktopPatterns = ["yast2_basis", "yast2_desktop", "yast2_server", "multimedia", "office"];
+    const nonDesktopPatterns = [
+      "yast2_basis",
+      "yast2_desktop",
+      "yast2_server",
+      "multimedia",
+      "office",
+    ];
     expect(patchConfig).toHaveBeenCalledWith({
       software: {
         patterns: {

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -38,6 +38,7 @@ const patternsWithPreselected = [
     summary: "Preselected Pattern",
     order: "1225",
     preselected: true,
+    desktop: false,
   },
 ];
 
@@ -304,6 +305,93 @@ describe("SoftwarePatternsSelection", () => {
           },
         },
       });
+    });
+  });
+});
+
+describe("SoftwarePatternsSelection scope", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows only desktop patterns when scope is 'desktops'", async () => {
+    installerRender(<SoftwarePatternsSelection scope="desktops" />);
+
+    expect(await screen.findByRole("checkbox", { name: /GNOME/ })).toBeInTheDocument();
+    expect(await screen.findByRole("checkbox", { name: /KDE/ })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: /YaST Base/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: /Multimedia/ })).not.toBeInTheDocument();
+  });
+
+  it("shows only non-desktop patterns when scope is 'other'", async () => {
+    installerRender(<SoftwarePatternsSelection scope="other" />);
+
+    expect(await screen.findByRole("checkbox", { name: /YaST Base/ })).toBeInTheDocument();
+    expect(await screen.findByRole("checkbox", { name: /Multimedia/ })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: /GNOME/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: /KDE/ })).not.toBeInTheDocument();
+  });
+
+  it("preserves USER-selected desktop patterns in add when submitting with scope 'other'", async () => {
+    const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
+
+    // Touch a non-desktop pattern to make the form dirty
+    const serverCheckbox = await screen.findByRole("checkbox", { name: /Select YaST Server/ });
+    await user.click(serverCheckbox);
+
+    const acceptButton = screen.getByRole("button", { name: "Accept" });
+    await user.click(acceptButton);
+
+    // GNOME was USER-selected on the desktop scope and must survive submission here
+    expect(patchConfig).toHaveBeenCalledWith({
+      software: {
+        patterns: {
+          add: expect.arrayContaining(["gnome", "yast2_server"]),
+          remove: expect.not.arrayContaining(["gnome"]),
+        },
+      },
+    });
+  });
+
+  it("does not alter non-desktop patterns when submitting with scope 'desktops'", async () => {
+    const { user } = installerRender(<SoftwarePatternsSelection scope="desktops" />);
+
+    // Touch a desktop pattern to make the form dirty
+    const kdeCheckbox = await screen.findByRole("checkbox", { name: /Select KDE/ });
+    await user.click(kdeCheckbox);
+
+    const acceptButton = screen.getByRole("button", { name: "Accept" });
+    await user.click(acceptButton);
+
+    const nonDesktopPatterns = ["yast2_basis", "yast2_desktop", "yast2_server", "multimedia", "office"];
+    expect(patchConfig).toHaveBeenCalledWith({
+      software: {
+        patterns: {
+          add: expect.not.arrayContaining(nonDesktopPatterns),
+          remove: expect.not.arrayContaining(nonDesktopPatterns),
+        },
+      },
+    });
+  });
+
+  it("preserves REMOVED desktop patterns in remove when submitting with scope 'other'", async () => {
+    const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
+
+    // Touch a non-desktop pattern to make the form dirty
+    const serverCheckbox = await screen.findByRole("checkbox", { name: /Select YaST Server/ });
+    await user.click(serverCheckbox);
+
+    const acceptButton = screen.getByRole("button", { name: "Accept" });
+    await user.click(acceptButton);
+
+    // kde was REMOVED and must remain in remove even though it is not shown here
+    expect(patchConfig).toHaveBeenCalledWith({
+      software: {
+        patterns: {
+          add: expect.not.arrayContaining(["kde"]),
+          remove: expect.arrayContaining(["kde"]),
+        },
+      },
     });
   });
 });

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -71,66 +71,49 @@ const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the f
 type Scope = "all" | "desktops" | "other";
 
 /**
- * Whether a pattern should be added to the selection on submit.
+ * Resolves what action, if any, a pattern should produce on submit.
  *
- * Visible patterns (inScope) are added only when checked AND there is clear
- * user intent: the user just toggled it, or it was already their explicit
- * choice. This avoids re-adding auto-selected patterns the user never touched.
+ * Visible patterns (inScope):
+ * - "add" when checked AND there is clear user intent: the user just toggled it,
+ *   or it was already their explicit choice. Avoids re-adding auto-selected patterns
+ *   the user never touched.
+ * - "remove" when unchecked AND previously relevant: selected on load, a product
+ *   default, or already explicitly removed. Patterns never seen before are ignored.
+ * - null otherwise.
  *
- * Hidden patterns (not inScope) are passed through unchanged to avoid losing
- * selections made on a different scope. For example, when submitting the
- * patterns scope ("other"), GNOME selected on the desktop scope must survive.
+ * Hidden patterns (not inScope) pass through their existing config state unchanged,
+ * to avoid losing selections or removals made on a different scope.
  *
- * @param inScope - Whether the pattern is visible to the user in the current scope
+ * @param inScope - Whether the pattern is visible in the current scope
  * @param isChecked - Current checkbox value in the form
  * @param isDirty - Whether the user changed the checkbox from its initial value
- * @param selectionStatus - Current backend selection status for this pattern
- * @param inConfig - Whether the pattern is in the config's add list
- *   (for out-of-scope preservation)
- */
-const shouldAdd = (
-  inScope: boolean,
-  isChecked: boolean,
-  isDirty: boolean,
-  selectionStatus: SelectedBy | undefined,
-  inConfig: boolean,
-): boolean => {
-  if (!inScope && inConfig) return true;
-  if (!inScope) return false;
-  return isChecked && (isDirty || selectionStatus === SelectedBy.USER);
-};
-
-/**
- * Whether a pattern should be removed from the selection on submit.
- *
- * Visible patterns (inScope) are removed when unchecked AND previously known
- * to the selection: selected on load, a product default (preselected), or
- * already explicitly removed. Patterns never seen before are simply ignored.
- *
- * Hidden patterns (not inScope) preserve their existing removed state to avoid
- * undoing removals made on a different scope. For example, when submitting the
- * patterns scope ("other"), a GNOME removal made on the desktop scope is kept.
- *
- * @param inScope - Whether the pattern is visible to the user in the current scope
- * @param isChecked - Current checkbox value in the form
  * @param isPreselected - Whether the pattern is selected by default in the product
  * @param wasInitiallySelected - Whether the pattern was selected when the form loaded
  * @param selectionStatus - Current backend selection status for this pattern
- * @param inConfig - Whether the pattern is in the config's remove list (for out-of-scope preservation)
+ * @param inConfigAdd - Whether the pattern is in the config's add list (out-of-scope preservation)
+ * @param inConfigRemove - Whether the pattern is in the config's remove list (out-of-scope preservation)
  */
-const shouldRemove = (
+const resolvePatternAction = (
   inScope: boolean,
   isChecked: boolean,
+  isDirty: boolean,
   isPreselected: boolean,
   wasInitiallySelected: boolean,
   selectionStatus: SelectedBy | undefined,
-  inConfig: boolean,
-): boolean => {
-  if (!inScope && inConfig) return true;
-  if (!inScope) return false;
-  return (
-    !isChecked && (wasInitiallySelected || isPreselected || selectionStatus === SelectedBy.REMOVED)
-  );
+  inConfigAdd: boolean,
+  inConfigRemove: boolean,
+): "add" | "remove" | undefined => {
+  if (!inScope) {
+    if (inConfigAdd) return "add";
+    if (inConfigRemove) return "remove";
+    return;
+  }
+  if (isChecked && (isDirty || selectionStatus === SelectedBy.USER)) return "add";
+  if (
+    !isChecked &&
+    (wasInitiallySelected || isPreselected || selectionStatus === SelectedBy.REMOVED)
+  )
+    return "remove";
 };
 
 /** Values use `N_()` for extraction. Translate with `_()` at render time. */
@@ -195,28 +178,18 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
           const wasInitiallySelected = initialValues[p.name];
           const selectionStatus = selection[p.name];
 
-          if (
-            shouldAdd(
-              inScope,
-              isChecked,
-              isDirty,
-              selectionStatus,
-              userAddedPatterns.includes(p.name),
-            )
-          ) {
-            acc.add.push(p.name);
-          } else if (
-            shouldRemove(
-              inScope,
-              isChecked,
-              p.preselected,
-              wasInitiallySelected,
-              selectionStatus,
-              userRemovedPatterns.includes(p.name),
-            )
-          ) {
-            acc.remove.push(p.name);
-          }
+          const action = resolvePatternAction(
+            inScope,
+            isChecked,
+            isDirty,
+            p.preselected,
+            wasInitiallySelected,
+            selectionStatus,
+            userAddedPatterns.includes(p.name),
+            userRemovedPatterns.includes(p.name),
+          );
+
+          if (action) acc[action].push(p.name);
           return acc;
         },
         { add: [], remove: [] },

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -22,7 +22,6 @@
 
 import React, { useState } from "react";
 import {
-  Label,
   DataList,
   DataListCell,
   DataListCheck,
@@ -37,16 +36,18 @@ import {
 } from "@patternfly/react-core";
 import { formOptions } from "@tanstack/react-form";
 import { useNavigate } from "react-router";
-import { Page } from "~/components/core";
-import { _ } from "~/i18n";
-import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
-import { useSystem } from "~/hooks/model/system/software";
+import Page from "~/components/core/Page";
+import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { SelectedBy } from "~/model/proposal/software";
-import { useProposal } from "~/hooks/model/proposal/software";
 import { patchConfig } from "~/api";
-import { SOFTWARE } from "~/routes/paths";
+import { useSystem } from "~/hooks/model/system/software";
+import { useProposal } from "~/hooks/model/proposal/software";
 import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
+import { SOFTWARE } from "~/routes/paths";
+import { _ } from "~/i18n";
+
+import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 
 /**
  * Form options for pattern selection.
@@ -171,9 +172,7 @@ function SoftwarePatternsSelection() {
                                           <div>
                                             <b id={titleId}>{option.summary}</b>{" "}
                                             {selection[option.name] === SelectedBy.AUTO && (
-                                              <Label color="blue" isCompact>
-                                                {_("auto selected")}
-                                              </Label>
+                                              <AutoSelectedLabel />
                                             )}
                                             <span id={nextActionId} className={a11yStyles.hidden}>
                                               {selected ? _("Unselect") : _("Select")}

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -42,6 +42,7 @@ import { SelectedBy } from "~/model/proposal/software";
 import { patchConfig } from "~/api";
 import { useSystem } from "~/hooks/model/system/software";
 import { useProposal } from "~/hooks/model/proposal/software";
+import { useExtendedConfig } from "~/hooks/model/config";
 import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
 import { SOFTWARE } from "~/routes/paths";
@@ -82,16 +83,19 @@ type Scope = "all" | "desktops" | "other";
  * @param isChecked - Current checkbox value in the form
  * @param isDirty - Whether the user changed the checkbox from its initial value
  * @param selectionStatus - Current backend selection status for this pattern
+ * @param inConfig - Whether the pattern is in the config's add list (for out-of-scope preservation)
  */
 const shouldAdd = (
   inScope: boolean,
   isChecked: boolean,
   isDirty: boolean,
   selectionStatus: SelectedBy | undefined,
-): boolean =>
-  inScope
-    ? isChecked && (isDirty || selectionStatus === SelectedBy.USER)
-    : selectionStatus === SelectedBy.USER;
+  inConfig: boolean,
+): boolean => {
+  if (!inScope && inConfig) return true;
+  if (!inScope) return false;
+  return isChecked && (isDirty || selectionStatus === SelectedBy.USER);
+};
 
 /**
  * Whether a pattern should be removed from the selection on submit.
@@ -109,6 +113,7 @@ const shouldAdd = (
  * @param isPreselected - Whether the pattern is selected by default in the product
  * @param wasInitiallySelected - Whether the pattern was selected when the form loaded
  * @param selectionStatus - Current backend selection status for this pattern
+ * @param inConfig - Whether the pattern is in the config's remove list (for out-of-scope preservation)
  */
 const shouldRemove = (
   inScope: boolean,
@@ -116,11 +121,14 @@ const shouldRemove = (
   isPreselected: boolean,
   wasInitiallySelected: boolean,
   selectionStatus: SelectedBy | undefined,
-): boolean =>
-  inScope
-    ? !isChecked &&
-      (wasInitiallySelected || isPreselected || selectionStatus === SelectedBy.REMOVED)
-    : selectionStatus === SelectedBy.REMOVED;
+  inConfig: boolean,
+): boolean => {
+  if (!inScope && inConfig) return true;
+  if (!inScope) return false;
+  return (
+    !isChecked && (wasInitiallySelected || isPreselected || selectionStatus === SelectedBy.REMOVED)
+  );
+};
 
 /** Values use `N_()` for extraction. Translate with `_()` at render time. */
 const PAGE_TITLE: Record<Scope, string> = {
@@ -146,8 +154,18 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
       ? allPatterns
       : allPatterns.filter((p) => (scope === "desktops" ? p.desktop : !p.desktop));
   const proposal = useProposal();
+  const config = useExtendedConfig();
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
+
+  // Extract current user's explicit add/remove choices from config
+  const configPatterns = config?.software?.patterns;
+  const currentAdd =
+    typeof configPatterns === "object" && "add" in configPatterns ? configPatterns.add || [] : [];
+  const currentRemove =
+    typeof configPatterns === "object" && "remove" in configPatterns
+      ? configPatterns.remove || []
+      : [];
 
   // Build initial form values: each pattern name -> selected boolean
   const initialValues = patterns.reduce(
@@ -170,9 +188,17 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
           const wasInitiallySelected = initialValues[p.name];
           const selectionStatus = selection[p.name];
 
-          if (shouldAdd(inScope, isChecked, isDirty, selectionStatus)) acc.add.push(p.name);
+          if (shouldAdd(inScope, isChecked, isDirty, selectionStatus, currentAdd.includes(p.name)))
+            acc.add.push(p.name);
           if (
-            shouldRemove(inScope, isChecked, p.preselected, wasInitiallySelected, selectionStatus)
+            shouldRemove(
+              inScope,
+              isChecked,
+              p.preselected,
+              wasInitiallySelected,
+              selectionStatus,
+              currentRemove.includes(p.name),
+            )
           )
             acc.remove.push(p.name);
           return acc;

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -45,7 +45,7 @@ import { useProposal } from "~/hooks/model/proposal/software";
 import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
 import { SOFTWARE } from "~/routes/paths";
-import { _ } from "~/i18n";
+import { N_, _ } from "~/i18n";
 
 import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 
@@ -60,11 +60,91 @@ const softwarePatternsFormOptions = formOptions({
 const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the filter.")}</b>;
 
 /**
- * Pattern selector component
+ * Controls which patterns the selection page shows.
+ * - "all": all available patterns
+ * - "desktops": only patterns representing desktop environments
+ * - "other": non-desktop patterns
  */
-function SoftwarePatternsSelection() {
+type Scope = "all" | "desktops" | "other";
+
+/**
+ * Whether a pattern should be added to the selection on submit.
+ *
+ * Visible patterns (inScope) are added only when checked AND there is clear
+ * user intent: the user just toggled it, or it was already their explicit
+ * choice. This avoids re-adding auto-selected patterns the user never touched.
+ *
+ * Hidden patterns (not inScope) are passed through unchanged to avoid losing
+ * selections made on a different scope. For example, when submitting the
+ * patterns scope ("other"), GNOME selected on the desktop scope must survive.
+ *
+ * @param inScope - Whether the pattern is visible to the user in the current scope
+ * @param isChecked - Current checkbox value in the form
+ * @param isDirty - Whether the user changed the checkbox from its initial value
+ * @param selectionStatus - Current backend selection status for this pattern
+ */
+const shouldAdd = (
+  inScope: boolean,
+  isChecked: boolean,
+  isDirty: boolean,
+  selectionStatus: SelectedBy | undefined,
+): boolean =>
+  inScope
+    ? isChecked && (isDirty || selectionStatus === SelectedBy.USER)
+    : selectionStatus === SelectedBy.USER;
+
+/**
+ * Whether a pattern should be removed from the selection on submit.
+ *
+ * Visible patterns (inScope) are removed when unchecked AND previously known
+ * to the selection: selected on load, a product default (preselected), or
+ * already explicitly removed. Patterns never seen before are simply ignored.
+ *
+ * Hidden patterns (not inScope) preserve their existing removed state to avoid
+ * undoing removals made on a different scope. For example, when submitting the
+ * patterns scope ("other"), a GNOME removal made on the desktop scope is kept.
+ *
+ * @param inScope - Whether the pattern is visible to the user in the current scope
+ * @param isChecked - Current checkbox value in the form
+ * @param isPreselected - Whether the pattern is selected by default in the product
+ * @param wasInitiallySelected - Whether the pattern was selected when the form loaded
+ * @param selectionStatus - Current backend selection status for this pattern
+ */
+const shouldRemove = (
+  inScope: boolean,
+  isChecked: boolean,
+  isPreselected: boolean,
+  wasInitiallySelected: boolean,
+  selectionStatus: SelectedBy | undefined,
+): boolean =>
+  inScope
+    ? !isChecked &&
+      (wasInitiallySelected || isPreselected || selectionStatus === SelectedBy.REMOVED)
+    : selectionStatus === SelectedBy.REMOVED;
+
+/** Values use `N_()` for extraction. Translate with `_()` at render time. */
+const PAGE_TITLE: Record<Scope, string> = {
+  // TRANSLATORS: page title when selecting all software patterns
+  all: N_("Patterns selection"),
+  // TRANSLATORS: page title when selecting desktop environments
+  desktops: N_("Desktop selection"),
+  // TRANSLATORS: page title when selecting non-desktop software patterns
+  other: N_("Patterns selection"),
+};
+
+/**
+ * Pattern selector component.
+ *
+ * @param scope - Which patterns to show: "all", "desktops", or "other" (non-desktop patterns).
+ *   Defaults to "all".
+ */
+function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   const navigate = useNavigate();
-  const { patterns } = useSystem();
+  const { patterns: allPatterns } = useSystem();
+  const patterns =
+    scope === "all"
+      ? allPatterns
+      : allPatterns.filter((p) => (scope === "desktops" ? p.desktop : !p.desktop));
   const proposal = useProposal();
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
@@ -82,32 +162,23 @@ function SoftwarePatternsSelection() {
     ...softwarePatternsFormOptions,
     defaultValues: initialValues,
     onSubmit: async ({ value: formValues, formApi }) => {
-      // Add: selected patterns that user touched OR were already USER-selected
-      const add = patterns
-        .filter((p) => {
-          const isSelected = formValues[p.name];
-          if (!isSelected) return false;
-
-          const isDirty = formApi.getFieldMeta(p.name)?.isDirty;
-          const wasUserSelected = selection[p.name] === SelectedBy.USER;
-
-          // Add if user touched it OR it was already USER-selected
-          return isDirty || wasUserSelected;
-        })
-        .map((p) => p.name);
-
-      // Remove: unchecked patterns that were previously selected, preselected, or explicitly removed
-      const remove = patterns
-        .filter((p) => {
-          const isSelected = formValues[p.name];
-          if (isSelected) return false;
-
+      const { add, remove } = allPatterns.reduce(
+        (acc, p) => {
+          const inScope = p.name in initialValues;
+          const isChecked = formValues[p.name];
+          const isDirty = formApi.getFieldMeta(p.name)?.isDirty ?? false;
           const wasInitiallySelected = initialValues[p.name];
-          const wasExplicitlyRemoved = selection[p.name] === SelectedBy.REMOVED;
+          const selectionStatus = selection[p.name];
 
-          return wasInitiallySelected || p.preselected || wasExplicitlyRemoved;
-        })
-        .map((p) => p.name);
+          if (shouldAdd(inScope, isChecked, isDirty, selectionStatus)) acc.add.push(p.name);
+          if (
+            shouldRemove(inScope, isChecked, p.preselected, wasInitiallySelected, selectionStatus)
+          )
+            acc.remove.push(p.name);
+          return acc;
+        },
+        { add: [] as string[], remove: [] as string[] },
+      );
 
       await patchConfig({ software: { patterns: { add, remove } } });
     },
@@ -122,7 +193,14 @@ function SoftwarePatternsSelection() {
 
   return (
     <Page
-      breadcrumbs={[{ label: _("Software"), path: SOFTWARE.root }, { label: "Patterns selection" }]}
+      breadcrumbs={[
+        { label: _("Software"), path: SOFTWARE.root },
+        {
+          // TRANSLATORS: breadcrumb label for the pattern/desktop selection page
+          // eslint-disable-next-line agama-i18n/string-literals
+          label: _(PAGE_TITLE[scope]),
+        },
+      ]}
       progress={{ scope: "software" }}
     >
       <Page.Content>

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -49,13 +49,15 @@ import { SOFTWARE } from "~/routes/paths";
 import { N_, _ } from "~/i18n";
 
 import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
+import type { Pattern } from "~/model/system/software";
+import type { PatternsObject } from "~/openapi/config/software";
 
 /**
  * Form options for pattern selection.
  * Each pattern is a boolean field (pattern name -> selected state).
  */
 const softwarePatternsFormOptions = formOptions({
-  defaultValues: {} as Record<string, boolean>,
+  defaultValues: {},
 });
 
 const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the filter.")}</b>;
@@ -83,7 +85,8 @@ type Scope = "all" | "desktops" | "other";
  * @param isChecked - Current checkbox value in the form
  * @param isDirty - Whether the user changed the checkbox from its initial value
  * @param selectionStatus - Current backend selection status for this pattern
- * @param inConfig - Whether the pattern is in the config's add list (for out-of-scope preservation)
+ * @param inConfig - Whether the pattern is in the config's add list
+ *   (for out-of-scope preservation)
  */
 const shouldAdd = (
   inScope: boolean,
@@ -148,39 +151,43 @@ const PAGE_TITLE: Record<Scope, string> = {
  */
 function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   const navigate = useNavigate();
-  const { patterns: allPatterns } = useSystem();
-  const patterns =
-    scope === "all"
-      ? allPatterns
-      : allPatterns.filter((p) => (scope === "desktops" ? p.desktop : !p.desktop));
+  const { patterns: systemPatterns } = useSystem();
   const proposal = useProposal();
   const config = useExtendedConfig();
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
 
-  // Extract current user's explicit add/remove choices from config
-  const configPatterns = config?.software?.patterns;
-  const currentAdd =
-    typeof configPatterns === "object" && "add" in configPatterns ? configPatterns.add || [] : [];
-  const currentRemove =
-    typeof configPatterns === "object" && "remove" in configPatterns
-      ? configPatterns.remove || []
-      : [];
+  // NOTE: patterns is typed as PatternsArray | PatternsObject, but a flat array
+  // makes little sense here. It may be a design issue in the openapi spec worth
+  // revisiting. In any case, cast is safe: accessing .add/.remove on an array
+  // returns undefined, handled by ?? []
+  const patternConfig = (config?.software?.patterns ?? {}) as PatternsObject;
+  const userAddedPatterns = patternConfig.add ?? [];
+  const userRemovedPatterns = patternConfig.remove ?? [];
+
+  let scopedPatterns: Pattern[];
+  switch (scope) {
+    case "desktops":
+      scopedPatterns = systemPatterns.filter((p) => p.desktop);
+      break;
+    case "other":
+      scopedPatterns = systemPatterns.filter((p) => !p.desktop);
+      break;
+    default:
+      scopedPatterns = systemPatterns;
+  }
 
   // Build initial form values: each pattern name -> selected boolean
-  const initialValues = patterns.reduce(
-    (acc, pattern) => {
-      acc[pattern.name] = isPatternSelected(selection, pattern.name);
-      return acc;
-    },
-    {} as Record<string, boolean>,
-  );
+  const initialValues = scopedPatterns.reduce((acc, pattern) => {
+    acc[pattern.name] = isPatternSelected(selection, pattern.name);
+    return acc;
+  }, {});
 
   const form = usePristineSafeForm({
     ...softwarePatternsFormOptions,
     defaultValues: initialValues,
     onSubmit: async ({ value: formValues, formApi }) => {
-      const { add, remove } = allPatterns.reduce(
+      const { add, remove } = systemPatterns.reduce(
         (acc, p) => {
           const inScope = p.name in initialValues;
           const isChecked = formValues[p.name];
@@ -188,22 +195,31 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
           const wasInitiallySelected = initialValues[p.name];
           const selectionStatus = selection[p.name];
 
-          if (shouldAdd(inScope, isChecked, isDirty, selectionStatus, currentAdd.includes(p.name)))
-            acc.add.push(p.name);
           if (
+            shouldAdd(
+              inScope,
+              isChecked,
+              isDirty,
+              selectionStatus,
+              userAddedPatterns.includes(p.name),
+            )
+          ) {
+            acc.add.push(p.name);
+          } else if (
             shouldRemove(
               inScope,
               isChecked,
               p.preselected,
               wasInitiallySelected,
               selectionStatus,
-              currentRemove.includes(p.name),
+              userRemovedPatterns.includes(p.name),
             )
-          )
+          ) {
             acc.remove.push(p.name);
+          }
           return acc;
         },
-        { add: [] as string[], remove: [] as string[] },
+        { add: [], remove: [] },
       );
 
       await patchConfig({ software: { patterns: { add, remove } } });
@@ -212,7 +228,7 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   });
 
   // initial empty screen, the patterns are loaded very quickly, no need for any progress
-  const visiblePatterns = filterPatterns(patterns, searchValue);
+  const visiblePatterns = filterPatterns(scopedPatterns, searchValue);
   if (visiblePatterns.length === 0 && searchValue === "") return null;
 
   const groups = groupPatterns(visiblePatterns);

--- a/web/src/components/software/patterns.test.json
+++ b/web/src/components/software/patterns.test.json
@@ -5,7 +5,9 @@
     "icon": "./pattern-gnome-wayland",
     "description": "The GNOME desktop environment is an intuitive and attractive desktop for users.\nThis pattern installs components for GNOME to run with Wayland and X11 technologies.",
     "summary": "GNOME Desktop Environment (Wayland)",
-    "order": "1010"
+    "order": "1010",
+    "preselected": false,
+    "desktop": true
   },
   {
     "name": "kde",
@@ -13,7 +15,9 @@
     "icon": "./pattern-kde",
     "description": "Packages providing the Plasma desktop environment and applications from KDE.",
     "summary": "KDE Applications and Plasma 5 Desktop",
-    "order": "1110"
+    "order": "1110",
+    "preselected": false,
+    "desktop": true
   },
   {
     "name": "yast2_basis",
@@ -21,7 +25,9 @@
     "icon": "./yast",
     "description": "YaST tools for basic system administration.",
     "summary": "YaST Base Utilities",
-    "order": "1220"
+    "order": "1220",
+    "preselected": false,
+    "desktop": false
   },
   {
     "name": "yast2_desktop",
@@ -29,7 +35,9 @@
     "icon": "./yast",
     "description": "YaST tools for desktop system administration.",
     "summary": "YaST Desktop Utilities",
-    "order": "1222"
+    "order": "1222",
+    "preselected": false,
+    "desktop": false
   },
   {
     "name": "yast2_server",
@@ -37,7 +45,9 @@
     "icon": "./yast",
     "description": "YaST tools for server system administration.",
     "summary": "YaST Server Utilities",
-    "order": "1224"
+    "order": "1224",
+    "preselected": false,
+    "desktop": false
   },
   {
     "name": "xfce",
@@ -45,7 +55,9 @@
     "icon": "./pattern-xfce",
     "description": "Xfce is a lightweight desktop environment for various *NIX systems.",
     "summary": "XFCE Desktop Environment",
-    "order": "1310"
+    "order": "1310",
+    "preselected": false,
+    "desktop": true
   },
   {
     "name": "multimedia",
@@ -53,7 +65,9 @@
     "icon": "./pattern-multimedia",
     "description": "Multimedia players, sound editing tools, video and image manipulation applications.",
     "summary": "Multimedia",
-    "order": "1580"
+    "order": "1580",
+    "preselected": false,
+    "desktop": false
   },
   {
     "name": "office",
@@ -61,7 +75,9 @@
     "icon": "./pattern-office",
     "description": "Office software for your desktop environment including LibreOffice.",
     "summary": "Office Software",
-    "order": "1640"
+    "order": "1640",
+    "preselected": false,
+    "desktop": false
   },
   {
     "name": "basic_desktop",
@@ -69,6 +85,8 @@
     "icon": "./pattern-x11",
     "description": "This pattern installs a rather basic desktop (icewm)",
     "summary": "A very basic desktop (previously part of x11 pattern)",
-    "order": "1802"
+    "order": "1802",
+    "preselected": false,
+    "desktop": true
   }
 ]

--- a/web/src/model/system/software.ts
+++ b/web/src/model/system/software.ts
@@ -42,6 +42,11 @@ type Pattern = {
   icon: string;
   /** Whether the pattern is selected by default */
   preselected: boolean;
+  /**
+   * Whether the pattern represents a desktop environment, useful to split
+   * desktops from other patterns
+   * */
+  desktop: boolean;
 };
 
 type Repository = {

--- a/web/src/routes/paths.ts
+++ b/web/src/routes/paths.ts
@@ -71,6 +71,7 @@ const USER = {
 
 const SOFTWARE = {
   root: "/software",
+  desktopSelection: "/software/desktops/select",
   patternsSelection: "/software/patterns/select",
   conflicts: "/software/conflicts",
 };

--- a/web/src/routes/software.tsx
+++ b/web/src/routes/software.tsx
@@ -39,8 +39,12 @@ const routes = (): Route => ({
       element: <SoftwarePage />,
     },
     {
+      path: PATHS.desktopSelection,
+      element: <SoftwarePatternsSelection scope="desktops" />,
+    },
+    {
       path: PATHS.patternsSelection,
-      element: <SoftwarePatternsSelection />,
+      element: <SoftwarePatternsSelection scope="other" />,
     },
   ],
 });

--- a/web/src/utils/software.test.ts
+++ b/web/src/utils/software.test.ts
@@ -26,7 +26,6 @@ import { SelectedBy } from "~/model/proposal/software";
 import {
   filterPatterns,
   groupPatterns,
-  isDesktopPattern,
   isPatternSelected,
   sortGroupNames,
 } from "./software";
@@ -41,6 +40,7 @@ describe("groupPatterns", () => {
       order: 2,
       icon: "icon1",
       preselected: false,
+      desktop: false,
     },
     {
       name: "pattern2",
@@ -50,6 +50,7 @@ describe("groupPatterns", () => {
       order: 1,
       icon: "icon2",
       preselected: false,
+      desktop: false,
     },
     {
       name: "pattern3",
@@ -59,6 +60,7 @@ describe("groupPatterns", () => {
       order: 2,
       icon: "icon3",
       preselected: false,
+      desktop: false,
     },
     {
       name: "pattern4",
@@ -68,6 +70,7 @@ describe("groupPatterns", () => {
       order: 1,
       icon: "icon4",
       preselected: false,
+      desktop: false,
     },
   ];
 
@@ -112,6 +115,7 @@ describe("filterPatterns", () => {
       order: 1,
       icon: "icon1",
       preselected: false,
+      desktop: false,
     },
     {
       name: "office",
@@ -121,6 +125,7 @@ describe("filterPatterns", () => {
       order: 2,
       icon: "icon2",
       preselected: false,
+      desktop: false,
     },
     {
       name: "development",
@@ -130,6 +135,7 @@ describe("filterPatterns", () => {
       order: 3,
       icon: "icon3",
       preselected: false,
+      desktop: false,
     },
   ];
 
@@ -197,88 +203,3 @@ describe("isPatternSelected", () => {
   });
 });
 
-describe("isDesktopPattern", () => {
-  it("returns true for standard Graphical Environments category", () => {
-    const pattern: Pattern = {
-      name: "gnome",
-      category: "Graphical Environments",
-      summary: "GNOME Desktop",
-      description: "GNOME desktop environment",
-      order: 1,
-      icon: "icon",
-      preselected: false,
-    };
-
-    expect(isDesktopPattern(pattern)).toBe(true);
-  });
-
-  it("returns true for lowercase category", () => {
-    const pattern: Pattern = {
-      name: "kde",
-      category: "graphical environments",
-      summary: "KDE Desktop",
-      description: "KDE desktop environment",
-      order: 1,
-      icon: "icon",
-      preselected: false,
-    };
-
-    expect(isDesktopPattern(pattern)).toBe(true);
-  });
-
-  it("returns true for uppercase category", () => {
-    const pattern: Pattern = {
-      name: "xfce",
-      category: "GRAPHICAL ENVIRONMENTS",
-      summary: "XFCE Desktop",
-      description: "XFCE desktop environment",
-      order: 1,
-      icon: "icon",
-      preselected: false,
-    };
-
-    expect(isDesktopPattern(pattern)).toBe(true);
-  });
-
-  it("returns true for category with extra whitespace", () => {
-    const pattern: Pattern = {
-      name: "basic_desktop",
-      category: "  Graphical Environments  ",
-      summary: "Basic Desktop",
-      description: "Basic desktop environment",
-      order: 1,
-      icon: "icon",
-      preselected: false,
-    };
-
-    expect(isDesktopPattern(pattern)).toBe(true);
-  });
-
-  it("returns false for non-desktop category", () => {
-    const pattern: Pattern = {
-      name: "office",
-      category: "Desktop Functions",
-      summary: "Office Software",
-      description: "Office applications",
-      order: 1,
-      icon: "icon",
-      preselected: false,
-    };
-
-    expect(isDesktopPattern(pattern)).toBe(false);
-  });
-
-  it("returns false for Base Technologies category", () => {
-    const pattern: Pattern = {
-      name: "yast2_basis",
-      category: "Base Technologies",
-      summary: "YaST Base",
-      description: "YaST tools",
-      order: 1,
-      icon: "icon",
-      preselected: false,
-    };
-
-    expect(isDesktopPattern(pattern)).toBe(false);
-  });
-});

--- a/web/src/utils/software.test.ts
+++ b/web/src/utils/software.test.ts
@@ -23,12 +23,7 @@
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
-import {
-  filterPatterns,
-  groupPatterns,
-  isPatternSelected,
-  sortGroupNames,
-} from "./software";
+import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "./software";
 
 describe("groupPatterns", () => {
   const patterns: Pattern[] = [
@@ -202,4 +197,3 @@ describe("isPatternSelected", () => {
     expect(isPatternSelected(selection, "unknown")).toBe(false);
   });
 });
-

--- a/web/src/utils/software.test.ts
+++ b/web/src/utils/software.test.ts
@@ -23,7 +23,13 @@
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
-import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "./software";
+import {
+  filterPatterns,
+  groupPatterns,
+  isDesktopPattern,
+  isPatternSelected,
+  sortGroupNames,
+} from "./software";
 
 describe("groupPatterns", () => {
   const patterns: Pattern[] = [
@@ -188,5 +194,91 @@ describe("isPatternSelected", () => {
 
   it("returns false for unknown patterns", () => {
     expect(isPatternSelected(selection, "unknown")).toBe(false);
+  });
+});
+
+describe("isDesktopPattern", () => {
+  it("returns true for standard Graphical Environments category", () => {
+    const pattern: Pattern = {
+      name: "gnome",
+      category: "Graphical Environments",
+      summary: "GNOME Desktop",
+      description: "GNOME desktop environment",
+      order: 1,
+      icon: "icon",
+      preselected: false,
+    };
+
+    expect(isDesktopPattern(pattern)).toBe(true);
+  });
+
+  it("returns true for lowercase category", () => {
+    const pattern: Pattern = {
+      name: "kde",
+      category: "graphical environments",
+      summary: "KDE Desktop",
+      description: "KDE desktop environment",
+      order: 1,
+      icon: "icon",
+      preselected: false,
+    };
+
+    expect(isDesktopPattern(pattern)).toBe(true);
+  });
+
+  it("returns true for uppercase category", () => {
+    const pattern: Pattern = {
+      name: "xfce",
+      category: "GRAPHICAL ENVIRONMENTS",
+      summary: "XFCE Desktop",
+      description: "XFCE desktop environment",
+      order: 1,
+      icon: "icon",
+      preselected: false,
+    };
+
+    expect(isDesktopPattern(pattern)).toBe(true);
+  });
+
+  it("returns true for category with extra whitespace", () => {
+    const pattern: Pattern = {
+      name: "basic_desktop",
+      category: "  Graphical Environments  ",
+      summary: "Basic Desktop",
+      description: "Basic desktop environment",
+      order: 1,
+      icon: "icon",
+      preselected: false,
+    };
+
+    expect(isDesktopPattern(pattern)).toBe(true);
+  });
+
+  it("returns false for non-desktop category", () => {
+    const pattern: Pattern = {
+      name: "office",
+      category: "Desktop Functions",
+      summary: "Office Software",
+      description: "Office applications",
+      order: 1,
+      icon: "icon",
+      preselected: false,
+    };
+
+    expect(isDesktopPattern(pattern)).toBe(false);
+  });
+
+  it("returns false for Base Technologies category", () => {
+    const pattern: Pattern = {
+      name: "yast2_basis",
+      category: "Base Technologies",
+      summary: "YaST Base",
+      description: "YaST tools",
+      order: 1,
+      icon: "icon",
+      preselected: false,
+    };
+
+    expect(isDesktopPattern(pattern)).toBe(false);
   });
 });

--- a/web/src/utils/software.ts
+++ b/web/src/utils/software.ts
@@ -89,3 +89,13 @@ export function isPatternSelected(selection: PatternsSelection, patternName: str
   const status = selection[patternName];
   return status === SelectedBy.USER || status === SelectedBy.AUTO;
 }
+
+/**
+ * Checks if a pattern represents a desktop environment.
+ *
+ * @param pattern - Pattern to check
+ * @returns True if the pattern is a desktop environment
+ */
+export function isDesktopPattern(pattern: Pattern): boolean {
+  return pattern.category.trim().toLowerCase() === "graphical environments";
+}

--- a/web/src/utils/software.ts
+++ b/web/src/utils/software.ts
@@ -86,5 +86,6 @@ export function filterPatterns(patterns: Pattern[], searchValue = ""): Pattern[]
  * @returns True if the pattern is selected by USER or AUTO
  */
 export function isPatternSelected(selection: PatternsSelection, patternName: string): boolean {
-  return [SelectedBy.USER, SelectedBy.AUTO].includes(selection[patternName]);
+  const status = selection[patternName];
+  return status === SelectedBy.USER || status === SelectedBy.AUTO;
 }

--- a/web/src/utils/software.ts
+++ b/web/src/utils/software.ts
@@ -25,10 +25,8 @@ import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
 
-/**
- * PatternGroups mapping "group name" => list of patterns
- */
-export type PatternsGroups = { [key: string]: Pattern[] };
+/** PatternGroups mapping "group name" => list of patterns */
+type PatternsGroups = { [key: string]: Pattern[] };
 
 /**
  * Groups patterns by category and sorts them by order within each group.
@@ -36,7 +34,7 @@ export type PatternsGroups = { [key: string]: Pattern[] };
  * @param patterns - Array of patterns to group
  * @returns Object mapping category names to sorted pattern arrays
  */
-export function groupPatterns(patterns: Pattern[]): PatternsGroups {
+function groupPatterns(patterns: Pattern[]): PatternsGroups {
   const groups = group(patterns, (p) => p.category);
 
   // Sort patterns within each group by order, then by name
@@ -56,7 +54,7 @@ export function groupPatterns(patterns: Pattern[]): PatternsGroups {
  * @param groups - Pattern groups to sort
  * @returns Array of sorted group names
  */
-export function sortGroupNames(groups: PatternsGroups): string[] {
+function sortGroupNames(groups: PatternsGroups): string[] {
   return sort(Object.keys(groups), (groupName) => groups[groupName][0].order);
 }
 
@@ -68,7 +66,7 @@ export function sortGroupNames(groups: PatternsGroups): string[] {
  * @param searchValue - Search string to filter by
  * @returns Filtered array of patterns
  */
-export function filterPatterns(patterns: Pattern[], searchValue = ""): Pattern[] {
+function filterPatterns(patterns: Pattern[], searchValue = ""): Pattern[] {
   if (searchValue.trim() === "") return patterns;
 
   const searchData = searchValue.toUpperCase();
@@ -85,17 +83,10 @@ export function filterPatterns(patterns: Pattern[], searchValue = ""): Pattern[]
  * @param patternName - Name of the pattern to check
  * @returns True if the pattern is selected by USER or AUTO
  */
-export function isPatternSelected(selection: PatternsSelection, patternName: string): boolean {
+function isPatternSelected(selection: PatternsSelection, patternName: string): boolean {
   const status = selection[patternName];
   return status === SelectedBy.USER || status === SelectedBy.AUTO;
 }
 
-/**
- * Checks if a pattern represents a desktop environment.
- *
- * @param pattern - Pattern to check
- * @returns True if the pattern is a desktop environment
- */
-export function isDesktopPattern(pattern: Pattern): boolean {
-  return pattern.category.trim().toLowerCase() === "graphical environments";
-}
+export type { PatternsGroups };
+export { groupPatterns, sortGroupNames, filterPatterns, isPatternSelected };


### PR DESCRIPTION
## Context

This PR is part of a broader feature request to add a mechanism for desktop selection in openSUSE (https://github.com/agama-project/agama/discussions/3335, https://trello.com/c/6kaMm7Kf (protected link))

That initiative covers:

* Extending the product definition to indicate whether desktop selection is suggested (https://github.com/agama-project/agama/pull/3390)
* A way to indicate whether a pattern corresponds to a desktop (https://github.com/agama-project/agama/pull/3403)
* Improving UX of selecting patterns (a bonus, previous PR https://github.com/agama-project/agama/pull/3389)
* Revamping the software UI to expose desktop selection (**this PR**).
* Warning the user (based on desktop_selection) in the confirmation dialog if no desktop was selected (follow-up PR)


## Problem

Within that context, the software page did not clearly distinguish between pattern selection and desktop environment selection. This might make difficult for certain users to tell whether a desktop environment had been selected, or which ones are.

Additionally, auto-selected patterns were indistinguishable from user-selected ones, and lengthy pattern descriptions made the interface harder to scan.

## Solution

* Separate desktop environment and pattern selection into clearly defined sections
* Add a visible label to auto-selected patterns so users can easily distinguish them from manual selections and to better realize about patterns that might  automatically resolved after submission.
* Truncate pattern descriptions to improve readability and scanning
* Removed patterns no longer appear in the selected list  (bug fix)


## Screencast of new behavior (skipping previous)


https://github.com/user-attachments/assets/e86adb01-b2f4-483d-8363-eb10e1e37e09



## Notes for reviewers

**The target branch is a feature request. The changelog entry will be added later.**

> [!WARNING]
>                                                                                                     
> This PR also removes the `ReloadSection` component and its surrounding dead code (the `repos`, `loading`, and `startProbing` logic in `PageContent`). Commit https://github.com/agama-project/agama/pull/3396/commits/2aac9e4c3017a142bcc5d996fecc335aa3ee595a
> 
> This code was _disabled_ during the migration to API v2, and still pending of backend endpoint that has not been implemented yet. Thus, better to drop it rather than keeping it around and dead forever: the backend repository response (system -> software -> repositories) does not include the `loaded` field the alert relies on, so it could not be wired up as-is. 
> 
> **The feature can be reintroduced properly once the backend API is ready.**                                                                          
                          
