### PR TITLE
Import the ntp-client section from AutoYaST profiles

### DIFF
--- a/service/.rubocop.yml
+++ b/service/.rubocop.yml
@@ -27,7 +27,7 @@ Lint/UselessAssignment:
 
 # be less strict
 Metrics/AbcSize:
-  Max: 32
+  Max: 33
 
 Metrics/ParameterLists:
   Max: 6

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -26,6 +26,7 @@ require "agama/autoyast/hostname_reader"
 require "agama/autoyast/iscsi_reader"
 require "agama/autoyast/localization_reader"
 require "agama/autoyast/network_reader"
+require "agama/autoyast/ntp_client_reader"
 require "agama/autoyast/product_reader"
 require "agama/autoyast/root_reader"
 require "agama/autoyast/scripts_reader"
@@ -34,7 +35,6 @@ require "agama/autoyast/software_reader"
 require "agama/autoyast/storage_reader"
 require "agama/autoyast/user_reader"
 require "agama/autoyast/zfcp_reader"
-require "agama/autoyast/ntp_client_reader"
 
 module Agama
   module AutoYaST
@@ -57,6 +57,7 @@ module Agama
           HostnameReader.new(profile).read,
           IscsiReader.new(profile).read,
           LocalizationReader.new(profile).read,
+          NtpClientReader.new(profile).read,
           NetworkReader.new(profile).read,
           ProductReader.new(profile).read,
           RootReader.new(profile).read,
@@ -65,8 +66,7 @@ module Agama
           SoftwareReader.new(profile).read,
           StorageReader.new(profile).read,
           UserReader.new(profile).read,
-          ZFCPReader.new(profile).read,
-          NtpClientReader.new(profile).read
+          ZFCPReader.new(profile).read
         ].inject(:merge)
       end
     end

--- a/service/lib/agama/autoyast/converter.rb
+++ b/service/lib/agama/autoyast/converter.rb
@@ -34,6 +34,7 @@ require "agama/autoyast/software_reader"
 require "agama/autoyast/storage_reader"
 require "agama/autoyast/user_reader"
 require "agama/autoyast/zfcp_reader"
+require "agama/autoyast/ntp_client_reader"
 
 module Agama
   module AutoYaST
@@ -64,7 +65,8 @@ module Agama
           SoftwareReader.new(profile).read,
           StorageReader.new(profile).read,
           UserReader.new(profile).read,
-          ZFCPReader.new(profile).read
+          ZFCPReader.new(profile).read,
+          NtpClientReader.new(profile).read
         ].inject(:merge)
       end
     end

--- a/service/lib/agama/autoyast/ntp_client_reader.rb
+++ b/service/lib/agama/autoyast/ntp_client_reader.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Agama
+  module AutoYaST
+    # Builds the Agama "ntp" section from an AutoYaST profile
+    class NtpClientReader
+      # @param profile [ProfileHash] AutoYaST profile
+      def initialize(profile)
+        @profile = profile
+      end
+
+      # @return [Hash] Agama "ntp" section.
+      def read
+        ntp = {}
+        section = profile.fetch_as_hash("ntp-client")
+        servers = section.fetch_as_array("ntp_servers")
+        if !servers.empty?
+          ntp["sources"] = servers.map do |s|
+            s.merge("type" => "pool")
+          end
+        end
+
+        return {} if ntp.empty?
+
+        { "ntp" => ntp }
+      end
+
+    private
+
+      attr_reader :profile
+    end
+  end
+end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  7 12:11:45 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Import the ntp-client section from a AutoYaST profiles
+  (jsc#PED-15144).
+
+-------------------------------------------------------------------
 Fri Apr 17 10:29:38 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Add support for configuring pervasive encryption APQNs and key

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -550,7 +550,21 @@
   { "key": "nfs_server", "support": "no" },
   { "key": "nis", "support": "no" },
   { "key": "nis_server", "support": "no" },
-  { "key": "ntp-client", "support": "no" },
+  {
+    "key": "ntp-client",
+    "children": [
+      { "key": "ntp_policy", "support": "no" },
+      { "key": "ntp_servers[]",
+        "notes": "All servers are considered of type 'pool'",
+        "children": [
+          { "key": "address", "support": "yes" },
+          { "key": "iburst", "support": "yes" },
+          { "key": "offline", "support": "yes" }
+        ]
+      },
+      { "key": "ntp_sync", "support": "no" }
+    ]
+  },
   { "key": "printer", "support": "no" },
   {
     "key": "proxy",

--- a/service/test/agama/autoyast/ntp_client_reader_test.rb
+++ b/service/test/agama/autoyast/ntp_client_reader_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/ntp_client_reader"
+
+Yast.import "Profile"
+
+describe Agama::AutoYaST::NtpClientReader do
+  let(:profile) do
+    {
+      "ntp-client" => {
+        "ntp_servers" => [
+          server1
+        ]
+      }
+    }
+  end
+
+  let(:server1) do
+    { "address" => "cz.pool.ntp.org", "iburst" => true, "offline" => false }
+  end
+
+  subject do
+    described_class.new(Yast::ProfileHash.new(profile))
+  end
+
+  describe "#read" do
+    context "when there is no 'ntp-client' section" do
+      let(:profile) { {} }
+
+      it "returns an empty hash" do
+        expect(subject.read).to be_empty
+      end
+    end
+
+    it "returns a hash containing the 'ntp' section with the given servers as pools" do
+      expect(subject.read["ntp"]).to eq("sources" => [server1.merge("type" => "pool")])
+    end
+  end
+end


### PR DESCRIPTION
Follow-up of #3446.

Read the `ntp-client` section from AutoYaST profiles.

## Example

``` xml
  <ntp-client>
    <ntp_policy>auto</ntp_policy>
    <ntp_servers config:type="list">
      <ntp_server>
        <address>1.opensuse.pool.ntp.org</address>
        <iburst config:type="boolean">true</iburst>
        <offline config:type="boolean">false</offline>
      </ntp_server>
    </ntp_servers>
  </ntp-client>
</profile>
```

The excerpt above is converted to:

``` json
{
  "ntp": {
    "sources": [
      { "type": "pool", "address": "1.opensuse.pool.ntp.org", "iburst": true, "offline": false }
    ]
  }
}
```

## Testing

- Added a new unit test
- Tested manually

## Follow-up

- Update the documentation about AutoYaST compatibility.