### PR TITLE
Add desktop property to user patterns

### DIFF
--- a/products.d/leap_161.yaml
+++ b/products.d/leap_161.yaml
@@ -70,10 +70,14 @@ software:
     - enhanced_base # only pattern that is shared among all roles on Leap
   optional_patterns: [] # no optional pattern shared
   user_patterns:
-    - gnome
-    - kde
-    - xfce_wayland
-    - lxqt_wayland
+    - name: gnome
+      desktop: true
+    - name: kde
+      desktop: true
+    - name: xfce_wayland
+      desktop: true
+    - name: lxqt_wayland
+      desktop: true
     - openSUSEway
     - multimedia
     - office

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -200,7 +200,8 @@ software:
     - kvm_tools
     - lamp_server
     - mail_server
-    - gnome
+    - name: gnome
+      desktop: true
     - gnome_internet
     - devel_basis
     - devel_kernel

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -180,7 +180,8 @@ software:
     - kvm_tools
     - lamp_server
     - mail_server
-    - gnome
+    - name: gnome
+      desktop: true
     - gnome_internet
     - devel_basis
     - devel_kernel

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -100,8 +100,10 @@ software:
   optional_patterns: []
   user_patterns:
     - basic-desktop
-    - gnome
-    - kde
+    - name: gnome
+      desktop: true
+    - name: kde
+      desktop: true
     - yast2_basis
     - yast2_desktop
     - yast2_server

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -132,11 +132,16 @@ software:
     - enhanced_base # only pattern that is shared among all roles on TW
   optional_patterns: [] # no optional pattern shared
   user_patterns:
-    - basic_desktop
-    - xfce_wayland
-    - kde
-    - gnome
-    - lxqt_wayland
+    - name: basic_desktop
+      desktop: true
+    - name: xfce_wayland
+      desktop: true
+    - name: kde
+      desktop: true
+    - name: gnome
+      desktop: true
+    - name: lxqt_wayland
+      desktop: true
     - openSUSEway
     - hyprland
     - multimedia

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -30,7 +30,7 @@ use agama_utils::{
         Config, PatternsConfig, ProductConfig, RepositoryConfig, SoftwareConfig, SystemInfo,
     },
     kernel_cmdline::KernelCmdline,
-    products::{ProductSpec, UserPattern},
+    products::{ProductSpec, UserPatternSpec},
 };
 use url::Url;
 
