### PR TITLE
Restore the checkmedia option back

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May  7 13:06:27 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Restore back the checkmedia option in the *.kiwi file
+  (reverts the change for bsc#1262229, the latest checkmedia
+  supports GPT partition tables and kiwi improved the check to
+  detect the checkmedia version)
+
+-------------------------------------------------------------------
 Thu May  7 08:19:56 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - bsc#1264099

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -38,17 +38,17 @@
     </preferences>
     <!-- the ISO Volume ID is set by the fix_bootconfig script -->
     <preferences arch="ppc64le" profiles="openSUSE,SUSE_SLE_16.1,Leap_16.1">
-        <type image="iso" flags="dmsquash"  firmware="ofw" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash"  firmware="ofw" mediacheck="true" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
             <bootloader name="grub2" console="serial" timeout="10"/>
         </type>
     </preferences>
     <preferences arch="aarch64,x86_64" profiles="openSUSE,SUSE_SLE_16.1,Leap_16.1">
-        <type image="iso" flags="dmsquash" firmware="uefi" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash" firmware="uefi" mediacheck="true" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
             <bootloader name="grub2" timeout="10"/>
         </type>
     </preferences>
     <preferences arch="s390x" profiles="openSUSE,SUSE_SLE_16.1,Leap_16.1">
-        <type image="iso" flags="dmsquash" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
+        <type image="iso" flags="dmsquash" mediacheck="true" publisher="SUSE LLC" editbootconfig="fix_bootconfig">
             <bootloader name="custom" />
         </type>
     </preferences>


### PR DESCRIPTION
## Problem

- Removing the checkmedia option caused that the "Check Installation Medium" boot option does not work anymore because the medium does not contain any checksum.
- https://bugzilla.suse.com/show_bug.cgi?id=1262229

## Details

- The option was removed from the *.kiwi file (#3410) because kiwi started reporting an error that checkmedia does not work with GPT partition table and building the Agama Live ISO failed
  (https://github.com/OSInside/kiwi/pull/2964)
- However, then checkmedia has been fixed to support GPT
   (https://github.com/openSUSE/checkmedia/pull/22)
- Then kiwi relaxed the check so it reports that error only for the old checkmedia versions (<6.6)
  (https://github.com/OSInside/kiwi/pull/2991)
- As everything should work now we can revert the previous fix 

## Solution

- Revert the change from #3410 

