### PR TITLE
refactor(web): extract connection form validation to separate module

### DIFF
--- a/web/src/components/network/ConnectionForm.tsx
+++ b/web/src/components/network/ConnectionForm.tsx
@@ -23,7 +23,7 @@
 import React from "react";
 import { formOptions } from "@tanstack/react-form";
 import { generatePath, useNavigate, useParams } from "react-router";
-import { isEmpty, shake, unique } from "radashi";
+import { unique } from "radashi";
 import { Alert, ActionGroup, Flex, Form } from "@patternfly/react-core";
 import Page from "~/components/core/Page";
 import { BreadcrumbProps } from "~/components/core/Breadcrumbs";
@@ -52,14 +52,12 @@ import {
   ensureIPPrefix,
   formatIp,
   generateConnectionName,
-  isValidIPv4,
-  isValidIPv6,
   isValidIPv4Address,
-  isValidIPv6Address,
   isValidNameserver,
   isValidDNSSearchDomain,
 } from "~/utils/network";
 import { _ } from "~/i18n";
+import { validateConnectionForm } from "./connectionFormValidation";
 
 /**
  * Form IP mode values.
@@ -129,7 +127,6 @@ export const connectionFormOptions = formOptions({
 });
 
 type FormValues = typeof connectionFormOptions.defaultValues;
-type FormFieldErrors = Partial<Record<keyof FormValues, string>>;
 
 /**
  * Infers the form IPvX mode from a stored {@link ConnectionMethod} and addresses.
@@ -188,176 +185,6 @@ function connectionToFormValues(connection: Connection): Partial<FormValues> {
     bondOptions: connection.bond?.options ? connection.bond.options.split(" ") : [],
     bondPorts: connection.bond?.ports ?? [],
   };
-}
-
-/**
- * Returns an error when the given list is active and has invalid or missing entries.
- * Returns undefined when inactive or when all entries are valid.
- *
- * @param active - Whether the list should be validated at all.
- * @param emptyMsg - Error to return when the list is empty. Omit for optional
- *   lists where entries are not required but must be valid when provided.
- */
-function validateActiveList(
-  active: boolean,
-  values: string[],
-  isValid: (v: string) => boolean,
-  emptyMsg: string | undefined,
-  invalidMsg: string,
-): string | undefined {
-  if (!active) return undefined;
-  if (emptyMsg !== undefined && values.length === 0) return emptyMsg;
-  if (values.some((v) => !isValid(v))) return invalidMsg;
-}
-
-/**
- * Returns an error for an IP addresses list based on the current IP mode.
- *
- * - MANUAL: addresses are required and must be valid.
- * - ADVANCED_AUTO: addresses are required and must be valid.
- * - AUTO: no validation.
- */
-function validateIpAddresses(
-  mode: FormIpMode,
-  addresses: string[],
-  isValid: (v: string) => boolean,
-  emptyMsg: string,
-  invalidMsg: string,
-): string | undefined {
-  const required = ADDRESS_REQUIRED_MODES.includes(mode);
-  const active = required || addresses.length > 0;
-  return validateActiveList(
-    active,
-    addresses,
-    isValid,
-    required ? emptyMsg : undefined,
-    invalidMsg,
-  );
-}
-
-/**
- * Returns an error for a gateway value under its protocol mode.
- *
- * - MANUAL: gateway is required and must be valid.
- * - ADVANCED_AUTO: gateway is optional but must be valid when provided.
- * - AUTO: no validation.
- */
-function validateGateway(
-  mode: FormIpMode,
-  gateway: string,
-  validAddresses: string[],
-  isValid: (v: string) => boolean,
-  emptyMsg: string,
-  invalidMsg: string,
-): string | undefined {
-  if (mode === FormIpMode.MANUAL) {
-    if (!gateway) return emptyMsg;
-    return isValid(gateway) ? undefined : invalidMsg;
-  }
-  if (mode === FormIpMode.ADVANCED_AUTO && gateway) {
-    return isValid(gateway) ? undefined : invalidMsg;
-  }
-}
-
-/**
- * Validates the connection form values.
- *
- * Returns a map of field errors when validation fails, or undefined when all
- * values are valid. Validation is intentionally done here rather than in
- * per-field onSubmit validators — see the {@link ConnectionForm} remarks.
- */
-function validateConnectionForm(formValues: FormValues): FormFieldErrors | undefined {
-  const validAddresses4 = formValues.addresses4.filter(isValidIPv4Address);
-  const validAddresses6 = formValues.addresses6.filter(isValidIPv6Address);
-
-  const fieldErrors = shake({
-    // TRANSLATORS: validation error for the connection name field.
-    name: !formValues.name.trim() ? _("Name is required") : undefined,
-    addresses4: validateIpAddresses(
-      formValues.ipv4Mode,
-      formValues.addresses4,
-      isValidIPv4Address,
-      // TRANSLATORS: validation error for the IPv4 addresses field.
-      _("At least one IPv4 address is required"),
-      // TRANSLATORS: validation error for the IPv4 addresses field.
-      _("Some IPv4 addresses are invalid"),
-    ),
-    addresses6: validateIpAddresses(
-      formValues.ipv6Mode,
-      formValues.addresses6,
-      isValidIPv6Address,
-      // TRANSLATORS: validation error for the IPv6 addresses field.
-      _("At least one IPv6 address is required"),
-      // TRANSLATORS: validation error for the IPv6 addresses field.
-      _("Some IPv6 addresses are invalid"),
-    ),
-    gateway4: validateGateway(
-      formValues.ipv4Mode,
-      formValues.gateway4,
-      validAddresses4,
-      isValidIPv4,
-      // TRANSLATORS: validation error for the IPv4 gateway field.
-      _("IPv4 gateway is required"),
-      // TRANSLATORS: validation error for the IPv4 gateway field.
-      _("Invalid IPv4 gateway"),
-    ),
-    gateway6: validateGateway(
-      formValues.ipv6Mode,
-      formValues.gateway6,
-      validAddresses6,
-      isValidIPv6,
-      // TRANSLATORS: validation error for the IPv6 gateway field.
-      _("IPv6 gateway is required"),
-      // TRANSLATORS: validation error for the IPv6 gateway field.
-      _("Invalid IPv6 gateway"),
-    ),
-    nameservers: validateActiveList(
-      formValues.customDns,
-      formValues.nameservers,
-      isValidNameserver,
-      // TRANSLATORS: validation error for the DNS servers field.
-      _("At least one DNS server is required"),
-      // TRANSLATORS: validation error for the DNS servers field.
-      _("Some DNS server addresses are invalid"),
-    ),
-    dnsSearchList: validateActiveList(
-      formValues.customDnsSearch,
-      formValues.dnsSearchList,
-      isValidDNSSearchDomain,
-      // TRANSLATORS: validation error for the DNS search domains field.
-      _("At least one DNS search domain is required"),
-      // TRANSLATORS: validation error for the DNS search domains field.
-      _("Some DNS search domains are invalid"),
-    ),
-    bondIface:
-      formValues.type === ConnectionType.BOND && !formValues.bondIface.trim()
-        ? // TRANSLATORS: validation error for the bond device name field.
-          _("Device name is required")
-        : undefined,
-    bondMode:
-      formValues.type === ConnectionType.BOND && !formValues.bondMode.trim()
-        ? // TRANSLATORS: validation error for the bond mode field.
-          _("Bond mode is required")
-        : undefined,
-    bondPorts:
-      formValues.type === ConnectionType.BOND && formValues.bondPorts.length === 0
-        ? // TRANSLATORS: validation error for the bond ports field.
-          _("At least one bond port is required")
-        : undefined,
-    bondOptions:
-      formValues.type === ConnectionType.BOND &&
-      ![BondMode.ACTIVE_BACKUP, BondMode.BALANCE_TLB, BondMode.BALANCE_ALB].includes(
-        formValues.bondMode,
-      ) &&
-      formValues.bondOptions.some((o) => o.startsWith("primary="))
-        ? // TRANSLATORS: validation error for the bond options field when the 'primary' option is used in an invalid mode.
-          _(
-            "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
-          )
-        : undefined,
-  });
-
-  if (!isEmpty(fieldErrors)) return fieldErrors;
 }
 
 /**

--- a/web/src/components/network/connectionFormValidation.ts
+++ b/web/src/components/network/connectionFormValidation.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Validation logic for ConnectionForm.
+ *
+ * This module centralizes all validation functions for network connection
+ * form, organized by connection type (common fields, bond-specific,
+ * bridge-specific, etc.).
+ *
+ * Keeping validation here ensures ConnectionForm.tsx remains focused on UI
+ * concerns and provides a single location to add type-specific validators as
+ * new connection types (e.g., Bridge, VLAN) are introduced.
+ *
+ * Validators are tested indirectly through ConnectionForm integration tests,
+ * rather than as standalone unit tests.
+ */
+
+import { sprintf } from "sprintf-js";
+import { isEmpty, shake } from "radashi";
+import { BondMode, ConnectionType } from "~/types/network";
+import {
+  isValidIPv4,
+  isValidIPv6,
+  isValidIPv4Address,
+  isValidIPv6Address,
+  isValidNameserver,
+  isValidDNSSearchDomain,
+} from "~/utils/network";
+import { _, formatList } from "~/i18n";
+import { connectionFormOptions, FormIpMode, ADDRESS_REQUIRED_MODES } from "./ConnectionForm";
+
+type FormValues = typeof connectionFormOptions.defaultValues;
+type FormFieldErrors = Partial<Record<keyof FormValues, string>>;
+
+/**
+ * Bond modes that support the "primary" bond option.
+ */
+const PRIMARY_BOND_OPTION_MODES: readonly BondMode[] = [
+  BondMode.ACTIVE_BACKUP,
+  BondMode.BALANCE_TLB,
+  BondMode.BALANCE_ALB,
+];
+
+/**
+ * Returns an error when the given list is active and has invalid or missing entries.
+ * Returns undefined when inactive or when all entries are valid.
+ *
+ * @param active - Whether the list should be validated at all.
+ * @param emptyMsg - Error to return when the list is empty. Omit for optional
+ *   lists where entries are not required but must be valid when provided.
+ */
+function validateActiveList(
+  active: boolean,
+  values: string[],
+  isValid: (v: string) => boolean,
+  emptyMsg: string | undefined,
+  invalidMsg: string,
+): string | undefined {
+  if (!active) return undefined;
+  if (emptyMsg !== undefined && values.length === 0) return emptyMsg;
+  if (values.some((v) => !isValid(v))) return invalidMsg;
+}
+
+/**
+ * Returns an error for an IP addresses list based on the current IP mode.
+ *
+ * - MANUAL: addresses are required and must be valid.
+ * - ADVANCED_AUTO: addresses are required and must be valid.
+ * - AUTO: no validation.
+ */
+function validateIpAddresses(
+  mode: FormIpMode,
+  addresses: string[],
+  isValid: (v: string) => boolean,
+  emptyMsg: string,
+  invalidMsg: string,
+): string | undefined {
+  const required = ADDRESS_REQUIRED_MODES.includes(mode);
+  const active = required || addresses.length > 0;
+  return validateActiveList(
+    active,
+    addresses,
+    isValid,
+    required ? emptyMsg : undefined,
+    invalidMsg,
+  );
+}
+
+/**
+ * Returns an error for a gateway value under its protocol mode.
+ *
+ * - MANUAL: gateway is required and must be valid.
+ * - ADVANCED_AUTO: gateway is optional but must be valid when provided.
+ * - AUTO: no validation.
+ */
+function validateGateway(
+  mode: FormIpMode,
+  gateway: string,
+  validAddresses: string[],
+  isValid: (v: string) => boolean,
+  emptyMsg: string,
+  invalidMsg: string,
+): string | undefined {
+  if (mode === FormIpMode.MANUAL) {
+    if (!gateway) return emptyMsg;
+    return isValid(gateway) ? undefined : invalidMsg;
+  }
+  if (mode === FormIpMode.ADVANCED_AUTO && gateway) {
+    return isValid(gateway) ? undefined : invalidMsg;
+  }
+}
+
+/**
+ * Validates bond options for the given mode.
+ */
+function validateBondOptions(mode: BondMode, options: string[]): string | undefined {
+  const hasPrimaryOption = options.some((o) => o.startsWith("primary="));
+  if (!hasPrimaryOption) return undefined;
+
+  if (PRIMARY_BOND_OPTION_MODES.includes(mode)) return undefined;
+
+  const modeNames = PRIMARY_BOND_OPTION_MODES.map((m) => `'${m}'`);
+  // TRANSLATORS: validation error for the bond options field when the 'primary' option is used in an invalid mode.
+  // %s is replaced with a list of valid mode names.
+  return sprintf(_("The 'primary' option is only valid for %s modes"), formatList(modeNames));
+}
+
+/**
+ * Validates common fields (name, addresses, gateways, DNS) for all connection types.
+ */
+function validateCommonFields(formValues: FormValues): Partial<FormFieldErrors> {
+  const validAddresses4 = formValues.addresses4.filter(isValidIPv4Address);
+  const validAddresses6 = formValues.addresses6.filter(isValidIPv6Address);
+
+  return {
+    // TRANSLATORS: validation error for the connection name field.
+    name: !formValues.name.trim() ? _("Name is required") : undefined,
+    addresses4: validateIpAddresses(
+      formValues.ipv4Mode,
+      formValues.addresses4,
+      isValidIPv4Address,
+      // TRANSLATORS: validation error for the IPv4 addresses field.
+      _("At least one IPv4 address is required"),
+      // TRANSLATORS: validation error for the IPv4 addresses field.
+      _("Some IPv4 addresses are invalid"),
+    ),
+    addresses6: validateIpAddresses(
+      formValues.ipv6Mode,
+      formValues.addresses6,
+      isValidIPv6Address,
+      // TRANSLATORS: validation error for the IPv6 addresses field.
+      _("At least one IPv6 address is required"),
+      // TRANSLATORS: validation error for the IPv6 addresses field.
+      _("Some IPv6 addresses are invalid"),
+    ),
+    gateway4: validateGateway(
+      formValues.ipv4Mode,
+      formValues.gateway4,
+      validAddresses4,
+      isValidIPv4,
+      // TRANSLATORS: validation error for the IPv4 gateway field.
+      _("IPv4 gateway is required"),
+      // TRANSLATORS: validation error for the IPv4 gateway field.
+      _("Invalid IPv4 gateway"),
+    ),
+    gateway6: validateGateway(
+      formValues.ipv6Mode,
+      formValues.gateway6,
+      validAddresses6,
+      isValidIPv6,
+      // TRANSLATORS: validation error for the IPv6 gateway field.
+      _("IPv6 gateway is required"),
+      // TRANSLATORS: validation error for the IPv6 gateway field.
+      _("Invalid IPv6 gateway"),
+    ),
+    nameservers: validateActiveList(
+      formValues.customDns,
+      formValues.nameservers,
+      isValidNameserver,
+      // TRANSLATORS: validation error for the DNS servers field.
+      _("At least one DNS server is required"),
+      // TRANSLATORS: validation error for the DNS servers field.
+      _("Some DNS server addresses are invalid"),
+    ),
+    dnsSearchList: validateActiveList(
+      formValues.customDnsSearch,
+      formValues.dnsSearchList,
+      isValidDNSSearchDomain,
+      // TRANSLATORS: validation error for the DNS search domains field.
+      _("At least one DNS search domain is required"),
+      // TRANSLATORS: validation error for the DNS search domains field.
+      _("Some DNS search domains are invalid"),
+    ),
+  };
+}
+
+/**
+ * Validates bond-specific fields.
+ */
+function validateBondFields(formValues: FormValues): Partial<FormFieldErrors> {
+  if (formValues.type !== ConnectionType.BOND) return {};
+
+  return {
+    // TRANSLATORS: validation error for the bond device name field.
+    bondIface: !formValues.bondIface.trim() ? _("Device name is required") : undefined,
+    // TRANSLATORS: validation error for the bond mode field.
+    bondMode: !formValues.bondMode.trim() ? _("Bond mode is required") : undefined,
+    bondPorts:
+      formValues.bondPorts.length === 0
+        ? // TRANSLATORS: validation error for the bond ports field.
+          _("At least one bond port is required")
+        : undefined,
+    bondOptions: validateBondOptions(formValues.bondMode, formValues.bondOptions),
+  };
+}
+
+/**
+ * Validates the connection form values.
+ *
+ * Returns a map of field errors when validation fails, or undefined when all
+ * values are valid.
+ */
+export function validateConnectionForm(formValues: FormValues): FormFieldErrors | undefined {
+  const fieldErrors = shake({
+    ...validateCommonFields(formValues),
+    ...validateBondFields(formValues),
+  });
+
+  if (!isEmpty(fieldErrors)) return fieldErrors;
+}


### PR DESCRIPTION
Moves validation logic from `ConnectionForm.tsx` into a dedicated `connectionFormValidation.ts` module to prepare for adding Bridge, VLAN, and other connection types.

The previous approach had inline type checks (formValues.type === ConnectionType.BOND) scattered throughout validateConnectionForm, which would not scale well. The new structure uses type-specific validator functions (validateBondFields, validateCommonFields) that are composed together, making it straightforward to add new types.

Also makes use of  formatList for proper i18n of the mode names list for a primary option bond validation.