### PR TITLE
Install packages matching the target locale (bsc#1260423)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
 name = "agama-files"
 version = "0.1.0"
 dependencies = [
+ "agama-l10n",
  "agama-software",
  "agama-utils",
  "async-trait",

--- a/rust/agama-files/Cargo.toml
+++ b/rust/agama-files/Cargo.toml
@@ -5,7 +5,6 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-l10n = { path = "../agama-l10n" }
 agama-software = { version = "0.1.0", path = "../agama-software" }
 agama-utils = { path = "../agama-utils" }
 async-trait = "0.1.89"
@@ -17,6 +16,7 @@ tokio = { version = "1.48.0", features = ["sync"] }
 tracing = "0.1.41"
 
 [dev-dependencies]
+agama-l10n = { path = "../agama-l10n" }
 tokio-test = "0.4.4"
 test-context = "0.4.1"
 serde_json = "1.0.145"

--- a/rust/agama-files/Cargo.toml
+++ b/rust/agama-files/Cargo.toml
@@ -5,6 +5,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
+agama-l10n = { path = "../agama-l10n" }
 agama-software = { version = "0.1.0", path = "../agama-software" }
 agama-utils = { path = "../agama-utils" }
 async-trait = "0.1.89"

--- a/rust/agama-files/src/lib.rs
+++ b/rust/agama-files/src/lib.rs
@@ -31,6 +31,7 @@ pub use runner::ScriptsRunner;
 mod tests {
     use std::path::PathBuf;
 
+    use agama_l10n::test_utils::start_service as start_l10n_service;
     use agama_software::test_utils::start_service as start_software_service;
     use agama_utils::{
         actor::Handler,
@@ -70,9 +71,12 @@ mod tests {
             let issues = issue::Service::starter(events_tx.clone()).start();
             let progress = progress::Service::starter(events_tx.clone()).start();
             let questions = question::start(events_tx.clone()).await.unwrap();
+            let l10n = start_l10n_service(events_tx.clone(), issues.clone()).await;
+
             let software = start_software_service(
                 events_tx.clone(),
                 issues,
+                l10n,
                 progress.clone(),
                 questions.clone(),
             )

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -280,6 +280,7 @@ impl Starter {
                 software::Service::starter(
                     self.events.clone(),
                     issues.clone(),
+                    l10n.clone(),
                     progress.clone(),
                     self.questions.clone(),
                     security.clone(),

--- a/rust/agama-manager/src/test_utils.rs
+++ b/rust/agama-manager/src/test_utils.rs
@@ -63,10 +63,11 @@ pub async fn start_service(events: event::Sender, dbus: zbus::Connection) -> Han
         dbus.clone(),
     )
     .await;
+    let l10n = start_l10n_service(events.clone(), issues.clone()).await;
 
     Service::starter(questions.clone(), events.clone(), dbus.clone())
         .with_hostname(start_hostname_service(events.clone(), issues.clone()).await)
-        .with_l10n(start_l10n_service(events.clone(), issues.clone()).await)
+        .with_l10n(l10n.clone())
         .with_storage(storage)
         .with_iscsi(iscsi)
         .with_s390(s390)
@@ -74,7 +75,7 @@ pub async fn start_service(events: event::Sender, dbus: zbus::Connection) -> Han
         .with_network(start_network_service(events.clone(), progress.clone()).await)
         .with_proxy(start_proxy_service(events.clone()).await)
         .with_security(security.clone())
-        .with_software(start_software_service(events, issues, progress, questions).await)
+        .with_software(start_software_service(events, issues, l10n, progress, questions).await)
         .with_hardware(hardware::Registry::new_from_file(
             fixtures.join("lshw.json"),
         ))

--- a/rust/agama-software/examples/write_bench.rs
+++ b/rust/agama-software/examples/write_bench.rs
@@ -126,6 +126,7 @@ async fn main() {
         .send(SoftwareAction::Write {
             state: software_state,
             progress: progress_handler.clone(),
+            l10n: None,
             question: question_handler.clone(),
             security: security_handler.clone(),
             tx,
@@ -164,6 +165,7 @@ async fn main() {
         .send(SoftwareAction::Write {
             state: software_state,
             progress: progress_handler.clone(),
+            l10n: None,
             question: question_handler.clone(),
             security: security_handler.clone(),
             tx,
@@ -188,6 +190,7 @@ async fn main() {
         .send(SoftwareAction::Write {
             state: software_state,
             progress: progress_handler.clone(),
+            l10n: None,
             question: question_handler.clone(),
             security: security_handler.clone(),
             tx,

--- a/rust/agama-software/src/model.rs
+++ b/rust/agama-software/src/model.rs
@@ -85,6 +85,7 @@ pub trait ModelAdapter: Send + Sync + 'static {
     async fn write(
         &mut self,
         software: SoftwareState,
+        l10n: Handler<agama_l10n::Service>,
         progress: Handler<progress::Service>,
     ) -> Result<WriteIssues, service::Error>;
 }
@@ -131,12 +132,19 @@ impl ModelAdapter for Model {
     async fn write(
         &mut self,
         software: SoftwareState,
+        l10n: Handler<agama_l10n::Service>,
         progress: Handler<progress::Service>,
     ) -> Result<WriteIssues, service::Error> {
         let (tx, rx) = oneshot::channel();
+        let l10n_proposal = l10n
+            .call(agama_l10n::message::GetProposal)
+            .await
+            .unwrap_or_default();
+
         self.zypp_sender.send(SoftwareAction::Write {
             state: software,
             progress,
+            l10n: l10n_proposal,
             security: self.security.clone(),
             question: self.question.clone(),
             tx,

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -26,6 +26,7 @@ use crate::{
     zypp_server::{self, SoftwareAction, ZyppServer},
     Model, ResolvableType,
 };
+use agama_l10n;
 use agama_security as security;
 use agama_utils::{
     actor::{self, Actor, Handler, MessageHandler},
@@ -88,6 +89,7 @@ pub struct Starter {
     model: Option<Arc<Mutex<dyn ModelAdapter + Send + 'static>>>,
     events: event::Sender,
     issues: Handler<issue::Service>,
+    l10n: Handler<agama_l10n::Service>,
     progress: Handler<progress::Service>,
     questions: Handler<question::Service>,
     security: Handler<security::Service>,
@@ -97,6 +99,7 @@ impl Starter {
     pub fn new(
         events: event::Sender,
         issues: Handler<issue::Service>,
+        l10n: Handler<agama_l10n::Service>,
         progress: Handler<progress::Service>,
         questions: Handler<question::Service>,
         security: Handler<security::Service>,
@@ -105,6 +108,7 @@ impl Starter {
             model: None,
             events,
             issues,
+            l10n,
             progress,
             questions,
             security,
@@ -151,6 +155,7 @@ impl Starter {
             state,
             events: self.events,
             issues: self.issues,
+            l10n: self.l10n,
             progress: self.progress,
             product: None,
             kernel_cmdline,
@@ -170,6 +175,7 @@ impl Starter {
 pub struct Service {
     model: Arc<Mutex<dyn ModelAdapter + Send + 'static>>,
     issues: Handler<issue::Service>,
+    l10n: Handler<agama_l10n::Service>,
     progress: Handler<progress::Service>,
     events: event::Sender,
     state: Arc<RwLock<ServiceState>>,
@@ -190,11 +196,12 @@ impl Service {
     pub fn starter(
         events: event::Sender,
         issues: Handler<issue::Service>,
+        l10n: Handler<agama_l10n::Service>,
         progress: Handler<progress::Service>,
         questions: Handler<question::Service>,
         security: Handler<security::Service>,
     ) -> Starter {
-        Starter::new(events, issues, progress, questions, security)
+        Starter::new(events, issues, l10n, progress, questions, security)
     }
 
     pub async fn setup(&mut self) -> Result<(), Error> {
@@ -264,6 +271,7 @@ impl Service {
         let model = self.model.clone();
         let progress = self.progress.clone();
         let issues = self.issues.clone();
+        let l10n = self.l10n.clone();
         let state = self.state.clone();
         let events = self.events.clone();
         tracing::info!("Synchronizing the wanted software state");
@@ -271,7 +279,7 @@ impl Service {
         tokio::task::spawn(async move {
             let mut my_model = model.lock().await;
             let found_issues = my_model
-                .write(wanted_state, progress)
+                .write(wanted_state, l10n, progress)
                 .await
                 .unwrap_or_else(|e| {
                     let new_issue = Issue::new(

--- a/rust/agama-software/src/test_utils.rs
+++ b/rust/agama-software/src/test_utils.rs
@@ -37,6 +37,8 @@ use crate::{
     ModelAdapter, Service,
 };
 
+use agama_l10n;
+
 pub struct TestModel;
 
 #[async_trait]
@@ -76,6 +78,7 @@ impl ModelAdapter for TestModel {
     async fn write(
         &mut self,
         _software: SoftwareState,
+        _l10n: Handler<agama_l10n::Service>,
         _progress: Handler<progress::Service>,
     ) -> Result<WriteIssues, service::Error> {
         Ok(Default::default())
@@ -86,11 +89,12 @@ impl ModelAdapter for TestModel {
 pub async fn start_service(
     events: event::Sender,
     issues: Handler<issue::Service>,
+    l10n: Handler<agama_l10n::Service>,
     progress: Handler<progress::Service>,
     questions: Handler<question::Service>,
 ) -> Handler<Service> {
     let security = start_security_service(questions.clone()).await;
-    Service::starter(events, issues, progress, questions, security)
+    Service::starter(events, issues, l10n, progress, questions, security)
         .with_model(TestModel {})
         .start()
         .await

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -22,7 +22,7 @@ use agama_security as security;
 use agama_utils::{
     actor::Handler,
     api::{
-        self,
+        self, l10n,
         software::{Pattern, SelectedBy, SoftwareProposal, SystemInfo},
         Issue, Scope,
     },
@@ -120,6 +120,7 @@ pub enum SoftwareAction {
     Write {
         state: SoftwareState,
         progress: Handler<progress::Service>,
+        l10n: Option<l10n::Proposal>,
         question: Handler<question::Service>,
         security: Handler<security::Service>,
         tx: oneshot::Sender<ZyppServerResult<WriteIssues>>,
@@ -226,6 +227,7 @@ impl ZyppServer {
             SoftwareAction::Write {
                 state,
                 progress,
+                l10n,
                 question,
                 security: security_srv,
                 tx,
@@ -234,6 +236,7 @@ impl ZyppServer {
                 self.write(
                     state,
                     progress,
+                    l10n,
                     question,
                     security_srv,
                     &mut security_callback,
@@ -321,6 +324,7 @@ impl ZyppServer {
         &mut self,
         state: SoftwareState,
         progress: Handler<progress::Service>,
+        l10n: Option<l10n::Proposal>,
         _questions: Handler<question::Service>,
         security_srv: Handler<security::Service>,
         security: &mut callbacks::Security,
@@ -495,6 +499,11 @@ impl ZyppServer {
                 // by dependencies
                 ResolvableSelection::Removed => {}
             };
+        }
+
+        if let Some(proposal) = l10n {
+            let locale = proposal.locale;
+            zypp.select_locale(locale.language, locale.territory);
         }
 
         // if registered select products from add-on services

--- a/rust/agama-software/tests/zypp_server.rs
+++ b/rust/agama-software/tests/zypp_server.rs
@@ -127,6 +127,7 @@ async fn test_start_zypp_server() {
         .send(SoftwareAction::Write {
             state: software_state,
             progress: progress_handler,
+            l10n: None,
             question: question_handler.clone(),
             security: security_handler,
             tx,

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -404,6 +404,14 @@ impl Zypp {
         }
     }
 
+    pub fn select_locale(&self, language: String, country: String) {
+        unsafe {
+            let c_language = CString::new(language).unwrap();
+            let c_country = CString::new(country).unwrap();
+            zypp_agama_sys::select_locale(self.ptr, c_language.as_ptr(), c_country.as_ptr());
+        }
+    }
+
     pub fn is_package_selected(&self, tag: &str) -> ZyppResult<bool> {
         unsafe {
             let mut status: Status = Status::default();

--- a/rust/zypp-agama/zypp-agama-sys/c-layer/include/lib.h
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/include/lib.h
@@ -195,6 +195,10 @@ struct Products get_products(struct Zypp *_zypp,
                              struct Status *status) noexcept;
 void free_products(const struct Products *products) noexcept;
 
+/// Select locale packages to install
+void select_locale(struct Zypp *_zypp, const char *language,
+                   const char *country) noexcept;
+
 void import_gpg_key(struct Zypp *zypp, const char *const pathname,
                     struct Status *status) noexcept;
 

--- a/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
@@ -520,6 +520,33 @@ void free_products(const struct Products *products) noexcept {
   free((void *)products->list);
 }
 
+void select_locale(struct Zypp *_zypp, const char *language,
+                   const char *country) noexcept {
+  LOG_LOCATION("Selecting locale packages");
+
+  if (strlen(country) == 0) {
+    WAR << "Locale language not specified" << std::endl;
+    return;
+  }
+
+  MIL << "Locale to install: " << language << std::endl;
+  zypp::LocaleSet locales;
+  zypp::Locale locale(language);
+  locales.insert(locale);
+
+  if (strlen(country) > 0) {
+    std::string locale_str(language);
+    locale_str.append("_");
+    locale_str.append(country);
+    MIL << "Locale to install: " << locale_str << std::endl;
+
+    zypp::Locale full_locale = zypp::Locale(locale_str);
+    locales.insert(full_locale);
+  }
+
+  zypp::sat::Pool::instance().setRequestedLocales(locales);
+}
+
 bool run_solver(struct Zypp *zypp, bool only_required,
                 struct Status *status) noexcept {
   LOG_LOCATION("Running solver");

--- a/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
@@ -524,7 +524,7 @@ void select_locale(struct Zypp *_zypp, const char *language,
                    const char *country) noexcept {
   LOG_LOCATION("Selecting locale packages");
 
-  if (strlen(country) == 0) {
+  if (strlen(language) == 0) {
     WAR << "Locale language not specified" << std::endl;
     return;
   }

--- a/rust/zypp-agama/zypp-agama-sys/src/bindings.rs
+++ b/rust/zypp-agama/zypp-agama-sys/src/bindings.rs
@@ -653,6 +653,12 @@ unsafe extern "C" {
     #[doc = " Get Product details."]
     pub fn get_products(_zypp: *mut Zypp, status: *mut Status) -> Products;
     pub fn free_products(products: *const Products);
+    #[doc = " Select locale packages to install"]
+    pub fn select_locale(
+        _zypp: *mut Zypp,
+        language: *const ::std::os::raw::c_char,
+        country: *const ::std::os::raw::c_char,
+    );
     pub fn import_gpg_key(
         zypp: *mut Zypp,
         pathname: *const ::std::os::raw::c_char,


### PR DESCRIPTION
## Problem

- The language related packages are not installed.
- https://bugzilla.suse.com/show_bug.cgi?id=1260423

## Solution

- When selecting the packages to install query the target system locale and select that locale to install in libzypp.

## Testing

- Tested manually.
- Works both for locales set using the web UI and using CLI.
- The English locale is automatically selected by libzypp, this works the same way as in YaST in SLE15.

After selecting the Czech language the solver run reports these selected locales:

```
PoolImpl.cc(logSat):134: [libsolv] job: install providing namespace:language(cs_CZ)
PoolImpl.cc(logSat):134: [libsolv]   - job Rule #20819:
PoolImpl.cc(logSat):134: [libsolv]     system:system.noarch [1] (w1)
PoolImpl.cc(logSat):134: [libsolv] job: install providing namespace:language(en)
PoolImpl.cc(logSat):134: [libsolv]   - job Rule #20820:
PoolImpl.cc(logSat):134: [libsolv]     system:system.noarch [1] (w1)
PoolImpl.cc(logSat):134: [libsolv] job: install providing namespace:language(cs)
PoolImpl.cc(logSat):134: [libsolv]   - job Rule #20821:
PoolImpl.cc(logSat):134: [libsolv]     system:system.noarch [1] (w1)
```

<details><summary>In the target system the Czech language related packages are installed.</summary>

```console
agama:/ # rpm -qa --provides | grep "locale\(.*:cs\)" | xargs -n1 rpm -q --whatprovides | sort -u
bash-lang-5.3.9-6.3.noarch
cnf-locale-0.9.0~0-1.3.noarch
coreutils-lang-9.11-1.1.noarch
cpupower-lang-6.19.12-13.37.noarch
cryptsetup-lang-2.8.6-1.1.noarch
diffutils-lang-3.12-1.2.noarch
findutils-lang-4.10.0-2.4.noarch
firewalld-lang-2.1.2-9.3.noarch
fwupd-lang-2.0.20-1.2.noarch
gcr-lang-4.4.0.1-3.1.noarch
gdk-pixbuf-lang-2.44.6-1.1.noarch
glib2-lang-2.88.0-1.1.noarch
glibc-lang-2.42-3.3.noarch
glibc-locale-2.42-3.3.x86_64
glib-networking-lang-2.80.1-2.1.noarch
gpg2-lang-2.5.18-1.1.noarch
grep-lang-3.12-1.2.noarch
gsettings-desktop-schemas-lang-50.1-1.1.noarch
gstreamer-lang-1.28.2-1.1.noarch
gstreamer-plugins-base-lang-1.28.2-1.1.noarch
gtk3-lang-3.24.52-1.2.noarch
gtk4-lang-4.22.3-1.1.noarch
gvfs-lang-1.60.0-2.1.noarch
info-lang-7.3-1.1.noarch
json-glib-lang-1.10.8-1.3.noarch
libbytesize-lang-2.12-1.3.noarch
libidn2-lang-2.3.8-1.2.noarch
libpwquality-lang-1.4.5-5.4.noarch
libsecret-lang-0.21.7-2.1.noarch
libsoup-lang-3.6.6-4.1.noarch
libstorage-ng-lang-4.5.314-1.1.noarch
man-pages-cs-4.28.0-1.2.noarch
nano-lang-9.0-1.1.noarch
net-tools-lang-2.10+1-4.2.noarch
NetworkManager-lang-1.54.3-3.3.noarch
notification-daemon-lang-3.20.0-8.3.noarch
parted-lang-3.7-1.1.noarch
plymouth-lang-22.02.122+94.4bd41a3-20.2.noarch
popt-lang-1.19-2.1.noarch
psmisc-lang-23.7-5.2.noarch
sed-lang-4.9-2.9.noarch
shared-mime-info-lang-2.4-3.7.noarch
sharutils-lang-4.15.2-10.2.noarch
systemd-lang-260.1-1.2.noarch
tar-lang-1.35-6.1.noarch
udisks2-lang-2.11.0-2.2.noarch
util-linux-lang-2.41.3-5.2.noarch
wget-lang-1.25.0-2.3.noarch
xkeyboard-config-lang-2.47-2.1.noarch
xz-lang-5.8.3-1.1.noarch
yast2-trans-cs-84.87.20260414.0f82ab3540-1.1.noarch
```

The `*-lang` packages match lots of different languages but the `man-pages-cs` and `yast2-trans-cs` are Czech specific.
</details>