### PR TITLE
Don't run obs-staging-debug in fork

### DIFF
--- a/.github/workflows/obs-staging-debug.yml
+++ b/.github/workflows/obs-staging-debug.yml
@@ -20,6 +20,8 @@ env:
 jobs:
   test:
 
+    if: "!github.event.repository.fork"
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

This test always fails in my fork.

## Solution

Disable the test in forks.

## Testing

https://github.com/jcronenberg/agama/actions/runs/25382893364/job/74435802793