### PR TITLE
fix(web): prevent focus loss when tabbing out of SuggestionsTextField

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 12 16:26:43 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Prevent focus loss and reduce flicker in storage forms using
+  SuggestionsTextField by deferring blur updates and increasing
+  debounce to 600ms (gh#agama-project/agama#3489).
+
+-------------------------------------------------------------------
 Tue May 12 10:29:09 UTC 2026 - David Díaz <dgonzalez@suse.com>
 
 - Improve keyboard accessibility for dropdown components by enabling

--- a/web/src/components/form/SuggestionsTextField.test.tsx
+++ b/web/src/components/form/SuggestionsTextField.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import SuggestionsTextField from "./SuggestionsTextField";
 
@@ -146,25 +146,11 @@ describe("SuggestionsTextField", () => {
     expect(screen.getByLabelText("Test field")).toHaveValue("/home");
   });
 
-  it("ignores external value changes while focused", async () => {
-    // NOTE: This tests focus tracking behavior that acts as a safeguard against
-    // race conditions, but doesn't typically happen with current forms.
-    // Current forms (PartitionPage, etc.) use useState and pass the value back
-    // that the input itself sent via onChange callback - so external value usually
-    // matches what user typed. This is the "tricky" controlled component pattern
-    // where the input sends a value up, parent updates state, re-renders, and
-    // sends the same value back down.
-    // Focus tracking prevents issues if parent sends a DIFFERENT value while
-    // user is typing (edge case). With TanStack Form, this won't be needed at all
-    // since field state is managed internally.
-    const { user, rerender } = installerRender(
-      <SuggestionsTextField
-        id="test-field"
-        value="/boot"
-        onChange={jest.fn()}
-        aria-label="Test field"
-      />,
-    );
+  it("ignores external value changes while focused (real-world scenario)", async () => {
+    // This tests the typical controlled component pattern where the parent
+    // responds to onChange and sends back the same value. Focus tracking
+    // prevents race conditions from the debounced onChange.
+    const { user } = installerRender(<ControlledSuggestionsTextField initialValue="/boot" />);
 
     const input = screen.getByLabelText("Test field");
     expect(input).toHaveValue("/boot");
@@ -176,24 +162,13 @@ describe("SuggestionsTextField", () => {
     await user.type(input, "test");
     expect(input).toHaveValue("/boottest");
 
-    // Parent tries to update value while focused - should be ignored
-    rerender(
-      <SuggestionsTextField
-        id="test-field"
-        value="/home"
-        onChange={jest.fn()}
-        aria-label="Test field"
-      />,
-    );
-
-    // Value should NOT change because input is focused
-    expect(input).toHaveValue("/boottest");
-
     // Blur the input
     await user.tab();
 
-    // After blur, should sync with external value
-    expect(input).toHaveValue("/home");
+    // After blur, value should match what we typed
+    await waitFor(() => {
+      expect(input).toHaveValue("/boottest");
+    });
   });
 
   it("clears the value when external value is cleared", async () => {

--- a/web/src/components/form/SuggestionsTextField.tsx
+++ b/web/src/components/form/SuggestionsTextField.tsx
@@ -206,24 +206,29 @@ function SuggestionsTextField({
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    isFocused.current = false;
-
-    // Cancel debounced onChange and sync immediately on blur
+    // Cancel debounced onChange
     if (debounceTimeout.current !== null) {
       window.clearTimeout(debounceTimeout.current);
       debounceTimeout.current = null;
     }
 
-    if (onChange) {
-      onChange(event, internalValue);
-    }
-
-    // Sync with external value on blur in case parent transformed it
-    setInternalValue(String(externalValue || ""));
-
-    if (onBlur) {
-      onBlur(event);
-    }
+    // Defer these updates using setTimeout(..., 0) so they run after the blur
+    // event. If onChange or onBlur are called immediately during blur, a React
+    // re-render can happen before the browser finishes moving focus (e.g., when
+    // pressing TAB), causing focus loss.
+    //
+    // More on how event loop and task queues work:
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
+    const currentValue = internalValue;
+    setTimeout(() => {
+      isFocused.current = false;
+      if (onChange) {
+        onChange(event, currentValue);
+      }
+      if (onBlur) {
+        onBlur(event);
+      }
+    }, 0);
   };
 
   return (

--- a/web/src/components/form/SuggestionsTextField.tsx
+++ b/web/src/components/form/SuggestionsTextField.tsx
@@ -50,7 +50,7 @@ export type SuggestionsTextFieldProps = Omit<TextInputProps, "list"> & {
  *
  * This component uses TWO mechanisms to prevent flickering and focus loss:
  *
- * ### 1. Debounced onChange (400ms)
+ * ### 1. Debounced onChange (600ms)
  *
  * **Why it's needed:**
  * Current parent forms (PartitionPage, LogicalVolumePage,
@@ -80,7 +80,7 @@ export type SuggestionsTextFieldProps = Omit<TextInputProps, "list"> & {
  *  - Flickering and input lag
  *  - Focus loss mid-typing
  *
- * Debouncing (400ms) reduces parent updates while user is typing.
+ * Debouncing (600ms) reduces parent updates while user is typing.
  *
  * ### 2. Focus Tracking
  *
@@ -89,7 +89,7 @@ export type SuggestionsTextFieldProps = Omit<TextInputProps, "list"> & {
  * ```
  *  1. User types "/h"        → internalValue = "/h" (onChange debounced)
  *  2. User types "ome"       → internalValue = "/home"
- *  3. 400ms after step 1     → onChange("/h") fires → parent updates
+ *  3. 600ms after step 1     → onChange("/h") fires → parent updates
  *  4. Parent re-renders      → externalValue = "/h"
  *  5. Effect runs            → setInternalValue("/h")
  *  6. User's "ome" is lost!  → Input shows "/h" instead of "/home"
@@ -101,7 +101,7 @@ export type SuggestionsTextFieldProps = Omit<TextInputProps, "list"> & {
  *
  * ### Behavior Summary
  *
- * - **While typing (focused)**: Internal state only, onChange debounced (400ms)
+ * - **While typing (focused)**: Internal state only, onChange debounced (600ms)
  * - **On blur**: Cancel debounce, fire onChange immediately, sync with parent value
  * - **External updates when unfocused**: Sync immediately (form reset, initial load)
  * - **External updates when focused**: Ignored (prevents race conditions)
@@ -201,7 +201,7 @@ function SuggestionsTextField({
     if (onChange) {
       debounceTimeout.current = window.setTimeout(() => {
         onChange(event, newValue);
-      }, 400);
+      }, 600);
     }
   };
 

--- a/web/src/components/storage/FormattableDevicePage.test.tsx
+++ b/web/src/components/storage/FormattableDevicePage.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { installerRender, mockParams } from "~/test-utils";
 import FormattableDevicePage from "~/components/storage/FormattableDevicePage";
 import type { Storage } from "~/model/system";
@@ -105,9 +105,11 @@ describe("FormattableDevicePage", () => {
 
     await user.type(mountPoint, "/home");
     await user.tab();
-    // Valid mount point selected, enable file system field
-    expect(filesystem).toBeEnabled();
-    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    // Valid mount point selected, enable file system field (deferred onChange)
+    await waitFor(() => {
+      expect(filesystem).toBeEnabled();
+      expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    });
     // Display available file systems
     await user.click(filesystem);
     screen.getByRole("listbox", { name: "Available file systems" });
@@ -123,17 +125,23 @@ describe("FormattableDevicePage", () => {
 
     await user.type(mountPoint, "/home");
     await user.tab();
-    expect(mountPoint).toHaveValue("/home");
-    expect(filesystem).toBeEnabled();
-    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    // Wait for deferred onChange to update parent state
+    await waitFor(() => {
+      expect(mountPoint).toHaveValue("/home");
+      expect(filesystem).toBeEnabled();
+      expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    });
 
     await user.click(mountPoint);
     await user.clear(mountPoint);
     await user.tab();
-    expect(mountPoint).toHaveValue("");
-    // File system field is disabled until a valid mount point selected
-    expect(filesystem).toBeDisabled();
-    expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+    // Wait for deferred onChange to update parent state
+    await waitFor(() => {
+      expect(mountPoint).toHaveValue("");
+      // File system field is disabled until a valid mount point selected
+      expect(filesystem).toBeDisabled();
+      expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+    });
   });
 
   describe("if the device has already a filesystem config", () => {

--- a/web/src/components/storage/PartitionPage.test.tsx
+++ b/web/src/components/storage/PartitionPage.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { installerRender, mockParams } from "~/test-utils";
 import PartitionPage from "./PartitionPage";
 import type { ConfigModel } from "~/model/storage/config-model";
@@ -172,10 +172,12 @@ describe("PartitionPage", () => {
 
     await user.type(mountPoint, "/home");
     await user.tab();
+    // Wait for deferred onChange to update parent state
+    await waitFor(() => {
+      expect(filesystem).toBeEnabled();
+      expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    });
     const size = screen.getByRole("button", { name: "Size mode" });
-    // Valid mount point selected, enable file system and size fields
-    expect(filesystem).toBeEnabled();
-    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
     expect(size).toBeEnabled();
     // Display mount point options
     await user.click(mountPointMode);
@@ -204,17 +206,23 @@ describe("PartitionPage", () => {
     expect(size).toBeDisabled();
     await user.type(mountPoint, "/home");
     await user.tab();
-    expect(mountPoint).toHaveValue("/home");
-    expect(filesystem).toBeEnabled();
-    expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    // Wait for deferred onChange to update parent state
+    await waitFor(() => {
+      expect(mountPoint).toHaveValue("/home");
+      expect(filesystem).toBeEnabled();
+      expect(screen.queryByRole("textbox", { name: "File system label" })).toBeInTheDocument();
+    });
     size = screen.getByRole("button", { name: "Size mode" });
     expect(size).toBeEnabled();
     await user.clear(mountPoint);
     await user.tab();
-    expect(mountPoint).toHaveValue("");
-    // File system and size fields disabled until valid mount point selected
-    expect(filesystem).toBeDisabled();
-    expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+    // Wait for deferred onChange to update parent state
+    await waitFor(() => {
+      expect(mountPoint).toHaveValue("");
+      // File system and size fields disabled until valid mount point selected
+      expect(filesystem).toBeDisabled();
+      expect(screen.queryByRole("textbox", { name: "File system label" })).not.toBeInTheDocument();
+    });
     size = screen.getByRole("button", { name: "Size mode" });
     expect(size).toBeDisabled();
   });


### PR DESCRIPTION
During post-merge manual testing of #3445, @ancorgs noticed a focus-loss issue in storage forms. When users type quickly and press TAB to move between fields, focus could be lost, disrupting the expected workflow and undermining the user experience.

From the main commit of this PR

> When typing quickly in the mount point field and pressing TAB to move to the next field, focus could be lost instead of advancing correctly.
> 
> This happens in certain storage forms that perform intensive callbacks and validations. The blur handler triggered an immediate parent update, causing a React re-render while the browser was still processing the focus transition.
> 
> Defer the blur-time onChange until after the blur event completes using setTimeout(..., 0), so the browser can finish moving focus before re-rendering occurs.
> 
> This issue is expected to stop once these forms are migrated to TanStackForm.

---

 **Note on testing**: This fix addresses a timing-dependent race condition that occurs with fast typing and immediate TAB press. It's difficult to reproduce reliably in unit tests since  RTL `user.type()` deliberately adds realistic delays between keystrokes (https://testing-library.com/docs/user-event/options/#advancetimers) that prevent reproducing the race condition. The fix has been manually verified to work.

---
https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide