### PR TITLE
refactor(web): simplify Bridge/STP helper texts for clarity

### DIFF
--- a/web/src/components/network/BridgeSettings.tsx
+++ b/web/src/components/network/BridgeSettings.tsx
@@ -23,6 +23,7 @@
 import React from "react";
 import { sprintf } from "sprintf-js";
 import Interpolate from "~/components/core/Interpolate";
+import NestedContent from "~/components/core/NestedContent";
 import { connectionFormOptions } from "~/components/network/ConnectionForm";
 import { withForm } from "~/hooks/form";
 import { useDevices } from "~/hooks/model/system/network";
@@ -97,7 +98,7 @@ const BridgeSettings = withForm({
         <form.Subscribe selector={(s) => s.values.bridgeStp}>
           {(bridgeStp) =>
             bridgeStp && (
-              <>
+              <NestedContent margin="mxLg">
                 <form.AppField name="bridgePriority">
                   {(field) => (
                     <field.NumberField
@@ -167,7 +168,7 @@ const BridgeSettings = withForm({
                     />
                   )}
                 </form.AppField>
-              </>
+              </NestedContent>
             )
           }
         </form.Subscribe>

--- a/web/src/components/network/BridgeSettings.tsx
+++ b/web/src/components/network/BridgeSettings.tsx
@@ -22,6 +22,7 @@
 
 import React from "react";
 import { sprintf } from "sprintf-js";
+import Interpolate from "~/components/core/Interpolate";
 import { connectionFormOptions } from "~/components/network/ConnectionForm";
 import { withForm } from "~/hooks/form";
 import { useDevices } from "~/hooks/model/system/network";
@@ -105,10 +106,17 @@ const BridgeSettings = withForm({
                         _("Priority")
                       }
                       helperText={
-                        // TRANSLATORS: helper text for the bridge priority field.
-                        _(
-                          "Determines the root bridge. Lower values have higher priority. Range: 0 - 61440. E.g., 32768.",
-                        )
+                        <Interpolate
+                          sentence={
+                            // TRANSLATORS: Helper text for the bridge priority
+                            // field. Text inside square brackets [] is
+                            // semantically and visually emphasized. Keep the
+                            // brackets.
+                            _("Root bridge selection (0-61440). [Lower is higher priority].")
+                          }
+                        >
+                          {(text) => <strong>{text}</strong>}
+                        </Interpolate>
                       }
                       min={0}
                       max={61440}
@@ -124,9 +132,7 @@ const BridgeSettings = withForm({
                       }
                       helperText={
                         // TRANSLATORS: helper text for the bridge forward delay field.
-                        _(
-                          "Time spent in listening and learning states. Range: 4 - 30 seconds. E.g., 15.",
-                        )
+                        _("Listening and learning time (4-30 seconds).")
                       }
                       min={4}
                       max={30}
@@ -142,7 +148,7 @@ const BridgeSettings = withForm({
                       }
                       helperText={
                         // TRANSLATORS: helper text for the bridge hello time field.
-                        _("Interval between sending BPDU packets. Range: 1 - 10 seconds. E.g., 2.")
+                        _("Protocol message interval (1-10 seconds).")
                       }
                     />
                   )}
@@ -156,9 +162,7 @@ const BridgeSettings = withForm({
                       }
                       helperText={
                         // TRANSLATORS: helper text for the bridge max message age field.
-                        _(
-                          "Time to store BPDU info before discarding it. Range: 6 - 40 seconds. E.g., 20.",
-                        )
+                        _("Protocol message retention time (6-40 seconds).")
                       }
                     />
                   )}


### PR DESCRIPTION
Shortens helper texts for bridge STP fields to make them more user-friendly and easier to scan. Removes technical jargon and verbose explanations in favor of concise descriptions.

Priority field now emphasizes the counter-intuitive "lower is higher" concept within a single string.

> [!WARNING]
> Examples were removed from these helper texts because the fields already use them as default input values. In other words, live examples are present, so including them in the helper text would be redundant.

### Comparison table

| Field | Before | After |
|-------|--------|-------|
| **Priority** | Determines the root bridge. Lower values have higher priority. Range: 0 - 61440. E.g., 32768. | Root bridge selection (0-61440). **Lower is higher priority.** |
| **Forward delay** | Time spent in listening and learning states. Range: 4 - 30 seconds. E.g., 15. | Listening and learning time (4-30 seconds). |
| **Hello time** | Interval between sending BPDU packets. Range: 1 - 10 seconds. E.g., 2. | Protocol message interval (1-10 seconds). |
| **Max message age** | Time to store BPDU info before discarding it. Range: 6 - 40 seconds. E.g., 20. | Protocol message retention time (6-40 seconds). |


### Screenshots

#### Before

<img width="1233" height="1176" alt="Screenshot_2026-05-04_22-44-33" src="https://github.com/user-attachments/assets/5aebe58b-0374-4180-8239-27c5ab82ede6" />


#### After

<img width="1233" height="1176" alt="Screenshot_2026-05-04_22-44-12" src="https://github.com/user-attachments/assets/6130a764-6f68-4cef-8262-e194e35a9f2f" />


### Notes

Failing linter comes form feature branch the PR is against. Out of scope fixing it in this small one.
