### PR TITLE
refactor(web): decouple `ConnectionType` from UI concerns

### DIFF
--- a/web/src/components/network/BindingSettingsForm.test.tsx
+++ b/web/src/components/network/BindingSettingsForm.test.tsx
@@ -28,15 +28,15 @@ import {
   Connection,
   ConnectionMethod,
   ConnectionState,
-  ConnectionType,
   Device,
   DeviceState,
 } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 
 const mockDevice: Device = {
   name: "enp1s0",
   connection: "Network 1",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.69.201", prefix: 24 }],
   nameservers: ["192.168.69.100"],

--- a/web/src/components/network/BondSettings.test.tsx
+++ b/web/src/components/network/BondSettings.test.tsx
@@ -25,20 +25,21 @@ import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { useAppForm } from "~/hooks/form";
 import { connectionFormOptions } from "~/components/network/ConnectionForm";
-import { ConnectionType, DeviceState } from "~/types/network";
+import { DeviceState } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 import BondSettings from "./BondSettings";
 
 const mockDevice1 = {
   name: "enp1s0",
   macAddress: "00:11:22:33:44:55",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
 };
 
 const mockDevice2 = {
   name: "enp2s0",
   macAddress: "AA:BB:CC:DD:EE:FF",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.DISCONNECTED,
 };
 
@@ -58,7 +59,7 @@ function TestForm({
     defaultValues: {
       ...connectionFormOptions.defaultValues,
       name: "test-bond",
-      type: ConnectionType.BOND,
+      type: CONNECTION_TYPE.BOND,
       ...defaultValues,
     },
   });

--- a/web/src/components/network/ConnectionDetails.test.tsx
+++ b/web/src/components/network/ConnectionDetails.test.tsx
@@ -28,10 +28,10 @@ import {
   Connection,
   ConnectionMethod,
   ConnectionState,
-  ConnectionType,
   Device,
   DeviceState,
 } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 
 jest.mock("~/components/network/InstallationOnlySwitch", () => () => (
   <div>InstallationOnlySwitch mock</div>
@@ -40,7 +40,7 @@ jest.mock("~/components/network/InstallationOnlySwitch", () => () => (
 const mockDevice: Device = {
   name: "enp1s0",
   connection: "Network #1",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.69.201", prefix: 24 }],
   nameservers: ["192.168.69.100"],
@@ -56,7 +56,7 @@ const mockDevice: Device = {
 const mockAnotherDevice: Device = {
   name: "enp1s1",
   connection: "Network #1",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.69.101", prefix: 24 }],
   nameservers: ["192.168.69.50"],

--- a/web/src/components/network/ConnectionForm.test.tsx
+++ b/web/src/components/network/ConnectionForm.test.tsx
@@ -28,22 +28,22 @@ import {
   ConnectionMethod,
   ConnectionState,
   ConnectionStatus,
-  ConnectionType,
   DeviceState,
 } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 import ConnectionForm from "~/components/network/ConnectionForm";
 
 const mockDevice1 = {
   name: "enp1s0",
   macAddress: "00:11:22:33:44:55",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
 };
 
 const mockDevice2 = {
   name: "enp2s0",
   macAddress: "AA:BB:CC:DD:EE:FF",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.DISCONNECTED,
 };
 

--- a/web/src/components/network/ConnectionForm.tsx
+++ b/web/src/components/network/ConnectionForm.tsx
@@ -49,6 +49,8 @@ import {
   buildAddress,
   connectionBindingMode,
   connectionType,
+  CONNECTION_TYPE,
+  connectionTypeLabel,
   ensureIPPrefix,
   formatIp,
   generateConnectionName,
@@ -101,11 +103,14 @@ const MODE_TO_METHOD: Record<FormIpMode, ConnectionMethod> = {
  *
  * Sub-components spread these options in their `withForm` definition so
  * TanStack Form can infer the field types, enabling type-safe props.
+ *
+ * Note: Type casts widen literal defaults to their union types, allowing
+ * fields to accept any value from the union, not just the initial value.
  */
 export const connectionFormOptions = formOptions({
   defaultValues: {
     name: "",
-    type: ConnectionType.ETHERNET as ConnectionType,
+    type: CONNECTION_TYPE.ETHERNET as ConnectionType,
     iface: "",
     ifaceMac: "",
     ipv4Mode: FormIpMode.AUTO as FormIpMode,
@@ -127,6 +132,11 @@ export const connectionFormOptions = formOptions({
 });
 
 type FormValues = typeof connectionFormOptions.defaultValues;
+
+/**
+ * Connection types supported by this form.
+ */
+const SUPPORTED_CONNECTION_TYPES = [CONNECTION_TYPE.ETHERNET, CONNECTION_TYPE.BOND] as const;
 
 /**
  * Infers the form IPvX mode from a stored {@link ConnectionMethod} and addresses.
@@ -203,7 +213,7 @@ function buildConnection(formValues: FormValues): Connection {
 
   let iface = "";
 
-  if (formValues.type === ConnectionType.BOND) {
+  if (formValues.type === CONNECTION_TYPE.BOND) {
     iface = formValues.bondIface;
   } else if (formValues.bindingMode === "iface") {
     iface = formValues.iface;
@@ -220,7 +230,7 @@ function buildConnection(formValues: FormValues): Connection {
     nameservers: formValues.customDns ? formValues.nameservers : [],
     dnsSearchList: formValues.customDnsSearch ? formValues.dnsSearchList : [],
     bond:
-      formValues.type === ConnectionType.BOND
+      formValues.type === CONNECTION_TYPE.BOND
         ? {
             mode: formValues.bondMode,
             options: formValues.bondOptions.join(" "),
@@ -296,8 +306,6 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
     listeners: isEditing ? undefined : { onMount: ({ formApi }) => syncName(formApi) },
   });
 
-  const typeOptions = () => ConnectionType.options([ConnectionType.BOND, ConnectionType.ETHERNET]);
-
   return (
     <form.AppForm>
       <Form
@@ -345,7 +353,10 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
                     // TRANSLATORS: checkbox label for custom DNS server configuration.
                     _("Type")
                   }
-                  options={typeOptions()}
+                  options={SUPPORTED_CONNECTION_TYPES.map((type) => ({
+                    value: type,
+                    label: connectionTypeLabel(type),
+                  }))}
                 />
               )}
             </form.AppField>
@@ -365,7 +376,9 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
 
         <form.Subscribe selector={(s) => s.values.type}>
           {(type) =>
-            ([ConnectionType.ETHERNET, ConnectionType.WIFI] as ConnectionType[]).includes(type) && (
+            ([CONNECTION_TYPE.ETHERNET, CONNECTION_TYPE.WIFI] as ConnectionType[]).includes(
+              type,
+            ) && (
               <Flex alignItems={{ default: "alignItemsFlexEnd" }} gap={{ default: "gapMd" }}>
                 <BindingModeSelector form={form} />
 
@@ -396,7 +409,7 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
 
         <form.Subscribe selector={(s) => s.values.type}>
           {(type) =>
-            type === ConnectionType.BOND && <BondSettings form={form} isEditing={isEditing} />
+            type === CONNECTION_TYPE.BOND && <BondSettings form={form} isEditing={isEditing} />
           }
         </form.Subscribe>
 

--- a/web/src/components/network/ConnectionsTable.tsx
+++ b/web/src/components/network/ConnectionsTable.tsx
@@ -45,7 +45,7 @@ import SimpleSelector from "~/components/core/SimpleSelector";
 import { useConnections, useConnectionMutation } from "~/hooks/model/config/network";
 import { useDevices, useSystem } from "~/hooks/model/system/network";
 import { sortCollection } from "~/utils";
-import { connectionType, formatIp } from "~/utils/network";
+import { connectionType, CONNECTION_TYPE, connectionTypeLabel, formatIp } from "~/utils/network";
 import { _ } from "~/i18n";
 import { Connection, ConnectionStatus, ConnectionType, Device } from "~/types/network";
 import { NETWORK } from "~/routes/paths";
@@ -151,7 +151,7 @@ const createColumns = (devices: Device[]) => [
   },
   {
     name: _("Type"),
-    value: (c: Connection) => ConnectionType.label(connectionType(c)),
+    value: (c: Connection) => connectionTypeLabel(connectionType(c)),
     sortingKey: (c: Connection) => connectionType(c),
   },
   {
@@ -281,9 +281,9 @@ export default function ConnectionsTable() {
                 value={state.filters.type}
                 options={{
                   all: _("All"),
-                  [ConnectionType.WIFI]: ConnectionType.label(ConnectionType.WIFI),
-                  [ConnectionType.ETHERNET]: ConnectionType.label(ConnectionType.ETHERNET),
-                  [ConnectionType.BOND]: ConnectionType.label(ConnectionType.BOND),
+                  [CONNECTION_TYPE.WIFI]: connectionTypeLabel(CONNECTION_TYPE.WIFI),
+                  [CONNECTION_TYPE.ETHERNET]: connectionTypeLabel(CONNECTION_TYPE.ETHERNET),
+                  [CONNECTION_TYPE.BOND]: connectionTypeLabel(CONNECTION_TYPE.BOND),
                 }}
                 onChange={(_, v) => onFilterChange("type", v)}
               />

--- a/web/src/components/network/DeviceSelector.test.tsx
+++ b/web/src/components/network/DeviceSelector.test.tsx
@@ -24,7 +24,8 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { useAppForm } from "~/hooks/form";
-import { ConnectionType, DeviceState } from "~/types/network";
+import { DeviceState } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 import { connectionFormOptions } from "~/components/network/ConnectionForm";
 import DeviceSelector from "./DeviceSelector";
 
@@ -32,13 +33,13 @@ const mockDevices = [
   {
     name: "enp1s0",
     macAddress: "00:11:22:33:44:55",
-    type: ConnectionType.ETHERNET,
+    type: CONNECTION_TYPE.ETHERNET,
     state: DeviceState.CONNECTED,
   },
   {
     name: "enp2s0",
     macAddress: "AA:BB:CC:DD:EE:FF",
-    type: ConnectionType.ETHERNET,
+    type: CONNECTION_TYPE.ETHERNET,
     state: DeviceState.DISCONNECTED,
   },
 ];

--- a/web/src/components/network/DevicesSelector.test.tsx
+++ b/web/src/components/network/DevicesSelector.test.tsx
@@ -24,12 +24,13 @@ import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import DevicesSelector from "./DevicesSelector";
-import { ConnectionMethod, ConnectionType, Device, DeviceState } from "~/types/network";
+import { ConnectionMethod, Device, DeviceState } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 
 const mockDevice1: Device = {
   name: "enp1s0",
   connection: "Network 1",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.69.201", prefix: 24 }],
   nameservers: ["192.168.69.100"],
@@ -46,7 +47,7 @@ const mockDevice1: Device = {
 const mockDevice2: Device = {
   name: "wlan0",
   connection: "Network 2",
-  type: ConnectionType.WIFI,
+  type: CONNECTION_TYPE.WIFI,
   state: DeviceState.DISCONNECTED,
   addresses: [{ address: "192.168.1.50", prefix: 24 }],
   nameservers: [],

--- a/web/src/components/network/DevicesSelector.tsx
+++ b/web/src/components/network/DevicesSelector.tsx
@@ -23,7 +23,8 @@
 import React from "react";
 import { sprintf } from "sprintf-js";
 import { FormSelect, FormSelectOption, FormSelectProps } from "@patternfly/react-core";
-import { ConnectionType, Device } from "~/types/network";
+import { Device } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 import { useDevices, useSystem } from "~/hooks/model/system/network";
 import { _ } from "~/i18n";
 
@@ -59,7 +60,7 @@ export default function DevicesSelector({
 
   const filteredDevices = state.wirelessEnabled
     ? devices
-    : devices.filter((d) => d.type !== ConnectionType.WIFI);
+    : devices.filter((d) => d.type !== CONNECTION_TYPE.WIFI);
 
   const labelAttrs = valueKey === "macAddress" ? ["macAddress", "name"] : ["name", "macAddress"];
 

--- a/web/src/components/network/WifiNetworksList.test.tsx
+++ b/web/src/components/network/WifiNetworksList.test.tsx
@@ -27,18 +27,18 @@ import {
   Connection,
   ConnectionMethod,
   ConnectionState,
-  ConnectionType,
   Device,
   DeviceState,
   SecurityProtocols,
   WifiNetwork,
   WifiNetworkStatus,
 } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 
 const wlan0: Device = {
   name: "wlan0",
   connection: "Network 1",
-  type: ConnectionType.WIFI,
+  type: CONNECTION_TYPE.WIFI,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.69.201", prefix: 24 }],
   nameservers: ["192.168.69.1"],

--- a/web/src/components/network/connectionFormValidation.ts
+++ b/web/src/components/network/connectionFormValidation.ts
@@ -37,8 +37,9 @@
 
 import { sprintf } from "sprintf-js";
 import { isEmpty, shake } from "radashi";
-import { BondMode, ConnectionType } from "~/types/network";
+import { BondMode } from "~/types/network";
 import {
+  CONNECTION_TYPE,
   isValidIPv4,
   isValidIPv6,
   isValidIPv4Address,
@@ -218,7 +219,7 @@ function validateCommonFields(formValues: FormValues): Partial<FormFieldErrors> 
  * Validates bond-specific fields.
  */
 function validateBondFields(formValues: FormValues): Partial<FormFieldErrors> {
-  if (formValues.type !== ConnectionType.BOND) return {};
+  if (formValues.type !== CONNECTION_TYPE.BOND) return {};
 
   return {
     // TRANSLATORS: validation error for the bond device name field.

--- a/web/src/hooks/model/system/network.test.ts
+++ b/web/src/hooks/model/system/network.test.ts
@@ -25,10 +25,10 @@ import {
   Connection,
   ConnectionMethod,
   ConnectionState,
-  ConnectionType,
   Device,
   DeviceState,
 } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
 
 const createConnection = (
   id: string,
@@ -45,7 +45,7 @@ const createConnection = (
 
 const createDevice = (overrides: Partial<Device> = {}): Device => ({
   name: "eth0",
-  type: ConnectionType.ETHERNET,
+  type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.1.100", prefix: 24 }],
   nameservers: [],
@@ -229,7 +229,7 @@ describe("getIpAddresses", () => {
     const linkedDevice = createDevice({ connection: connection.id });
     const unlinkedDevice = createDevice({
       name: "wlan0",
-      type: ConnectionType.WIFI,
+      type: CONNECTION_TYPE.WIFI,
       state: DeviceState.DISCONNECTED,
       addresses: [{ address: "192.168.1.200", prefix: 24 }],
       gateway4: "",
@@ -256,7 +256,7 @@ describe("getIpAddresses", () => {
     const device2 = createDevice({
       name: "wlan0",
       connection: connection2.id,
-      type: ConnectionType.WIFI,
+      type: CONNECTION_TYPE.WIFI,
       addresses: [{ address: "10.0.0.50", prefix: 8 }],
       gateway4: "10.0.0.1",
       macAddress: "BB:11:22:33:44:55",

--- a/web/src/types/network.ts
+++ b/web/src/types/network.ts
@@ -21,7 +21,6 @@
  */
 
 import { isBoolean, isEmpty, isObject } from "radashi";
-import { _, N_ } from "~/i18n";
 import {
   buildAddress,
   buildAddresses,
@@ -30,39 +29,17 @@ import {
   securityFromFlags,
 } from "~/utils/network";
 
-const connectionTypeValues = {
-  ETHERNET: "ethernet",
-  WIFI: "wireless",
-  LOOPBACK: "loopback",
-  BOND: "bond",
-  BRIDGE: "bridge",
-  VLAN: "vlan",
-  UNKNOWN: "unknown",
-} as const;
-
-export type ConnectionType = (typeof connectionTypeValues)[keyof typeof connectionTypeValues];
-
-const connectionTypeLabels: Record<ConnectionType, string> = {
-  [connectionTypeValues.ETHERNET]: N_("Ethernet"),
-  [connectionTypeValues.WIFI]: N_("Wi-Fi"),
-  [connectionTypeValues.LOOPBACK]: N_("Loopback"),
-  [connectionTypeValues.BOND]: N_("Bond"),
-  [connectionTypeValues.BRIDGE]: N_("Bridge"),
-  [connectionTypeValues.VLAN]: N_("VLAN"),
-  [connectionTypeValues.UNKNOWN]: N_("Unknown"),
-};
-
-export const ConnectionType = {
-  ...connectionTypeValues,
-
-  /** Returns the translated label for the connection type */
-  // eslint-disable-next-line agama-i18n/string-literals
-  label: (type: ConnectionType): string => _(connectionTypeLabels[type]),
-
-  /** Returns options for a dropdown/select component */
-  options: (types: ConnectionType[]): { value: ConnectionType; label: string }[] =>
-    types.map((type) => ({ value: type, label: ConnectionType.label(type) })),
-};
+/**
+ * Union type of all connection type string values.
+ */
+export type ConnectionType =
+  | "ethernet"
+  | "wireless"
+  | "loopback"
+  | "bond"
+  | "bridge"
+  | "vlan"
+  | "unknown";
 
 /**
  * Enum for AccessPoint flags

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -34,6 +34,41 @@ import {
   Route,
   SecurityProtocols,
 } from "~/types/network";
+import { _, N_ } from "~/i18n";
+
+/**
+ * Connection type constants.
+ *
+ * TypeScript enforces that all values match the ConnectionType union.
+ */
+export const CONNECTION_TYPE = {
+  ETHERNET: "ethernet",
+  WIFI: "wireless",
+  LOOPBACK: "loopback",
+  BOND: "bond",
+  BRIDGE: "bridge",
+  VLAN: "vlan",
+  UNKNOWN: "unknown",
+} as const satisfies Record<string, ConnectionType>;
+
+/**
+ * Translatable labels for connection types.
+ */
+const CONNECTION_TYPE_LABELS: Record<ConnectionType, string> = {
+  [CONNECTION_TYPE.ETHERNET]: N_("Ethernet"),
+  [CONNECTION_TYPE.WIFI]: N_("Wi-Fi"),
+  [CONNECTION_TYPE.LOOPBACK]: N_("Loopback"),
+  [CONNECTION_TYPE.BOND]: N_("Bond"),
+  [CONNECTION_TYPE.BRIDGE]: N_("Bridge"),
+  [CONNECTION_TYPE.VLAN]: N_("VLAN"),
+  [CONNECTION_TYPE.UNKNOWN]: N_("Unknown"),
+};
+
+/**
+ * Returns the translated label for a connection type.
+ */
+// eslint-disable-next-line agama-i18n/string-literals
+const connectionTypeLabel = (type: ConnectionType): string => _(CONNECTION_TYPE_LABELS[type]);
 
 /**
  * Returns the type for the given connection.
@@ -41,11 +76,11 @@ import {
 const connectionType = (connection: Connection): ConnectionType => {
   const { wireless, bond } = connection;
   if (wireless) {
-    return ConnectionType.WIFI;
+    return CONNECTION_TYPE.WIFI;
   } else if (bond) {
-    return ConnectionType.BOND;
+    return CONNECTION_TYPE.BOND;
   } else {
-    return ConnectionType.ETHERNET;
+    return CONNECTION_TYPE.ETHERNET;
   }
 };
 
@@ -353,6 +388,7 @@ export {
   connectionAddresses,
   connectionBindingMode,
   connectionType,
+  connectionTypeLabel,
   ensureIPPrefix,
   formatIp,
   generateConnectionName,


### PR DESCRIPTION
The previous implementation mixed type definitions with UI logic by placing `ConnectionType.label()` and `ConnectionType.options()` directly in `types/network.ts`.

Before:

  - The types module imported i18n functions for translations.
  - `ConnectionType` included UI helper methods (`.label()`, `.options()`).

Now:

  - Types no longer contain UI responsibilities.
  - Introduces a standalone utility to retrieve human-readable labels for connection types.
