### PR TITLE
fix(web): avoid misleading UI when no desktops are available

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 27 11:00:16 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Handle desktop selection when no desktop environments are available
+  (gh#agama-project/agama#3436, related to gh#agama-project/agama#3420).
+
+-------------------------------------------------------------------
 Fri Apr 24 15:21:18 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Sort software patterns by their order field within each category

--- a/web/src/components/overview/SoftwareSummary.test.tsx
+++ b/web/src/components/overview/SoftwareSummary.test.tsx
@@ -23,7 +23,11 @@ import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender, mockProgresses } from "~/test-utils";
 import { useProposal } from "~/hooks/model/proposal/software";
-import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
+import {
+  useAvailablePatterns,
+  useIsDesktopMissing,
+  useSelectedPatterns,
+} from "~/hooks/model/system/software";
 import { useIssues } from "~/hooks/model/issue";
 import { SOFTWARE } from "~/routes/paths";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
@@ -31,6 +35,7 @@ import SoftwareSummary from "./SoftwareSummary";
 
 const mockUseProposalFn: jest.Mock<ReturnType<typeof useProposal>> = jest.fn();
 const mockUseSelectedPatternsFn: jest.Mock<ReturnType<typeof useSelectedPatterns>> = jest.fn();
+const mockUseAvailablePatternsFn: jest.Mock<ReturnType<typeof useAvailablePatterns>> = jest.fn();
 const mockUseIsDesktopMissingFn: jest.Mock<ReturnType<typeof useIsDesktopMissing>> = jest.fn();
 const mockUseIssuesFn: jest.Mock<ReturnType<typeof useIssues>> = jest.fn();
 
