### PR TITLE
Remove mediacheck

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 22 06:43:48 UTC 2026 - Michal Filka <mfilka@suse.com>
+
+- bsc#1262229
+  - Dropped mediacheck from the kiwi file as it caused build errors
+    after kiwi upgraded to new version 
+
+-------------------------------------------------------------------
 Fri Apr 17 10:26:35 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - bsc#1261932

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -38,17 +38,17 @@
     </preferences>
     <!-- the ISO Volume ID is set by the fix_bootconfig script -->
     <preferences arch="ppc64le" profiles="openSUSE,SUSE_SLE_16.1,Leap_16.1">
-        <type image="iso" flags="dmsquash"  firmware="ofw" mediacheck="true" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash"  firmware="ofw" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences arch="aarch64,x86_64" profiles="openSUSE,SUSE_SLE_16.1,Leap_16.1">
-        <type image="iso" flags="dmsquash" firmware="uefi" mediacheck="true" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash" firmware="uefi" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
             <bootloader name="grub2" timeout="10"/>
         </type>
     </preferences>
     <preferences arch="s390x" profiles="openSUSE,SUSE_SLE_16.1,Leap_16.1">
-        <type image="iso" flags="dmsquash" mediacheck="true" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
             <bootloader name="custom" />
         </type>
     </preferences>


### PR DESCRIPTION
## Problem

In new version KIWI reports misused mediacheck as an error (was silently ignored until now)

- [*Bugzilla link*](https://bugzilla.suse.com/show_bug.cgi?id=1262229)

## Solution

Discussed with mschaefer and kiwi supports mediacheck only for non-uefi builds on x86_64 arch. Which is ... none in case of agama. So mediacheck was removed from image definitions.