### PR TITLE
fix(web): sort software patterns by their order field

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 24 15:21:18 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Sort software patterns by their order field within each category
+  (gh#agama-project/agama#3425).
+
+-------------------------------------------------------------------
 Thu Apr 23 15:59:34 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Revamp the software selection page to separate desktop

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -83,6 +83,28 @@ describe("SoftwarePatternsSelection", () => {
     expect(ids).toEqual(["yast2_basis", "yast2_desktop", "yast2_server", "preselected_pattern"]);
   });
 
+  it("sorts patterns by their order field within each category", async () => {
+    installerRender(<SoftwarePatternsSelection />);
+
+    await screen.findByRole("heading", { name: /Graphical Environments/, level: 3 });
+    const allCheckboxes = screen.getAllByRole("checkbox");
+
+    // Graphical Environments patterns should be ordered by their order field:
+    // gnome (1010), kde (1110), xfce (1310), basic_desktop (1802)
+    const graphicalStartIndex = allCheckboxes.findIndex((c) => c.id === "gnome");
+    const graphicalIds = allCheckboxes
+      .slice(graphicalStartIndex, graphicalStartIndex + 4)
+      .map((c) => c.id);
+    expect(graphicalIds).toEqual(["gnome", "kde", "xfce", "basic_desktop"]);
+
+    // Desktop Functions patterns should be ordered: multimedia (1580), office (1640)
+    const desktopFuncStartIndex = allCheckboxes.findIndex((c) => c.id === "multimedia");
+    const desktopFuncIds = allCheckboxes
+      .slice(desktopFuncStartIndex, desktopFuncStartIndex + 2)
+      .map((c) => c.id);
+    expect(desktopFuncIds).toEqual(["multimedia", "office"]);
+  });
+
   it("renders a search input with placeholder and accessible name", async () => {
     installerRender(<SoftwarePatternsSelection />);
     // The textbox has an aria-label for screen readers
@@ -191,6 +213,19 @@ describe("SoftwarePatternsSelection", () => {
       expect(screen.queryByText(/0 match the filter/)).toBeNull();
       const emptyStates = screen.getAllByText(/No patterns match the filter/i);
       expect(emptyStates).toHaveLength(2);
+    });
+
+    it("maintains pattern order when filtering", async () => {
+      const { user } = installerRender(<SoftwarePatternsSelection />);
+
+      const searchFilter = await screen.findByRole("textbox", { name: /Filter/ });
+      await user.type(searchFilter, "yast");
+
+      // Should match yast2_basis (1220), yast2_desktop (1222), yast2_server (1224)
+      // in order by their order field
+      const visibleCheckboxes = screen.getAllByRole("checkbox");
+      const ids = visibleCheckboxes.map((c) => c.id);
+      expect(ids).toEqual(["yast2_basis", "yast2_desktop", "yast2_server"]);
     });
   });
 

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -31,7 +31,7 @@ import {
   Stack,
   Title,
 } from "@patternfly/react-core";
-import { group } from "radashi";
+import { group, sort } from "radashi";
 import { sprintf } from "sprintf-js";
 import { formOptions } from "@tanstack/react-form";
 import { useNavigate } from "react-router";
@@ -332,8 +332,9 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
 
   // Build the canonical category list from the unfiltered scope so categories
   // never disappear as the user types.
-  const allGroups = groupPatterns(scopedPatterns);
-  const visiblePatterns = filterPatterns(scopedPatterns, searchValue);
+  const sortedPatterns = sort(scopedPatterns, (p) => p.order);
+  const allGroups = groupPatterns(sortedPatterns);
+  const visiblePatterns = filterPatterns(sortedPatterns, searchValue);
   const visibleByCategory = group(visiblePatterns, (p) => p.category);
   const isFiltering = searchValue.trim() !== "";
 
@@ -354,7 +355,7 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
           _("No patterns match")
         : // TRANSLATORS: search results badge on the filter input.
           // %1$d is matches found, %2$d is the total number of patterns.
-          sprintf(_("%1$d of %2$d patterns"), visiblePatterns.length, scopedPatterns.length);
+          sprintf(_("%1$d of %2$d patterns"), visiblePatterns.length, sortedPatterns.length);
   }
 
   return (


### PR DESCRIPTION
## Problem

https://github.com/agama-project/agama/issues/3425

## Solution

Sort software patterns by their order field within each category

## Testing

- Added a new unit test
- Tested manually

## Screenshots

<img width="2048" height="1598" alt="localhost_8080_ (38)" src="https://github.com/user-attachments/assets/d6861cfe-1c07-4e42-b254-63032b126d3b" />
