### PR TITLE
Fix new build

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May  4 10:46:08 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- fix zypp tests to work with new rpm with more tight permissions
+  (bsc#1254914)
+
+-------------------------------------------------------------------
 Thu Apr 30 09:04:17 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - CLI: add new `agama status` command that prints current state of

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -772,7 +772,8 @@ mod tests {
     use std::process::Command;
 
     fn setup() {
-        // empty now
+        let root = get_fixture_root().unwrap();
+        init_rpmdb(&root).unwrap();
     }
 
     fn progress_cb(_text: String, _step: u32, _total: u32) {
@@ -787,12 +788,22 @@ mod tests {
         Ok(())
     }
 
+    fn get_fixture_root() -> Result<String, Box<dyn Error>> {
+        let cwd = std::env::current_dir()?;
+        let root_buf = cwd.join("fixtures/zypp_root");
+        root_buf
+            .try_exists()
+            .expect("run this from the dir that has fixtures/");
+        Ok(root_buf.to_str().expect("CWD is not UTF-8").to_string())
+    }
+
     #[test]
     fn init_target() -> Result<(), Box<dyn Error>> {
         // run just single test to avoid threads as it cause zypp to be locked to one of those threads
         {
+            let root = get_fixture_root()?;
             setup();
-            let result = Zypp::init_target("/", progress_cb);
+            let result = Zypp::init_target(&root, progress_cb);
             assert!(result.is_ok());
         }
         {
@@ -803,9 +814,9 @@ mod tests {
         }
         {
             setup();
-
+            let root = get_fixture_root()?;
             // double init of target
-            let z1 = Zypp::init_target("/", progress_cb);
+            let z1 = Zypp::init_target(&root, progress_cb);
             let z2 = Zypp::init_target("/mnt", progress_cb);
             assert!(z2.is_err());
 
@@ -815,15 +826,8 @@ mod tests {
         {
             // list repositories test
             setup();
-            let cwd = std::env::current_dir()?;
-            let root_buf = cwd.join("fixtures/zypp_root");
-            root_buf
-                .try_exists()
-                .expect("run this from the dir that has fixtures/");
-            let root = root_buf.to_str().expect("CWD is not UTF-8");
-
-            init_rpmdb(root)?;
-            let zypp = Zypp::init_target(root, progress_cb)?;
+            let root = get_fixture_root()?;
+            let zypp = Zypp::init_target(&root, progress_cb)?;
             let repos = zypp.list_repositories()?;
             assert!(repos.len() == 1);
         }


### PR DESCRIPTION
## Problem

Fix build failure in zypp testsuite with new rpm. It is caused by more strict permissions for global rpm database, so non root access to it failed.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1254914


## Solution

Always use fixture directory with user created rpm database.


## Testing

- Use modified source to build in Staging:C and build passes.