### PR TITLE
fix(web): move bond validation tests to ConnectionForm

### DIFF
--- a/web/src/components/network/BondSettings.test.tsx
+++ b/web/src/components/network/BondSettings.test.tsx
@@ -21,11 +21,11 @@
  */
 
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { useAppForm } from "~/hooks/form";
-import { connectionFormOptions, validateConnectionForm } from "~/components/network/ConnectionForm";
-import { BondMode, ConnectionType, DeviceState } from "~/types/network";
+import { connectionFormOptions } from "~/components/network/ConnectionForm";
+import { ConnectionType, DeviceState } from "~/types/network";
 import BondSettings from "./BondSettings";
 
 const mockDevice1 = {
@@ -61,28 +61,11 @@ function TestForm({
       type: ConnectionType.BOND,
       ...defaultValues,
     },
-    validators: {
-      onSubmitAsync: async ({ value }) => {
-        const errors = validateConnectionForm(value);
-        if (errors) return { fields: errors };
-      },
-    },
   });
 
   return (
     <form.AppForm>
       <BondSettings form={form} isEditing={isEditing} />
-      <form.Subscribe selector={(s) => [s.canSubmit, s.isSubmitting]}>
-        {([canSubmit, isSubmitting]) => (
-          <button
-            type="submit"
-            disabled={!canSubmit || isSubmitting}
-            onClick={() => form.handleSubmit()}
-          >
-            Accept
-          </button>
-        )}
-      </form.Subscribe>
     </form.AppForm>
   );
 }
@@ -120,46 +103,5 @@ describe("BondSettings", () => {
     installerRender(<TestForm isEditing />);
 
     expect(screen.queryByLabelText("Device name")).not.toBeInTheDocument();
-  });
-
-  it("shows an error when no bond ports are selected", async () => {
-    const { user } = installerRender(<TestForm />);
-
-    await user.click(await screen.findByRole("button", { name: "Accept" }));
-
-    await screen.findByText("At least one bond port is required");
-  });
-
-  it("shows an error when 'primary' option is used with an invalid bond mode", async () => {
-    const { user } = installerRender(<TestForm />);
-
-    // Default mode is balance-rr, which does not support 'primary'
-    await user.type(await screen.findByLabelText("Bond options"), "primary=enp1s0{enter}");
-    await user.type(screen.getByRole("textbox", { name: "Bond ports" }), "enp1s0{enter}");
-
-    await user.click(screen.getByRole("button", { name: "Accept" }));
-
-    await screen.findByText(
-      "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
-    );
-  });
-
-  it("allows 'primary' option with active-backup mode", async () => {
-    const { user } = installerRender(
-      <TestForm defaultValues={{ bondMode: BondMode.ACTIVE_BACKUP }} />,
-    );
-
-    await user.type(await screen.findByLabelText("Bond options"), "primary=enp1s0{enter}");
-    await user.type(screen.getByRole("textbox", { name: "Bond ports" }), "enp1s0{enter}");
-
-    await user.click(screen.getByRole("button", { name: "Accept" }));
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
-        ),
-      ).not.toBeInTheDocument();
-    });
   });
 });

--- a/web/src/components/network/ConnectionForm.test.tsx
+++ b/web/src/components/network/ConnectionForm.test.tsx
@@ -605,4 +605,65 @@ describe("ConnectionForm", () => {
       );
     });
   });
+
+  describe("validation", () => {
+    describe("Bond", () => {
+      it("shows an error when no bond ports are selected", async () => {
+        const { user } = installerRender(<ConnectionForm />);
+
+        await user.click(screen.getByLabelText("Type"));
+        await user.click(screen.getByText("Bond"));
+        await user.type(await screen.findByLabelText("Name"), "test-bond");
+
+        await user.click(screen.getByRole("button", { name: "Accept" }));
+
+        await screen.findByText("At least one bond port is required");
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+      });
+
+      it("shows an error when 'primary' option is used with an invalid bond mode", async () => {
+        const { user } = installerRender(<ConnectionForm />);
+
+        await user.click(screen.getByLabelText("Type"));
+        await user.click(screen.getByText("Bond"));
+        await user.type(await screen.findByLabelText("Name"), "test-bond");
+
+        // Default mode is balance-rr, which does not support 'primary'
+        await user.type(screen.getByLabelText("Bond options"), "primary=enp1s0{enter}");
+        await user.type(screen.getByRole("textbox", { name: "Bond ports" }), "enp1s0{enter}");
+
+        await user.click(screen.getByRole("button", { name: "Accept" }));
+
+        await screen.findByText(
+          "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
+        );
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+      });
+
+      it("allows 'primary' option with active-backup mode", async () => {
+        const { user } = installerRender(<ConnectionForm />);
+
+        await user.click(screen.getByLabelText("Type"));
+        await user.click(screen.getByText("Bond"));
+        await user.type(await screen.findByLabelText("Name"), "test-bond");
+
+        await user.click(screen.getByLabelText("Bond mode"));
+        await user.click(screen.getByRole("option", { name: /active-backup/ }));
+
+        await user.type(screen.getByLabelText("Bond options"), "primary=enp1s0{enter}");
+        await user.type(screen.getByRole("textbox", { name: "Bond ports" }), "enp1s0{enter}");
+
+        await user.click(screen.getByRole("button", { name: "Accept" }));
+
+        await waitFor(() => {
+          expect(
+            screen.queryByText(
+              "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
+            ),
+          ).not.toBeInTheDocument();
+          expect(mockMutateAsync).toHaveBeenCalled();
+        });
+      });
+    });
+  });
 });

