### PR TITLE
Update CLI documentation link in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,6 @@
 - <https://agama-project.github.io/> ([source][gh.io])
 - Run: `git ls-files '*.md'`
 
-[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md
+[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/reference/cli.md
 [profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
 [gh.io]: https://github.com/agama-project/agama-project.github.io/


### PR DESCRIPTION
## Problem

This link has been broken (since August):

> - Is the CLI affected? See [cli.md][] for a complete overview ...

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md

## Solution

Fix the link:

> - Is the CLI affected? See [cli.md][fix] for a complete overview ...

[fix]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/reference/cli.md

## Testing

- You are doing it right now

## Screenshots

No

## Documentation

 - Is the CLI affec--
 
No it isn't. The bug and fix *are* the documentation.