### PR TITLE
Option to enable systemd-boot preview

### DIFF
--- a/service/lib/agama/cmdline_args.rb
+++ b/service/lib/agama/cmdline_args.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,9 +22,14 @@
 require "logger"
 
 module Agama
+  # TODO: Drop this class. The command line arguments are already parsed by the rust code, see
+  #   rust/agama-utils/src/kernel_cmdline.rs.
+  #
+  #   The arguments should be passed to the D-Bus service, similar to setting a locale.
+  #
   # This class is responsible for reading Agama kernel cmdline options
   class CmdlineArgs
-    CMDLINE_PATH = "/proc/cmdline"
+    KERNEL_CMDLINE_FILE = "/run/agama/cmdline.d/agama.conf"
     CMDLINE_PREFIX = "inst."
 
     attr_accessor :config_url
@@ -37,8 +42,8 @@ module Agama
       @data = data
     end
 
-    def self.read
-      read_from("/run/agama/cmdline.d/agama.conf")
+    def self.read_from_kernel
+      read_from(KERNEL_CMDLINE_FILE)
     end
 
     # Reads the kernel command line options
@@ -53,7 +58,7 @@ module Agama
         next unless option.start_with?(CMDLINE_PREFIX)
 
         key, value = option.split("=", 2)
-        key.delete_prefix!(CMDLINE_PREFIX)
+        key.delete_prefix!(CMDLINE_PREFIX).downcase!
         # Omit config_url from Config options
         next args.config_url = value if key == "config_url"
 

--- a/service/lib/agama/cmdline_args.rb
+++ b/service/lib/agama/cmdline_args.rb
@@ -58,7 +58,7 @@ module Agama
         next unless option.start_with?(CMDLINE_PREFIX)
 
         key, value = option.split("=", 2)
-        key.delete_prefix!(CMDLINE_PREFIX).downcase!
+        key.delete_prefix!(CMDLINE_PREFIX)
         # Omit config_url from Config options
         next args.config_url = value if key == "config_url"
 

--- a/service/lib/agama/storage/bootloader_config_solver.rb
+++ b/service/lib/agama/storage/bootloader_config_solver.rb
@@ -19,9 +19,10 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/cmdline_args"
 require "agama/storage/bootloader_type"
-require "yast"
 require "bootloader/systeminfo"
+require "yast"
 
 module Agama
   module Storage
@@ -45,8 +46,8 @@ module Agama
         return if config.type
 
         config.type =
-          if bls?
-            product_bls_type || DEFAULT_BLS_TYPE
+          if bls_compliant_system?
+            kernel_bls_type || product_bls_type || DEFAULT_BLS_TYPE
           else
             DEFAULT_TYPE
           end
@@ -71,18 +72,40 @@ module Agama
       BLS_ARCHS = [:x86_64, :i386, :aarch64, :arm, :riscv64].freeze
       private_constant :BLS_ARCHS
 
+      # Whether the usage of a BLS-compliant bootloader is supported
+      #
+      # @return [Boolean]
+      def bls_compliant_system?
+        return false unless ::Bootloader::Systeminfo.efi?
+
+        BLS_ARCHS.any? { |a| Yast::Arch.public_send(a) }
+      end
+
       # @return [BootloaderType, nil]
       def product_bls_type
         BootloaderType.find(product_config.data.dig("boot", "default_efi_bootloader"))
       end
 
-      # Whether the usage of a BLS-compliant bootloader is supported
+      # Bootloader type indicated in the kernel options.
       #
-      # @return [Boolean]
-      def bls?
-        return false unless ::Bootloader::Systeminfo.efi?
+      # This is only used for the systemd-boot preview and will be dropped once the config allows
+      # changing the bootloader
+      #
+      # @return [BootloaderType, nil] nil if "systemd_boot_preview" kernel option is not set.
+      def kernel_bls_type
+        arg_value = kernel_args.data["systemd_boot_preview"]
 
-        BLS_ARCHS.any? { |a| Yast::Arch.public_send(a) }
+        return nil unless [true, "1", "yes"].include?(arg_value)
+
+        BootloaderType::SYSTEMD_BOOT
+      end
+
+      # Kernel arguments.
+      #
+      # The class {CmdlineArgs} is still used here because it is only needed for the systemd-boot
+      #   preview. This will be dropped once the config allows changing the bootloader.
+      def kernel_args
+        @kernel_args ||= CmdlineArgs.read_from_kernel
       end
     end
   end

--- a/service/lib/agama/storage/bootloader_config_solver.rb
+++ b/service/lib/agama/storage/bootloader_config_solver.rb
@@ -95,7 +95,7 @@ module Agama
       def kernel_bls_type
         arg_value = kernel_args.data["systemd_boot_preview"]
 
-        return nil unless [true, "1", "yes"].include?(arg_value)
+        return unless arg_value == "1"
 
         BootloaderType::SYSTEMD_BOOT
       end

--- a/service/test/agama/storage/bootloader_config_solver_test.rb
+++ b/service/test/agama/storage/bootloader_config_solver_test.rb
@@ -116,25 +116,14 @@ describe Agama::Storage::BootloaderConfigSolver do
             end
           end
 
-          context "when systemd_boot_preview kernel parameter is set to 'yes'" do
+          context "when systemd_boot_preview kernel parameter has invalid value" do
             let(:cmdline_args) do
               instance_double(Agama::CmdlineArgs, data: { "systemd_boot_preview" => "yes" })
             end
 
-            it "sets the type to SYSTEMD_BOOT" do
+            it "ignores the parameter and uses product/default bootloader" do
               solver.solve(bootloader_config)
