### PR TITLE
Fixed medium check (bsc#1262311)

### DIFF
--- a/live/live-root/etc/systemd/system/checkmedia.service
+++ b/live/live-root/etc/systemd/system/checkmedia.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Installation medium integrity check
 
-# before X11 because it switches the terminal to VT7
+# before starting the installer to possibly avoid installing from a broken medium
 Before=agama.service
 
 # copied from YaST2-Second-Stage.service
@@ -38,6 +38,7 @@ ExecStartPost=dmesg --console-on
 # enable back the systemd status messages on the console
 ExecStartPost=kill -SIGRTMIN+20 1
 
+StandardInput=tty
 StandardOutput=tty
 RemainAfterExit=true
 TimeoutStartSec=infinity

--- a/live/live-root/usr/bin/checkmedia-service
+++ b/live/live-root/usr/bin/checkmedia-service
@@ -4,16 +4,24 @@
 
 # get the partition where the live ISO is mounted, the real name is set by the
 # config.sh script which gets the live partition label name from KIWI
-disk=$(blkid -L "@@LIVE_MEDIUM_LABEL@@")
+label="@@LIVE_MEDIUM_LABEL@@"
+disk="/dev/disk/by-label/$label"
 
-if [ -z "$disk" ]; then
-  echo -e "\e[31mPartition \"@@LIVE_MEDIUM_LABEL@@\" not found, skipping media check\e[0m"
+if [ -b "$disk" ]; then
+  # when booting from disk/USB flash checkmedia expects the device name, not the partition
+  # get the parent device if there is any
+  parent=$(lsblk --noheadings --output PKNAME "$disk")
+  [ -b "/dev/$parent" ] && disk="/dev/$parent"
+fi
+
+if [ ! -b "$disk" ]; then
+  echo -e "\e[31mPartition \"$label\" not found, skipping media check\e[0m"
   read -n1 -s -p "Press any key to continue... "
   echo
   exit 0
 fi
 
-echo "Checking data integrity of device $disk (@@LIVE_MEDIUM_LABEL@@)..."
+echo "Checking data integrity of device $disk ($label))..."
 
 if checkmedia -v "$disk"; then
   echo -e "\e[32mMedium check succeeded\e[0m"

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 23 08:20:09 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed medium check (bsc#1262311)
+  - Properly check the medium when booting from HDD or USB flash
+  - Fixed waiting for a key press when the check is finished
+
+-------------------------------------------------------------------
 Wed Apr 22 06:43:48 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - bsc#1262229


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1262311
- The medium check does not work when booting from HDD or USB flash
- It does not wait for a key press after printing the result

## Solution

- When when booting from HDD or USB flash the label points to a partition, the `checkmedia` tool expects whole disk as input (`/dev/sda`), not a partition (`/dev/sda2`). Try getting the parent device if there is any.
- Fixed waiting for a key press by specifying tty as input in the systemd service file

## Testing

- Tested manually

## Screenshots

Now it properly tests the `/dev/sda` disk and waits for a key press.

### When the check fails 
<img width="601" height="81" alt="agama-checkmedium-failed" src="https://github.com/user-attachments/assets/5de14c26-438b-4c88-8c13-c16feecdabf7" />

### When the check succeeds 
<img width="641" height="273" alt="agama-checkmedium-success" src="https://github.com/user-attachments/assets/0e47c814-b630-41e9-9fb4-5a6cb1af45a5" />

