### PR TITLE
fix(web): add missing desktop property in two patterns

### DIFF
--- a/products.d/leap_161.yaml
+++ b/products.d/leap_161.yaml
@@ -78,7 +78,8 @@ software:
       desktop: true
     - name: lxqt_wayland
       desktop: true
-    - openSUSEway
+    - name: openSUSEway
+      desktop: true
     - multimedia
     - office
     - cockpit

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -142,8 +142,10 @@ software:
       desktop: true
     - name: lxqt_wayland
       desktop: true
-    - openSUSEway
-    - hyprland
+    - name: openSUSEway
+      desktop: true
+    - name: hyprland
+      desktop: true
     - multimedia
     - office
     - name: selinux


### PR DESCRIPTION
Add `desktop: true` to _openSUSEway_ and _hyprland_ patterns.

Related to https://github.com/agama-project/agama/pull/3403#pullrequestreview-4141806828

---

Note: the target branch is a feature request. The changelog entry will be added later.