-              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
-            end
-          end
-
-          context "when systemd_boot_preview kernel parameter is set to true" do
-            let(:cmdline_args) do
-              instance_double(Agama::CmdlineArgs, data: { "systemd_boot_preview" => true })
-            end
-
-            it "sets the type to SYSTEMD_BOOT" do
-              solver.solve(bootloader_config)
-              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
             end
           end
 

--- a/service/test/agama/storage/bootloader_config_solver_test.rb
+++ b/service/test/agama/storage/bootloader_config_solver_test.rb
@@ -25,6 +25,7 @@ require "agama/storage/bootloader_config_solver"
 require "agama/storage/bootloader_config"
 require "agama/storage/bootloader_type"
 require "agama/config"
+require "agama/cmdline_args"
 
 describe Agama::Storage::BootloaderConfigSolver do
   subject(:solver) { described_class.new(product_config) }
@@ -32,6 +33,11 @@ describe Agama::Storage::BootloaderConfigSolver do
   let(:product_config) { instance_double(Agama::Config, data: product_data) }
   let(:product_data) { {} }
   let(:bootloader_config) { Agama::Storage::BootloaderConfig.new }
+  let(:cmdline_args) { instance_double(Agama::CmdlineArgs, data: {}) }
+
+  before do
+    allow(Agama::CmdlineArgs).to receive(:read_from_kernel).and_return(cmdline_args)
+  end
 
   describe "#solve" do
     context "when the config already has a type set" do
@@ -86,39 +92,89 @@ describe Agama::Storage::BootloaderConfigSolver do
             allow(Yast::Arch).to receive(:riscv64).and_return(false)
           end
 
-          context "when the product does not specify a default EFI bootloader" do
-            let(:product_data) { {} }
+          context "when systemd_boot_preview kernel parameter is set" do
+            let(:cmdline_args) do
+              instance_double(Agama::CmdlineArgs, data: { "systemd_boot_preview" => "1" })
+            end
 
-            it "sets the type to GRUB2 (default BLS type)" do
-              solver.solve(bootloader_config)
-              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+            context "and the product does not specify a default EFI bootloader" do
+              let(:product_data) { {} }
+
+              it "sets the type to SYSTEMD_BOOT (from kernel args)" do
+                solver.solve(bootloader_config)
+                expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+              end
+            end
+
+            context "and the product specifies a different bootloader" do
+              let(:product_data) { { "boot" => { "default_efi_bootloader" => "grub2-bls" } } }
+
+              it "sets the type to SYSTEMD_BOOT (kernel args take priority)" do
+                solver.solve(bootloader_config)
+                expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+              end
             end
           end
 
-          context "when the product specifies a default EFI bootloader" do
-            let(:product_data) { { "boot" => { "default_efi_bootloader" => "systemd-boot" } } }
+          context "when systemd_boot_preview kernel parameter is set to 'yes'" do
+            let(:cmdline_args) do
+              instance_double(Agama::CmdlineArgs, data: { "systemd_boot_preview" => "yes" })
+            end
 
-            it "sets the type to the product-specified bootloader" do
+            it "sets the type to SYSTEMD_BOOT" do
               solver.solve(bootloader_config)
               expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
             end
           end
 
-          context "when the product specifies grub2-bls as default EFI bootloader" do
-            let(:product_data) { { "boot" => { "default_efi_bootloader" => "grub2-bls" } } }
+          context "when systemd_boot_preview kernel parameter is set to true" do
+            let(:cmdline_args) do
+              instance_double(Agama::CmdlineArgs, data: { "systemd_boot_preview" => true })
+            end
 
-            it "sets the type to GRUB2_BLS" do
+            it "sets the type to SYSTEMD_BOOT" do
               solver.solve(bootloader_config)
-              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2_BLS)
+              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
             end
           end
 
-          context "when the product specifies an invalid bootloader type" do
-            let(:product_data) { { "boot" => { "default_efi_bootloader" => "invalid" } } }
+          context "when systemd_boot_preview kernel parameter is not set" do
+            let(:cmdline_args) { instance_double(Agama::CmdlineArgs, data: {}) }
 
-            it "falls back to GRUB2 (default BLS type)" do
-              solver.solve(bootloader_config)
-              expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+            context "and the product does not specify a default EFI bootloader" do
+              let(:product_data) { {} }
+
+              it "sets the type to GRUB2 (default BLS type)" do
+                solver.solve(bootloader_config)
+                expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+              end
+            end
+
+            context "and the product specifies a default EFI bootloader" do
+              let(:product_data) { { "boot" => { "default_efi_bootloader" => "systemd-boot" } } }
+
+              it "sets the type to the product-specified bootloader" do
+                solver.solve(bootloader_config)
+                expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::SYSTEMD_BOOT)
+              end
+            end
+
+            context "and the product specifies grub2-bls as default EFI bootloader" do
+              let(:product_data) { { "boot" => { "default_efi_bootloader" => "grub2-bls" } } }
+
+              it "sets the type to GRUB2_BLS" do
+                solver.solve(bootloader_config)
+                expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2_BLS)
+              end
+            end
+
+            context "and the product specifies an invalid bootloader type" do
+              let(:product_data) { { "boot" => { "default_efi_bootloader" => "invalid" } } }
+
+              it "falls back to GRUB2 (default BLS type)" do
+                solver.solve(bootloader_config)
+                expect(bootloader_config.type).to eq(Agama::Storage::BootloaderType::GRUB2)
+              end
             end
           end
         end


### PR DESCRIPTION
Add kernel option `inst.systemd_boot_preview=1` for selecting systemd-boot bootloader. It fallbacks to grub2 bootloader if the system is not BLS compliant.  

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

Note: The target of this PR is a feature branch. The changelog entries will be added later.