@@ -40,6 +45,7 @@ jest.mock("~/hooks/model/proposal/software", () => ({
 
 jest.mock("~/hooks/model/system/software", () => ({
   useSelectedPatterns: () => mockUseSelectedPatternsFn(),
+  useAvailablePatterns: () => mockUseAvailablePatternsFn(),
   useIsDesktopMissing: () => mockUseIsDesktopMissingFn(),
 }));
 
@@ -76,6 +82,11 @@ describe("SoftwareSummary", () => {
     mockUseIssuesFn.mockReturnValue([]);
     mockUseProposalFn.mockReturnValue({ usedSpace: 6239191, patterns: {} }); // ~5.95 GiB
     mockUseSelectedPatternsFn.mockReturnValue([]);
+    mockUseAvailablePatternsFn.mockReturnValue({
+      all: [gnome, yast2Basis],
+      desktops: [gnome],
+      other: [yast2Basis],
+    });
     mockUseIsDesktopMissingFn.mockReturnValue(false);
   });
 

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -30,7 +30,11 @@ import Link from "~/components/core/Link";
 import Text from "~/components/core/Text";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
-import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
+import {
+  useAvailablePatterns,
+  useIsDesktopMissing,
+  useSelectedPatterns,
+} from "~/hooks/model/system/software";
 import { useIssues } from "~/hooks/model/issue";
 import { SOFTWARE } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
@@ -53,8 +57,8 @@ const patternsCount = (qty: number): string =>
  * Renders the headline text for the software summary.
  *
  * Priority order:
- *   1. "No desktop selected" hint when the product suggests one and none is
- *      selected.
+ *   1. "No desktop selected" hint when the product suggests one, desktops are
+ *      available, but none is selected.
  *   2. The selected desktop's summary when exactly one is selected.
  *   3. "N desktops selected" when more than one desktop is selected.
  *   4. "Using N additional patterns" when the user picked non-desktop
@@ -64,9 +68,10 @@ const patternsCount = (qty: number): string =>
 const Value = () => {
   const patterns = useSelectedPatterns();
   const isDesktopMissing = useIsDesktopMissing();
+  const { desktops: availableDesktops } = useAvailablePatterns();
   const desktops = patterns.filter((p) => p.desktop);
 
-  if (isDesktopMissing) {
+  if (isDesktopMissing && availableDesktops.length > 0) {
     // TRANSLATORS: shown in the software summary when no desktop is selected.
     return <Text isBold>{_("No desktop selected")}</Text>;
   }

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -30,11 +30,7 @@ import Link from "~/components/core/Link";
 import Text from "~/components/core/Text";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
-import {
-  useAvailablePatterns,
-  useIsDesktopMissing,
-  useSelectedPatterns,
-} from "~/hooks/model/system/software";
+import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
 import { useIssues } from "~/hooks/model/issue";
 import { SOFTWARE } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
@@ -68,10 +64,9 @@ const patternsCount = (qty: number): string =>
 const Value = () => {
   const patterns = useSelectedPatterns();
   const isDesktopMissing = useIsDesktopMissing();
-  const { desktops: availableDesktops } = useAvailablePatterns();
   const desktops = patterns.filter((p) => p.desktop);
 
-  if (isDesktopMissing && availableDesktops.length > 0) {
+  if (isDesktopMissing) {
     // TRANSLATORS: shown in the software summary when no desktop is selected.
     return <Text isBold>{_("No desktop selected")}</Text>;
   }

--- a/web/src/components/software/NoDesktopAlert.test.tsx
+++ b/web/src/components/software/NoDesktopAlert.test.tsx
@@ -22,10 +22,51 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
+import { useAvailablePatterns } from "~/hooks/model/system/software";
 import { SOFTWARE } from "~/routes/paths";
 import NoDesktopAlert from "./NoDesktopAlert";
 
+const mockUseAvailablePatternsFn: jest.Mock<ReturnType<typeof useAvailablePatterns>> = jest.fn();
+
+jest.mock("~/hooks/model/system/software", () => ({
+  useAvailablePatterns: () => mockUseAvailablePatternsFn(),
+}));
+
+const gnome = {
+  name: "gnome",
+  category: "Graphical Environments",
+  icon: "./pattern-gnome-wayland",
+  description: "The GNOME desktop environment ...",
+  summary: "GNOME Desktop",
+  order: 1010,
+  preselected: false,
+  desktop: true,
+};
+
+const yast2Basis = {
+  name: "yast2_basis",
+  category: "Base Technologies",
+  icon: "./yast",
+  description: "YaST tools for basic system administration.",
+  summary: "YaST Base Utilities",
+  order: 1220,
+  preselected: false,
+  desktop: false,
+};
+
 describe("NoDesktopAlert", () => {
+  beforeEach(() => {
+    mockUseAvailablePatternsFn.mockReturnValue({
+      all: [gnome, yast2Basis],
+      desktops: [gnome],
+      other: [yast2Basis],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders the headline and the command-line consequence", () => {
     installerRender(<NoDesktopAlert />);
 
@@ -38,5 +79,18 @@ describe("NoDesktopAlert", () => {
 
     const link = screen.getByRole("link", { name: "software" });
     expect(link).toHaveAttribute("href", expect.stringContaining(SOFTWARE.root));
+  });
+
+  it("returns null when no desktop patterns are available", () => {
+    mockUseAvailablePatternsFn.mockReturnValue({
+      all: [yast2Basis],
+      desktops: [],
+      other: [yast2Basis],
+    });
+
+    const { container } = installerRender(<NoDesktopAlert />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText("No desktop selected")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/software/NoDesktopAlert.tsx
+++ b/web/src/components/software/NoDesktopAlert.tsx
@@ -24,6 +24,7 @@ import React from "react";
 import { Alert, Content } from "@patternfly/react-core";
 import Link from "~/components/core/Link";
 import Interpolate from "~/components/core/Interpolate";
+import { useAvailablePatterns } from "~/hooks/model/system/software";
 import { SOFTWARE } from "~/routes/paths";
 import { _ } from "~/i18n";
 
@@ -33,8 +34,15 @@ import { _ } from "~/i18n";
  * having to cancel the current flow manually.
  *
  * Intended for confirmation dialogs on products that suggest a desktop.
+ *
+ * Returns `null` when no desktop patterns are available, preventing the alert
+ * from suggesting an action that is impossible to complete.
  */
 export default function NoDesktopAlert() {
+  const { desktops } = useAvailablePatterns();
+
+  if (desktops.length === 0) return null;
+
   return (
     <Alert
       isInline

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -29,6 +29,9 @@ import SoftwarePage from "./SoftwarePage";
 
 const mockProposal = jest.fn();
 
+const desktops = testingPatterns.filter((p) => p.desktop);
+const other = testingPatterns.filter((p) => !p.desktop);
+
 jest.mock("~/components/layout/Header", () => () => <div>Header Mock</div>);
 jest.mock("~/components/questions/Questions", () => () => <div>Questions Mock</div>);
 
@@ -41,7 +44,11 @@ jest.mock("~/hooks/model/proposal/software", () => ({
 }));
 
 jest.mock("~/hooks/model/system/software", () => ({
-  useSystem: () => ({ patterns: testingPatterns }),
+  useAvailablePatterns: () => ({
+    all: testingPatterns,
+    desktops,
+    other,
+  }),
 }));
 
 describe("SoftwarePage", () => {

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -46,7 +46,7 @@ import Text from "~/components/core/Text";
 import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
-import { useSystem } from "~/hooks/model/system/software";
+import { useAvailablePatterns } from "~/hooks/model/system/software";
 import { isPatternSelected } from "~/utils/software";
 import { SOFTWARE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
@@ -77,6 +77,19 @@ const NothingSelected = ({
         </Link>
       </EmptyStateActions>
     </EmptyStateFooter>
+  </EmptyState>
+);
+
+/**
+ * Informational empty state shown when no desktop patterns are available.
+ */
+const NoDesktopsAvailable = () => (
+  // TRANSLATORS: empty state title when no desktop environments are available
+  <EmptyState headingLevel="h4" titleText={_("No desktops available")} variant="sm">
+    <EmptyStateBody>
+      {/* TRANSLATORS: explanation shown when the product has no desktop environments */}
+      {_("This product does not provide desktop environments.")}
+    </EmptyStateBody>
   </EmptyState>
 );
 
@@ -244,7 +257,7 @@ const SoftwareSection = ({
       }
       description={description}
       pfCardProps={{ isFullHeight: false }}
-      actions={!noneSelected && <Link to={selectionPath}>{buttonText}</Link>}
+      actions={!noneSelected && totalCount > 0 && <Link to={selectionPath}>{buttonText}</Link>}
     >
       <SelectedPatternsList patterns={patterns} selection={selection} emptyContent={emptyContent} />
     </Page.Section>
@@ -270,7 +283,7 @@ However, you can add additional software once the installation is finished.",
  * Main content of the software page.
  */
 const SoftwarePageContent = () => {
-  const { patterns } = useSystem();
+  const { all: patterns, desktops: allDesktops, other: allOtherPatterns } = useAvailablePatterns();
   const proposal = useProposal();
   const issues = useIssues("software");
 
@@ -283,7 +296,6 @@ const SoftwarePageContent = () => {
     ? xbytes(proposal.usedSpace * 1024, { iec: true })
     : undefined;
 
-  const [allDesktops, allOtherPatterns] = fork(patterns, (p) => p.desktop);
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
   const [desktops, otherPatterns] = fork(selectedPatterns, (p) => p.desktop);
 
@@ -313,13 +325,17 @@ const SoftwarePageContent = () => {
               selection={proposal.patterns}
               selectionPath={PATHS.desktopSelection}
               emptyContent={
-                <NothingSelected
-                  to={PATHS.desktopSelection}
-                  // TRANSLATORS: hint shown when no desktop environment has been chosen
-                  body={_("Select a desktop environment to get a graphical interface.")}
-                  // TRANSLATORS: button to go to the desktop environment selection page
-                  buttonText={_("Select a desktop")}
-                />
+                allDesktops.length === 0 ? (
+                  <NoDesktopsAvailable />
+                ) : (
+                  <NothingSelected
+                    to={PATHS.desktopSelection}
+                    // TRANSLATORS: hint shown when no desktop environment has been chosen
+                    body={_("Select a desktop environment to get a graphical interface.")}
+                    // TRANSLATORS: button to go to the desktop environment selection page
+                    buttonText={_("Select a desktop")}
+                  />
+                )
               }
             />
           </GridItem>

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -42,8 +42,15 @@ const patternsWithPreselected = [
   },
 ];
 
+const desktops = patternsWithPreselected.filter((p) => p.desktop);
+const other = patternsWithPreselected.filter((p) => !p.desktop);
+
 jest.mock("~/hooks/model/system/software", () => ({
-  useSystem: () => ({ patterns: patternsWithPreselected }),
+  useAvailablePatterns: () => ({
+    all: patternsWithPreselected,
+    desktops,
+    other,
+  }),
 }));
 
 jest.mock("~/hooks/model/proposal/software", () => ({

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -34,7 +34,7 @@ import {
 import { group, sort } from "radashi";
 import { sprintf } from "sprintf-js";
 import { formOptions } from "@tanstack/react-form";
-import { useNavigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import NestedContent from "~/components/core/NestedContent";
 import Page from "~/components/core/Page";
 import SubtleContent from "~/components/core/SubtleContent";
@@ -42,7 +42,7 @@ import Text from "~/components/core/Text";
 import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import { SelectedBy } from "~/model/proposal/software";
 import { patchConfig } from "~/api";
-import { useSystem } from "~/hooks/model/system/software";
+import { useAvailablePatterns } from "~/hooks/model/system/software";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { usePristineSafeForm } from "~/hooks/form";
 import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from "~/utils/software";
@@ -251,7 +251,7 @@ const PatternCheckbox = ({
  */
 function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   const navigate = useNavigate();
-  const { patterns: systemPatterns } = useSystem();
+  const { all: systemPatterns, [scope]: scopedPatterns } = useAvailablePatterns();
   const proposal = useProposal();
   const selection = proposal?.patterns || {};
   const [searchValue, setSearchValue] = useState("");
@@ -275,18 +275,6 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
       setFilterHeight(filterRef.current.offsetHeight);
     }
   }, [searchValue]);
-
-  let scopedPatterns: Pattern[];
-  switch (scope) {
-    case "desktops":
-      scopedPatterns = systemPatterns.filter((p) => p.desktop);
-      break;
-    case "other":
-      scopedPatterns = systemPatterns.filter((p) => !p.desktop);
-      break;
-    default:
-      scopedPatterns = systemPatterns;
-  }
 
   // Build initial form values: each pattern name -> selected boolean
   const initialValues = scopedPatterns.reduce((acc, pattern) => {
@@ -326,9 +314,12 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
     onSubmitComplete: () => navigate(SOFTWARE.root),
   });
 
-  // Initial empty screen guard: patterns load very quickly, but on the very
-  // first render the system list may be empty. Avoid flashing an empty page.
-  if (scopedPatterns.length === 0 && searchValue === "") return null;
+  // Redirect to main software page when no patterns are available for the
+  // current scope. This handles users landing via direct URL or cached links
+  // when desktop patterns don't exist.
+  if (scopedPatterns.length === 0 && searchValue === "") {
+    return <Navigate to={SOFTWARE.root} replace />;
+  }
 
   // Build the canonical category list from the unfiltered scope so categories
   // never disappear as the user types.

--- a/web/src/hooks/model/system/software.test.ts
+++ b/web/src/hooks/model/system/software.test.ts
@@ -25,7 +25,11 @@ import { renderHook } from "@testing-library/react";
 import { clearMockedQueries, mockQuery, mockSystemQuery } from "~/test-utils/tanstack-query";
 import { SelectedBy } from "~/model/proposal/software";
 import type { Product, Software } from "~/model/system";
-import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
+import {
+  useAvailablePatterns,
+  useIsDesktopMissing,
+  useSelectedPatterns,
+} from "~/hooks/model/system/software";
 
 const gnomePattern: Software.Pattern = {
   name: "gnome",
@@ -45,6 +49,28 @@ const basePattern: Software.Pattern = {
   description: "YaST tools for basic system administration.",
   order: 1220,
   icon: "./yast",
+  preselected: false,
+  desktop: false,
+};
+
+const kdePattern: Software.Pattern = {
+  name: "kde",
+  category: "Graphical Environments",
+  summary: "KDE Plasma Desktop",
+  description: "The KDE desktop environment",
+  order: 1020,
+  icon: "./kde",
+  preselected: false,
+  desktop: true,
+};
+
+const lampPattern: Software.Pattern = {
+  name: "lamp_server",
+  category: "Server Functions",
+  summary: "Web and LAMP Server",
+  description: "Apache, MySQL, and PHP",
+  order: 2010,
+  icon: "./lamp",
   preselected: false,
   desktop: false,
 };
@@ -81,6 +107,66 @@ function mockScenario(product: Product, patterns: Software.Pattern[], selection:
   mockQuery(["extendedConfig"], { product: { id: product.id } });
   mockQuery(["proposal"], { software: { patterns: selection, usedSpace: 0 } });
 }
+
+describe("useAvailablePatterns", () => {
+  beforeEach(() => {
+    clearMockedQueries();
+  });
+
+  it("returns all patterns in the 'all' property", () => {
+    mockScenario(tumbleweed, [gnomePattern, kdePattern, basePattern, lampPattern], {});
+
+    const { result } = renderHook(() => useAvailablePatterns());
+
+    expect(result.current.all).toEqual([gnomePattern, kdePattern, basePattern, lampPattern]);
+  });
+
+  it("returns desktop patterns into 'desktops' property", () => {
+    mockScenario(tumbleweed, [gnomePattern, kdePattern, basePattern, lampPattern], {});
+
+    const { result } = renderHook(() => useAvailablePatterns());
+
+    expect(result.current.desktops).toEqual([gnomePattern, kdePattern]);
+  });
+
+  it("returns non-desktop patterns into 'other' property", () => {
+    mockScenario(tumbleweed, [gnomePattern, kdePattern, basePattern, lampPattern], {});
+
+    const { result } = renderHook(() => useAvailablePatterns());
+
+    expect(result.current.other).toEqual([basePattern, lampPattern]);
+  });
+
+  it("returns empty arrays when no patterns are available", () => {
+    mockScenario(tumbleweed, [], {});
+
+    const { result } = renderHook(() => useAvailablePatterns());
+
+    expect(result.current.all).toEqual([]);
+    expect(result.current.desktops).toEqual([]);
+    expect(result.current.other).toEqual([]);
+  });
+
+  it("returns empty 'desktops' when only non-desktop patterns exist", () => {
+    mockScenario(sles, [basePattern, lampPattern], {});
+
+    const { result } = renderHook(() => useAvailablePatterns());
+
+    expect(result.current.all).toEqual([basePattern, lampPattern]);
+    expect(result.current.desktops).toEqual([]);
+    expect(result.current.other).toEqual([basePattern, lampPattern]);
+  });
+
+  it("returns empty 'other' when only desktop patterns exist", () => {
+    mockScenario(tumbleweed, [gnomePattern, kdePattern], {});
+
+    const { result } = renderHook(() => useAvailablePatterns());
+
+    expect(result.current.all).toEqual([gnomePattern, kdePattern]);
+    expect(result.current.desktops).toEqual([gnomePattern, kdePattern]);
+    expect(result.current.other).toEqual([]);
+  });
+});
 
 describe("useIsDesktopMissing", () => {
   beforeEach(() => {
@@ -126,6 +212,14 @@ describe("useIsDesktopMissing", () => {
       mockScenario(tumbleweed, [gnomePattern, basePattern], {
         gnome: SelectedBy.USER,
       });
+
+      const { result } = renderHook(() => useIsDesktopMissing());
+
+      expect(result.current).toBe(false);
+    });
+
+    it("returns false if no desktop patterns are available", () => {
+      mockScenario(tumbleweed, [basePattern, lampPattern], {});
 
       const { result } = renderHook(() => useIsDesktopMissing());
 

--- a/web/src/hooks/model/system/software.ts
+++ b/web/src/hooks/model/system/software.ts
@@ -21,6 +21,7 @@
  */
 
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { fork } from "radashi";
 import { systemQuery } from "~/hooks/model/system";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProductInfo } from "~/hooks/model/config/product";
@@ -35,6 +36,26 @@ function useSystem(): Software.System | null {
     select: selectSystem,
   });
   return data;
+}
+
+type AvailablePatterns = {
+  all: Software.Pattern[];
+  desktops: Software.Pattern[];
+  other: Software.Pattern[];
+};
+
+/**
+ * Retrieves all available patterns categorized by type.
+ *
+ * Returns three lists:
+ * - `all`: every pattern available in the system
+ * - `desktops`: patterns flagged as desktop environments
+ * - `other`: non-desktop patterns
+ */
+function useAvailablePatterns(): AvailablePatterns {
+  const { patterns } = useSystem();
+  const [desktops, other] = fork(patterns, (p) => p.desktop);
+  return { all: patterns, desktops, other };
 }
 
 /**
@@ -59,15 +80,18 @@ function useSelectedPatterns() {
  * Use this to decide whether to hint the user in UI surfaces such as the
  * software summary or the installation confirmation. Returns `false` for
  * products that do not declare `desktopSelection` or declare it as
- * `"optional"`.
+ * `"optional"`, and also returns `false` when no desktop patterns are
+ * available (can't be missing if none exist).
  */
 function useIsDesktopMissing(): boolean {
   const product = useProductInfo();
   const selectedPatterns = useSelectedPatterns();
+  const { desktops: availableDesktops } = useAvailablePatterns();
 
   if (product?.desktopSelection !== "suggested") return false;
+  if (availableDesktops.length === 0) return false;
 
   return !selectedPatterns.some((p) => p.desktop);
 }
 
-export { useSystem, useSelectedPatterns, useIsDesktopMissing };
+export { useSystem, useSelectedPatterns, useAvailablePatterns, useIsDesktopMissing };


### PR DESCRIPTION
While presenting the work done at https://github.com/agama-project/agama/pull/3420, @joseivanlopez  identified a corner case not handled by it: when products do not offer any desktop environments.

The previous implementation could show misleading messages such as “No desktop selected,” offer links to select a desktop that didn't exist, or display an empty desktop selection page. While this didn't make Agama crash, it created a confusing and unexpected experience.

This PR ensures the UI adapts gracefully with a few behavioral changes:

* **Avoid misleading messages** by only showing “No desktop selected” when desktops are actually available, **regardless of whether the product is configured to suggest a desktop selection**. 
* **Prevent empty views and maintain UI consistency** by redirecting users away from the desktop selection page when no desktops exist and displaying a clear informational message in the software page section. The desktop section is intentionally **not hidden** in this case to preserve layout consistency.


## Before

<img width="2148" height="1578" alt="localhost_8080_ (41)" src="https://github.com/user-attachments/assets/210250ca-7cd7-40af-a830-2a4d1ab5df27" />


## After

<img width="2148" height="1578" alt="localhost_8080_ (39)" src="https://github.com/user-attachments/assets/4f80e5b4-0c70-4812-8c5d-752e286523d3" />


---

> [!NOTE]
>
> Although no screenshots are included, these changes also suppress the desktop selection alert in the confirmation dialog when no desktops are available.