@@ -385,7 +385,7 @@ impl<'a> SoftwareStateBuilder<'a> {
         }
 
         for pattern in &software.user_patterns {
-            if let UserPattern::Preselected(user_pattern) = pattern {
+            if let UserPatternSpec::Object(user_pattern) = pattern {
                 if user_pattern.selected {
                     resolvables.add_or_replace(
                         &user_pattern.name,

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -763,11 +763,19 @@ impl ZyppServer {
             .filter(|p| p.preselected())
             .map(|p| p.name())
             .collect();
+        let desktop_patterns: Vec<_> = product
+            .software
+            .user_patterns
+            .iter()
+            .filter(|p| p.desktop())
+            .map(|p| p.name())
+            .collect();
 
         let patterns = self
             .user_patterns(product, zypp)?
             .map(|p| {
                 let preselected = preselected_patterns.contains(&p.name.as_str());
+                let desktop = desktop_patterns.contains(&p.name.as_str());
                 Pattern {
                     name: p.name,
                     category: p.category,
@@ -776,6 +784,7 @@ impl ZyppServer {
                     summary: p.summary,
                     order: p.order,
                     preselected,
+                    desktop,
                 }
             })
             .collect();

--- a/rust/agama-utils/src/api/software/system_info.rs
+++ b/rust/agama-utils/src/api/software/system_info.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -69,6 +69,8 @@ pub struct Pattern {
     pub order: String,
     /// Whether the pattern is selected by default
     pub preselected: bool,
+    /// Whether the pattern represents a desktop (e.g., gnome).
+    pub desktop: bool,
 }
 
 #[skip_serializing_none]

--- a/rust/agama-utils/src/products.rs
+++ b/rust/agama-utils/src/products.rs
@@ -320,7 +320,7 @@ pub struct SoftwareSpec {
     pub installation_labels: Vec<LabelSpec>,
     #[serde(default)]
     #[merge(strategy = merge::vec::append)]
-    pub user_patterns: Vec<UserPattern>,
+    pub user_patterns: Vec<UserPatternSpec>,
     #[serde(default)]
     #[merge(strategy = merge::vec::append)]
     pub mandatory_patterns: Vec<String>,
@@ -354,33 +354,44 @@ impl SoftwareSpec {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
-pub enum UserPattern {
+pub enum UserPatternSpec {
     Plain(String),
-    Preselected(PreselectedPattern),
+    Object(UserPattern),
 }
 
-impl UserPattern {
+impl UserPatternSpec {
     /// Pattern name.
     pub fn name(&self) -> &str {
         match self {
-            UserPattern::Plain(name) => name,
-            UserPattern::Preselected(pattern) => &pattern.name,
+            UserPatternSpec::Plain(name) => name,
+            UserPatternSpec::Object(pattern) => &pattern.name,
         }
     }
 
     /// Whether the pattern is preselected.
     pub fn preselected(&self) -> bool {
         match self {
-            UserPattern::Plain(_) => false,
-            UserPattern::Preselected(pattern) => pattern.selected,
+            UserPatternSpec::Plain(_) => false,
+            UserPatternSpec::Object(pattern) => pattern.selected,
+        }
+    }
+
+    /// Whether the pattern represents a desktop.
+    pub fn desktop(&self) -> bool {
+        match self {
+            UserPatternSpec::Plain(_) => false,
+            UserPatternSpec::Object(pattern) => pattern.desktop,
         }
     }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct PreselectedPattern {
+pub struct UserPattern {
     pub name: String,
+    #[serde(default)]
     pub selected: bool,
+    #[serde(default)]
+    pub desktop: bool,
 }
 
 #[serde_as]
@@ -540,18 +551,24 @@ mod test {
         assert_eq!(software.base_product.as_ref().unwrap(), "openSUSE");
         assert_eq!(software.user_patterns.len(), 11);
 
-        let preselected = software
+        let selinux = software
             .user_patterns
             .iter()
-            .find(|p| matches!(p, UserPattern::Preselected(_)));
-        let expected_pattern = PreselectedPattern {
+            .find(|p| p.name() == "selinux");
+        let expected_pattern = UserPattern {
             name: "selinux".to_string(),
             selected: true,
+            desktop: false,
         };
-        assert_eq!(
-            preselected,
-            Some(&UserPattern::Preselected(expected_pattern))
-        );
+        assert_eq!(selinux, Some(&UserPatternSpec::Object(expected_pattern)));
+
+        let gnome = software.user_patterns.iter().find(|p| p.name() == "gnome");
+        let expected_pattern = UserPattern {
+            name: "gnome".to_string(),
+            selected: false,
+            desktop: true,
+        };
+        assert_eq!(gnome, Some(&UserPatternSpec::Object(expected_pattern)));
     }
 
     #[test_context(Context)]

--- a/rust/test/share/products.d/tumbleweed.yaml
+++ b/rust/test/share/products.d/tumbleweed.yaml
@@ -102,9 +102,12 @@ software:
   optional_patterns: [] # no optional pattern shared
   user_patterns:
     - basic_desktop
-    - xfce
-    - kde
-    - gnome
+    - name: xfce
+      desktop: true
+    - name: kde
+      desktop: true
+    - name: gnome
+      desktop: true
     - yast2_basis
     - yast2_desktop
     - yast2_server


### PR DESCRIPTION
Allow to mark the user patterns with a desktop flag. This is required for the UI to properly distinguish the patterns that represent a desktop enviroment.

Note: the target branch is a feature request. The changelog entry will be added later. 