### PR TITLE
fix(web): decouple field width from form-group wrapper

### DIFF
--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -417,6 +417,14 @@ label.pf-m-disabled + .pf-v6-c-check__description {
 
 .pf-v6-c-form__group {
   justify-self: flex-start;
+
+  // Prevent form inputs from stretching to match the width of long helper text
+  // or instructions. Inputs size themselves based on content and explicit
+  // width constraints, while text elements flow at their natural width.
+  .pf-v6-c-form-control,
+  .pf-v6-c-text-input-group {
+    max-width: fit-content;
+  }
 }
 
 // Fix select toggle icon visibility by creating more space at the end :/

--- a/web/src/components/network/BridgeSettings.tsx
+++ b/web/src/components/network/BridgeSettings.tsx
@@ -144,6 +144,8 @@ const BridgeSettings = withForm({
                         // TRANSLATORS: helper text for the bridge hello time field.
                         _("Interval between sending BPDU packets. Range: 1 - 10 seconds. E.g., 2.")
                       }
+                      min={1}
+                      max={10}
                     />
                   )}
                 </form.AppField>
@@ -160,6 +162,8 @@ const BridgeSettings = withForm({
                           "Time to store BPDU info before discarding it. Range: 6 - 40 seconds. E.g., 20.",
                         )
                       }
+                      min={6}
+                      max={40}
                     />
                   )}
                 </form.AppField>


### PR DESCRIPTION
Adjust CSS to override default PatternFly behavior so that input/field width is independent of the form-group container, preventing fields from growing to match the width of their parent because of the width of any of its siblings.


### Before

<img width="1233" height="1176" alt="Screenshot_2026-05-04_22-14-03" src="https://github.com/user-attachments/assets/982b3980-dbea-4a0a-8ced-d21f98e1e7a2" />


### After

<img width="1233" height="1176" alt="Screenshot_2026-05-04_22-13-22" src="https://github.com/user-attachments/assets/b7e1bac6-2d9a-423b-8646-91d4f2df186b" />

### Notes

Failing linter comes form feature branch the PR is against. Out of scope fixing it in this small one.
