### PR TITLE
Improved adding libzypp service (related to bsc#1261351)

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May  7 10:56:21 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Improved saving libzypp service (related to bsc#1261351)
+
+-------------------------------------------------------------------
 Thu May  7 09:50:03 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improve handling of updates in the "agama monitor" command

--- a/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
+++ b/rust/zypp-agama/zypp-agama-sys/c-layer/lib.cxx
@@ -587,7 +587,14 @@ void add_service(struct Zypp *zypp, const char *alias, const char *url,
     zypp::ServiceInfo zypp_service = zypp::ServiceInfo(alias);
     zypp_service.setUrl(zypp::Url(url));
 
-    zypp->repo_manager->addService(zypp_service);
+    const zypp::ServiceInfo stored = zypp->repo_manager->getService(alias);
+    if (stored == zypp::ServiceInfo::noService) {
+      // the service does not exist, add it
+      zypp->repo_manager->addService(zypp_service);
+    } else {
+      // the service already exists, modify the existing one
+      zypp->repo_manager->modifyService(zypp_service);
+    }
     STATUS_OK(status);
   } catch (zypp::Exception &excpt) {
     STATUS_EXCEPT(status, excpt);


### PR DESCRIPTION
## Problem

- When the PackageHub GPG key is rejected then Agama reports "Service already exists" error which is confusing
- Libzypp complains when adding a service which already exists

## Solution

- Check whether the service already exists, if so modify the existing service instead of adding it again

## Testing

- Tested manually, now Agama reports "Failed to retrieve new repository metadata." which describes the real problem caused by rejecting the repository GPG key

