### PR TITLE
Gnome kiosk wrapper

### DIFF
--- a/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
+++ b/live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
@@ -3,6 +3,4 @@
 # exists in the original service file. If not systemd will try
 # to start every ExecStart (original even the one added bellow)
 ExecStart=
-# gnome-kiosk >= 50 blocks switching to virtual console by default
-# --enable-vt-switch enables that. bsc#1261932
-ExecStart=/usr/bin/gnome-kiosk --enable-vt-switch
+ExecStart=/root/.local/bin/gnome-kiosk-wrapper

--- a/live/live-root/root/.local/bin/gnome-kiosk-wrapper
+++ b/live/live-root/root/.local/bin/gnome-kiosk-wrapper
@@ -9,7 +9,7 @@ OPTS="";
 
 # We need to invoke gnome-kiosk with option --enable-vt-switch for versions >= 50.
 # Otherwise switching to virtual console will be blocked by default. bsc#1261932
-if [[ $(gnome-kiosk --help 2> /dev/null | grep 'enable-vt-switch') ]]; then
+if gnome-kiosk --help 2> /dev/null | grep -q 'enable-vt-switch'; then
     OPTS="--enable-vt-switch";
 fi;
 

--- a/live/live-root/root/.local/bin/gnome-kiosk-wrapper
+++ b/live/live-root/root/.local/bin/gnome-kiosk-wrapper
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Wrapper for starting gnome-kiosk itself (do not mess with gnome-kiosk-script).
+# Only purpose of this script is to deal with various gnome-kiosk versions used
+# in different products. This is intented to be called from systemd unit file
+# see live/live-root/root/.config/systemd/user/org.gnome.Kiosk@wayland.service.d/override.conf
+
+OPTS="";
+
+# We need to invoke gnome-kiosk with option --enable-vt-switch for versions >= 50.
+# Otherwise switching to virtual console will be blocked by default. bsc#1261932
+if [[ $(gnome-kiosk --help 2> /dev/null | grep 'enable-vt-switch') ]]; then
+    OPTS="--enable-vt-switch";
+fi;
+
+exec /usr/bin/gnome-kiosk $OPTS

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  7 08:19:56 UTC 2026 - Michal Filka <mfilka@suse.com>
+
+- bsc#1264099
+  - use --enable-vt-switch option conditionally only if gnome-kiosk
+    supports it
+
+-------------------------------------------------------------------
 Wed May  6 14:11:57 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Removed development GPG keys (bsc#1262143)


### PR DESCRIPTION
## Problem

--enable-vt-switch is mandatory for newer gnome kiosk instances (>= 50). However older versions crashes when started with this option (because of unknown option)

- [*Bugzilla link*](https://bugzilla.suse.com/show_bug.cgi?id=1264099)


## Solution

Start gnome kiosk with --enable-vt-switch option only if current kiosk instance supports it


## Testing

- *Tested manually*
