### PR TITLE
feat(web): handle unavailable software selection

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr 28 15:43:35 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Show contextual hints when software selection is unavailable and
+  handle empty states when no patterns are available
+  (gh#agama-project/agama#3441, related to gh#agama-project/agama#3436
+  and gh#agama-project/agama#3420).
+
+-------------------------------------------------------------------
 Mon Apr 27 11:00:16 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Handle desktop selection when no desktop environments are available

--- a/web/src/components/layout/Icon.tsx
+++ b/web/src/components/layout/Icon.tsx
@@ -28,6 +28,7 @@ import React from "react";
 import Add from "@icons/add.svg?component";
 import AddCircle from "@icons/add_circle.svg?component";
 import Apps from "@icons/apps.svg?component";
+import AppsOutage from "@icons/apps_outage.svg?component";
 import AppRegistration from "@icons/app_registration.svg?component";
 import ArrowDropDown from "@icons/arrow_drop_down.svg?component";
 import Backspace from "@icons/backspace.svg?component";
@@ -78,6 +79,7 @@ const icons = {
   add: Add,
   add_circle: AddCircle,
   apps: Apps,
+  apps_outage: AppsOutage,
   app_registration: AppRegistration,
   arrow_drop_down: ArrowDropDown,
   backspace: Backspace,

--- a/web/src/components/software/PatternSelectionUnavailable.test.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.test.tsx
@@ -26,14 +26,20 @@ import { installerRender } from "~/test-utils";
 import PatternSelectionUnavailable from "./PatternSelectionUnavailable";
 
 const mockUseIssues = jest.fn();
+const mockUseAvailablePatterns = jest.fn();
 
 jest.mock("~/hooks/model/issue", () => ({
   useIssues: (scope) => mockUseIssues(scope),
 }));
 
+jest.mock("~/hooks/model/system/software", () => ({
+  useAvailablePatterns: () => mockUseAvailablePatterns(),
+}));
+
 describe("PatternSelectionUnavailable", () => {
   it("renders the unavailable message", () => {
     mockUseIssues.mockReturnValue([]);
+    mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
     installerRender(<PatternSelectionUnavailable />);
     screen.getByText("Software selection is not available");
@@ -48,6 +54,7 @@ describe("PatternSelectionUnavailable", () => {
           description: "Product registration is required",
         },
       ]);
+      mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
       installerRender(<PatternSelectionUnavailable />);
       screen.getByText("Product registration is required");
@@ -61,6 +68,7 @@ describe("PatternSelectionUnavailable", () => {
           description: "Product registration is required",
         },
       ]);
+      mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
       installerRender(<PatternSelectionUnavailable />);
       const link = screen.getByRole("link", { name: /Go to registration/ });
@@ -77,6 +85,7 @@ describe("PatternSelectionUnavailable", () => {
           description: "Base product is not available",
         },
       ]);
+      mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
       installerRender(<PatternSelectionUnavailable />);
       screen.getByText("Base product is not available");
@@ -90,6 +99,7 @@ describe("PatternSelectionUnavailable", () => {
           description: "Base product is not available",
         },
       ]);
+      mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
       installerRender(<PatternSelectionUnavailable />);
       screen.getByText(/This might be due to network connectivity/);
@@ -103,6 +113,7 @@ describe("PatternSelectionUnavailable", () => {
           description: "Base product is not available",
         },
       ]);
+      mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
       installerRender(<PatternSelectionUnavailable />);
       const link = screen.getByRole("link", { name: /Go to network settings/ });
@@ -111,11 +122,48 @@ describe("PatternSelectionUnavailable", () => {
   });
 
   describe("when there are no product issues", () => {
-    it("does not show any links", () => {
-      mockUseIssues.mockReturnValue([]);
+    describe("and there are zero patterns available", () => {
+      it("shows message about adding software after installation", () => {
+        mockUseIssues.mockReturnValue([]);
+        mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
-      installerRender(<PatternSelectionUnavailable />);
-      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+        installerRender(<PatternSelectionUnavailable />);
+        screen.getByText(/This product does not allow selecting software at installation time/);
+      });
+
+      it("does not show any links", () => {
+        mockUseIssues.mockReturnValue([]);
+        mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
+
+        installerRender(<PatternSelectionUnavailable />);
+        expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("and patterns exist but selection could not be loaded", () => {
+      it("shows generic error message", () => {
+        mockUseIssues.mockReturnValue([]);
+        mockUseAvailablePatterns.mockReturnValue({
+          all: [{ name: "base", summary: "Base System", description: "...", desktop: false }],
+          desktops: [],
+          other: [{ name: "base", summary: "Base System", description: "...", desktop: false }],
+        });
+
+        installerRender(<PatternSelectionUnavailable />);
+        screen.getByText(/The software selection could not be loaded/);
+      });
+
+      it("does not show any links", () => {
+        mockUseIssues.mockReturnValue([]);
+        mockUseAvailablePatterns.mockReturnValue({
+          all: [{ name: "base", summary: "Base System", description: "...", desktop: false }],
+          desktops: [],
+          other: [{ name: "base", summary: "Base System", description: "...", desktop: false }],
+        });
+
+        installerRender(<PatternSelectionUnavailable />);
+        expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/web/src/components/software/PatternSelectionUnavailable.test.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender } from "~/test-utils";
+import PatternSelectionUnavailable from "./PatternSelectionUnavailable";
+
+const mockUseIssues = jest.fn();
+
+jest.mock("~/hooks/model/issue", () => ({
+  useIssues: (scope) => mockUseIssues(scope),
+}));
+
+describe("PatternSelectionUnavailable", () => {
+  it("renders the unavailable message", () => {
+    mockUseIssues.mockReturnValue([]);
+
+    installerRender(<PatternSelectionUnavailable />);
+    screen.getByText("Software selection is not available");
+  });
+
+  describe("when there is a missing_registration issue", () => {
+    it("shows the issue description", () => {
+      mockUseIssues.mockReturnValue([
+        {
+          scope: "product",
+          class: "missing_registration",
+          description: "Product registration is required",
+        },
+      ]);
+
+      installerRender(<PatternSelectionUnavailable />);
+      screen.getByText("Product registration is required");
+    });
+
+    it("shows a link to registration", () => {
+      mockUseIssues.mockReturnValue([
+        {
+          scope: "product",
+          class: "missing_registration",
+          description: "Product registration is required",
+        },
+      ]);
+
+      installerRender(<PatternSelectionUnavailable />);
+      const link = screen.getByRole("link", { name: /Go to registration/ });
+      expect(link).toHaveAttribute("href", "/registration");
+    });
+  });
+
+  describe("when there is a missing_product issue", () => {
+    it("shows the issue description", () => {
+      mockUseIssues.mockReturnValue([
+        {
+          scope: "product",
+          class: "missing_product",
+          description: "Base product is not available",
+        },
+      ]);
+
+      installerRender(<PatternSelectionUnavailable />);
+      screen.getByText("Base product is not available");
+    });
+
+    it("shows an additional hint about network connectivity", () => {
+      mockUseIssues.mockReturnValue([
+        {
+          scope: "product",
+          class: "missing_product",
+          description: "Base product is not available",
+        },
+      ]);
+
+      installerRender(<PatternSelectionUnavailable />);
+      screen.getByText(/This might be due to network connectivity/);
+    });
+
+    it("shows a link to network settings", () => {
+      mockUseIssues.mockReturnValue([
+        {
+          scope: "product",
+          class: "missing_product",
+          description: "Base product is not available",
+        },
+      ]);
+
+      installerRender(<PatternSelectionUnavailable />);
+      const link = screen.getByRole("link", { name: /Go to network settings/ });
+      expect(link).toHaveAttribute("href", "/network");
+    });
+  });
+
+  describe("when there are no product issues", () => {
+    it("does not show any links", () => {
+      mockUseIssues.mockReturnValue([]);
+
+      installerRender(<PatternSelectionUnavailable />);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/software/PatternSelectionUnavailable.test.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.test.tsx
@@ -128,7 +128,7 @@ describe("PatternSelectionUnavailable", () => {
         mockUseAvailablePatterns.mockReturnValue({ all: [], desktops: [], other: [] });
 
         installerRender(<PatternSelectionUnavailable />);
-        screen.getByText(/This product does not allow selecting software at installation time/);
+        screen.getByText(/Additional software can be added after the installation is complete/);
       });
 
       it("does not show any links", () => {

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -139,7 +139,7 @@ export default function PatternSelectionUnavailable() {
         description={
           // TRANSLATORS: shown when the product provides zero patterns
           _(
-            "This product does not allow selecting software at installation time. You can add additional software after the installation is complete.",
+            "This product does not allow selecting software at installation time. Additional software can be added after the installation is complete.",
           )
         }
       />

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -31,69 +31,127 @@ import {
 import { Icon } from "~/components/layout";
 import Link from "~/components/core/Link";
 import { useIssues } from "~/hooks/model/issue";
+import { useAvailablePatterns } from "~/hooks/model/system/software";
 import { REGISTRATION, NETWORK } from "~/routes/paths";
 import { _ } from "~/i18n";
+
+const EmptyStateIcon = () => <Icon name="apps_outage" />;
+
+type UnavailableStateProps = {
+  /** Optional title for the empty state. */
+  title?: React.ReactNode;
+  /** Main description text explaining why software selection is unavailable. */
+  description: React.ReactNode;
+  /** Optional additional hint text displayed below the description. */
+  hint?: string;
+  /** Optional action link with destination path and label. */
+  actionLink?: { to: string; label: string };
+};
+
+/**
+ * Base empty state component for unavailable software selection scenarios.
+ *
+ * Renders a consistent empty state with an icon, title, description, optional
+ * hint, and optional action link. Used to display different messages based on
+ * why software selection is unavailable.
+ */
+const UnavailableState = ({
+  // TRANSLATORS: empty state title when software cannot be selected
+  title = _("Software selection is not available"),
+  description,
+  hint,
+  actionLink,
+}: UnavailableStateProps) => {
+  return (
+    <EmptyState headingLevel="h2" titleText={title} variant="lg" icon={EmptyStateIcon}>
+      <EmptyStateBody>
+        <Content component="p" isEditorial>
+          {description}
+        </Content>
+        {hint && <Content component="small">{hint}</Content>}
+      </EmptyStateBody>
+      {actionLink && (
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Link to={actionLink.to} variant="link" isInline>
+              {actionLink.label}
+            </Link>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      )}
+    </EmptyState>
+  );
+};
 
 /**
  * Empty state shown when software selection is unavailable.
  *
- * This happens when there are product issues preventing software selection:
- * - missing_registration: base product missing because not registered
- * - missing_product: base product missing
+ * Displays contextual messages and actions based on why software cannot be
+ * selected:
  *
- * The component reads product issues from the backend and displays the appropriate
- * description and action links.
+ *   - Missing registration: prompts to complete product registration
+ *   - Missing product: suggests checking network connectivity and settings
+ *   - No software available: informs that software can be added after
+ *     installation
  */
 export default function PatternSelectionUnavailable() {
   const issues = useIssues("product");
+  const { all: patterns } = useAvailablePatterns();
 
   const missingRegistration = issues.find((i) => i.class === "missing_registration");
   const missingProduct = issues.find((i) => i.class === "missing_product");
 
-  const EmptyStateIcon = () => <Icon name="apps_outage" />;
+  if (missingRegistration) {
+    return (
+      <UnavailableState
+        description={missingRegistration.description}
+        actionLink={{
+          to: REGISTRATION.root,
+          label:
+            // TRANSLATORS: link to go to registration settings
+            _("Go to registration"),
+        }}
+      />
+    );
+  }
+
+  if (missingProduct) {
+    return (
+      <UnavailableState
+        description={missingProduct.description}
+        hint={
+          // TRANSLATORS: additional hint when base product is missing
+          _("This might be due to network connectivity.")
+        }
+        actionLink={{
+          to: NETWORK.root,
+          label:
+            // TRANSLATORS: link to go to network settings
+            _("Go to network settings"),
+        }}
+      />
+    );
+  }
+
+  if (patterns.length === 0) {
+    return (
+      <UnavailableState
+        description={
+          // TRANSLATORS: shown when the product provides zero patterns
+          _(
+            "This product does not allow selecting software at installation time. You can add additional software after the installation is complete.",
+          )
+        }
+      />
+    );
+  }
 
   return (
-    // TRANSLATORS: empty state title when software cannot be selected
-    <EmptyState
-      headingLevel="h2"
-      titleText={_("Software selection is not available")}
-      variant="lg"
-      icon={EmptyStateIcon}
-    >
-      <EmptyStateBody>
-        {missingRegistration && (
-          <Content component="p" isEditorial>
-            {missingRegistration.description}
-          </Content>
-        )}
-        {missingProduct && (
-          <>
-            <Content component="p" isEditorial>
-              {missingProduct.description}
-            </Content>
-            <Content component="small">
-              {/* TRANSLATORS: additional hint when base product is missing */}
-              {_("This might be due to network connectivity.")}
-            </Content>
-          </>
-        )}
-      </EmptyStateBody>
-      <EmptyStateFooter>
-        <EmptyStateActions>
-          {missingRegistration && (
-            <Link to={REGISTRATION.root} variant="link" isInline>
-              {/* TRANSLATORS: link to go to registration settings */}
-              {_("Go to registration")}
-            </Link>
-          )}
-          {missingProduct && (
-            <Link to={NETWORK.root} variant="link" isInline>
-              {/* TRANSLATORS: link to go to network settings */}
-              {_("Go to network settings")}
-            </Link>
-          )}
-        </EmptyStateActions>
-      </EmptyStateFooter>
-    </EmptyState>
+    <UnavailableState
+      description={
+        // TRANSLATORS: shown when software selection cannot be determined
+        _("The software selection could not be loaded.")
+      }
+    />
   );
 }

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import {
+  Content,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+} from "@patternfly/react-core";
+import { Icon } from "~/components/layout";
+import Link from "~/components/core/Link";
+import { useIssues } from "~/hooks/model/issue";
+import { REGISTRATION, NETWORK } from "~/routes/paths";
+import { _ } from "~/i18n";
+
+/**
+ * Empty state shown when software selection is unavailable.
+ *
+ * This happens when there are product issues preventing software selection:
+ * - missing_registration: base product missing because not registered
+ * - missing_product: base product missing
+ *
+ * The component reads product issues from the backend and displays the appropriate
+ * description and action links.
+ */
+export default function PatternSelectionUnavailable() {
+  const issues = useIssues("product");
+
+  const missingRegistration = issues.find((i) => i.class === "missing_registration");
+  const missingProduct = issues.find((i) => i.class === "missing_product");
+
+  const EmptyStateIcon = () => <Icon name="apps_outage" />;
+
+  return (
+    // TRANSLATORS: empty state title when software cannot be selected
+    <EmptyState
+      headingLevel="h2"
+      titleText={_("Software selection is not available")}
+      variant="lg"
+      icon={EmptyStateIcon}
+    >
+      <EmptyStateBody>
+        {missingRegistration && (
+          <Content component="p" isEditorial>
+            {missingRegistration.description}
+          </Content>
+        )}
+        {missingProduct && (
+          <>
+            <Content component="p" isEditorial>
+              {missingProduct.description}
+            </Content>
+            <Content component="small">
+              {/* TRANSLATORS: additional hint when base product is missing */}
+              {_("This might be due to network connectivity.")}
+            </Content>
+          </>
+        )}
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          {missingRegistration && (
+            <Link to={REGISTRATION.root} variant="link" isInline>
+              {/* TRANSLATORS: link to go to registration settings */}
+              {_("Go to registration")}
+            </Link>
+          )}
+          {missingProduct && (
+            <Link to={NETWORK.root} variant="link" isInline>
+              {/* TRANSLATORS: link to go to network settings */}
+              {_("Go to network settings")}
+            </Link>
+          )}
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+}

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -28,6 +28,7 @@ import testingProposal from "./proposal.test.json";
 import SoftwarePage from "./SoftwarePage";
 
 const mockProposal = jest.fn();
+const mockAvailablePatterns = jest.fn();
 
 const desktops = testingPatterns.filter((p) => p.desktop);
 const other = testingPatterns.filter((p) => !p.desktop);
@@ -44,16 +45,17 @@ jest.mock("~/hooks/model/proposal/software", () => ({
 }));
 
 jest.mock("~/hooks/model/system/software", () => ({
-  useAvailablePatterns: () => ({
-    all: testingPatterns,
-    desktops,
-    other,
-  }),
+  useAvailablePatterns: () => mockAvailablePatterns(),
 }));
 
 describe("SoftwarePage", () => {
   beforeEach(() => {
     mockProposal.mockReturnValue(testingProposal);
+    mockAvailablePatterns.mockReturnValue({
+      all: testingPatterns,
+      desktops,
+      other,
+    });
   });
 
   it("renders the Desktops section with the selected desktop", () => {
@@ -199,6 +201,40 @@ describe("SoftwarePage", () => {
     it("renders an informative message", () => {
       installerRender(<SoftwarePage />);
       screen.getByText("No information available yet");
+    });
+  });
+
+  describe("when the product provides no desktops", () => {
+    beforeEach(() => {
+      mockAvailablePatterns.mockReturnValue({
+        all: other,
+        desktops: [],
+        other,
+      });
+    });
+
+    it("shows an informative empty state instead of selection UI", () => {
+      installerRender(<SoftwarePage />);
+      screen.getByText("No desktops available");
+      screen.getByText("This product does not provide desktop environments.");
+      expect(screen.queryByRole("link", { name: /Select a desktop/ })).toBeNull();
+    });
+  });
+
+  describe("when the product provides no additional patterns", () => {
+    beforeEach(() => {
+      mockAvailablePatterns.mockReturnValue({
+        all: desktops,
+        desktops,
+        other: [],
+      });
+    });
+
+    it("shows an informative empty state instead of selection UI", () => {
+      installerRender(<SoftwarePage />);
+      screen.getByText("No additional patterns available");
+      screen.getByText("This product does not provide additional patterns.");
+      expect(screen.queryByRole("link", { name: /Select patterns/ })).toBeNull();
     });
   });
 });

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -82,15 +82,11 @@ const NothingSelected = ({
 );
 
 /**
- * Informational empty state shown when no desktop patterns are available.
+ * Informational empty state shown when patterns are not available.
  */
-const NoDesktopsAvailable = () => (
-  // TRANSLATORS: empty state title when no desktop environments are available
-  <EmptyState headingLevel="h4" titleText={_("No desktops available")} variant="sm">
-    <EmptyStateBody>
-      {/* TRANSLATORS: explanation shown when the product has no desktop environments */}
-      {_("This product does not provide desktop environments.")}
-    </EmptyStateBody>
+const NoAvailable = ({ title, body }: { title: string; body: string }) => (
+  <EmptyState headingLevel="h4" titleText={title} variant="sm">
+    <EmptyStateBody>{body}</EmptyStateBody>
   </EmptyState>
 );
 
@@ -286,6 +282,42 @@ const SoftwarePageContent = () => {
 
   if (isEmpty(proposal.patterns)) return <PatternSelectionUnavailable />;
 
+  const desktopsEmptyContent =
+    allDesktops.length === 0 ? (
+      <NoAvailable
+        // TRANSLATORS: empty state title when no desktop environments are available
+        title={_("No desktops available")}
+        // TRANSLATORS: explanation shown when the product has no desktop environments
+        body={_("This product does not provide desktop environments.")}
+      />
+    ) : (
+      <NothingSelected
+        to={PATHS.desktopSelection}
+        // TRANSLATORS: hint shown when no desktop environment has been chosen
+        body={_("Select a desktop environment to get a graphical interface.")}
+        // TRANSLATORS: button to go to the desktop environment selection page
+        buttonText={_("Select a desktop")}
+      />
+    );
+
+  const additionalPatternsEmptyContent =
+    allOtherPatterns.length === 0 ? (
+      <NoAvailable
+        // TRANSLATORS: empty state title when no additional patterns are available
+        title={_("No additional patterns available")}
+        // TRANSLATORS: explanation shown when the product has no additional patterns
+        body={_("This product does not provide additional patterns.")}
+      />
+    ) : (
+      <NothingSelected
+        to={PATHS.patternsSelection}
+        // TRANSLATORS: hint shown when no additional software patterns have been chosen
+        body={_("Select one or more to extend the system.")}
+        // TRANSLATORS: button to go to the pattern selection page
+        buttonText={_("Select patterns")}
+      />
+    );
+
   return (
     <>
       <Content>
@@ -307,19 +339,7 @@ const SoftwarePageContent = () => {
             patterns={desktops}
             selection={proposal.patterns}
             selectionPath={PATHS.desktopSelection}
-            emptyContent={
-              allDesktops.length === 0 ? (
-                <NoDesktopsAvailable />
-              ) : (
-                <NothingSelected
-                  to={PATHS.desktopSelection}
-                  // TRANSLATORS: hint shown when no desktop environment has been chosen
-                  body={_("Select a desktop environment to get a graphical interface.")}
-                  // TRANSLATORS: button to go to the desktop environment selection page
-                  buttonText={_("Select a desktop")}
-                />
-              )
-            }
+            emptyContent={desktopsEmptyContent}
           />
         </GridItem>
         <GridItem lg={6}>
@@ -335,15 +355,7 @@ const SoftwarePageContent = () => {
             patterns={otherPatterns}
             selection={proposal.patterns}
             selectionPath={PATHS.patternsSelection}
-            emptyContent={
-              <NothingSelected
-                to={PATHS.patternsSelection}
-                // TRANSLATORS: hint shown when no additional software patterns have been chosen
-                body={_("Select one or more to extend the system.")}
-                // TRANSLATORS: button to go to the pattern selection page
-                buttonText={_("Select patterns")}
-              />
-            }
+            emptyContent={additionalPatternsEmptyContent}
           />
         </GridItem>
       </Grid>

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -44,6 +44,7 @@ import Page from "~/components/core/Page";
 import SubtleContent from "~/components/core/SubtleContent";
 import Text from "~/components/core/Text";
 import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
+import PatternSelectionUnavailable from "~/components/software/PatternSelectionUnavailable";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useAvailablePatterns } from "~/hooks/model/system/software";
@@ -265,27 +266,11 @@ const SoftwareSection = ({
 };
 
 /**
- * Fallback section shown when the product does not support pattern selection.
- */
-const PatternSelectionUnavailable = () => (
-  <Page.Section title={_("Patterns")}>
-    <Content component="p">
-      {/* TRANSLATORS: shown when the product does not support pattern selection at install time */}
-      {_(
-        "This product does not allow to select software patterns during installation. \
-However, you can add additional software once the installation is finished.",
-      )}
-    </Content>
-  </Page.Section>
-);
-
-/**
  * Main content of the software page.
  */
 const SoftwarePageContent = () => {
   const { all: patterns, desktops: allDesktops, other: allOtherPatterns } = useAvailablePatterns();
   const proposal = useProposal();
-  const issues = useIssues("software");
 
   if (!proposal) {
     // TRANSLATORS: shown while the software proposal is not yet available
@@ -299,73 +284,70 @@ const SoftwarePageContent = () => {
   const selectedPatterns = patterns.filter((p) => isPatternSelected(proposal.patterns, p.name));
   const [desktops, otherPatterns] = fork(selectedPatterns, (p) => p.desktop);
 
+  if (isEmpty(proposal.patterns)) return <PatternSelectionUnavailable />;
+
   return (
-    <Page.Content>
+    <>
       <Content>
         <SpaceRequirements usedSize={usedSize} hasSelection={selectedPatterns.length > 0} />
       </Content>
-      <IssuesAlert issues={issues} />
-      {isEmpty(proposal.patterns) ? (
-        <PatternSelectionUnavailable />
-      ) : (
-        <Grid hasGutter>
-          <GridItem lg={6}>
-            <SoftwareSection
-              title={_("Desktops")}
-              description={_(
-                // TRANSLATORS: description for the Desktops section
-                "Graphical desktop environments for the system.",
-              )}
-              buttonText={
-                // TRANSLATORS: button to change the desktop selection
-                n_("Change desktop", "Change desktops", desktops.length)
-              }
-              totalCount={allDesktops.length}
-              patterns={desktops}
-              selection={proposal.patterns}
-              selectionPath={PATHS.desktopSelection}
-              emptyContent={
-                allDesktops.length === 0 ? (
-                  <NoDesktopsAvailable />
-                ) : (
-                  <NothingSelected
-                    to={PATHS.desktopSelection}
-                    // TRANSLATORS: hint shown when no desktop environment has been chosen
-                    body={_("Select a desktop environment to get a graphical interface.")}
-                    // TRANSLATORS: button to go to the desktop environment selection page
-                    buttonText={_("Select a desktop")}
-                  />
-                )
-              }
-            />
-          </GridItem>
-          <GridItem lg={6}>
-            <SoftwareSection
-              title={_("Additional patterns")}
-              description={_(
-                // TRANSLATORS: description for the Additional software section
-                "Curated sets of packages for common use cases and features to extend the system.",
-              )}
-              // TRANSLATORS: button to change the additional software selection
-              buttonText={_("Change patterns")}
-              totalCount={allOtherPatterns.length}
-              patterns={otherPatterns}
-              selection={proposal.patterns}
-              selectionPath={PATHS.patternsSelection}
-              emptyContent={
+      <Grid hasGutter>
+        <GridItem lg={6}>
+          <SoftwareSection
+            title={_("Desktops")}
+            description={_(
+              // TRANSLATORS: description for the Desktops section
+              "Graphical desktop environments for the system.",
+            )}
+            buttonText={
+              // TRANSLATORS: button to change the desktop selection
+              n_("Change desktop", "Change desktops", desktops.length)
+            }
+            totalCount={allDesktops.length}
+            patterns={desktops}
+            selection={proposal.patterns}
+            selectionPath={PATHS.desktopSelection}
+            emptyContent={
+              allDesktops.length === 0 ? (
+                <NoDesktopsAvailable />
+              ) : (
                 <NothingSelected
-                  to={PATHS.patternsSelection}
-                  // TRANSLATORS: hint shown when no additional software patterns have been chosen
-                  body={_("Select one or more to extend the system.")}
-                  // TRANSLATORS: button to go to the pattern selection page
-                  buttonText={_("Select patterns")}
+                  to={PATHS.desktopSelection}
+                  // TRANSLATORS: hint shown when no desktop environment has been chosen
+                  body={_("Select a desktop environment to get a graphical interface.")}
+                  // TRANSLATORS: button to go to the desktop environment selection page
+                  buttonText={_("Select a desktop")}
                 />
-              }
-            />
-          </GridItem>
-        </Grid>
-      )}
-    </Page.Content>
+              )
+            }
+          />
+        </GridItem>
+        <GridItem lg={6}>
+          <SoftwareSection
+            title={_("Additional patterns")}
+            description={_(
+              // TRANSLATORS: description for the Additional software section
+              "Curated sets of packages for common use cases and features to extend the system.",
+            )}
+            // TRANSLATORS: button to change the additional software selection
+            buttonText={_("Change patterns")}
+            totalCount={allOtherPatterns.length}
+            patterns={otherPatterns}
+            selection={proposal.patterns}
+            selectionPath={PATHS.patternsSelection}
+            emptyContent={
+              <NothingSelected
+                to={PATHS.patternsSelection}
+                // TRANSLATORS: hint shown when no additional software patterns have been chosen
+                body={_("Select one or more to extend the system.")}
+                // TRANSLATORS: button to go to the pattern selection page
+                buttonText={_("Select patterns")}
+              />
+            }
+          />
+        </GridItem>
+      </Grid>
+    </>
   );
 };
 
@@ -373,9 +355,14 @@ const SoftwarePageContent = () => {
  * Software page component
  */
 function SoftwarePage() {
+  const issues = useIssues("software");
+
   return (
     <Page breadcrumbs={[{ label: _("Software") }]} progress={{ scope: "software" }}>
-      <SoftwarePageContent />
+      <Page.Content>
+        <IssuesAlert issues={issues} />
+        <SoftwarePageContent />
+      </Page.Content>
     </Page>
   );
 }

--- a/web/src/components/software/SoftwarePatternsSelection.test.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.test.tsx
@@ -45,12 +45,10 @@ const patternsWithPreselected = [
 const desktops = patternsWithPreselected.filter((p) => p.desktop);
 const other = patternsWithPreselected.filter((p) => !p.desktop);
 
+const mockAvailablePatterns = jest.fn();
+
 jest.mock("~/hooks/model/system/software", () => ({
-  useAvailablePatterns: () => ({
-    all: patternsWithPreselected,
-    desktops,
-    other,
-  }),
+  useAvailablePatterns: () => mockAvailablePatterns(),
 }));
 
 jest.mock("~/hooks/model/proposal/software", () => ({
@@ -68,6 +66,14 @@ jest.mock("~/api", () => ({
 }));
 
 describe("SoftwarePatternsSelection", () => {
+  beforeEach(() => {
+    mockAvailablePatterns.mockReturnValue({
+      all: patternsWithPreselected,
+      desktops,
+      other,
+    });
+  });
+
   it("renders one h3 per category, in order", async () => {
     installerRender(<SoftwarePatternsSelection />);
     const headings = await screen.findAllByRole("heading", { level: 3 });
@@ -521,5 +527,17 @@ describe("SoftwarePatternsSelection scope", () => {
         },
       },
     });
+  });
+
+  it("redirects to main software page when no patterns are available for the scope", () => {
+    mockAvailablePatterns.mockReturnValue({
+      all: other,
+      desktops: [],
+      other,
+    });
+
+    installerRender(<SoftwarePatternsSelection scope="desktops" />);
+
+    screen.getByText("Navigating to /software");
   });
 });

--- a/web/src/components/software/SoftwarePatternsSelection.tsx
+++ b/web/src/components/software/SoftwarePatternsSelection.tsx
@@ -317,7 +317,7 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
   // Redirect to main software page when no patterns are available for the
   // current scope. This handles users landing via direct URL or cached links
   // when desktop patterns don't exist.
-  if (scopedPatterns.length === 0 && searchValue === "") {
+  if (scopedPatterns.length === 0) {
     return <Navigate to={SOFTWARE.root} replace />;
   }
 


### PR DESCRIPTION
During the code review of [PR #3436](https://github.com/agama-project/agama/pull/3436), @joseivanlopez identified additional cases not covered by the revamp shipped in [PR #3420](https://github.com/agama-project/agama/pull/3420):

* Product might not offer additional patterns.
* Software selection might be not possible due to issues preventing the calculation of the proposal.

This PR addresses these gaps by improving the handling of unavailable software selection and adding an _not-available-empty-state_ to "Additional patterns" section.

### Screenshots

<img width="2048" height="1536" alt="localhost_8080_ (42)" src="https://github.com/user-attachments/assets/145b5e12-ea38-454b-b3be-d92e0156387b" />

---

<img width="2048" height="1536" alt="localhost_8080_ (43)" src="https://github.com/user-attachments/assets/50c1a6b6-9d39-478b-b032-72c48d83fdea" />

---

<img width="2048" height="1536" alt="localhost_8080_ (44)" src="https://github.com/user-attachments/assets/b63b60f5-0fb8-4822-a46a-e8a449dc156e" />
