### PR TITLE
feat(web): reduce visual noise of input instructions

### DIFF
--- a/web/src/components/form/ArrayField.test.tsx
+++ b/web/src/components/form/ArrayField.test.tsx
@@ -77,10 +77,36 @@ function TestForm({
 }
 
 describe("ArrayField", () => {
-  it("renders label and usage", () => {
+  it("renders label", () => {
     installerRender(<TestForm />);
     screen.getByText("Tags");
-    screen.getByText(/Enter or Tab to add/);
+  });
+
+  it("always provides screen reader instructions via aria-describedby", () => {
+    installerRender(<TestForm />);
+    const input = screen.getByRole("textbox", { name: "Tags" });
+    const instructions = screen.getByText(/Escape to exit/);
+    const instructionsId = instructions.closest("[id]")?.id;
+    expect(input.getAttribute("aria-describedby")).toContain(instructionsId);
+  });
+
+  it("does not show sighted instructions on empty field", () => {
+    installerRender(<TestForm />);
+    expect(
+      screen.queryByText("Enter or Tab to add", { selector: ":not([class*='screenReader'])" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows sighted instructions when field has draft content", async () => {
+    const { user } = installerRender(<TestForm />);
+    const input = screen.getByRole("textbox", { name: "Tags" });
+    await user.type(input, "a");
+    screen.getByText("Enter or Tab to add");
+  });
+
+  it("shows sighted instructions when field has entries", () => {
+    installerRender(<TestForm defaultValues={["alpha"]} />);
+    screen.getByText("Enter or Tab to add, Backspace or Delete to remove, arrow keys to navigate");
   });
 
   it("renders given existing values", () => {

--- a/web/src/components/form/ArrayField.tsx
+++ b/web/src/components/form/ArrayField.tsx
@@ -132,6 +132,49 @@ function filterNew(existing: string[], normalized: string[]): string[] {
   return unique([...existing, ...normalized]).slice(existing.length);
 }
 
+/**
+ * Renders keyboard usage instructions for screen readers.
+ *
+ * Always rendered but visually hidden, accessed via aria-describedby.
+ * Provides complete keyboard navigation instructions.
+ */
+function ScreenReaderInstructions({ id }: { id: string }) {
+  return (
+    <HelperTextItem id={id}>
+      <Text srOnly>
+        {
+          // TRANSLATORS: keyboard usage hint for screen readers.
+          _(
+            "Enter or Tab to add, Backspace or Delete to remove, arrow keys to navigate entries, Escape to exit",
+          )
+        }
+      </Text>
+    </HelperTextItem>
+  );
+}
+
+/**
+ * Renders keyboard usage instructions for sighted users.
+ *
+ * Shows context-aware hints based on whether entries exist.
+ * Only rendered when field is dirty (has entries or draft content).
+ */
+function SightedInstructions({ hasEntries, isDirty }: { hasEntries: boolean; isDirty: boolean }) {
+  if (!isDirty) return null;
+
+  return (
+    <HelperTextItem>
+      <Text textStyle={["fontSizeXs", "textColorSubtle"]}>
+        {hasEntries
+          ? // TRANSLATORS: keyboard usage hint when entries exist.
+            _("Enter or Tab to add, Backspace or Delete to remove, arrow keys to navigate")
+          : // TRANSLATORS: keyboard usage hint when field is empty.
+            _("Enter or Tab to add")}
+      </Text>
+    </HelperTextItem>
+  );
+}
+
 type EntryProps = {
   /** Raw stored value, not necessarily the display form. */
   item: string;
@@ -632,18 +675,13 @@ export default function ArrayField({
 
       <FormHelperText>
         <HelperText>
+          <ScreenReaderInstructions id={instructionsId} />
+          <SightedInstructions
+            hasEntries={value.length > 0}
+            isDirty={value.length > 0 || draft !== ""}
+          />
           <HelperTextItem id={hintId}>
             {helperText && <Text textStyle={["fontSizeSm", "textColorSubtle"]}>{helperText}</Text>}
-          </HelperTextItem>
-          <HelperTextItem id={instructionsId}>
-            <Text textStyle={["fontSizeXs", "textColorSubtle"]}>
-              {
-                // TRANSLATORS: keyboard usage hint shown below the field.
-                _(
-                  "Enter or Tab to add; arrow keys to navigate entries, Ctrl+arrows to reorder, Escape to exit; Backspace or Delete to remove.",
-                )
-              }
-            </Text>
           </HelperTextItem>
           {hasAnyError && (
             <HelperTextItem variant="error">


### PR DESCRIPTION
`ArrayField`'s Instructions now only appear when field is dirty (has content), making empty fields cleaner and less overwhelming. Also repositioned before helper text for better scanning, and updated keyboard hints to use consistent punctuation and more logical ordering.

### Before


https://github.com/user-attachments/assets/7793c071-035f-467e-9867-4c1bf801b49a



### After


https://github.com/user-attachments/assets/cb2791f8-1e1b-4551-89f1-d46ab0e5d71a


### Notes

Failing linter comes form feature branch the PR is against. Out of scope fixing it in this small one.
