### PR TITLE
refactor(web): infer pattern state from proposal

### DIFF
--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -56,17 +56,6 @@ jest.mock("~/hooks/model/proposal/software", () => ({
   }),
 }));
 
-jest.mock("~/hooks/model/config", () => ({
-  useExtendedConfig: () => ({
-    software: {
-      patterns: {
-        add: ["gnome"],
-        remove: ["kde"],
-      },
-    },
-  }),
-}));
-
 jest.mock("~/api", () => ({
   patchConfig: jest.fn(),
 }));

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -42,7 +42,6 @@ import { SelectedBy } from "~/model/proposal/software";
 import { patchConfig } from "~/api";
 import { useSystem } from "~/hooks/model/system/software";
 import { useProposal } from "~/hooks/model/proposal/software";
-import { useExtendedConfig } from "~/hooks/model/config";
 import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
 import { SOFTWARE } from "~/routes/paths";
@@ -50,7 +49,6 @@ import { N_, _ } from "~/i18n";
 
 import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 import type { Pattern } from "~/model/system/software";
-import type { PatternsObject } from "~/openapi/config/software";
 
 /**
  * Form options for pattern selection.
@@ -81,8 +79,10 @@ type Scope = "all" | "desktops" | "other";
  *   default, or already explicitly removed. Patterns never seen before are ignored.
  * - null otherwise.
  *
- * Hidden patterns (not inScope) pass through their existing config state unchanged,
- * to avoid losing selections or removals made on a different scope.
+ * Hidden patterns (not inScope) pass through their existing user selection unchanged,
+ * preserving choices made on a different scope. The proposal's selection status is
+ * the source of truth: USER means the user explicitly added it, REMOVED means the
+ * user explicitly removed it.
  *
  * @param inScope - Whether the pattern is visible in the current scope
  * @param isChecked - Current checkbox value in the form
@@ -90,8 +90,6 @@ type Scope = "all" | "desktops" | "other";
  * @param isPreselected - Whether the pattern is selected by default in the product
  * @param wasInitiallySelected - Whether the pattern was selected when the form loaded
  * @param selectionStatus - Current backend selection status for this pattern
- * @param inConfigAdd - Whether the pattern is in the config's add list (out-of-scope preservation)
- * @param inConfigRemove - Whether the pattern is in the config's remove list (out-of-scope preservation)
  */
 const resolvePatternAction = (
   inScope: boolean,
@@ -100,12 +98,10 @@ const resolvePatternAction = (
   isPreselected: boolean,
   wasInitiallySelected: boolean,
   selectionStatus: SelectedBy | undefined,
-  inConfigAdd: boolean,
-  inConfigRemove: boolean,
 ): "add" | "remove" | undefined => {
   if (!inScope) {
-    if (inConfigAdd) return "add";
-    if (inConfigRemove) return "remove";
+    if (selectionStatus === SelectedBy.USER) return "add";
+    if (selectionStatus === SelectedBy.REMOVED) return "remove";
     return;
   }
   if (isChecked && (isDirty || selectionStatus === SelectedBy.USER)) return "add";
@@ -136,17 +132,8 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   const navigate = useNavigate();
   const { patterns: systemPatterns } = useSystem();
   const proposal = useProposal();
-  const config = useExtendedConfig();
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
-
-  // NOTE: patterns is typed as PatternsArray | PatternsObject, but a flat array
-  // makes little sense here. It may be a design issue in the openapi spec worth
-  // revisiting. In any case, cast is safe: accessing .add/.remove on an array
-  // returns undefined, handled by ?? []
-  const patternConfig = (config?.software?.patterns ?? {}) as PatternsObject;
-  const userAddedPatterns = patternConfig.add ?? [];
-  const userRemovedPatterns = patternConfig.remove ?? [];
 
   let scopedPatterns: Pattern[];
   switch (scope) {
@@ -185,8 +172,6 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
             p.preselected,
             wasInitiallySelected,
             selectionStatus,
-            userAddedPatterns.includes(p.name),
-            userRemovedPatterns.includes(p.name),
           );
 
           if (action) acc[action].push(p.name);


### PR DESCRIPTION
After a talk with @imobachgs about [NOTE](https://github.com/agama-project/agama/blob/1738812122e5c413f35daad534ebd654e8e4d1d3/web/src/components/software/SoftwarePatternsSelection.tsx#L143-L149) introduced in https://github.com/agama-project/agama/pull/3396, he explained to me the rationale and importance of PatternsArray type there:  users can provide a profile with the exact patterns they wanna use to avoid both, auto and pre selections.

>   // NOTE: patterns is typed as PatternsArray | PatternsObject, but a flat array
>  // makes little sense here. It may be a design issue in the openapi spec worth
>  // revisiting. In any case, cast is safe: accessing .add/.remove on an array
>  // returns undefined, handled by ?? []

Wrongly assuming it was a design issue lead the implementation of SoftwarePatternsSelection to read the extended config to decide which patterns to preserve across different scope submissions. That required casting patterns: PatternsArray | PatternsObject to PatternsObject, which **silently discards user choices when a profile supplies the array form.**

@imobachgs  encourages to the usage of proposal instead, since it already carries the same intent through the SelectedBy value: USER means the user explicitly added the pattern, REMOVED means they explicitly removed it. 

In fact, using it removes the cast, drops the useExtendedConfig dependency, and simplifies resolvePatternAction by two parameters.

> [!WARNING]
> However, there is a problem with this approach since looks like the backend does not reliably persist REMOVED in `proposal.patterns` once no auto-selection is pulling the pattern. In other words, REMOVED silently flipping to NONE after the pattern creating the auto-dependency is removed.
>
> That's mean user can 
>
> Select Gnome from desktops page,  then remove Multimedia on the patterns page, later unselect Gnome and ultimately re-select it once more: Multimedia is auto-selected again instead of staying removed.
>
> See screenshots below
>
> **Multimedia removed in proposal**
> <img width="1056" height="977" alt="Screenshot_2026-04-21_17-05-40" src="https://github.com/user-attachments/assets/d0b929f8-aa4b-4b8f-91eb-0204e3e92d44" />
> 
> **Multimedia removed in extendedConfig**
> <img width="1056" height="977" alt="Screenshot_2026-04-21_17-06-15" src="https://github.com/user-attachments/assets/c01c1398-5cb7-4392-9588-dc551b455383" />
> 
>  **But none in proposal**
> <img width="1056" height="977" alt="Screenshot_2026-04-21_17-05-59" src="https://github.com/user-attachments/assets/dcb8f65a-3db8-48ff-a954-9b8153e4477b" />

---

**Note: the target branch is a feature request. The changelog entry will be added later.**


