### PR TITLE
feat(web): polish patterns selection page UX

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -266,6 +266,15 @@ strong {
   top: 1em;
 }
 
+.agm-sticky-category-header {
+  position: sticky;
+  background: var(--pf-t--global--background--color--primary--default);
+  z-index: 2;
+  padding-block-start: var(--pf-t--global--spacer--sm);
+  padding-block-end: var(--pf-t--global--spacer--sm);
+  border-bottom: var(--pf-t--global--border--width--regular) solid rgb(0 0 0 / 10%);
+}
+
 #productSelectionForm {
   input[type="radio"] {
     align-self: center;

--- a/web/src/components/software/AutoSelectedLabel.tsx
+++ b/web/src/components/software/AutoSelectedLabel.tsx
@@ -29,7 +29,7 @@ import { _ } from "~/i18n";
  */
 export default function AutoSelectedLabel(): React.ReactNode {
   return (
-    <Label color="blue" isCompact>
+    <Label color="teal" isCompact>
       {/* TRANSLATORS: label shown for patterns automatically selected as dependencies */}
       {_("auto selected")}
     </Label>

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { patchConfig } from "~/api";
 import testingPatterns from "./patterns.test.json";
@@ -128,15 +128,14 @@ describe("SoftwarePatternsSelection", () => {
     const basisCheckbox = await screen.findByRole("checkbox", {
       name: y2BasisPattern.summary,
     });
-    const row = basisCheckbox.closest('[class*="pf-v6-l-flex"]');
 
-    // yast2_basis is AUTO in the mock: the label is rendered in the row.
-    expect(within(row).queryAllByText(/auto selected/i)).toHaveLength(1);
+    // 5 patterns are AUTO in the mock: yast2_basis, yast2_desktop, office,
+    // multimedia, and preselected_pattern.
+    expect(screen.getAllByText(/auto selected/i)).toHaveLength(5);
 
     await user.click(basisCheckbox);
 
-    // Once the field is dirty, the row no longer shows the label.
-    expect(within(row).queryAllByText(/auto selected/i)).toHaveLength(0);
+    expect(screen.queryAllByText(/auto selected/i)).toHaveLength(4);
   });
 
   describe("when the search filter is active", () => {

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { patchConfig } from "~/api";
 import testingPatterns from "./patterns.test.json";
@@ -61,57 +61,120 @@ jest.mock("~/api", () => ({
 }));
 
 describe("SoftwarePatternsSelection", () => {
-  it("displays the pattern in the correct order", async () => {
+  it("renders one h3 per category, in order", async () => {
     installerRender(<SoftwarePatternsSelection />);
-    const headings = screen.getAllByRole("heading", { level: 3 });
+    const headings = await screen.findAllByRole("heading", { level: 3 });
     const headingsText = headings.map((node) => node.textContent);
-    expect(headingsText).toEqual([
-      "Patterns",
-      "Graphical Environments",
-      "Base Technologies",
-      "Desktop Functions",
-    ]);
-
-    // the "Base Technologies" pattern group
-    const baseGroup = await screen.findByRole("list", { name: "Base Technologies" });
-    // the "Base Technologies" pattern items
-    const items = within(baseGroup).getAllByRole("listitem");
-    expect(items[0]).toHaveTextContent(/YaST Base Utilities/);
-    expect(items[1]).toHaveTextContent(/YaST Desktop Utilities/);
-    expect(items[2]).toHaveTextContent(/YaST Server Utilities/);
+    expect(headingsText[0]).toMatch(/^Graphical Environments/);
+    expect(headingsText[1]).toMatch(/^Base Technologies/);
+    expect(headingsText[2]).toMatch(/^Desktop Functions/);
+    expect(headings).toHaveLength(3);
   });
 
-  it("displays only the matching patterns when filtering", async () => {
+  it("renders each category containing its patterns in order", async () => {
+    installerRender(<SoftwarePatternsSelection />);
+
+    await screen.findByRole("heading", { name: /Base Technologies/, level: 3 });
+    // Find the checkboxes that come after the Base Technologies heading
+    const allCheckboxes = screen.getAllByRole("checkbox");
+    const baseStartIndex = allCheckboxes.findIndex((c) => c.id === "yast2_basis");
+    const ids = allCheckboxes.slice(baseStartIndex, baseStartIndex + 4).map((c) => c.id);
+    // Order is driven by the `order` field on each pattern.
+    expect(ids).toEqual(["yast2_basis", "yast2_desktop", "yast2_server", "preselected_pattern"]);
+  });
+
+  it("renders a search input with placeholder and accessible name", async () => {
+    installerRender(<SoftwarePatternsSelection />);
+    // The textbox has an aria-label for screen readers
+    const searchInput = await screen.findByRole("textbox", {
+      name: /Filter by name and description/,
+    });
+    // And a placeholder for sighted users
+    expect(searchInput).toHaveAttribute("placeholder", "Filter by name and description");
+  });
+
+  it("shows a per-category 'X of Y selected' counter", async () => {
+    installerRender(<SoftwarePatternsSelection />);
+    // 3 of 4 in Base Technologies are auto-selected in the mock proposal
+    // (yast2_basis, yast2_desktop, preselected_pattern); yast2_server is "none".
+    await screen.findByText(/3 of 4 selected/);
+  });
+
+  it("updates the counter live as the user toggles a checkbox", async () => {
     const { user } = installerRender(<SoftwarePatternsSelection />);
 
-    // enter "multimedia" into the search filter
-    const searchFilter = await screen.findByRole("textbox", { name: /Filter/ });
-    await user.type(searchFilter, "multimedia");
+    await screen.findByText(/3 of 4 selected/);
 
-    const headings = screen.getAllByRole("heading", { level: 3 });
-    const headingsText = headings.map((node) => node.textContent);
-    expect(headingsText).toEqual(["Patterns", "Desktop Functions"]);
+    const serverCheckbox = screen.getByRole("checkbox", { name: /YaST Server/ });
+    await user.click(serverCheckbox);
 
-    const desktopGroup = screen.getByRole("list", { name: "Desktop Functions" });
-    expect(within(desktopGroup).queryByText(/Multimedia$/)).toBeInTheDocument();
-    expect(within(desktopGroup).queryByText(/Office Software/)).not.toBeInTheDocument();
+    screen.getByText(/4 of 4 selected/);
   });
 
-  it("displays the checkbox reflecting the current pattern selection status", async () => {
-    installerRender(<SoftwarePatternsSelection />);
+  it("toggles the checkbox when the user clicks its label", async () => {
+    const { user } = installerRender(<SoftwarePatternsSelection />);
 
-    // the "Base Technologies" pattern group
-    const baseGroup = await screen.findByRole("list", { name: "Base Technologies" });
+    const checkbox = await screen.findByRole("checkbox", { name: /YaST Server/ });
+    expect(checkbox).not.toBeChecked();
 
-    const basisCheckbox = await within(baseGroup).findByRole("checkbox", {
-      name: /Unselect YaST Base/,
+    await user.click(screen.getByText(/YaST Server Utilities/));
+    expect(checkbox).toBeChecked();
+  });
+
+  describe("when the search filter is active", () => {
+    it("shows the match count with total context on the filter input badge", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const searchFilter = await screen.findByRole("textbox", { name: /Filter/ });
+      await user.type(searchFilter, "multimedia");
+
+      screen.getByText(/1 of 10 patterns/);
     });
-    expect(basisCheckbox).toBeChecked();
 
-    const serverCheckbox = await within(baseGroup).findByRole("checkbox", {
-      name: /Select YaST Server/,
+    it("shows an explicit empty state on the filter input badge when nothing matches", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const searchFilter = await screen.findByRole("textbox", { name: /Filter/ });
+      await user.type(searchFilter, "zzz-nothing-matches");
+
+      screen.getByText("No patterns match");
+      expect(screen.queryByText(/0 of \d+ patterns/)).toBeNull();
     });
-    expect(serverCheckbox).not.toBeChecked();
+
+    it("keeps every category visible and shows a placeholder for the empty ones", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const searchFilter = await screen.findByRole("textbox", { name: /Filter/ });
+      await user.type(searchFilter, "multimedia");
+
+      const headings = screen.getAllByRole("heading", { level: 3 });
+      expect(headings).toHaveLength(3);
+
+      screen.getByRole("checkbox", { name: /Multimedia/ });
+      expect(screen.queryByRole("checkbox", { name: /Office/ })).toBeNull();
+
+      screen.getByRole("heading", { name: /Base Technologies/, level: 3 });
+      screen.getByRole("heading", { name: /Graphical Environments/, level: 3 });
+
+      const placeholders = screen.getAllByText(/No patterns match the filter/i);
+      expect(placeholders).toHaveLength(2);
+    });
+
+    it("shows the match count or the empty-state placeholder next to each per-category counter", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const searchFilter = await screen.findByRole("textbox", { name: /Filter/ });
+      await user.type(searchFilter, "multimedia");
+
+      screen.getByText(/3 of 4 selected/);
+
+      // n_() picks the singular form at count === 1: "1 matches the filter".
+      screen.getByText(/1 matches the filter/);
+
+      expect(screen.queryByText(/0 match the filter/)).toBeNull();
+      const emptyStates = screen.getAllByText(/No patterns match the filter/i);
+      expect(emptyStates).toHaveLength(2);
+    });
   });
 
   describe("when submitting the form", () => {
@@ -124,7 +187,7 @@ describe("SoftwarePatternsSelection", () => {
       const y2BasisPattern = testingPatterns.find((p) => p.name === "yast2_basis");
 
       const basisCheckbox = await screen.findByRole("checkbox", {
-        name: `Unselect ${y2BasisPattern.summary}`,
+        name: y2BasisPattern.summary,
       });
       expect(basisCheckbox).toBeChecked();
 
@@ -149,7 +212,7 @@ describe("SoftwarePatternsSelection", () => {
       const gnomePattern = testingPatterns.find((p) => p.name === "gnome");
 
       const gnomeCheckbox = await screen.findByRole("checkbox", {
-        name: `Unselect ${gnomePattern.summary}`,
+        name: gnomePattern.summary,
       });
       expect(gnomeCheckbox).toBeChecked();
 
@@ -174,7 +237,7 @@ describe("SoftwarePatternsSelection", () => {
       const kdePattern = testingPatterns.find((p) => p.name === "kde");
 
       const kdeCheckbox = await screen.findByRole("checkbox", {
-        name: `Select ${kdePattern.summary}`,
+        name: kdePattern.summary,
       });
       expect(kdeCheckbox).not.toBeChecked();
 
@@ -210,7 +273,7 @@ describe("SoftwarePatternsSelection", () => {
 
       // Touch one pattern (select kde)
       const kdeCheckbox = await screen.findByRole("checkbox", {
-        name: `Select ${kdePattern.summary}`,
+        name: kdePattern.summary,
       });
       await user.click(kdeCheckbox);
 
@@ -259,7 +322,7 @@ describe("SoftwarePatternsSelection", () => {
 
       // Make a change to make form dirty (toggle gnome off then on)
       const gnomeCheckbox = await screen.findByRole("checkbox", {
-        name: `Unselect ${gnomePattern.summary}`,
+        name: gnomePattern.summary,
       });
       await user.click(gnomeCheckbox);
       await user.click(gnomeCheckbox);
@@ -283,7 +346,7 @@ describe("SoftwarePatternsSelection", () => {
       const y2BasisPattern = testingPatterns.find((p) => p.name === "yast2_basis");
 
       const basisCheckbox = await screen.findByRole("checkbox", {
-        name: `Unselect ${y2BasisPattern.summary}`,
+        name: y2BasisPattern.summary,
       });
       expect(basisCheckbox).toBeChecked();
 
@@ -317,26 +380,26 @@ describe("SoftwarePatternsSelection scope", () => {
   it("shows only desktop patterns when scope is 'desktops'", async () => {
     installerRender(<SoftwarePatternsSelection scope="desktops" />);
 
-    expect(await screen.findByRole("checkbox", { name: /GNOME/ })).toBeInTheDocument();
-    expect(await screen.findByRole("checkbox", { name: /KDE/ })).toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: /YaST Base/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: /Multimedia/ })).not.toBeInTheDocument();
+    await screen.findByRole("checkbox", { name: /GNOME/ });
+    await screen.findByRole("checkbox", { name: /KDE/ });
+    expect(screen.queryByRole("checkbox", { name: /YaST Base/ })).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: /Multimedia/ })).toBeNull();
   });
 
   it("shows only non-desktop patterns when scope is 'other'", async () => {
     installerRender(<SoftwarePatternsSelection scope="other" />);
 
-    expect(await screen.findByRole("checkbox", { name: /YaST Base/ })).toBeInTheDocument();
-    expect(await screen.findByRole("checkbox", { name: /Multimedia/ })).toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: /GNOME/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: /KDE/ })).not.toBeInTheDocument();
+    await screen.findByRole("checkbox", { name: /YaST Base/ });
+    await screen.findByRole("checkbox", { name: /Multimedia/ });
+    expect(screen.queryByRole("checkbox", { name: /GNOME/ })).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: /KDE/ })).toBeNull();
   });
 
   it("preserves REMOVED desktop patterns (in the 'remove' key) when submitting with scope 'other'", async () => {
     const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
 
     // Touch a non-desktop pattern to make the form dirty
-    const serverCheckbox = await screen.findByRole("checkbox", { name: /Select YaST Server/ });
+    const serverCheckbox = await screen.findByRole("checkbox", { name: /YaST Server/ });
     await user.click(serverCheckbox);
 
     const acceptButton = screen.getByRole("button", { name: "Accept" });
@@ -357,7 +420,7 @@ describe("SoftwarePatternsSelection scope", () => {
     const { user } = installerRender(<SoftwarePatternsSelection scope="desktops" />);
 
     // Touch a desktop pattern to make the form dirty
-    const kdeCheckbox = await screen.findByRole("checkbox", { name: /Select KDE/ });
+    const kdeCheckbox = await screen.findByRole("checkbox", { name: /KDE/ });
     await user.click(kdeCheckbox);
 
     const acceptButton = screen.getByRole("button", { name: "Accept" });
@@ -384,7 +447,7 @@ describe("SoftwarePatternsSelection scope", () => {
     const { user } = installerRender(<SoftwarePatternsSelection scope="other" />);
 
     // Touch a non-desktop pattern to make the form dirty
-    const serverCheckbox = await screen.findByRole("checkbox", { name: /Select YaST Server/ });
+    const serverCheckbox = await screen.findByRole("checkbox", { name: /YaST Server/ });
     await user.click(serverCheckbox);
 
     const acceptButton = screen.getByRole("button", { name: "Accept" });

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { patchConfig } from "~/api";
 import testingPatterns from "./patterns.test.json";
@@ -119,6 +119,24 @@ describe("SoftwarePatternsSelection", () => {
 
     await user.click(screen.getByText(/YaST Server Utilities/));
     expect(checkbox).toBeChecked();
+  });
+
+  it("hides the 'auto selected' label on an AUTO pattern once the user touches it", async () => {
+    const { user } = installerRender(<SoftwarePatternsSelection />);
+    const y2BasisPattern = testingPatterns.find((p) => p.name === "yast2_basis");
+
+    const basisCheckbox = await screen.findByRole("checkbox", {
+      name: y2BasisPattern.summary,
+    });
+    const row = basisCheckbox.closest('[class*="pf-v6-l-flex"]');
+
+    // yast2_basis is AUTO in the mock: the label is rendered in the row.
+    expect(within(row).queryAllByText(/auto selected/i)).toHaveLength(1);
+
+    await user.click(basisCheckbox);
+
+    // Once the field is dirty, the row no longer shows the label.
+    expect(within(row).queryAllByText(/auto selected/i)).toHaveLength(0);
   });
 
   describe("when the search filter is active", () => {

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -408,8 +408,13 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
               </div>
             </PageSection>
 
-            <form.Subscribe selector={(s) => s.values as Record<string, boolean>}>
-              {(formValues) => (
+            <form.Subscribe
+              selector={(s) => ({
+                values: s.values as Record<string, boolean>,
+                fieldMeta: s.fieldMeta,
+              })}
+            >
+              {({ values: formValues, fieldMeta }) => (
                 <Stack hasGutter>
                   {sortGroupNames(allGroups).map((groupName) => {
                     const groupAll = allGroups[groupName];
@@ -437,21 +442,27 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
                         {groupVisible.length > 0 && (
                           <NestedContent>
                             <Stack hasGutter>
-                              {groupVisible.map((pattern) => (
-                                <PatternCheckbox
-                                  key={pattern.name}
-                                  id={pattern.name}
-                                  label={pattern.summary}
-                                  description={pattern.description}
-                                  isChecked={!!formValues[pattern.name]}
-                                  onChange={(value) => form.setFieldValue(pattern.name, value)}
-                                  extra={
-                                    selection[pattern.name] === SelectedBy.AUTO && (
-                                      <AutoSelectedLabel />
-                                    )
-                                  }
-                                />
-                              ))}
+                              {groupVisible.map((pattern) => {
+                                const isAutoSelected =
+                                  selection[pattern.name] === SelectedBy.AUTO;
+                                const isDirty = fieldMeta[pattern.name]?.isDirty ?? false;
+
+                                return (
+                                  <PatternCheckbox
+                                    key={pattern.name}
+                                    id={pattern.name}
+                                    label={pattern.summary}
+                                    description={pattern.description}
+                                    isChecked={!!formValues[pattern.name]}
+                                    onChange={(value) =>
+                                      form.setFieldValue(pattern.name, value)
+                                    }
+                                    extra={
+                                      isAutoSelected && !isDirty && <AutoSelectedLabel />
+                                    }
+                                  />
+                                );
+                              })}
                             </Stack>
                           </NestedContent>
                         )}

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -443,8 +443,7 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
                           <NestedContent>
                             <Stack hasGutter>
                               {groupVisible.map((pattern) => {
-                                const isAutoSelected =
-                                  selection[pattern.name] === SelectedBy.AUTO;
+                                const isAutoSelected = selection[pattern.name] === SelectedBy.AUTO;
                                 const isDirty = fieldMeta[pattern.name]?.isDirty ?? false;
 
                                 return (
@@ -454,12 +453,8 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
                                     label={pattern.summary}
                                     description={pattern.description}
                                     isChecked={!!formValues[pattern.name]}
-                                    onChange={(value) =>
-                                      form.setFieldValue(pattern.name, value)
-                                    }
-                                    extra={
-                                      isAutoSelected && !isDirty && <AutoSelectedLabel />
-                                    }
+                                    onChange={(value) => form.setFieldValue(pattern.name, value)}
+                                    extra={isAutoSelected && !isDirty && <AutoSelectedLabel />}
                                   />
                                 );
                               })}

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -20,23 +20,25 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 import {
-  DataList,
-  DataListCell,
-  DataListCheck,
-  DataListItem,
-  DataListItemCells,
-  DataListItemRow,
+  ActionGroup,
+  Checkbox,
+  Flex,
+  Form,
+  PageSection,
   SearchInput,
   Stack,
-  Content,
-  ActionGroup,
-  Form,
+  Title,
 } from "@patternfly/react-core";
+import { group } from "radashi";
+import { sprintf } from "sprintf-js";
 import { formOptions } from "@tanstack/react-form";
 import { useNavigate } from "react-router";
+import NestedContent from "~/components/core/NestedContent";
 import Page from "~/components/core/Page";
+import SubtleContent from "~/components/core/SubtleContent";
+import Text from "~/components/core/Text";
 import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { SelectedBy } from "~/model/proposal/software";
 import { patchConfig } from "~/api";
@@ -45,20 +47,13 @@ import { useProposal } from "~/hooks/model/proposal/software";
 import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
 import { SOFTWARE } from "~/routes/paths";
-import { N_, _ } from "~/i18n";
+import { N_, _, n_ } from "~/i18n";
 
-import a11yStyles from "@patternfly/react-styles/css/utilities/Accessibility/accessibility";
 import type { Pattern } from "~/model/system/software";
 
-/**
- * Form options for pattern selection.
- * Each pattern is a boolean field (pattern name -> selected state).
- */
 const softwarePatternsFormOptions = formOptions({
   defaultValues: {},
 });
-
-const NoMatches = (): React.ReactNode => <b>{_("None of the patterns match the filter.")}</b>;
 
 /**
  * Controls which patterns the selection page shows.
@@ -122,6 +117,132 @@ const PAGE_TITLE: Record<Scope, string> = {
   other: N_("Patterns selection"),
 };
 
+type CategoryCounterProps = {
+  /** All patterns in the category, regardless of the active filter. */
+  patterns: Pattern[];
+  /** Number of patterns from `patterns` that match the active filter. */
+  matchCount: number;
+  /** Whether the user has typed something in the search input. */
+  isFiltering: boolean;
+  /** Live selection map (pattern name -> checked) from the form state. */
+  formValues: Record<string, boolean>;
+};
+
+/**
+ * Inline subtle counter rendered next to a category heading.
+ *
+ * Always shows "X of Y selected" so the user can see selections persist even
+ * when the filter hides patterns. When the filter is active, appends either "N
+ * match the filter" (visible subset) or "No patterns match the filter" (empty
+ * subset), avoiding a redundant placeholder in the body below.
+ */
+const CategoryCounter = ({
+  patterns,
+  matchCount,
+  isFiltering,
+  formValues,
+}: CategoryCounterProps) => {
+  const selectedCount = patterns.filter((p) => formValues[p.name]).length;
+  // TRANSLATORS: %1$d is selected count, %2$d is total available count
+  const selectedText = sprintf(_("%1$d of %2$d selected"), selectedCount, patterns.length);
+
+  if (!isFiltering) {
+    return <Text textStyle={["fontSizeSm", "textColorSubtle"]}>{selectedText}</Text>;
+  }
+
+  const matchText =
+    matchCount === 0
+      ? // TRANSLATORS: shown next to a category heading when the search filter excludes all its patterns
+        _("No patterns match the filter")
+      : // TRANSLATORS: count of patterns matching the search filter in this category
+        sprintf(n_("%d matches the filter", "%d match the filter", matchCount), matchCount);
+
+  return (
+    <Flex spaceItems={{ default: "spaceItemsMd" }}>
+      <Text textStyle={["fontSizeSm", "textColorSubtle"]}>{selectedText}</Text>
+      <Text textStyle={["fontSizeXs", "textColorSubtle"]}>{matchText}</Text>
+    </Flex>
+  );
+};
+
+type PatternCheckboxProps = {
+  /** Checkbox input id */
+  id: string;
+  /** Pattern title displayed next to the checkbox */
+  label: string;
+  /** Optional pattern description shown below */
+  description?: string;
+  /** Whether the checkbox is checked */
+  isChecked: boolean;
+  /** Called when the checkbox value changes */
+  onChange: (checked: boolean) => void;
+  /**
+   * Optional non-interactive content (e.g., badge, icon) rendered next to the label.
+   * Sits outside the clickable label area, so clicking it won't toggle the checkbox.
+   */
+  extra?: React.ReactNode;
+};
+
+/**
+ * Internal checkbox component with external label structure.
+ *
+ * Unlike PatternFly's standard Checkbox component (where the `label` prop
+ * creates a clickable area that includes all its content), this component uses
+ * an external `<label htmlFor={id}>` element, allowing non-interactive content
+ * to be placed alongside the label without being part of the click target.
+ *
+ * **Structure:**
+ * - Outer Flex (column): checkbox row + description
+ * - Inner Flex (row): checkbox + label + extra content
+ * - Checkbox without label/description props (input only)
+ * - External `<label htmlFor={id}>` that targets the checkbox input
+ * - Extra content outside the label (truly non-interactive)
+ * - Description indented to align with label text
+ *
+ * **Use case:** When you need to display supplementary information (badges, icons)
+ * next to a checkbox label without making that information clickable.
+ *
+ * **Note:** If this pattern is needed elsewhere in the codebase, consider extracting
+ * to `components/form/` with proper TanStack Form integration.
+ *
+ * @example
+ * ```tsx
+ * <PatternCheckbox
+ *   id="pattern-gnome"
+ *   label="GNOME Desktop"
+ *   description="Modern desktop environment"
+ *   isChecked={isSelected}
+ *   onChange={setSelected}
+ *   extra={<AutoSelectedLabel />}
+ * />
+ * ```
+ */
+const PatternCheckbox = ({
+  id,
+  label,
+  description,
+  isChecked,
+  onChange,
+  extra,
+}: PatternCheckboxProps) => {
+  return (
+    <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsXs" }}>
+      <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsFlexEnd" }}>
+        <Checkbox id={id} isChecked={isChecked} onChange={(_, checked) => onChange(checked)} />
+        <label htmlFor={id}>
+          <Text textStyle="fontSizeMd">{label}</Text>
+        </label>
+        {extra}
+      </Flex>
+      {description && (
+        <NestedContent margin="mlLg">
+          <SubtleContent>{description}</SubtleContent>
+        </NestedContent>
+      )}
+    </Flex>
+  );
+};
+
 /**
  * Pattern selector component.
  *
@@ -134,6 +255,26 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   const proposal = useProposal();
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
+
+  // Category headers stick below the filter as the user scrolls. To position
+  // them correctly, we need the filter's height. We measure it dynamically
+  // because the filter might wrap differently at various viewport widths or
+  // when showing the results count badge.
+  //
+  // useLayoutEffect fires synchronously after DOM mutations but before paint,
+  // so the measurement completes before the browser renders. This prevents
+  // visual flicker that would occur with useEffect (which fires after paint).
+  //
+  // We re-measure when searchValue changes because the SearchInput's results
+  // count can affect the filter's height (wrapping on narrow viewports).
+  const filterRef = useRef<HTMLDivElement>(null);
+  const [filterHeight, setFilterHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (filterRef.current) {
+      setFilterHeight(filterRef.current.offsetHeight);
+    }
+  }, [searchValue]);
 
   let scopedPatterns: Pattern[];
   switch (scope) {
@@ -185,11 +326,36 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
     onSubmitComplete: () => navigate(SOFTWARE.root),
   });
 
-  // initial empty screen, the patterns are loaded very quickly, no need for any progress
-  const visiblePatterns = filterPatterns(scopedPatterns, searchValue);
-  if (visiblePatterns.length === 0 && searchValue === "") return null;
+  // Initial empty screen guard: patterns load very quickly, but on the very
+  // first render the system list may be empty. Avoid flashing an empty page.
+  if (scopedPatterns.length === 0 && searchValue === "") return null;
 
-  const groups = groupPatterns(visiblePatterns);
+  // Build the canonical category list from the unfiltered scope so categories
+  // never disappear as the user types.
+  const allGroups = groupPatterns(scopedPatterns);
+  const visiblePatterns = filterPatterns(scopedPatterns, searchValue);
+  const visibleByCategory = group(visiblePatterns, (p) => p.category);
+  const isFiltering = searchValue.trim() !== "";
+
+  // TRANSLATORS: screen reader announcement when filter results change.
+  // %d is the number of patterns matching the current filter.
+  const filterAnnouncement = isFiltering
+    ? sprintf(
+        n_("%d pattern found", "%d patterns found", visiblePatterns.length),
+        visiblePatterns.length,
+      )
+    : "";
+
+  let filterResultsCount: string | undefined;
+  if (isFiltering) {
+    filterResultsCount =
+      visiblePatterns.length === 0
+        ? // TRANSLATORS: search results badge on the filter input when no pattern matches
+          _("No patterns match")
+        : // TRANSLATORS: search results badge on the filter input.
+          // %1$d is matches found, %2$d is the total number of patterns.
+          sprintf(_("%1$d of %2$d patterns"), visiblePatterns.length, scopedPatterns.length);
+  }
 
   return (
     <Page
@@ -205,74 +371,96 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
     >
       <Page.Content>
         <form.AppForm>
+          {/* TODO: extract to global ARIA live region for announcements.
+              Screen reader users need feedback when filter results change, but
+              each component creating its own live region is not ideal. A single
+              global announcements region would be more maintainable and avoid
+              potential conflicts. */}
+          <div aria-live="polite" aria-atomic="true" className="pf-v6-u-screen-reader">
+            {filterAnnouncement}
+          </div>
           <Form
             onSubmit={(e) => {
               e.preventDefault();
               form.handleSubmit();
             }}
           >
-            <SearchInput
-              // TRANSLATORS: search field placeholder text
-              placeholder={_("Filter by pattern title or description")}
-              aria-label={_("Filter by pattern title or description")}
-              value={searchValue}
-              onChange={(_event, value) => setSearchValue(value)}
-              onClear={() => setSearchValue("")}
-              resultsCount={visiblePatterns.length}
-            />
-            <Page.Section title="Patterns">
-              <Stack hasGutter>
-                {sortGroupNames(groups).map((groupName) => (
-                  <section key={groupName}>
-                    <Content component="h3">{groupName}</Content>
-                    <DataList isCompact aria-label={groupName}>
-                      {groups[groupName].map((option) => {
-                        const titleId = `${option.name}-title`;
-                        const descId = `${option.name}-desc`;
-                        const nextActionId = `${option.name}-next-action`;
+            <PageSection
+              component="div"
+              stickyOnBreakpoint={{ default: "top" }}
+              padding={{ default: "noPadding" }}
+              style={{
+                background: "var(--pf-t--global--background--color--primary--default)",
+                zIndex: 3,
+              }}
+            >
+              <div ref={filterRef}>
+                <SearchInput
+                  // TRANSLATORS: placeholder for the search field on the patterns selection page
+                  placeholder={_("Filter by name and description")}
+                  // SearchInput defaults aria-label to "Search input"; override for clarity.
+                  aria-label={_("Filter by name and description")}
+                  value={searchValue}
+                  onChange={(_event, value) => setSearchValue(value)}
+                  onClear={() => setSearchValue("")}
+                  resultsCount={filterResultsCount}
+                />
+              </div>
+            </PageSection>
 
-                        return (
-                          <DataListItem key={option.name}>
-                            <form.Subscribe selector={(s) => s.values[option.name]}>
-                              {(selected) => (
-                                <DataListItemRow>
-                                  <DataListCheck
-                                    onChange={(_, value) => {
-                                      form.setFieldValue(option.name, value);
-                                    }}
-                                    aria-labelledby={[nextActionId, titleId].join(" ")}
-                                    isChecked={selected}
-                                  />
-                                  <DataListItemCells
-                                    dataListCells={[
-                                      <DataListCell key="summary">
-                                        <Stack hasGutter>
-                                          <div>
-                                            <b id={titleId}>{option.summary}</b>{" "}
-                                            {selection[option.name] === SelectedBy.AUTO && (
-                                              <AutoSelectedLabel />
-                                            )}
-                                            <span id={nextActionId} className={a11yStyles.hidden}>
-                                              {selected ? _("Unselect") : _("Select")}
-                                            </span>
-                                          </div>
-                                          <div id={descId}>{option.description}</div>
-                                        </Stack>
-                                      </DataListCell>,
-                                    ]}
-                                  />
-                                </DataListItemRow>
-                              )}
-                            </form.Subscribe>
-                          </DataListItem>
-                        );
-                      })}
-                    </DataList>
-                  </section>
-                ))}
-              </Stack>
-              {visiblePatterns.length === 0 && <NoMatches />}
-            </Page.Section>
+            <form.Subscribe selector={(s) => s.values as Record<string, boolean>}>
+              {(formValues) => (
+                <Stack hasGutter>
+                  {sortGroupNames(allGroups).map((groupName) => {
+                    const groupAll = allGroups[groupName];
+                    const groupVisible = visibleByCategory[groupName] || [];
+
+                    return (
+                      <Stack key={groupName} hasGutter>
+                        <div
+                          className="agm-sticky-category-header"
+                          style={{ top: `${filterHeight}px` }}
+                        >
+                          <Flex
+                            spaceItems={{ default: "spaceItemsSm" }}
+                            alignItems={{ default: "alignItemsBaseline" }}
+                          >
+                            <Title headingLevel="h3">{groupName}</Title>
+                            <CategoryCounter
+                              patterns={groupAll}
+                              matchCount={groupVisible.length}
+                              isFiltering={isFiltering}
+                              formValues={formValues}
+                            />
+                          </Flex>
+                        </div>
+                        {groupVisible.length > 0 && (
+                          <NestedContent>
+                            <Stack hasGutter>
+                              {groupVisible.map((pattern) => (
+                                <PatternCheckbox
+                                  key={pattern.name}
+                                  id={pattern.name}
+                                  label={pattern.summary}
+                                  description={pattern.description}
+                                  isChecked={!!formValues[pattern.name]}
+                                  onChange={(value) => form.setFieldValue(pattern.name, value)}
+                                  extra={
+                                    selection[pattern.name] === SelectedBy.AUTO && (
+                                      <AutoSelectedLabel />
+                                    )
+                                  }
+                                />
+                              ))}
+                            </Stack>
+                          </NestedContent>
+                        )}
+                      </Stack>
+                    );
+                  })}
+                </Stack>
+              )}
+            </form.Subscribe>
 
             <ActionGroup>
               <form.SubmitButton />


### PR DESCRIPTION
## TL;DR

Jump directly to Screenshots and Screencast sections at the end of the description.

## Summary

Polish the patterns selection page focused on two small UX wins:

- **Sticky category headers, inline counters, smarter filter feedback**: categories
  stay visible when scrolling; each one shows "X of Y selected"; filter feedback is contextual ("N of M patterns" / "No patterns match") instead of bare numbers.
- **"Auto selected" label fades on touch**: once the user explicitly toggles an auto-selected pattern, the badge steps aside (the choice is no longer purely
  automatic).

## Motivation

After revamping the software page, a few rough edges showed in the selection patterns form

- With long lists or small enough viewports, you lose track of which category you're in once you scroll past the heading.
- It was hidding categories on filter, making user lost the information about patterns selected on them.
- The search input badge was just a number, which works for sighted users who have the list right there but doesn't anchor the count to anything.
- The "auto selected" badge stayed on a pattern even after the user explicitly unchecked or rechecked it, which was misleading: the system isn't choosing it anymore, the user is.
- The badge color was loud enough to compete visually with the pattern title.

## Changes

### Sticky headers + inline counters

- Category headings are sticky below the search input as the user scrolls.
- Each category shows "X of Y selected" (live, reacts to checkbox toggles).
- When filtering: appends "N matches the filter" or "No patterns match the filter" inline. The body placeholder is gone.
- The SearchInput results badge now reads "N of M patterns" or "No patterns match" instead of a bare number.
- Adds a screen-reader live region announcing filter result changes.
- Pattern rows refactored into a small `PatternCheckbox` so a non-clickable badge (the "auto selected" label) can sit next to the title without being part of the click target.

### "Auto selected" label hides on touch

- Reads `isDirty` from the field's TanStack Form meta and only renders the badge
  while the pattern is both AUTO in the proposal **and** untouched in the form.

### Subtler label color

- Switches `AutoSelectedLabel` to a different color that helps to read it as informative metadata rather than a call to action.


## Screenshots

### Before

<img width="1058" height="742" alt="Screenshot_2026-04-23_10-24-28" src="https://github.com/user-attachments/assets/c3f594dc-3cd2-4f41-9e88-cdd66c13bfc7" />


### After

<img width="1058" height="742" alt="Screenshot_2026-04-23_10-23-27" src="https://github.com/user-attachments/assets/b298d4d0-a48f-421e-9ad8-c58061c36d7a" />

## Screencast


https://github.com/user-attachments/assets/6e664788-c834-4beb-8b71-2f2afa2303af



## Notes for reviewers

> [!NOTE]  
> The target branch is a feature request. The changelog entry will be added later.