### PR TITLE
refactor(web): split bond interface name from binding mode field

### DIFF
--- a/web/src/components/network/BondSettings.tsx
+++ b/web/src/components/network/BondSettings.tsx
@@ -70,7 +70,7 @@ const BondSettings = withForm({
           </>
         )}
         {!isEditing && (
-          <form.AppField name="iface">
+          <form.AppField name="bondIface">
             {(field) => (
               <field.TextField
                 label={

--- a/web/src/components/network/ConnectionForm.test.tsx
+++ b/web/src/components/network/ConnectionForm.test.tsx
@@ -116,22 +116,26 @@ describe("ConnectionForm", () => {
       screen.getByText("Bond ports");
     });
 
-    it("resets the device name when switching from Bond back to Ethernet", async () => {
+    it("preserves user input when switching between connection types", async () => {
       const { user } = installerRender(<ConnectionForm />);
 
-      // Switch to Bond
+      // Switch to Bond and enter a device name
+      await user.click(screen.getByLabelText("Type"));
+      await user.click(screen.getByText("Bond"));
+      const deviceNameField = await screen.findByLabelText("Device name");
+      await user.type(deviceNameField, "bond0");
+      expect(deviceNameField).toHaveValue("bond0");
+
+      // Switch to Ethernet and select a binding mode
+      await user.click(screen.getByLabelText("Type"));
+      await user.click(screen.getByText("Ethernet"));
+      await user.click(screen.getByLabelText("Device"));
+      await user.click(screen.getByRole("option", { name: /^Chosen by name/ }));
+
+      // Switch back to Bond - the device name should be preserved
       await user.click(screen.getByLabelText("Type"));
       await user.click(screen.getByText("Bond"));
       expect(await screen.findByLabelText("Device name")).toHaveValue("bond0");
-
-      // Switch back to Ethernet
-      await user.click(screen.getByLabelText("Type"));
-      await user.click(screen.getByText("Ethernet"));
-
-      // It should not show the Bond's device name field anymore
-      expect(screen.queryByDisplayValue("bond0")).not.toBeInTheDocument();
-      // Binding mode should be back to "Any" (default)
-      expect(screen.getByLabelText("Device")).toHaveTextContent("Any");
     });
   });
 

--- a/web/src/components/network/ConnectionForm.tsx
+++ b/web/src/components/network/ConnectionForm.tsx
@@ -121,6 +121,7 @@ export const connectionFormOptions = formOptions({
     customDns: false,
     customDnsSearch: false,
     bindingMode: "none" as ConnectionBindingMode,
+    bondIface: "",
     bondMode: BondMode.BALANCE_ROUND_ROBIN as BondMode,
     bondOptions: [] as string[],
     bondPorts: [] as string[],
@@ -327,6 +328,11 @@ export function validateConnectionForm(formValues: FormValues): FormFieldErrors 
       // TRANSLATORS: validation error for the DNS search domains field.
       _("Some DNS search domains are invalid"),
     ),
+    bondIface:
+      formValues.type === ConnectionType.BOND && !formValues.bondIface.trim()
+        ? // TRANSLATORS: validation error for the bond device name field.
+          _("Device name is required")
+        : undefined,
     bondMode:
       formValues.type === ConnectionType.BOND && !formValues.bondMode.trim()
         ? // TRANSLATORS: validation error for the bond mode field.
@@ -348,11 +354,6 @@ export function validateConnectionForm(formValues: FormValues): FormFieldErrors 
             "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
           )
         : undefined,
-    iface:
-      formValues.type === ConnectionType.BOND && !formValues.iface.trim()
-        ? // TRANSLATORS: validation error for the bond device name field.
-          _("Device name is required")
-        : undefined,
   });
 
   if (!isEmpty(fieldErrors)) return fieldErrors;
@@ -372,8 +373,16 @@ function buildConnection(formValues: FormValues): Connection {
     ? formValues.addresses6.map(buildAddress)
     : [];
 
+  let iface = "";
+
+  if (formValues.type === ConnectionType.BOND) {
+    iface = formValues.bondIface;
+  } else if (formValues.bindingMode === "iface") {
+    iface = formValues.iface;
+  }
+
   return new Connection(formValues.name, {
-    iface: formValues.bindingMode === "iface" ? formValues.iface : "",
+    iface,
     macAddress: formValues.bindingMode === "mac" ? formValues.ifaceMac : "",
     method4: MODE_TO_METHOD[formValues.ipv4Mode],
     gateway4: ipv4Addresses.length > 0 ? formValues.gateway4 : "",
@@ -428,39 +437,13 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
   const syncName = (formApi) => {
     const type = formApi.getFieldValue("type");
 
-    if (!formApi.getFieldMeta("name")?.isDirty) {
-      const existingIds = new Set(systemConns.map((c) => c.id));
-      formApi.setFieldValue("name", generateConnectionName(type, existingIds), {
-        dontUpdateMeta: true,
-        dontRunListeners: true,
-      });
-    }
+    if (formApi.getFieldMeta("name")?.isDirty) return;
 
-    if (type === ConnectionType.BOND && !isEditing) {
-      if (!formApi.getFieldValue("iface") || formApi.getFieldValue("iface") === devices[0]?.name) {
-        formApi.setFieldValue("iface", "bond0", {
-          dontUpdateMeta: true,
-          dontRunListeners: true,
-        });
-      }
-      formApi.setFieldValue("bindingMode", "iface", {
-        dontUpdateMeta: true,
-        dontRunListeners: true,
-      });
-    } else if (!isEditing) {
-      if (formApi.getFieldValue("iface") === "bond0") {
-        formApi.setFieldValue("iface", devices[0]?.name ?? "", {
-          dontUpdateMeta: true,
-          dontRunListeners: true,
-        });
-      }
-      if (formApi.getFieldValue("bindingMode") === "iface") {
-        formApi.setFieldValue("bindingMode", "none", {
-          dontUpdateMeta: true,
-          dontRunListeners: true,
-        });
-      }
-    }
+    const existingIds = new Set(systemConns.map((c) => c.id));
+    formApi.setFieldValue("name", generateConnectionName(type, existingIds), {
+      dontUpdateMeta: true,
+      dontRunListeners: true,
+    });
   };
 
   const form = useAppForm({


### PR DESCRIPTION
Bond connections require a device name (e.g., `bond0`) that is different from the interface binding mode used by other connection types. The binding mode determines how a connection matches a device (by interface name or MAC address), while a bond's interface name is the name of the virtual bond device itself.

This change introduces a dedicated `bondIface` field to store the bond device name, preventing confusion with the `iface` field used for binding mode selection. It also simplifies the type listener logic by removing bond-specific field synchronization that was overwriting user input when switching connection types.

This aligns with the conventions of preserving user input, allowing users to switch between connection types without losing their configuration.