### PR TITLE
fix(web): refetch storage model data

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 12 13:35:54 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Fix query refetch when activating zFCP devices (bsc#1263808).
+
+-------------------------------------------------------------------
 Tue May 12 10:29:09 UTC 2026 - David Díaz <dgonzalez@suse.com>
 
 - Improve keyboard accessibility for dropdown components by enabling
@@ -23,7 +28,7 @@ Thu Apr 30 13:01:05 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Added support for configuring a network bridge using the UI
   (gh#agama-project/agama#3435).
-  
+
 -------------------------------------------------------------------
 Tue Apr 28 15:43:35 UTC 2026 - David Diaz <dgonzalez@suse.com>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,7 @@ import { useSystemChanges } from "~/hooks/model/system";
 import { useProposal, useProposalChanges } from "~/hooks/model/proposal";
 import { useIssues, useIssuesChanges } from "~/hooks/model/issue";
 import { useProductInfo } from "~/hooks/model/config/product";
+import { useConfigModel } from "~/hooks/model/storage/config-model";
 import { useQueryClient } from "@tanstack/react-query";
 import { InstallationFinished, InstallationProgress } from "./components/core";
 import InstallationFailed from "./components/core/InstallationFailed";
@@ -45,6 +46,7 @@ const Content = () => {
   // https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation
   useProposal();
   useIssues();
+  useConfigModel();
 
   const location = useLocation();
   const product = useProductInfo();


### PR DESCRIPTION
## Problem

* When navigating from `ZFCPPage` to `ProposalPage`, the `STORAGE_MODEL_KEY` query was being invalidated but not refetched immediately (since `ZFCPPage` didn't use `useConfigModel()`)
* When arriving at `ProposalPage`, the query would refetch quickly
* But then `useProgressTracking()` would wait for queries to refetch AFTER the progress finished, missing the refetch that already happened.
* https://bugzilla.suse.com/show_bug.cgi?id=1263808

## Solution:

* Added `useConfigModel()` to *App.tsx* `Content` component
* This ensures the query is always actively observed and refetches immediately when invalidated, matching the existing pattern for `useProposal()` and `useIssues()`
