### PR TITLE
Improve handling of updates in monitor command

### DIFF
--- a/rust/agama-cli/src/progress.rs
+++ b/rust/agama-cli/src/progress.rs
@@ -157,12 +157,18 @@ impl ProgressMonitor {
         let mut receiver = self.monitor.subscribe();
         loop {
             let new_status = receiver.recv().await;
-            let Ok(new_status) = new_status else {
-                return Err(anyhow::Error::msg("Communication with agama server failed"));
-            };
 
-            if !self.handle_status_update(new_status).await? {
-                break;
+            match new_status {
+                Ok(new_status) => {
+                    if !self.handle_status_update(new_status).await? {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::msg(format!(
+                        "Communication with the Agama server failed: {e}"
+                    )));
+                }
             }
         }
 

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -160,7 +160,7 @@ impl Monitor {
         http_client: &BaseHTTPClient,
     ) -> Result<(MonitorClient, InstallationStatus), MonitorError> {
         // Channel to send/receive commands from the client.
-        let (updates, _rx) = broadcast::channel(16);
+        let (updates, _rx) = broadcast::channel(100);
         let client = MonitorClient {
             updates: updates.clone(),
         };

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  7 09:50:03 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve handling of updates in the "agama monitor" command
+  (gh#agama-project/agama#3470).
+
+-------------------------------------------------------------------
 Thu May  7 06:03:28 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for synchronizing and configuring the NTP service


### PR DESCRIPTION
When monitoring the installer status, it might happen that we the channel that emits the updates gets full, producing a [Recv::Lagged](https://docs.rs/tokio/latest/tokio/sync/broadcast/error/enum.RecvError.html#variant.Lagged) error.

This PR introduces two changes:

* Use a bigger channel.
* Report what is exactly the problem (previously, we only got a generic message about a problem communicating with the Agama server).