### PR TITLE
Added "agama-journal" and "agama-zypp-journal" to the default bash history

### DIFF
--- a/live/live-root/root/.bash_history
+++ b/live/live-root/root/.bash_history
@@ -1,10 +1,10 @@
 mount | cut -f3 -d" " | grep /mnt | sort -r | xargs -r umount; swapon --show=NAME --noheadings | grep -v zram | xargs -r swapoff
 systemctl restart agama.service agama-web-server.service
 less /var/log/YaST2/y2log
-journalctl -u agama-web-server.service
-journalctl -u agama.service
+journalctl -t live-self-update
 systemctl status agama-web-server.service
 systemctl status agama.service
-journalctl -t live-self-update
+agama-zypp-journal
+agama-journal
 agama config show | jq
 agama logs store


### PR DESCRIPTION
## Description

- Use the `agama-journal` and `agama-zypp-journal` in the default Bash history instead of the old `journalctl` commands. These display more details like source code location.