### PR TITLE
[SLE-16] Replace symlinks by file copies (bsc#1261340)

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -109,6 +109,24 @@ jobs:
       run: bundle config set --local with 'development' && bundle install && bundle add ostruct &&
         bundle add cgi && bundle add fiddle
 
+    # "gem build" might create broken symlinks so we replaced them with a copy of the file,
+    # ensure that all copies are the same (see bsc#1261340)
+    - name: Check that the copied files are the same
+      run: |
+        cmp InstFunctions.rb ../../modules/InstFunctions.rb
+        cmp Package.rb ../../manager/modules/Package.rb
+        cmp PackagesProposal.rb ../../manager/modules/PackagesProposal.rb
+      working-directory: service/lib/agama/dbus/y2dir/storage/modules
+
+    - name: Check that no symlinks are used
+      run: |
+        result=$(find ./lib -type l)
+        if [ -n "$result" ];then
+          echo -e "Found symlinks:\n$result"
+          echo "Avoid using symlinks, see https://bugzilla.suse.com/show_bug.cgi?id=1261340"
+          exit 1
+        fi
+
     - name: Check collecting translatable strings
       run: |
         rake pot

--- a/service/lib/agama/dbus/y2dir/storage/modules/InstFunctions.rb
+++ b/service/lib/agama/dbus/y2dir/storage/modules/InstFunctions.rb
@@ -1,1 +1,58 @@
-../../modules/InstFunctions.rb
+# Copyright (c) [2022-2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Yast
+  # Replacement for the Yast::Package module
+  #
+  # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb
+  class InstFunctionsClass < Module
+    def main
+      puts "Loading mocked module #{__FILE__}"
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L56
+    def ignored_features
+      []
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L83
+    def reset_ignored_features; end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L91
+    def feature_ignored?(_feature_name)
+      false
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L107
+    def second_stage_required?
+      false
+    end
+
+    # @see https://github.com/yast/yast-installation/blob/279b7d108eab24082237cf5e3f02a31f58fef8da/src/modules/InstFunctions.rb#L137
+    def self_update_explicitly_enabled?
+      false
+    end
+  end
+
+  InstFunctions = InstFunctionsClass.new
+  InstFunctions.main
+end

--- a/service/lib/agama/dbus/y2dir/storage/modules/Package.rb
+++ b/service/lib/agama/dbus/y2dir/storage/modules/Package.rb
@@ -1,1 +1,63 @@
-../../manager/modules/Package.rb
+# Copyright (c) [2022-2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "agama/dbus/clients/software"
+
+# :nodoc:
+module Yast
+  # Replacement for the Yast::Package module.
+  class PackageClass < Module
+    def main
+      puts "Loading mocked module #{__FILE__}"
+      @client = Agama::DBus::Clients::Software.instance
+    end
+
+    # Determines whether a package is available.
+    #
+    # @param name [String] Package name.
+    # @return [Boolean]
+    def Available(name)
+      client.package_available?(name)
+    end
+
+    # Determines whether a set of packages is available.
+    #
+    # @param names [Array<String>] Names of the packages.
+    # @return [Boolean]
+    def AvailableAll(names)
+      names.all? { |name| client.package_available?(name) }
+    end
+
+    # Determines whether a package is installed in the target system.
+    #
+    # @param name [String] Package name.
+    # @return [Boolean]
+    def Installed(name, target: nil)
+      client.package_installed?(name)
+    end
+
+  private
+
+    attr_reader :client
+  end
+
+  Package = PackageClass.new
+  Package.main
+end

--- a/service/lib/agama/dbus/y2dir/storage/modules/PackagesProposal.rb
+++ b/service/lib/agama/dbus/y2dir/storage/modules/PackagesProposal.rb
@@ -1,1 +1,62 @@
-../../manager/modules/PackagesProposal.rb
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "agama/dbus/clients/software"
+
+# :nodoc:
+module Yast
+  # Replacement for the Yast::PackagesProposal module
+  class PackagesProposalClass < Module
+    def main
+      puts "Loading mocked module #{__FILE__}"
+      @client = Agama::DBus::Clients::Software.new
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L118
+    def AddResolvables(unique_id, type, resolvables, optional: false)
+      client.add_resolvables(unique_id, type, resolvables || [], optional: optional)
+      true
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L145
+    def SetResolvables(unique_id, type, resolvables, optional: false)
+      client.set_resolvables(unique_id, type, resolvables || [], optional: optional)
+      true
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L285
+    def GetResolvables(unique_id, type, optional: false)
+      client.get_resolvables(unique_id, type, optional: optional)
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L177
+    def RemoveResolvables(unique_id, type, resolvables, optional: false)
+      client.remove_resolvables(unique_id, type, resolvables || [], optional: optional)
+      true
+    end
+
+  private
+
+    attr_reader :client
+  end
+
+  PackagesProposal = PackagesProposalClass.new
+  PackagesProposal.main
+end


### PR DESCRIPTION
## Problem

- Broken symlinks in generated *.gem file when creating the package in Leap 15.6 (openSUSE Tumbleweed and Leap 16.0 are fine)
- https://bugzilla.suse.com/show_bug.cgi?id=1261340

## Solution

- Avoid using symlinks, copy the files instead

## Notes

- It turned out that the broken symlinks are generated by Ruby in Leap 15.6. But we should still remove the symlinks to avoid the same problem accidentally in the future.
- The  `gem build` command in openSUSE Tumbleweed and Leap 16.0 actually also replaces the symlinks with file copies so the generated *.gem file should be the same. No change from the OBS POV, it should receive the same files.
- Added CI checks to ensure no new symlinks are introduced and to check that all copies are the same.
- SLE 16.1 is not affected, there are no symlinks in the Ruby sources, this is SLE 16.0 specific.

## Testing

- Tested manually
- Verified the added CI tests:
  - After modifying one file the [CI fails](https://github.com/agama-project/agama/actions/runs/24835688632/job/72695285073#step:9:9)
  - After adding a new symlink the [CI fails](https://github.com/agama-project/agama/actions/runs/24835912519/job/72696082450#step:10:12)

