### PR TITLE
Fix set resolvables

### DIFF
--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -147,12 +147,12 @@ pub fn server_with_state(state: ServerState) -> Result<ApiRouter, ServiceError> 
                 .patch_with(update_question, update_question_docs),
         )
         .api_route("/licenses/{id}", get_with(get_license, get_license_docs))
-        .route("/resolvables/{id}", put(set_resolvables))
         .route(
             "/private/storage_model",
             get(get_storage_model).put(set_storage_model),
         )
         .route("/private/solve_storage_model", get(solve_storage_model))
+        .route("/private/resolvables/{id}", put(set_resolvables))
         .route("/private/download_logs", get(download_logs))
         .route("/private/password_check", post(check_password))
         .with_state(state))

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 28 11:02:40 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the path to the /private/resolvables/{id} endpoint (bsc#1262995).
+
+-------------------------------------------------------------------
 Mon Apr 27 16:12:45 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Prefer local media to download (gh#agama-project/agama#3405),


### PR DESCRIPTION
## Problem

- [Trello](https://trello.com/c/vwpkfnzO/5714-1262995-tw-cannot-boot-grub-not-installed-404-api-v2-private-resolvables-agama-bootloader)
- [bsc#1262995](https://bugzilla.suse.com/show_bug.cgi?id=1262995)


## Solution

Fix the path (and put it where it was before the wrong change in #3414.