--- a/web/src/components/network/ConnectionForm.test.tsx
+++ b/web/src/components/network/ConnectionForm.test.tsx
@@ -237,17 +237,6 @@ describe("ConnectionForm", () => {
     expect(screen.queryByText("IPv6 Addresses")).not.toBeInTheDocument();
   });
 
-  it("shows an error when addresses are invalid in automatic + manual mode", async () => {
-    const { user } = installerRender(<ConnectionForm />);
-    await user.type(screen.getByLabelText("Name"), "Test");
-    await user.click(screen.getByLabelText("IPv4 Settings"));
-    await user.click(screen.getByRole("option", { name: /^Automatic \+ manual/ }));
-    await user.type(screen.getByLabelText("IPv4 Addresses"), "not-an-ip{Enter}");
-    await user.click(screen.getByRole("button", { name: "Accept" }));
-    await screen.findByText(/Invalid IPv4 address/);
-    expect(mockMutateAsync).not.toHaveBeenCalled();
-  });
-
   it("submits empty addresses when both settings are automatic", async () => {
     const { user } = installerRender(<ConnectionForm />);
     await user.type(screen.getByLabelText("Name"), "Testing Connection 1");
@@ -607,6 +596,19 @@ describe("ConnectionForm", () => {
   });
 
   describe("validation", () => {
+    describe("IP Settings", () => {
+      it("shows an error when IPv4 addresses are invalid", async () => {
+        const { user } = installerRender(<ConnectionForm />);
+        await user.type(screen.getByLabelText("Name"), "Test");
+        await user.click(screen.getByLabelText("IPv4 Settings"));
+        await user.click(screen.getByRole("option", { name: /^Automatic \+ manual/ }));
+        await user.type(screen.getByLabelText("IPv4 Addresses"), "not-an-ip{Enter}");
+        await user.click(screen.getByRole("button", { name: "Accept" }));
+        await screen.findByText(/Invalid IPv4 address/);
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+      });
+    });
+
     describe("Bond", () => {
       it("shows an error when no bond ports are selected", async () => {
         const { user } = installerRender(<ConnectionForm />);

--- a/web/src/components/network/ConnectionForm.tsx
+++ b/web/src/components/network/ConnectionForm.tsx
@@ -264,7 +264,7 @@ function validateGateway(
  * values are valid. Validation is intentionally done here rather than in
  * per-field onSubmit validators — see the {@link ConnectionForm} remarks.
  */
-export function validateConnectionForm(formValues: FormValues): FormFieldErrors | undefined {
+function validateConnectionForm(formValues: FormValues): FormFieldErrors | undefined {
   const validAddresses4 = formValues.addresses4.filter(isValidIPv4Address);
   const validAddresses6 = formValues.addresses6.filter(isValidIPv6Address);
 


### PR DESCRIPTION
`BondSettings` validation tests were importing and testing `ConnectionForm`’s `validateConnectionForm` function. This creates an unnecessary coupling between `BondSettings` tests and the specific validation logic of `ConnectionForm`.

The validation rules such as required bond ports and primary option restrictions, actually belong to `ConnectionForm`, not `BondSettings`. If `BondSettings` were reused in a different form with different rules, these tests would become misleading.

It also moves the existing validation tests to the added `describe("validation")` block. While doing so, it was noticed that some other validations are missing. These, however, will be added in a separate PR that is not related to the implementation of bond connections.