### PR TITLE
feat(web): add ReadOnlyField component for forms

### DIFF
--- a/web/src/components/form/ReadOnlyField.test.tsx
+++ b/web/src/components/form/ReadOnlyField.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender } from "~/test-utils";
+import { useAppForm } from "~/hooks/form";
+
+function ReadOnlyFieldForm() {
+  const form = useAppForm({ defaultValues: { connectionType: "Bond" } });
+
+  return (
+    <form.AppForm>
+      <form.AppField name="connectionType">
+        {(field) => <field.ReadOnlyField label="Type" />}
+      </form.AppField>
+    </form.AppForm>
+  );
+}
+
+describe("ReadOnlyField", () => {
+  it("renders the label and value", () => {
+    installerRender(<ReadOnlyFieldForm />);
+    screen.getByText("Type");
+    screen.getByText("Bond");
+  });
+});

--- a/web/src/components/form/ReadOnlyField.tsx
+++ b/web/src/components/form/ReadOnlyField.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import Text from "~/components/core/Text";
+import { useFieldContext } from "~/hooks/form-contexts";
+
+import formStyles from "@patternfly/react-styles/css/components/Form/form";
+
+type ReadOnlyFieldProps = {
+  label: React.ReactNode;
+};
+
+/**
+ * Displays read-only information from a TanStack Form field.
+ * Must be used inside a `form.AppField` render prop.
+ *
+ * Use this when you need to show contextual information alongside editable
+ * fields without using disabled inputs. The label and value are read
+ * sequentially by screen readers, which is appropriate for simple read-only
+ * data display.
+ *
+ * @see useFieldContext for field component conventions.
+ *
+ * @example
+ * <form.AppField name="connectionType">
+ *   {(field) => <field.ReadOnlyField label={_("Type")} />}
+ * </form.AppField>
+ */
+export default function ReadOnlyField({ label }: ReadOnlyFieldProps) {
+  const field = useFieldContext<React.ReactNode>();
+
+  return (
+    <div className={formStyles.formGroup}>
+      <div className={formStyles.formLabel}>
+        <span className={formStyles.formLabelText}>{label}</span>
+      </div>
+      <Text>{field.state.value}</Text>
+    </div>
+  );
+}

--- a/web/src/components/form/conventions.md
+++ b/web/src/components/form/conventions.md
@@ -167,6 +167,27 @@ of users: that just adds an unnecessary click.
 **Examples:** "Use custom DNS" checkbox reveals the DNS servers field. "Use
 custom DNS search domains" checkbox reveals the DNS search domains field.
 
+## Read-only information
+
+Use `ReadOnlyField` to display contextual information alongside editable fields
+without using disabled inputs.
+
+Disabled inputs have accessibility limitations: they cannot receive focus, their
+values cannot be selected or copied, and they signal to the user that a field
+might become editable under different circumstances. When information should
+never be edited in the current context, it is clearer and more accessible to
+display it as read-only text rather than a disabled input.
+
+**Example:** When editing an existing connection, the connection type is shown
+with `ReadOnlyField` because the type cannot be changed after creation.
+Displaying it as a disabled input would suggest it might become editable, which
+is misleading.
+
+The label and value are read sequentially by screen readers, which provides
+clear context without requiring programmatic label association.
+
+---
+
 ## Accessibility notes
 
 ### Fields without a visible label

--- a/web/src/hooks/form.ts
+++ b/web/src/hooks/form.ts
@@ -26,6 +26,7 @@ import ArrayField from "~/components/form/ArrayField";
 import CancelButton from "~/components/form/CancelButton";
 import CheckboxField from "~/components/form/CheckboxField";
 import DropdownField from "~/components/form/DropdownField";
+import ReadOnlyField from "~/components/form/ReadOnlyField";
 import SubmitButton from "~/components/form/SubmitButton";
 import TextField from "~/components/form/TextField";
 
@@ -41,6 +42,7 @@ const { useAppForm, withForm } = createFormHook({
     ArrayField,
     CheckboxField,
     DropdownField,
+    ReadOnlyField,
     TextField,
   },
   formComponents: { CancelButton, SubmitButton },


### PR DESCRIPTION
While extending the `Network/ConnectionForm` to add bond support, the use of disabled inputs was proposed but rejected during review, in line with previously established decisions. Instead, forms should handle these values by directly rendering them in the DOM. To maintain a consistent look and feel with the rest of the form, this PR introduces a new `Field` component. It allows read-only information to be displayed alongside editable fields without relying on disabled inputs, which have known accessibility limitations.

Looking ahead, a richer UI element positioned on the right as a sidebar with useful information about the item being edited could be introduced. This would align with the existing widget displayed in both the change product form and the overview page. However, implementing this should be done in a dedicated PR, taking into account all available forms to ensure consistency and usefulness.

<img width="2048" height="1536" alt="localhost_8080_ (37)" src="https://github.com/user-attachments/assets/7c17cbdd-7b62-4827-b62e-564014abc326" />


