### PR TITLE
Adapt gnome kiosk options

### DIFF
--- a/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
+++ b/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
@@ -1,6 +1,6 @@
 [Service]
 # This is intentional
 ExecStart=
-# Gnome resp. Mutter version >= blocks switching to virtual console by default
+# gnome-kiosk >= 50 blocks switching to virtual console by default
 # --enable-vt-switch enables that. bsc#1261932
 ExecStart=/usr/bin/gnome-kiosk --enable-vt-switch

--- a/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
+++ b/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
@@ -1,5 +1,7 @@
 [Service]
-# This is intentional
+# We have to explicitly clear ExecStart which (most probably)
+# exists in the original service file. If not systemd will try
+# to start every ExecStart (original even the one added bellow)
 ExecStart=
 # gnome-kiosk >= 50 blocks switching to virtual console by default
 # --enable-vt-switch enables that. bsc#1261932

--- a/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
+++ b/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
@@ -1,0 +1,6 @@
+[Service]
+# This is intentional
+ExecStart=
+# Gnome resp. Mutter version >= blocks switching to virtual console by default
+# --enable-vt-switch enables that. bsc#1261932
+ExecStart=/usr/bin/gnome-kiosk --enable-vt-switch

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 17 10:26:35 UTC 2026 - Michal Filka <mfilka@suse.com>
+
+- bsc#1261932
+  - Explicitly allow virtual terminal switching for the gnome kiosk
+    session 
+
+-------------------------------------------------------------------
 Tue Apr 14 17:36:59 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 20


### PR DESCRIPTION
## Problem

New gnome-kiosk (resp. mutter) intentionally disables virtual terminal switching. To enable that gnome-kiosk has to be started with --enable-vt-switch option

- [*Bugzilla link*](https://bugzilla.suse.com/show_bug.cgi?id=1261932)

## Solution

gnome-kiosk service is started with required switch


## Testing

- *Tested manually*
