### PR TITLE
feat(web): hint users when no desktop is selected

### DIFF
--- a/web/src/components/core/Summary.tsx
+++ b/web/src/components/core/Summary.tsx
@@ -135,7 +135,12 @@ const Summary = ({
               <DescriptionSkeletons />
             ) : (
               description && (
-                <Text component="small" isBold={hasIssues} className={textStyles.textColorSubtle}>
+                <Text
+                  component="small"
+                  isBold={hasIssues}
+                  className={textStyles.textColorSubtle}
+                  style={{ textWrap: "balance" }}
+                >
                   {description}
                 </Text>
               )

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -25,6 +25,7 @@ import { isEmpty } from "radashi";
 import { sprintf } from "sprintf-js";
 import { Navigate } from "react-router";
 import {
+  Alert,
   Button,
   Content,
   Divider,
@@ -50,12 +51,15 @@ import ProductLogo from "~/components/product/ProductLogo";
 import { startInstallation } from "~/api";
 import { useProductInfo } from "~/hooks/model/config/product";
 import { useIssues } from "~/hooks/model/issue";
+import { useIsDesktopMissing } from "~/hooks/model/system/software";
 import { PRODUCT } from "~/routes/paths";
 import { useDestructiveActions } from "~/hooks/use-destructive-actions";
-import { _ } from "~/i18n";
-import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
+import { _ } from "~/i18n";
+
 import type { Product } from "~/model/system";
+
+import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 
 type ConfirmationPopupProps = {
   product: Product;
@@ -63,12 +67,31 @@ type ConfirmationPopupProps = {
   onCancel: () => void;
   onConfirm: () => void;
 };
+const NoDesktopAlert = () => (
+  <Alert
+    isInline
+    variant="custom"
+    // TRANSLATORS: alert title shown in the install confirmation dialog when no desktop is selected.
+    title={_("No desktop selected")}
+  >
+    <Content component="p" isEditorial>
+      {/* TRANSLATORS: explains the consequence of installing without a desktop. */}
+      {_("The system will boot to a command-line interface.")}
+    </Content>
+    <Content component="p">
+      {/* TRANSLATORS: suggests the action to take if a desktop is wanted. */}
+      {_("If that is not intended, cancel and select a desktop in the software settings.")}
+    </Content>
+  </Alert>
+);
+
 const ConfirmationPopup = ({
   product,
   isDangerous,
   onCancel,
   onConfirm,
 }: ConfirmationPopupProps) => {
+  const isDesktopMissing = useIsDesktopMissing();
   const title = sprintf(
     // TRANSLATORS: Confirmation dialog title. %s is replaced with the product name (e.g., "openSUSE Leap")
     isDangerous ? _("Delete existing data and install %s?") : _("Install %s?"),
@@ -79,15 +102,16 @@ const ConfirmationPopup = ({
 
   return (
     <Popup isOpen title={title}>
-      {isDangerous ? (
-        // TRANSLATORS: Warning shown when installation will delete existing data
-        <PotentialDataLossAlert hint={_("If unsure, cancel and review storage settings.")} />
-      ) : (
+      <Stack hasGutter>
         <Content isEditorial>
-          {/* TRANSLATORS: Information message confirming installation will proceed with current settings */}
-          {_("By proceeding, the installation will begin with defined settings.")}
+          {/* TRANSLATORS: shown at the top of the install confirmation dialog. */}
+          {_("Confirming starts the installation immediately with the defined settings.")}
         </Content>
-      )}
+        {isDesktopMissing && <NoDesktopAlert />}
+        {isDangerous && (
+          <PotentialDataLossAlert hint={_("If unsure, cancel and review storage settings.")} />
+        )}
+      </Stack>
       <Popup.Actions>
         {/* TRANSLATORS: Button to confirm and start the installation */}
         <ConfirmButton onClick={onConfirm}>{_("Confirm and install")}</ConfirmButton>

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -25,7 +25,6 @@ import { isEmpty } from "radashi";
 import { sprintf } from "sprintf-js";
 import { Navigate } from "react-router";
 import {
-  Alert,
   Button,
   Content,
   Divider,
@@ -42,6 +41,7 @@ import {
 import Page from "~/components/core/Page";
 import Text from "~/components/core/Text";
 import Popup from "~/components/core/Popup";
+import NoDesktopAlert from "~/components/software/NoDesktopAlert";
 import PotentialDataLossAlert from "~/components/storage/PotentialDataLossAlert";
 import InstallerL10nOptions from "~/components/core/InstallerL10nOptions";
 import InstallerOptionsMenu from "~/components/core/InstallerOptionsMenu";
@@ -67,24 +67,6 @@ type ConfirmationPopupProps = {
   onCancel: () => void;
   onConfirm: () => void;
 };
-const NoDesktopAlert = () => (
-  <Alert
-    isInline
-    variant="custom"
-    // TRANSLATORS: alert title shown in the install confirmation dialog when no desktop is selected.
-    title={_("No desktop selected")}
-  >
-    <Content component="p" isEditorial>
-      {/* TRANSLATORS: explains the consequence of installing without a desktop. */}
-      {_("The system will boot to a command-line interface.")}
-    </Content>
-    <Content component="p">
-      {/* TRANSLATORS: suggests the action to take if a desktop is wanted. */}
-      {_("If that is not intended, cancel and select a desktop in the software settings.")}
-    </Content>
-  </Alert>
-);
-
 const ConfirmationPopup = ({
   product,
   isDangerous,
@@ -108,9 +90,7 @@ const ConfirmationPopup = ({
           {_("Confirming starts the installation immediately with the defined settings.")}
         </Content>
         {isDesktopMissing && <NoDesktopAlert />}
-        {isDangerous && (
-          <PotentialDataLossAlert hint={_("If unsure, cancel and review storage settings.")} />
-        )}
+        {isDangerous && <PotentialDataLossAlert />}
       </Stack>
       <Popup.Actions>
         {/* TRANSLATORS: Button to confirm and start the installation */}

--- a/web/src/components/overview/SoftwareSummary.test.tsx
+++ b/web/src/components/overview/SoftwareSummary.test.tsx
@@ -166,7 +166,7 @@ describe("SoftwareSummary", () => {
         screen.getByText("Requires 5.95 GiB");
       });
 
-      it("falls back to 'Default selection' without a sub-line when the proposal size is not available", () => {
+      it("falls back to 'Default selection' without a summary description when the proposal size is not available", () => {
         mockUseProposalFn.mockReturnValue({ usedSpace: 0, patterns: {} });
         mockUseSelectedPatternsFn.mockReturnValue([]);
 
@@ -178,13 +178,23 @@ describe("SoftwareSummary", () => {
     });
 
     describe("and a desktop is selected", () => {
-      it("shows the desktop as the headline and size as the sub-line", () => {
+      it("shows the desktop as the headline and size as the summary description", () => {
         mockUseSelectedPatternsFn.mockReturnValue([gnome]);
 
         installerRender(<SoftwareSummary />);
 
         screen.getByText("GNOME Desktop");
-        screen.getByText("Includes 1 pattern. Requires 5.95 GiB");
+        screen.getByText("Requires 5.95 GiB");
+        expect(screen.queryByText(/additional pattern/)).toBeNull();
+      });
+
+      it("counts only non-desktop patterns in the summary description", () => {
+        mockUseSelectedPatternsFn.mockReturnValue([gnome, yast2Basis]);
+
+        installerRender(<SoftwareSummary />);
+
+        screen.getByText("GNOME Desktop");
+        screen.getByText("Includes 1 additional pattern. Requires 5.95 GiB");
       });
 
       it("shows the desktop count when several are selected", () => {
@@ -198,7 +208,8 @@ describe("SoftwareSummary", () => {
         screen.getByText("2 desktops selected");
         expect(screen.queryByText("GNOME Desktop")).toBeNull();
         expect(screen.queryByText("KDE Plasma")).toBeNull();
-        screen.getByText("Includes 2 patterns. Requires 5.95 GiB");
+        screen.getByText("Requires 5.95 GiB");
+        expect(screen.queryByText(/additional pattern/)).toBeNull();
       });
     });
 
@@ -207,7 +218,7 @@ describe("SoftwareSummary", () => {
         mockUseIsDesktopMissingFn.mockReturnValue(true);
       });
 
-      it("shows 'No desktop selected' as the headline and size as the sub-line", () => {
+      it("shows 'No desktop selected' as the headline and size as the summary description", () => {
         mockUseSelectedPatternsFn.mockReturnValue([]);
 
         installerRender(<SoftwareSummary />);
@@ -222,7 +233,7 @@ describe("SoftwareSummary", () => {
         installerRender(<SoftwareSummary />);
 
         expect(screen.getByText("No desktop selected")).toHaveClass(textStyles.fontWeightBold);
-        screen.getByText("Includes 1 pattern. Requires 5.95 GiB");
+        screen.getByText("Includes 1 additional pattern. Requires 5.95 GiB");
       });
     });
   });

--- a/web/src/components/overview/SoftwareSummary.test.tsx
+++ b/web/src/components/overview/SoftwareSummary.test.tsx
@@ -26,7 +26,7 @@ import { useProposal } from "~/hooks/model/proposal/software";
 import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
 import { useIssues } from "~/hooks/model/issue";
 import { SOFTWARE } from "~/routes/paths";
-import { SelectedBy } from "~/model/proposal/software";
+import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 import SoftwareSummary from "./SoftwareSummary";
 
 const mockUseProposalFn: jest.Mock<ReturnType<typeof useProposal>> = jest.fn();
@@ -48,11 +48,33 @@ jest.mock("~/hooks/model/issue", () => ({
   useIssues: () => mockUseIssuesFn(),
 }));
 
+const gnome = {
+  name: "gnome",
+  category: "Graphical Environments",
+  icon: "./pattern-gnome-wayland",
+  description: "The GNOME desktop environment ...",
+  summary: "GNOME Desktop",
+  order: 1010,
+  preselected: false,
+  desktop: true,
+};
+
+const yast2Basis = {
+  name: "yast2_basis",
+  category: "Base Technologies",
+  icon: "./yast",
+  description: "YaST tools for basic system administration.",
+  summary: "YaST Base Utilities",
+  order: 1220,
+  preselected: false,
+  desktop: false,
+};
+
 describe("SoftwareSummary", () => {
   beforeEach(() => {
     mockProgresses([]);
     mockUseIssuesFn.mockReturnValue([]);
-    mockUseProposalFn.mockReturnValue({ usedSpace: 6291456, patterns: {} }); // 6 GiB
+    mockUseProposalFn.mockReturnValue({ usedSpace: 6239191, patterns: {} }); // ~5.95 GiB
     mockUseSelectedPatternsFn.mockReturnValue([]);
     mockUseIsDesktopMissingFn.mockReturnValue(false);
   });
@@ -88,8 +110,7 @@ describe("SoftwareSummary", () => {
     it("renders skeleton instead of content", () => {
       installerRender(<SoftwareSummary />);
       screen.getByLabelText("Waiting for proposal");
-      expect(screen.queryByText(/Required packages/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/Needs about/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Requires/)).not.toBeInTheDocument();
     });
   });
 
@@ -110,85 +131,74 @@ describe("SoftwareSummary", () => {
         installerRender(<SoftwareSummary />);
 
         screen.getByText("Invalid software selection");
-        expect(screen.queryByText("Required packages")).toBeNull();
-        expect(screen.queryByText(/Needs about/)).toBeNull();
+        expect(screen.queryByText(/Requires/)).toBeNull();
       });
     });
 
-    it("renders 'Required packages' without patterns count when no none is selected", () => {
-      mockUseProposalFn.mockReturnValue({ usedSpace: 1955420, patterns: {} });
-      mockUseSelectedPatternsFn.mockReturnValue([]);
+    describe("and no desktop context applies", () => {
+      it("shows 'Default selection' as the headline when nothing is selected", () => {
+        mockUseProposalFn.mockReturnValue({ usedSpace: 1955420, patterns: {} });
+        mockUseSelectedPatternsFn.mockReturnValue([]);
 
-      installerRender(<SoftwareSummary />);
+        installerRender(<SoftwareSummary />);
 
-      screen.getByText("Required packages");
-      screen.getByText(/Needs about 1\.86 GiB/);
-    });
-
-    it("renders 'Required packages' and the patterns count with correct pluralization when some is selected", () => {
-      mockUseProposalFn.mockReturnValue({
-        usedSpace: 6239191,
-        patterns: {
-          yast2_server: SelectedBy.NONE,
-          basic_desktop: SelectedBy.NONE,
-          xfce: SelectedBy.NONE,
-          gnome: SelectedBy.USER,
-          yast2_desktop: SelectedBy.NONE,
-          kde: SelectedBy.NONE,
-          multimedia: SelectedBy.NONE,
-          office: SelectedBy.NONE,
-          yast2_basis: SelectedBy.AUTO,
-          selinux: SelectedBy.NONE,
-          apparmor: SelectedBy.NONE,
-        },
+        screen.getByText("Default selection");
+        screen.getByText("Requires 1.86 GiB");
       });
 
-      mockUseSelectedPatternsFn.mockReturnValue([
-        {
-          name: "gnome",
-          category: "Graphical Environments",
-          icon: "./pattern-gnome-wayland",
-          description: "The GNOME desktop environment ...",
-          summary: "GNOME Desktop Environment (Wayland)",
-          order: 1010,
-          preselected: false,
-          desktop: true,
-        },
-      ]);
+      it("shows the patterns count as the headline when patterns are selected", () => {
+        mockUseSelectedPatternsFn.mockReturnValue([yast2Basis]);
 
-      const { rerender } = installerRender(<SoftwareSummary />);
+        const { rerender } = installerRender(<SoftwareSummary />);
 
-      // Singular
-      screen.getByText("Required packages and 1 pattern");
-      screen.getByText(/Needs about 5\.95 GiB/);
+        // Singular
+        screen.getByText("Using 1 additional pattern");
+        screen.getByText("Requires 5.95 GiB");
 
-      mockUseSelectedPatternsFn.mockReturnValue([
-        {
-          name: "gnome",
-          category: "Graphical Environments",
-          icon: "./pattern-gnome-wayland",
-          description: "The GNOME desktop environment ...",
-          summary: "GNOME Desktop Environment (Wayland)",
-          order: 1010,
-          preselected: false,
-          desktop: true,
-        },
-        {
-          name: "yast2_basis",
-          category: "Base Technologies",
-          icon: "./yast",
-          description: "YaST tools for basic system administration.",
-          summary: "YaST Base Utilities",
-          order: 1220,
-          preselected: false,
-          desktop: false,
-        },
-      ]);
-      rerender(<SoftwareSummary />);
+        mockUseSelectedPatternsFn.mockReturnValue([
+          yast2Basis,
+          { ...yast2Basis, name: "selinux", summary: "SELinux" },
+        ]);
+        rerender(<SoftwareSummary />);
 
-      // Plural
-      screen.getByText("Required packages and 2 patterns");
-      screen.getByText(/Needs about 5\.95 GiB/);
+        // Plural
+        screen.getByText("Using 2 additional patterns");
+        screen.getByText("Requires 5.95 GiB");
+      });
+
+      it("falls back to 'Default selection' without a sub-line when the proposal size is not available", () => {
+        mockUseProposalFn.mockReturnValue({ usedSpace: 0, patterns: {} });
+        mockUseSelectedPatternsFn.mockReturnValue([]);
+
+        installerRender(<SoftwareSummary />);
+
+        screen.getByText("Default selection");
+        expect(screen.queryByText(/Requires/)).toBeNull();
+      });
+    });
+
+    describe("and a desktop is selected", () => {
+      it("shows the desktop as the headline and size as the sub-line", () => {
+        mockUseSelectedPatternsFn.mockReturnValue([gnome]);
+
+        installerRender(<SoftwareSummary />);
+
+        screen.getByText("GNOME Desktop");
+        screen.getByText("Using 1 additional pattern. Requires 5.95 GiB");
+      });
+
+      it("shows only the first desktop when several are selected", () => {
+        mockUseSelectedPatternsFn.mockReturnValue([
+          gnome,
+          { ...gnome, name: "kde", summary: "KDE Plasma" },
+        ]);
+
+        installerRender(<SoftwareSummary />);
+
+        screen.getByText("GNOME Desktop");
+        expect(screen.queryByText("KDE Plasma")).toBeNull();
+        screen.getByText("Using 2 additional patterns. Requires 5.95 GiB");
+      });
     });
 
     describe("and the missing-desktop hint is active", () => {
@@ -196,35 +206,22 @@ describe("SoftwareSummary", () => {
         mockUseIsDesktopMissingFn.mockReturnValue(true);
       });
 
-      it("renders 'No desktop selected' instead of the patterns summary", () => {
-        mockUseProposalFn.mockReturnValue({ usedSpace: 6239191, patterns: {} });
+      it("shows 'No desktop selected' as the headline and size as the sub-line", () => {
         mockUseSelectedPatternsFn.mockReturnValue([]);
 
         installerRender(<SoftwareSummary />);
 
-        screen.getByText("No desktop selected");
-        screen.getByText(/Needs about 5\.95 GiB/);
-        expect(screen.queryByText("Required packages")).toBeNull();
+        expect(screen.getByText("No desktop selected")).toHaveClass(textStyles.fontWeightBold);
+        screen.getByText("Requires 5.95 GiB");
       });
 
-      it("takes precedence over the patterns count", () => {
-        mockUseSelectedPatternsFn.mockReturnValue([
-          {
-            name: "yast2_basis",
-            category: "Base Technologies",
-            icon: "./yast",
-            description: "YaST tools for basic system administration.",
-            summary: "YaST Base Utilities",
-            order: 1220,
-            preselected: false,
-            desktop: false,
-          },
-        ]);
+      it("takes precedence over any other non-desktop selection", () => {
+        mockUseSelectedPatternsFn.mockReturnValue([yast2Basis]);
 
         installerRender(<SoftwareSummary />);
 
-        screen.getByText("No desktop selected");
-        expect(screen.queryByText(/Required packages and/)).toBeNull();
+        expect(screen.getByText("No desktop selected")).toHaveClass(textStyles.fontWeightBold);
+        screen.getByText("Using 1 additional pattern. Requires 5.95 GiB");
       });
     });
   });

--- a/web/src/components/overview/SoftwareSummary.test.tsx
+++ b/web/src/components/overview/SoftwareSummary.test.tsx
@@ -23,7 +23,7 @@ import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender, mockProgresses } from "~/test-utils";
 import { useProposal } from "~/hooks/model/proposal/software";
-import { useSelectedPatterns } from "~/hooks/model/system/software";
+import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
 import { useIssues } from "~/hooks/model/issue";
 import { SOFTWARE } from "~/routes/paths";
 import { SelectedBy } from "~/model/proposal/software";
@@ -31,6 +31,7 @@ import SoftwareSummary from "./SoftwareSummary";
 
 const mockUseProposalFn: jest.Mock<ReturnType<typeof useProposal>> = jest.fn();
 const mockUseSelectedPatternsFn: jest.Mock<ReturnType<typeof useSelectedPatterns>> = jest.fn();
+const mockUseIsDesktopMissingFn: jest.Mock<ReturnType<typeof useIsDesktopMissing>> = jest.fn();
 const mockUseIssuesFn: jest.Mock<ReturnType<typeof useIssues>> = jest.fn();
 
 jest.mock("~/hooks/model/proposal/software", () => ({
@@ -39,6 +40,7 @@ jest.mock("~/hooks/model/proposal/software", () => ({
 
 jest.mock("~/hooks/model/system/software", () => ({
   useSelectedPatterns: () => mockUseSelectedPatternsFn(),
+  useIsDesktopMissing: () => mockUseIsDesktopMissingFn(),
 }));
 
 jest.mock("~/hooks/model/issue", () => ({
@@ -52,6 +54,7 @@ describe("SoftwareSummary", () => {
     mockUseIssuesFn.mockReturnValue([]);
     mockUseProposalFn.mockReturnValue({ usedSpace: 6291456, patterns: {} }); // 6 GiB
     mockUseSelectedPatternsFn.mockReturnValue([]);
+    mockUseIsDesktopMissingFn.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -186,6 +189,43 @@ describe("SoftwareSummary", () => {
       // Plural
       screen.getByText("Required packages and 2 patterns");
       screen.getByText(/Needs about 5\.95 GiB/);
+    });
+
+    describe("and the missing-desktop hint is active", () => {
+      beforeEach(() => {
+        mockUseIsDesktopMissingFn.mockReturnValue(true);
+      });
+
+      it("renders 'No desktop selected' instead of the patterns summary", () => {
+        mockUseProposalFn.mockReturnValue({ usedSpace: 6239191, patterns: {} });
+        mockUseSelectedPatternsFn.mockReturnValue([]);
+
+        installerRender(<SoftwareSummary />);
+
+        screen.getByText("No desktop selected");
+        screen.getByText(/Needs about 5\.95 GiB/);
+        expect(screen.queryByText("Required packages")).toBeNull();
+      });
+
+      it("takes precedence over the patterns count", () => {
+        mockUseSelectedPatternsFn.mockReturnValue([
+          {
+            name: "yast2_basis",
+            category: "Base Technologies",
+            icon: "./yast",
+            description: "YaST tools for basic system administration.",
+            summary: "YaST Base Utilities",
+            order: 1220,
+            preselected: false,
+            desktop: false,
+          },
+        ]);
+
+        installerRender(<SoftwareSummary />);
+
+        screen.getByText("No desktop selected");
+        expect(screen.queryByText(/Required packages and/)).toBeNull();
+      });
     });
   });
 });

--- a/web/src/components/overview/SoftwareSummary.test.tsx
+++ b/web/src/components/overview/SoftwareSummary.test.tsx
@@ -184,10 +184,10 @@ describe("SoftwareSummary", () => {
         installerRender(<SoftwareSummary />);
 
         screen.getByText("GNOME Desktop");
-        screen.getByText("Using 1 additional pattern. Requires 5.95 GiB");
+        screen.getByText("Includes 1 pattern. Requires 5.95 GiB");
       });
 
-      it("shows only the first desktop when several are selected", () => {
+      it("shows the desktop count when several are selected", () => {
         mockUseSelectedPatternsFn.mockReturnValue([
           gnome,
           { ...gnome, name: "kde", summary: "KDE Plasma" },
@@ -195,9 +195,10 @@ describe("SoftwareSummary", () => {
 
         installerRender(<SoftwareSummary />);
 
-        screen.getByText("GNOME Desktop");
+        screen.getByText("2 desktops selected");
+        expect(screen.queryByText("GNOME Desktop")).toBeNull();
         expect(screen.queryByText("KDE Plasma")).toBeNull();
-        screen.getByText("Using 2 additional patterns. Requires 5.95 GiB");
+        screen.getByText("Includes 2 patterns. Requires 5.95 GiB");
       });
     });
 
@@ -221,7 +222,7 @@ describe("SoftwareSummary", () => {
         installerRender(<SoftwareSummary />);
 
         expect(screen.getByText("No desktop selected")).toHaveClass(textStyles.fontWeightBold);
-        screen.getByText("Using 1 additional pattern. Requires 5.95 GiB");
+        screen.getByText("Includes 1 pattern. Requires 5.95 GiB");
       });
     });
   });

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -27,19 +27,29 @@ import { sprintf } from "sprintf-js";
 
 import Summary from "~/components/core/Summary";
 import Link from "~/components/core/Link";
+import Text from "~/components/core/Text";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
-import { useSelectedPatterns } from "~/hooks/model/system/software";
+import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
 import { useIssues } from "~/hooks/model/issue";
 import { SOFTWARE } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 
 /**
  * Renders a summary text describing the software selection.
+ *
+ * Hints about a missing desktop when the product suggests one, taking
+ * precedence over the patterns count.
  */
 const Value = () => {
   const patterns = useSelectedPatterns();
+  const isDesktopMissing = useIsDesktopMissing();
   const patternsQty = patterns.length;
+
+  if (isDesktopMissing) {
+    // TRANSLATORS: shown in the software summary when no desktop is selected.
+    return <Text isBold>{_("No desktop selected")}</Text>;
+  }
 
   if (patternsQty === 0) {
     return _("Required packages");

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -55,23 +55,40 @@ const patternsCount = (qty: number): string =>
  * Priority order:
  *   1. "No desktop selected" hint when the product suggests one and none is
  *      selected.
- *   2. The selected desktop's summary when one is present.
- *   3. "Using N additional patterns" when the user picked non-desktop
+ *   2. The selected desktop's summary when exactly one is selected.
+ *   3. "N desktops selected" when more than one desktop is selected.
+ *   4. "Using N additional patterns" when the user picked non-desktop
  *      patterns on a product not suggesting a desktop.
- *   4. "Default selection" when nothing is selected.
+ *   5. "Default selection" when nothing is selected.
  */
 const Value = () => {
   const patterns = useSelectedPatterns();
   const isDesktopMissing = useIsDesktopMissing();
-  const [headlineDesktop] = patterns.filter((p) => p.desktop);
+  const desktops = patterns.filter((p) => p.desktop);
 
   if (isDesktopMissing) {
     // TRANSLATORS: shown in the software summary when no desktop is selected.
     return <Text isBold>{_("No desktop selected")}</Text>;
   }
 
-  if (headlineDesktop) {
-    return <Text>{headlineDesktop.summary}</Text>;
+  if (desktops.length === 1) {
+    return <Text>{desktops[0].summary}</Text>;
+  }
+
+  if (desktops.length > 1) {
+    // NOTE: n_() is needed even though desktops.length > 1 because some
+    // languages have multiple plural forms (e.g., Russian: 2-4 vs 5+).
+    //
+    // TRANSLATORS: shown in the software summary when multiple desktops are
+    // selected. %d is the number of desktops.
+    return (
+      <Text>
+        {sprintf(
+          n_("%d desktop selected", "%d desktops selected", desktops.length),
+          desktops.length,
+        )}
+      </Text>
+    );
   }
 
   if (patterns.length === 0) {
@@ -111,11 +128,7 @@ const Description = () => {
       // selected patterns with the required install size. %1$d is a number
       // of selected patterns; %2$s is a human-readable disk size
       // (e.g. "5.95 GiB").
-      n_(
-        "Using %1$d additional pattern. Requires %2$s",
-        "Using %1$d additional patterns. Requires %2$s",
-        qty,
-      ),
+      n_("Includes %1$d pattern. Requires %2$s", "Includes %1$d patterns. Requires %2$s", qty),
       qty,
       size,
     );

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -36,45 +36,94 @@ import { SOFTWARE } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 
 /**
- * Renders a summary text describing the software selection.
+ * Formats the pattern-count line used as the headline when the user picked
+ * non-desktop patterns on a product without desktop context, e.g.
+ *   "Using 1 additional pattern"
+ *   "Using 3 additional patterns"
+ */
+const patternsCount = (qty: number): string =>
+  sprintf(
+    // TRANSLATORS: count of patterns picked on top of the default selection.
+    // %d is a number.
+    n_("Using %d additional pattern", "Using %d additional patterns", qty),
+    qty,
+  );
+
+/**
+ * Renders the headline text for the software summary.
  *
- * Hints about a missing desktop when the product suggests one, taking
- * precedence over the patterns count.
+ * Priority order:
+ *   1. "No desktop selected" hint when the product suggests one and none is
+ *      selected.
+ *   2. The selected desktop's summary when one is present.
+ *   3. "Using N additional patterns" when the user picked non-desktop
+ *      patterns on a product not suggesting a desktop.
+ *   4. "Default selection" when nothing is selected.
  */
 const Value = () => {
   const patterns = useSelectedPatterns();
   const isDesktopMissing = useIsDesktopMissing();
-  const patternsQty = patterns.length;
+  const [headlineDesktop] = patterns.filter((p) => p.desktop);
 
   if (isDesktopMissing) {
     // TRANSLATORS: shown in the software summary when no desktop is selected.
     return <Text isBold>{_("No desktop selected")}</Text>;
   }
 
-  if (patternsQty === 0) {
-    return _("Required packages");
+  if (headlineDesktop) {
+    return <Text>{headlineDesktop.summary}</Text>;
   }
 
-  return sprintf(
-    // TRANSLATORS: %s will be replaced with amount of selected patterns.
-    n_("Required packages and %s pattern", "Required packages and %s patterns", patternsQty),
-    patternsQty,
-  );
+  if (patterns.length === 0) {
+    // TRANSLATORS: shown in the software summary when the user hasn't picked
+    // anything on top of the product's default selection.
+    return <Text>{_("Default selection")}</Text>;
+  }
+
+  return <Text>{patternsCount(patterns.length)}</Text>;
 };
 
 /**
- * Renders the estimated disk space required for the installation.
+ * Renders the sub-line of the software summary.
+ *
+ * When the headline is a desktop or the missing-desktop hint, the sub-line
+ * combines the pattern count (if any) with the required install size in a
+ * single translatable sentence so translators can adjust punctuation and
+ * order. When the headline already conveys the count, only the required
+ * size is shown.
+ *
+ * Returns `null` while the proposal size is still unavailable.
  */
 const Description = () => {
   const proposal = useProposal();
-  if (!proposal?.usedSpace) return;
+  const patterns = useSelectedPatterns();
+  const isDesktopMissing = useIsDesktopMissing();
 
-  return sprintf(
-    // TRANSLATORS: %s will be replaced with a human-readable installation size
-    // (e.g. 5.95 GiB).
-    _("Needs about %s"),
-    xbytes(proposal.usedSpace * 1024, { iec: true }),
-  );
+  if (!proposal?.usedSpace) return null;
+
+  const size = xbytes(proposal.usedSpace * 1024, { iec: true });
+  const hasDesktopContext = isDesktopMissing || patterns.some((p) => p.desktop);
+  const qty = patterns.length;
+
+  if (hasDesktopContext && qty > 0) {
+    return sprintf(
+      // TRANSLATORS: software summary sub-line combining the count of
+      // selected patterns with the required install size. %1$d is a number
+      // of selected patterns; %2$s is a human-readable disk size
+      // (e.g. "5.95 GiB").
+      n_(
+        "Using %1$d additional pattern. Requires %2$s",
+        "Using %1$d additional patterns. Requires %2$s",
+        qty,
+      ),
+      qty,
+      size,
+    );
+  }
+
+  // TRANSLATORS: total installation size shown in the software summary.
+  // %s is a human-readable disk size (e.g. "5.95 GiB").
+  return sprintf(_("Requires %s"), size);
 };
 
 /**

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -101,9 +101,9 @@ const Value = () => {
 };
 
 /**
- * Renders the sub-line of the software summary.
+ * Renders the description of the software summary.
  *
- * When the headline is a desktop or the missing-desktop hint, the sub-line
+ * When the headline is a desktop or the missing-desktop hint, the description
  * combines the pattern count (if any) with the required install size in a
  * single translatable sentence so translators can adjust punctuation and
  * order. When the headline already conveys the count, only the required
@@ -120,16 +120,20 @@ const Description = () => {
 
   const size = xbytes(proposal.usedSpace * 1024, { iec: true });
   const hasDesktopContext = isDesktopMissing || patterns.some((p) => p.desktop);
-  const qty = patterns.length;
+  const additionalQty = patterns.filter((p) => !p.desktop).length;
 
-  if (hasDesktopContext && qty > 0) {
+  if (hasDesktopContext && additionalQty > 0) {
     return sprintf(
-      // TRANSLATORS: software summary sub-line combining the count of
-      // selected patterns with the required install size. %1$d is a number
-      // of selected patterns; %2$s is a human-readable disk size
-      // (e.g. "5.95 GiB").
-      n_("Includes %1$d pattern. Requires %2$s", "Includes %1$d patterns. Requires %2$s", qty),
-      qty,
+      // TRANSLATORS: software summary description combining the count of
+      // non-desktop patterns selected on top of the desktop with the
+      // required install size. %1$d is a number of additional patterns;
+      // %2$s is a human-readable disk size (e.g. "5.95 GiB").
+      n_(
+        "Includes %1$d additional pattern. Requires %2$s",
+        "Includes %1$d additional patterns. Requires %2$s",
+        additionalQty,
+      ),
+      additionalQty,
       size,
     );
   }

--- a/web/src/components/software/NoDesktopAlert.test.tsx
+++ b/web/src/components/software/NoDesktopAlert.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender } from "~/test-utils";
+import { SOFTWARE } from "~/routes/paths";
+import NoDesktopAlert from "./NoDesktopAlert";
+
+describe("NoDesktopAlert", () => {
+  it("renders the headline and the command-line consequence", () => {
+    installerRender(<NoDesktopAlert />);
+
+    screen.getByText("No desktop selected");
+    screen.getByText("The system will boot to a command-line interface.");
+  });
+
+  it("offers a link that navigates to the software section", () => {
+    installerRender(<NoDesktopAlert />);
+
+    const link = screen.getByRole("link", { name: "software" });
+    expect(link).toHaveAttribute("href", expect.stringContaining(SOFTWARE.root));
+  });
+});

--- a/web/src/components/software/NoDesktopAlert.tsx
+++ b/web/src/components/software/NoDesktopAlert.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Alert, Content } from "@patternfly/react-core";
+import Link from "~/components/core/Link";
+import Interpolate from "~/components/core/Interpolate";
+import { SOFTWARE } from "~/routes/paths";
+import { _ } from "~/i18n";
+
+/**
+ * Alerts the user that no desktop environment is selected and offers a
+ * direct link to the software section so a desktop can be picked without
+ * having to cancel the current flow manually.
+ *
+ * Intended for confirmation dialogs on products that suggest a desktop.
+ */
+export default function NoDesktopAlert() {
+  return (
+    <Alert
+      isInline
+      variant="custom"
+      // TRANSLATORS: alert title shown in the install confirmation dialog when no desktop is selected.
+      title={_("No desktop selected")}
+    >
+      <Content component="p" isEditorial>
+        {/* TRANSLATORS: explains the consequence of installing without a desktop. */}
+        {_("The system will boot to a command-line interface.")}
+      </Content>
+      <Content component="p">
+        <Interpolate
+          // TRANSLATORS: suggests the action to take if a desktop is wanted.
+          // The text inside [] becomes a link that navigates to the software section.
+          sentence={_(
+            "If that is not intended, cancel and select a desktop in the [software] settings.",
+          )}
+        >
+          {(text) => (
+            <Link to={SOFTWARE.root} variant="link" isInline>
+              {text}
+            </Link>
+          )}
+        </Interpolate>
+      </Content>
+    </Alert>
+  );
+}

--- a/web/src/components/storage/PotentialDataLossAlert.test.tsx
+++ b/web/src/components/storage/PotentialDataLossAlert.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender } from "~/test-utils";
+import { useDestructiveActions } from "~/hooks/use-destructive-actions";
+import { STORAGE } from "~/routes/paths";
+import PotentialDataLossAlert from "./PotentialDataLossAlert";
+
+const mockUseDestructiveActionsFn: jest.Mock<ReturnType<typeof useDestructiveActions>> = jest.fn();
+
+jest.mock("~/hooks/use-destructive-actions", () => ({
+  useDestructiveActions: () => mockUseDestructiveActionsFn(),
+}));
+
+const deletePartitionAction = { device: 1, text: "Delete /dev/sda1", delete: true, subvol: false };
+const resizeAction = { device: 2, text: "Resize /dev/sda2", delete: false, subvol: false };
+
+describe("PotentialDataLossAlert", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when there are no destructive actions", () => {
+    beforeEach(() => {
+      mockUseDestructiveActionsFn.mockReturnValue({ actions: [], affectedSystems: [] });
+    });
+
+    it("renders nothing", () => {
+      const { container } = installerRender(<PotentialDataLossAlert />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("when there are destructive actions", () => {
+    beforeEach(() => {
+      mockUseDestructiveActionsFn.mockReturnValue({
+        actions: [deletePartitionAction, resizeAction],
+        affectedSystems: [],
+      });
+    });
+
+    it("renders a generic data-loss headline", () => {
+      installerRender(<PotentialDataLossAlert />);
+      screen.getByText("Proceeding may result in data loss");
+    });
+
+    it("lists each destructive action", () => {
+      installerRender(<PotentialDataLossAlert />);
+      screen.getByText("Delete /dev/sda1");
+      screen.getByText("Resize /dev/sda2");
+    });
+
+    it("offers a link that navigates to the storage section", () => {
+      installerRender(<PotentialDataLossAlert />);
+
+      const link = screen.getByRole("link", { name: "storage" });
+      expect(link).toHaveAttribute("href", expect.stringContaining(STORAGE.root));
+    });
+  });
+
+  describe("when existing systems will be wiped", () => {
+    beforeEach(() => {
+      mockUseDestructiveActionsFn.mockReturnValue({
+        actions: [deletePartitionAction],
+        affectedSystems: ["Windows", "openSUSE Tumbleweed"],
+      });
+    });
+
+    it("names the affected systems in the headline", () => {
+      installerRender(<PotentialDataLossAlert />);
+      screen.getByText(/Proceeding will delete existing data, including .*Windows.*Tumbleweed/);
+    });
+  });
+});

--- a/web/src/components/storage/PotentialDataLossAlert.tsx
+++ b/web/src/components/storage/PotentialDataLossAlert.tsx
@@ -22,15 +22,24 @@
 
 import React from "react";
 import { Alert, Content, List, ListItem, Stack } from "@patternfly/react-core";
-import Text from "~/components/core/Text";
+import Link from "~/components/core/Link";
+import Interpolate from "~/components/core/Interpolate";
 import { _, formatList } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import { useDestructiveActions } from "~/hooks/use-destructive-actions";
+import { STORAGE } from "~/routes/paths";
 
-export default function PotentialDataLossAlert({
-  isCompact = false,
-  hint = _("If you are unsure, check and adjust the storage settings."),
-}) {
+/**
+ * Warns the user about pending destructive storage actions before they
+ * proceed with the installation.
+ *
+ * Renders nothing when there are no destructive actions to report, so
+ * callers can mount it unconditionally. The headline adapts to whether
+ * existing systems will be wiped, and the sub-line offers a direct link to
+ * the storage section so the user can review or adjust settings without
+ * having to cancel the current flow manually.
+ */
+export default function PotentialDataLossAlert() {
   let title: string;
   const { actions, affectedSystems } = useDestructiveActions();
 
@@ -50,15 +59,23 @@ export default function PotentialDataLossAlert({
   return (
     <Alert isInline title={title} variant="danger">
       <Stack hasGutter>
-        {!isCompact && (
-          <List>
-            {actions.map((a, i) => (
-              <ListItem key={i}>{a.text}</ListItem>
-            ))}
-          </List>
-        )}
-        <Content component="p" isEditorial>
-          <Text isBold>{hint}</Text>
+        <List>
+          {actions.map((a, i) => (
+            <ListItem key={i}>{a.text}</ListItem>
+          ))}
+        </List>
+        <Content component="p">
+          <Interpolate
+            // TRANSLATORS: advice shown when destructive actions are pending.
+            // The text inside [] becomes a link that navigates to the storage section.
+            sentence={_("If unsure, cancel and review [storage] settings.")}
+          >
+            {(text) => (
+              <Link to={STORAGE.root} variant="link" isInline>
+                {text}
+              </Link>
+            )}
+          </Interpolate>
         </Content>
       </Stack>
     </Alert>

--- a/web/src/hooks/model/system/software.test.ts
+++ b/web/src/hooks/model/system/software.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { renderHook } from "@testing-library/react";
+// NOTE: check notes about mockSystemQuery in its documentation
+import { clearMockedQueries, mockQuery, mockSystemQuery } from "~/test-utils/tanstack-query";
+import { SelectedBy } from "~/model/proposal/software";
+import type { Product, Software } from "~/model/system";
+import { useIsDesktopMissing } from "~/hooks/model/system/software";
+
+const gnomePattern: Software.Pattern = {
+  name: "gnome",
+  category: "Graphical Environments",
+  summary: "GNOME Desktop Environment",
+  description: "The GNOME desktop environment",
+  order: 1010,
+  icon: "./gnome",
+  preselected: false,
+  desktop: true,
+};
+
+const basePattern: Software.Pattern = {
+  name: "yast2_basis",
+  category: "Base Technologies",
+  summary: "YaST Base Utilities",
+  description: "YaST tools for basic system administration.",
+  order: 1220,
+  icon: "./yast",
+  preselected: false,
+  desktop: false,
+};
+
+const tumbleweed: Product = {
+  id: "Tumbleweed",
+  name: "openSUSE Tumbleweed",
+  registration: false,
+  desktopSelection: "suggested",
+  modes: [],
+};
+
+const sles: Product = {
+  ...tumbleweed,
+  id: "SLES",
+  name: "SUSE Linux Enterprise Server",
+  desktopSelection: "optional",
+};
+
+const legacyProduct: Product = {
+  ...tumbleweed,
+  id: "Legacy",
+  name: "Legacy",
+  desktopSelection: undefined,
+};
+
+type Selection = Record<string, SelectedBy>;
+
+function mockScenario(product: Product, patterns: Software.Pattern[], selection: Selection) {
+  mockSystemQuery({
+    products: [product],
+    software: { patterns, addons: [], repositories: [] },
+  });
+  mockQuery(["extendedConfig"], { product: { id: product.id } });
+  mockQuery(["proposal"], { software: { patterns: selection, usedSpace: 0 } });
+}
+
+describe("useIsDesktopMissing", () => {
+  beforeEach(() => {
+    clearMockedQueries();
+  });
+
+  it("returns false when the product does not declare desktopSelection", () => {
+    mockScenario(legacyProduct, [gnomePattern, basePattern], {});
+
+    const { result } = renderHook(() => useIsDesktopMissing());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when the product's desktopSelection is 'optional'", () => {
+    mockScenario(sles, [gnomePattern, basePattern], {});
+
+    const { result } = renderHook(() => useIsDesktopMissing());
+
+    expect(result.current).toBe(false);
+  });
+
+  describe("when the product's desktopSelection is 'suggested'", () => {
+    it("returns true if no patterns are selected", () => {
+      mockScenario(tumbleweed, [gnomePattern, basePattern], {});
+
+      const { result } = renderHook(() => useIsDesktopMissing());
+
+      expect(result.current).toBe(true);
+    });
+
+    it("returns true if only non-desktop patterns are selected", () => {
+      mockScenario(tumbleweed, [gnomePattern, basePattern], {
+        yast2_basis: SelectedBy.USER,
+      });
+
+      const { result } = renderHook(() => useIsDesktopMissing());
+
+      expect(result.current).toBe(true);
+    });
+
+    it("returns false if a desktop pattern is selected", () => {
+      mockScenario(tumbleweed, [gnomePattern, basePattern], {
+        gnome: SelectedBy.USER,
+      });
+
+      const { result } = renderHook(() => useIsDesktopMissing());
+
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/web/src/hooks/model/system/software.test.ts
+++ b/web/src/hooks/model/system/software.test.ts
@@ -25,7 +25,7 @@ import { renderHook } from "@testing-library/react";
 import { clearMockedQueries, mockQuery, mockSystemQuery } from "~/test-utils/tanstack-query";
 import { SelectedBy } from "~/model/proposal/software";
 import type { Product, Software } from "~/model/system";
-import { useIsDesktopMissing } from "~/hooks/model/system/software";
+import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
 
 const gnomePattern: Software.Pattern = {
   name: "gnome",
@@ -131,5 +131,61 @@ describe("useIsDesktopMissing", () => {
 
       expect(result.current).toBe(false);
     });
+  });
+});
+
+describe("useSelectedPatterns", () => {
+  beforeEach(() => {
+    clearMockedQueries();
+  });
+
+  it("returns an empty list when no pattern is selected", () => {
+    mockScenario(tumbleweed, [gnomePattern, basePattern], {});
+
+    const { result } = renderHook(() => useSelectedPatterns());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns patterns selected by the user", () => {
+    mockScenario(tumbleweed, [gnomePattern, basePattern], {
+      gnome: SelectedBy.USER,
+    });
+
+    const { result } = renderHook(() => useSelectedPatterns());
+
+    expect(result.current).toEqual([gnomePattern]);
+  });
+
+  it("returns patterns auto-pulled as dependencies", () => {
+    mockScenario(tumbleweed, [gnomePattern, basePattern], {
+      yast2_basis: SelectedBy.AUTO,
+    });
+
+    const { result } = renderHook(() => useSelectedPatterns());
+
+    expect(result.current).toEqual([basePattern]);
+  });
+
+  it("excludes patterns explicitly marked as removed", () => {
+    mockScenario(tumbleweed, [gnomePattern, basePattern], {
+      gnome: SelectedBy.USER,
+      yast2_basis: SelectedBy.REMOVED,
+    });
+
+    const { result } = renderHook(() => useSelectedPatterns());
+
+    expect(result.current).toEqual([gnomePattern]);
+  });
+
+  it("excludes patterns marked as not selected", () => {
+    mockScenario(tumbleweed, [gnomePattern, basePattern], {
+      gnome: SelectedBy.USER,
+      yast2_basis: SelectedBy.NONE,
+    });
+
+    const { result } = renderHook(() => useSelectedPatterns());
+
+    expect(result.current).toEqual([gnomePattern]);
   });
 });

--- a/web/src/hooks/model/system/software.ts
+++ b/web/src/hooks/model/system/software.ts
@@ -20,12 +20,11 @@
  * find current contact information at www.suse.com.
  */
 
-import { shake } from "radashi";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { systemQuery } from "~/hooks/model/system";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProductInfo } from "~/hooks/model/config/product";
-import { SelectedBy } from "~/model/proposal/software";
+import { isPatternSelected } from "~/utils/software";
 import type { System, Software } from "~/model/system";
 
 const selectSystem = (data: System | null): Software.System => data?.software;
@@ -40,6 +39,9 @@ function useSystem(): Software.System | null {
 
 /**
  * Retrieves the list of patterns currently selected in the active proposal.
+ *
+ * Only patterns selected by the user or auto-pulled are included; patterns
+ * explicitly removed or not selected at all are excluded.
  */
 function useSelectedPatterns() {
   const proposal = useProposal();
@@ -47,11 +49,7 @@ function useSelectedPatterns() {
 
   if (!proposal) return [];
 
-  const selectedPatternsKeys = Object.keys(
-    shake(proposal.patterns, (value) => value === SelectedBy.NONE),
-  );
-
-  return patterns.filter((p) => selectedPatternsKeys.includes(p.name));
+  return patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
 }
 
 /**

--- a/web/src/hooks/model/system/software.ts
+++ b/web/src/hooks/model/system/software.ts
@@ -24,6 +24,7 @@ import { shake } from "radashi";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { systemQuery } from "~/hooks/model/system";
 import { useProposal } from "~/hooks/model/proposal/software";
+import { useProductInfo } from "~/hooks/model/config/product";
 import { SelectedBy } from "~/model/proposal/software";
 import type { System, Software } from "~/model/system";
 
@@ -53,4 +54,22 @@ function useSelectedPatterns() {
   return patterns.filter((p) => selectedPatternsKeys.includes(p.name));
 }
 
-export { useSystem, useSelectedPatterns };
+/**
+ * Whether the product suggests picking a desktop environment but none is
+ * currently selected.
+ *
+ * Use this to decide whether to hint the user in UI surfaces such as the
+ * software summary or the installation confirmation. Returns `false` for
+ * products that do not declare `desktopSelection` or declare it as
+ * `"optional"`.
+ */
+function useIsDesktopMissing(): boolean {
+  const product = useProductInfo();
+  const selectedPatterns = useSelectedPatterns();
+
+  if (product?.desktopSelection !== "suggested") return false;
+
+  return !selectedPatterns.some((p) => p.desktop);
+}
+
+export { useSystem, useSelectedPatterns, useIsDesktopMissing };

--- a/web/src/model/system.ts
+++ b/web/src/model/system.ts
@@ -43,6 +43,16 @@ type System = {
   zfcp?: ZFCP.System;
 };
 
+/**
+ * Indicates whether the product expects a desktop environment to be selected.
+ *
+ * - "optional": server-oriented products; the UI stays silent when no desktop
+ *   is selected.
+ * - "suggested": the product suggests a desktop; the UI hints the user when
+ *   none has been selected.
+ */
+type DesktopSelection = "optional" | "suggested";
+
 type Product = {
   /** Product ID (e.g., "Leap") */
   id: string;
@@ -56,6 +66,8 @@ type Product = {
   registration: boolean;
   /** The product license id, if any */
   license?: string;
+  /** Desktop selection mode; absent when the product does not declare it */
+  desktopSelection?: DesktopSelection;
   /** Translations */
   translations?: {
     /** The key is the locale (e.g., "en", "pt_BR") */
@@ -88,6 +100,7 @@ type LicenseContent = {
 export type {
   System,
   Product,
+  DesktopSelection,
   LicenseContent,
   L10n,
   Hardware,


### PR DESCRIPTION
## TL;DR

With this set of changes, the software summary reflects the user's actual selections instead of showing generic text, including the chosen desktop and patterns. It helps to detect when no desktop is selected for products that expect one, preventing accidental command-line-only installs. Additionally, it fixes incorrect pattern counting and adds direct navigation from alerts to the relevant settings.

## In details 

After introducing desktop selection capabilities (PR #3396), the overview page's software summary still displayed generic text regardless of the user's selection. This made it difficult to quickly determine whether a desktop environment was selected or how many additional patterns were chosen.

More importantly, products like openSUSE Tumbleweed and Leap expect users to select a desktop environment and intentionally do not select one by default. Skipping this step results in a command-line-only system, which is rarely what users want. Without clear information, users might not realize they forgot to pick a desktop.

This PR helps prevent that by adding relevant information in key places, as agreed in https://github.com/agama-project/agama/discussions/3335. It reduces the likelihood of users accidentally installing a system without a desktop due to oversight.

To achieve this, the software summary on the overview page now reflects the user's selection:

**Short-circuit states (take precedence)**

| Condition |  Value                         | Description     |
|-----------|-------------------------------|-----------------|
| Loading    | skeleton                      | skeleton        |
| Issues    | "Invalid software selection"  | (hidden)        |

**Products with `desktopSelection: "suggested"`**

| Scenario                           | Value                 | Description                                       |
|------------------------------------|-----------------------|---------------------------------------------------|
| Nothing selected yet               | "No desktop selected" | "Requires X"                                      |
| Only non-desktop patterns (M)      | "No desktop selected" | "Includes M additional pattern(s). Requires X"    |
| One desktop, no extras             | Desktop name     | "Requires X"                                      |
| One desktop + extras (M)           | Desktop name    | "Includes M additional pattern(s). Requires X"    |
| Multiple desktops, no extras       | "N desktops selected" | "Requires X"                                      |
| Multiple desktops + extras (M)     | "N desktops selected" | "Includes M additional pattern(s). Requires X"    |

**Products with `desktopSelection: "optional"` or undeclared**

| Scenario                           | Value                             | Description                                       |
|------------------------------------|-----------------------------------|---------------------------------------------------|
| Nothing selected yet               | "Default selection"               | "Requires X"                                      |
| Only non-desktop patterns (M)      | "Using M additional pattern(s)"   | "Requires X"                                      |
| One desktop, no extras             | Desktop name               | "Requires X"                                      |
| One desktop + extras (M)           | Desktop name                 | "Includes M additional pattern(s). Requires X"    |
| Multiple desktops, no extras       | "N desktops selected"             | "Requires X"                                      |
| Multiple desktops + extras (M)     | "N desktops selected"             | "Includes M additional pattern(s). Requires X"    |



**Notes:**
- Pattern count (N) always reflects the total number of selected patterns, even when a desktop is shown
- When the install size is unavailable, the Description returns `null` in all scenarios
- "Requires X" shows the install size (e.g., "Requires 5.95 GiB")

### Missing desktop warnings

When a product marks desktop selection as `suggested` (Tumbleweed, Leap) and no desktop is selected:

- **Overview page**: "No desktop selected" appears in the software summary
  
- **Install confirmation**: shows a `NoDesktopAlert` explaining that the system will boot to a command line, with a link to the software settings

Products that mark desktop selection as `optional` (SLES) are unaffected.

### Interactive alerts

Confirmation alerts link directly to their relevant sections.

Users can jump directly to the relevant section without needing to cancel the confirmation and manually navigate there.


### Bug fix: pattern counting

Fixed a bug where patterns explicitly removed by the user were still counted as selected. This caused the summary to report more patterns than were actually selected.

## Screencasts

### Product featuring `desktopSelection: "optional"`


https://github.com/user-attachments/assets/e541b011-a28e-4b3f-881a-18ca2a798dc4

### Product featuring `desktopSelection: "suggested"`

:warning: Outdated screencast, check newer one at https://github.com/agama-project/agama/pull/3409#issuecomment-4298277359

https://github.com/user-attachments/assets/76fda402-1d51-4970-9b33-88f590ab6f40



## Tests

- [x] Products with `desktopSelection: "suggested"` (Tumbleweed, Leap):
  - [x] No desktop selected shows a hint in the overview and confirmation
  - [x] Selecting a desktop clears the hint
  - [x] Desktop name appears in the software summary
  - [x] Alert links to software settings  
- [x] Products with `desktopSelection: "optional"` or undefined (SLES):
  - [x] No hints appear when no desktop is selected
  - [x] Desktop name is shown when selected
  - [x] Falls back to "Default selection" when nothing is customized  
- [x] Pattern counting:
  - [x] Removed patterns do not appear in the selected count
  - [x] Additional patterns are displayed correctly
  - [x] Count updates when patterns are added/removed  
- [x] Install size is displayed in all scenarios  
- [x] Alert navigation works correctly  

---

## Related

Part of the desktop selection feature initiative:

- #3390  
- #3403  
- #3389  
- #3396  
- https://trello.com/c/6kaMm7Kf/ (protected link)

---

## Notes for reviewers

> [!NOTE]  
> The target branch is a feature request. The changelog entry will be added later.