### PR TITLE
refactor(web): improve network edit breadcrumb

### DIFF
--- a/web/src/components/network/BindingSettingsForm.tsx
+++ b/web/src/components/network/BindingSettingsForm.tsx
@@ -109,7 +109,7 @@ export default function BindingSettingsForm() {
 
   const breadcrumbs = [
     { label: _("Network"), path: NETWORK.root },
-    { label: connection.id, path: generatePath(NETWORK.wiredConnection, { id: connection.id }) },
+    { label: connection.id, path: generatePath(NETWORK.connection.details, { id: connection.id }) },
     { label: _("Binding settings") },
   ];
 

--- a/web/src/components/network/ConnectionDetails.test.tsx
+++ b/web/src/components/network/ConnectionDetails.test.tsx
@@ -23,7 +23,7 @@
 import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
-import WiredConnectionDetails from "./WiredConnectionDetails";
+import ConnectionDetails from "~/components/network/ConnectionDetails";
 import {
   Connection,
   ConnectionMethod,
@@ -87,10 +87,10 @@ jest.mock("~/hooks/model/system/network", () => ({
   useDevices: () => networkDevices(),
 }));
 
-describe("WiredConnectionDetails", () => {
+describe("ConnectionDetails", () => {
   describe("Settings", () => {
     it("renders the connection settings (DCHP)", () => {
-      installerRender(<WiredConnectionDetails connection={mockConnection} />);
+      installerRender(<ConnectionDetails connection={mockConnection} />);
       const section = screen.getByRole("region", { name: "Settings" });
 
       within(section).getByText("IPv4 auto");
@@ -104,7 +104,7 @@ describe("WiredConnectionDetails", () => {
         state: ConnectionState.activated,
         iface: "enp1s0",
       });
-      installerRender(<WiredConnectionDetails connection={connection} />);
+      installerRender(<ConnectionDetails connection={connection} />);
       const section = screen.getByRole("region", { name: "Settings" });
 
       within(section).getByText("IPv4 None set");
@@ -113,7 +113,7 @@ describe("WiredConnectionDetails", () => {
 
     it("renders the connection settings (static)", () => {
       installerRender(
-        <WiredConnectionDetails
+        <ConnectionDetails
           connection={
             new Connection("Network #1", {
               state: ConnectionState.activated,
@@ -140,13 +140,13 @@ describe("WiredConnectionDetails", () => {
     });
 
     it("renders the switch for making connection available only during installation", () => {
-      installerRender(<WiredConnectionDetails connection={mockConnection} />);
+      installerRender(<ConnectionDetails connection={mockConnection} />);
       const section = screen.getByRole("region", { name: "Settings" });
       within(section).getByText("InstallationOnlySwitch mock");
     });
 
     it("renders link for editing connection", () => {
-      installerRender(<WiredConnectionDetails connection={mockConnection} />);
+      installerRender(<ConnectionDetails connection={mockConnection} />);
       const section = screen.getByRole("region", { name: "Settings" });
       const editLink = within(section).getByRole("link", { name: "Edit connection settings" });
       expect(editLink).toHaveAttribute("href", "/network/connections/Network%20%231/edit");
@@ -155,14 +155,14 @@ describe("WiredConnectionDetails", () => {
 
   describe("Binding settings section", () => {
     it("renders information aobut the binding mode (all)", () => {
-      installerRender(<WiredConnectionDetails connection={new Connection("Network #1")} />);
+      installerRender(<ConnectionDetails connection={new Connection("Network #1")} />);
       const section = screen.getByRole("region", { name: "Binding" });
       within(section).getByText("Connection is available to all devices.");
     });
 
     it("renders information aobut the binding mode (to MAC)", () => {
       installerRender(
-        <WiredConnectionDetails
+        <ConnectionDetails
           connection={new Connection("Network #1", { macAddress: "AA:11:22:33:44:FF" })}
         />,
       );
@@ -172,14 +172,14 @@ describe("WiredConnectionDetails", () => {
 
     it("renders information aobut the binding mode (to device)", () => {
       installerRender(
-        <WiredConnectionDetails connection={new Connection("Network #1", { iface: "enp1s0" })} />,
+        <ConnectionDetails connection={new Connection("Network #1", { iface: "enp1s0" })} />,
       );
       const section = screen.getByRole("region", { name: "Binding" });
       within(section).getByText("Connection is bound to device enp1s0.");
     });
 
     it("renders a link to for editing binding settings", () => {
-      installerRender(<WiredConnectionDetails connection={mockConnection} />);
+      installerRender(<ConnectionDetails connection={mockConnection} />);
       const section = screen.getByRole("region", { name: "Binding" });
       const editLink = within(section).getByRole("link", { name: "Edit binding settings" });
       expect(editLink).toHaveAttribute("href", "/network/connections/Network%20%231/binding/edit");
@@ -193,7 +193,7 @@ describe("WiredConnectionDetails", () => {
       });
 
       it("renders information about no devices using the connection", () => {
-        installerRender(<WiredConnectionDetails connection={mockConnection} />);
+        installerRender(<ConnectionDetails connection={mockConnection} />);
         const section = screen.getByRole("region", { name: "Connected devices" });
         within(section).getByText("No device is currently using this connection.");
       });
@@ -205,7 +205,7 @@ describe("WiredConnectionDetails", () => {
       });
 
       it("renders title in singluar along with device data", () => {
-        installerRender(<WiredConnectionDetails connection={mockConnection} />);
+        installerRender(<ConnectionDetails connection={mockConnection} />);
         const section = screen.getByRole("region", { name: "Connected device" });
         within(section).getByText("enp1s0");
         within(section).getByText("AA:11:22:33:44::FF");
@@ -222,7 +222,7 @@ describe("WiredConnectionDetails", () => {
       });
 
       it("renders title in plurarl and devices data in tabs", async () => {
-        const { user } = installerRender(<WiredConnectionDetails connection={mockConnection} />);
+        const { user } = installerRender(<ConnectionDetails connection={mockConnection} />);
         const section = screen.getByRole("region", { name: "Connected devices" });
         const enp1s0DeviceTab = within(section).getByRole("tab", { name: "enp1s0" });
         const enp1s1DeviceTab = within(section).getByRole("tab", { name: "enp1s1" });

--- a/web/src/components/network/ConnectionDetails.tsx
+++ b/web/src/components/network/ConnectionDetails.tsx
@@ -40,7 +40,7 @@ import {
 import { generatePath } from "react-router";
 import Text from "~/components/core/Text";
 import { Link, NestedContent, Page } from "~/components/core";
-import InstallationOnlySwitch from "./InstallationOnlySwitch";
+import InstallationOnlySwitch from "~/components/network/InstallationOnlySwitch";
 import { Connection, Device } from "~/types/network";
 import { connectionBindingMode, formatIp } from "~/utils/network";
 import { NETWORK } from "~/routes/paths";
@@ -74,7 +74,7 @@ const BindingSettings = ({ connection }: { connection: Connection }) => {
       pfCardProps={{ isPlain: false, isFullHeight: false }}
       actions={
         <Link
-          to={generatePath(NETWORK.editBindingSettings, {
+          to={generatePath(NETWORK.connection.editBinding, {
             id: connection.id,
           })}
         >
@@ -263,14 +263,14 @@ const DevicesDetails = ({ connection }: { connection: Connection }) => {
   );
 };
 
-const ConnectionDetails = ({ connection }: { connection: Connection }) => {
+const SettingsCard = ({ connection }: { connection: Connection }) => {
   const gateways = [connection.gateway4, connection.gateway6];
   return (
     <Page.Section
       title={_("Settings")}
       pfCardProps={{ isPlain: false, isFullHeight: false }}
       actions={
-        <Link to={generatePath(NETWORK.editConnection, { id: connection.id })}>
+        <Link to={generatePath(NETWORK.connection.edit, { id: connection.id })}>
           {_("Edit connection settings")}
         </Link>
       }
@@ -343,12 +343,12 @@ const ConnectionDetails = ({ connection }: { connection: Connection }) => {
   );
 };
 
-export default function WiredConnectionDetails({ connection }: { connection: Connection }) {
+export default function ConnectionDetails({ connection }: { connection: Connection }) {
   return (
     <Grid hasGutter>
       <GridItem md={6}>
         <Stack hasGutter>
-          <ConnectionDetails connection={connection} />
+          <SettingsCard connection={connection} />
         </Stack>
       </GridItem>
       <GridItem md={6} order={{ default: "1", md: "2" }}>

--- a/web/src/components/network/ConnectionForm.tsx
+++ b/web/src/components/network/ConnectionForm.tsx
@@ -22,10 +22,11 @@
 
 import React from "react";
 import { formOptions } from "@tanstack/react-form";
-import { useNavigate, useParams } from "react-router";
+import { generatePath, useNavigate, useParams } from "react-router";
 import { isEmpty, shake, unique } from "radashi";
 import { Alert, ActionGroup, Flex, Form } from "@patternfly/react-core";
 import Page from "~/components/core/Page";
+import { BreadcrumbProps } from "~/components/core/Breadcrumbs";
 import NestedContent from "~/components/core/NestedContent";
 import ResourceNotFound from "~/components/core/ResourceNotFound";
 import IpSettings from "~/components/network/IpSettings";
@@ -756,10 +757,23 @@ function EditConnectionForm() {
  */
 export default function ConnectionForm() {
   const { id } = useParams();
-  // TRANSLATORS: page title and breadcrumb label for creating a new connection.
-  const title = id ?? _("New connection");
-  // TRANSLATORS: breadcrumb label for the network configuration section.
-  const breadcrumbs = [{ label: _("Network"), path: NETWORK.root }, { label: title }];
+  const breadcrumbs: BreadcrumbProps[] = [
+    // TRANSLATORS: breadcrumb label for the network configuration section.
+    { label: _("Network"), path: NETWORK.root },
+  ];
+  if (id) {
+    breadcrumbs.push(
+      { label: id, path: generatePath(NETWORK.connection.details, { id }) },
+      // TRANSLATORS: breadcrumb label for the connection-edit form. Keep the
+      // noun ("connection"): the previous crumb is the connection name, so a
+      // bare "Edit" reads fine visually but leaves screen-reader users without
+      // the object being acted on when the crumb is announced on its own.
+      { label: _("Edit connection") },
+    );
+  } else {
+    // TRANSLATORS: breadcrumb label for the new-connection form.
+    breadcrumbs.push({ label: _("New connection") });
+  }
 
   return (
     <Page breadcrumbs={breadcrumbs}>

--- a/web/src/components/network/ConnectionForm.tsx
+++ b/web/src/components/network/ConnectionForm.tsx
@@ -60,7 +60,6 @@ import {
   isValidDNSSearchDomain,
 } from "~/utils/network";
 import { _ } from "~/i18n";
-import { Link } from "../core";
 
 /**
  * Form IP mode values.

--- a/web/src/components/network/ConnectionPage.test.tsx
+++ b/web/src/components/network/ConnectionPage.test.tsx
@@ -23,9 +23,9 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender, mockParams } from "~/test-utils";
-import WiredConnectionPage from "~/components/network/WiredConnectionPage";
-import { Connection, ConnectionState } from "~/types/network";
 import { useProgress } from "~/hooks/model/progress";
+import { Connection, ConnectionState } from "~/types/network";
+import ConnectionPage from "~/components/network/ConnectionPage";
 
 jest.mock("~/hooks/model/progress", () => ({
   useProgress: jest.fn(),
@@ -35,9 +35,7 @@ const mockConnection: Connection = new Connection("Network 1", {
   state: ConnectionState.activated,
 });
 
-jest.mock("~/components/network/WiredConnectionDetails", () => () => (
-  <div>WiredConnectionDetails Mock</div>
-));
+jest.mock("~/components/network/ConnectionDetails", () => () => <div>ConnectionDetails Mock</div>);
 
 jest.mock("~/components/network/NoPersistentConnectionsAlert", () => () => (
   <div>NoPersistentConnectionsAlert Mock</div>
@@ -48,9 +46,9 @@ jest.mock("~/hooks/model/proposal/network", () => ({
   useConnections: () => [mockConnection],
 }));
 
-describe("<WiredConnectionPage />", () => {
+describe("<ConnectionPage />", () => {
   it("mounts alert for all connections status", () => {
-    installerRender(<WiredConnectionPage />);
+    installerRender(<ConnectionPage />);
     screen.getByText("NoPersistentConnectionsAlert Mock");
   });
 
@@ -60,8 +58,8 @@ describe("<WiredConnectionPage />", () => {
     });
 
     it("mounts component for rendering connection details", () => {
-      installerRender(<WiredConnectionPage />);
-      screen.getByText("WiredConnectionDetails Mock");
+      installerRender(<ConnectionPage />);
+      screen.getByText("ConnectionDetails Mock");
     });
   });
 
@@ -71,7 +69,7 @@ describe("<WiredConnectionPage />", () => {
     });
 
     it("renders an informative message", () => {
-      installerRender(<WiredConnectionPage />);
+      installerRender(<ConnectionPage />);
       screen.getByText("Connection not found or lost");
     });
   });
@@ -89,7 +87,7 @@ describe("<WiredConnectionPage />", () => {
           : undefined,
       );
 
-      installerRender(<WiredConnectionPage />);
+      installerRender(<ConnectionPage />);
       expect(screen.queryByText("Performing some network task")).toBeInTheDocument();
     });
   });

--- a/web/src/components/network/ConnectionPage.tsx
+++ b/web/src/components/network/ConnectionPage.tsx
@@ -32,10 +32,10 @@ import { Link, Page } from "~/components/core";
 import { useConnections } from "~/hooks/model/proposal/network";
 import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
-import WiredConnectionDetails from "./WiredConnectionDetails";
-import { Icon } from "../layout";
+import ConnectionDetails from "~/components/network/ConnectionDetails";
+import { Icon } from "~/components/layout";
 import { NETWORK } from "~/routes/paths";
-import NoPersistentConnectionsAlert from "./NoPersistentConnectionsAlert";
+import NoPersistentConnectionsAlert from "~/components/network/NoPersistentConnectionsAlert";
 
 const ConnectionNotFound = ({ id }) => {
   // TRANSLATORS: %s will be replaced with connection id
@@ -59,13 +59,13 @@ const ConnectionNotFound = ({ id }) => {
   );
 };
 
-// TODO: evaluate whether this page and WiredConnectionDetails should merge config
+// TODO: evaluate whether this page and ConnectionDetails should merge config
 // and system connections (like EditConnectionForm does) so that displayed values
 // reflect what the user actually configured. Currently useConnections reads from
 // the proposal source, which always reports e.g. method4: "auto" even when the
 // config has no method set. If merging is not adopted here, ConnectionForm should
 // be made consistent and drop its own merge too.
-export default function WiredConnectionPage() {
+export default function ConnectionPage() {
   const { id } = useParams();
   const connections = useConnections();
   const connection = connections.find((c) => c.id === id);
@@ -78,7 +78,7 @@ export default function WiredConnectionPage() {
       <Page.Content>
         <NoPersistentConnectionsAlert />
         {connection ? (
-          <WiredConnectionDetails connection={connection} />
+          <ConnectionDetails connection={connection} />
         ) : (
           <ConnectionNotFound id={id} />
         )}

--- a/web/src/components/network/ConnectionsTable.test.tsx
+++ b/web/src/components/network/ConnectionsTable.test.tsx
@@ -132,18 +132,20 @@ describe("ConnectionsTable", () => {
     );
   });
 
-  it("navigates to the wired connection page when 'Details' is clicked for an ethernet connection", async () => {
+  it("navigates to the connection details page when 'Details' is clicked for an ethernet connection", async () => {
     const { user } = installerRender(<ConnectionsTable />);
     await user.click(screen.getByRole("button", { name: /actions for Wired connection 0/i }));
     await user.click(screen.getByText("Details"));
-    expect(mockNavigateFn).toHaveBeenCalledWith("/network/wired_connection/Wired%20connection%200");
+    expect(mockNavigateFn).toHaveBeenCalledWith(
+      "/network/connections/Wired%20connection%200/details",
+    );
   });
 
-  it("navigates to the wired connection page when 'Details' is clicked for a wifi connection", async () => {
+  it("navigates to the connection details page when 'Details' is clicked for a wifi connection", async () => {
     const { user } = installerRender(<ConnectionsTable />);
     await user.click(screen.getByRole("button", { name: /actions for Wifi1/i }));
     await user.click(screen.getByText("Details"));
-    expect(mockNavigateFn).toHaveBeenCalledWith("/network/wired_connection/Wifi1");
+    expect(mockNavigateFn).toHaveBeenCalledWith("/network/connections/Wifi1/details");
   });
 
   it("navigates to the edit connection page when 'Edit connection' is clicked", async () => {

--- a/web/src/components/network/ConnectionsTable.tsx
+++ b/web/src/components/network/ConnectionsTable.tsx
@@ -345,20 +345,17 @@ export default function ConnectionsTable() {
             {
               id: "details",
               title: _("Details"),
-              onClick: () => {
-                // FIXME: create a shared connection page and route
-                navigate(generatePath(NETWORK.wiredConnection, { id: c.id }));
-              },
+              onClick: () => navigate(generatePath(NETWORK.connection.details, { id: c.id })),
             },
             {
               id: "edit",
               title: _("Edit connection"),
-              onClick: () => navigate(generatePath(NETWORK.editConnection, { id: c.id })),
+              onClick: () => navigate(generatePath(NETWORK.connection.edit, { id: c.id })),
             },
             !(isWifi || isBond) && {
               id: "editBinding",
               title: _("Edit binding"),
-              onClick: () => navigate(generatePath(NETWORK.editBindingSettings, { id: c.id })),
+              onClick: () => navigate(generatePath(NETWORK.connection.editBinding, { id: c.id })),
             },
             {
               isSeparator: true,

--- a/web/src/components/network/NetworkPage.tsx
+++ b/web/src/components/network/NetworkPage.tsx
@@ -53,13 +53,13 @@ export default function NetworkPage() {
             pfCardProps={{ isCompact: true, component: "div", isFullHeight: false }}
             actions={
               <>
-                <Link to={NETWORK.newConnection} variant="plain">
+                <Link to={NETWORK.connection.new} variant="plain">
                   <Flex gap={{ default: "gapXs" }} alignItems={{ default: "alignItemsCenter" }}>
                     <Icon name="add_circle" /> {_("Add connection")}
                   </Flex>
                 </Link>
                 {state.wirelessEnabled && (
-                  <Link to={NETWORK.newWiFiConnection} variant="plain">
+                  <Link to={NETWORK.wifi.new} variant="plain">
                     <Flex gap={{ default: "gapSm" }} alignItems={{ default: "alignItemsCenter" }}>
                       <Icon name="wifi" /> {_("Connect to Wi-Fi network")}
                     </Flex>

--- a/web/src/components/network/WifiNetworksList.tsx
+++ b/web/src/components/network/WifiNetworksList.tsx
@@ -190,7 +190,7 @@ function WifiNetworksList({ showIp = true, ...props }: WifiNetworksListProps) {
 
   return (
     <DataList
-      onSelectDataListItem={(_, id) => navigate(generatePath(PATHS.wiredConnection, { id }))}
+      onSelectDataListItem={(_, id) => navigate(generatePath(PATHS.connection.details, { id }))}
       {...props}
     >
       {networks.map((n) => (

--- a/web/src/components/network/index.ts
+++ b/web/src/components/network/index.ts
@@ -21,4 +21,4 @@
  */
 
 export { default as NetworkPage } from "./NetworkPage";
-export { default as WiredConnectionPage } from "./WiredConnectionPage";
+export { default as ConnectionPage } from "./ConnectionPage";

--- a/web/src/routes/network.tsx
+++ b/web/src/routes/network.tsx
@@ -25,7 +25,7 @@ import ConnectionForm from "~/components/network/ConnectionForm";
 import BindingSettingsForm from "~/components/network/BindingSettingsForm";
 import NetworkPage from "~/components/network/NetworkPage";
 import WifiConnectionForm from "~/components/network/WifiConnectionForm";
-import WiredConnectionPage from "~/components/network/WiredConnectionPage";
+import ConnectionPage from "~/components/network/ConnectionPage";
 import { Route } from "~/types/routes";
 import { NETWORK as PATHS } from "~/routes/paths";
 import { N_ } from "~/i18n";
@@ -39,24 +39,24 @@ const routes = (): Route => ({
   children: [
     { index: true, element: <NetworkPage /> },
     {
-      path: PATHS.editConnection,
+      path: PATHS.connection.edit,
       element: <ConnectionForm />,
     },
     {
-      path: PATHS.newConnection,
+      path: PATHS.connection.new,
       element: <ConnectionForm />,
     },
     {
-      path: PATHS.editBindingSettings,
+      path: PATHS.connection.editBinding,
       element: <BindingSettingsForm />,
     },
     {
-      path: PATHS.newWiFiConnection,
+      path: PATHS.wifi.new,
       element: <WifiConnectionForm />,
     },
     {
-      path: PATHS.wiredConnection,
-      element: <WiredConnectionPage />,
+      path: PATHS.connection.details,
+      element: <ConnectionPage />,
     },
   ],
 });

--- a/web/src/routes/paths.ts
+++ b/web/src/routes/paths.ts
@@ -29,12 +29,15 @@ const L10N = {
 
 const NETWORK = {
   root: "/network",
-  newConnection: "/network/connections/new",
-  editConnection: "/network/connections/:id/edit",
-  editBindingSettings: "/network/connections/:id/binding/edit",
-  wiredConnection: "/network/wired_connection/:id",
-  newWiFiConnection: "/network/wifi_networks/new",
-  wifiConnection: "/network/wifi_networks/:id",
+  connection: {
+    new: "/network/connections/new",
+    details: "/network/connections/:id/details",
+    edit: "/network/connections/:id/edit",
+    editBinding: "/network/connections/:id/binding/edit",
+  },
+  wifi: {
+    new: "/network/wifi_networks/new",
+  },
 };
 
 const PRODUCT = {


### PR DESCRIPTION
Until now, the edit breadcrumb for network connections lacked context about being in edit mode. It showed just `Network > {connection name}`, with no indication of the current action.

This PR adds the "Edit connection" crumb improves context, taking the opportunity to make the connection name linkable to lets users navigate directly to details from there. 

To to it possible, it was  required a proper details route. The existing setup had `wiredConnection` and `wifiConnection` paths, but only the former was in use (WiFi navigated to `/network/wired_connection/:id` already). This made consolidation the natural next step.

## Screenshots


### Before

<img width="2048" height="1536" alt="localhost_8080_ (35)" src="https://github.com/user-attachments/assets/944f4229-15ca-4d88-8b53-e7ec3528d42d" />


### After

<img width="2048" height="1536" alt="localhost_8080_ (36)" src="https://github.com/user-attachments/assets/bc4e01cc-95c5-4f44-8323-c6680b141311" />
