### PR TITLE
Adapt network UI

### DIFF
--- a/rust/agama-network/src/nm/model.rs
+++ b/rust/agama-network/src/nm/model.rs
@@ -182,7 +182,7 @@ impl TryFrom<NmConnectionState> for ConnectionState {
 
     fn try_from(value: NmConnectionState) -> Result<Self, Self::Error> {
         match value {
-            NmConnectionState(0) => Ok(ConnectionState::Deactivated),
+            NmConnectionState(0) => Ok(ConnectionState::Unknown),
             NmConnectionState(1) => Ok(ConnectionState::Activating),
             NmConnectionState(2) => Ok(ConnectionState::Activated),
             NmConnectionState(3) => Ok(ConnectionState::Deactivating),

--- a/rust/agama-utils/src/api/network/types.rs
+++ b/rust/agama-utils/src/api/network/types.rs
@@ -558,6 +558,8 @@ pub enum DeviceState {
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub enum ConnectionState {
+    /// The connection state is unknown.
+    Unknown,
     /// The connection is getting activated.
     Activating,
     /// The connection is activated.

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 14 17:57:06 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Adapted the connections table to use the connections state
+  instead of the status (gh#agama-project/agama#3499,
+  related to bsc#1260465).
+
+-------------------------------------------------------------------
 Thu May 14 11:05:33 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update npm dependencies to safer versions (bsc#1264373,

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -28,6 +28,7 @@ import { Product } from "~/model/system";
 import { Keymap, Locale } from "~/model/system/l10n";
 import { Progress, Stage } from "~/model/status";
 import { System } from "~/model/system/network";
+import { ConnectivityState } from "~/types/network";
 import * as utils from "~/utils";
 import { ROOT } from "~/routes/paths";
 import InstallerL10nOptions, { InstallerL10nOptionsProps } from "./InstallerL10nOptions";
@@ -56,7 +57,7 @@ const network: System = {
   connections: [],
   devices: [],
   state: {
-    connectivity: true,
+    connectivity: ConnectivityState.FULL,
     copyNetwork: true,
     networkingEnabled: true,
     wirelessEnabled: true,

--- a/web/src/components/network/BindingSettingsForm.test.tsx
+++ b/web/src/components/network/BindingSettingsForm.test.tsx
@@ -51,7 +51,7 @@ const mockDevice: Device = {
 };
 
 let mockConnection: Connection = new Connection("Network 1", {
-  state: ConnectionState.activated,
+  state: ConnectionState.ACTIVATED,
 });
 
 const mockMutation = jest.fn(() => Promise.resolve());
@@ -157,7 +157,7 @@ describe("BindingSettingsForm", () => {
   describe("when the connection is bound by device name", () => {
     beforeEach(() => {
       mockConnection = new Connection("Network 1", {
-        state: ConnectionState.activated,
+        state: ConnectionState.ACTIVATED,
         iface: "enp1s0",
       });
     });
@@ -175,7 +175,7 @@ describe("BindingSettingsForm", () => {
   describe("when connection is bound MAC address", () => {
     beforeEach(() => {
       mockConnection = new Connection("Network 1", {
-        state: ConnectionState.activated,
+        state: ConnectionState.ACTIVATED,
         macAddress: "52:54:00:46:2A:F9",
       });
     });

--- a/web/src/components/network/ConnectionDetails.test.tsx
+++ b/web/src/components/network/ConnectionDetails.test.tsx
@@ -73,7 +73,7 @@ const mockAnotherDevice: Device = {
 };
 
 const mockConnection: Connection = new Connection("Network #1", {
-  state: ConnectionState.activated,
+  state: ConnectionState.ACTIVATED,
   iface: "enp1s0",
   method4: ConnectionMethod.AUTO,
   method6: ConnectionMethod.AUTO,
@@ -101,7 +101,7 @@ describe("ConnectionDetails", () => {
 
     it("renders 'None set' for IPv4 and IPv6 when no method is set", () => {
       const connection = new Connection("Network #1", {
-        state: ConnectionState.activated,
+        state: ConnectionState.ACTIVATED,
         iface: "enp1s0",
       });
       installerRender(<ConnectionDetails connection={connection} />);
@@ -116,7 +116,7 @@ describe("ConnectionDetails", () => {
         <ConnectionDetails
           connection={
             new Connection("Network #1", {
-              state: ConnectionState.activated,
+              state: ConnectionState.ACTIVATED,
               iface: "enp1s0",
               addresses: [{ address: "192.168.0.0", prefix: "24" }, { address: "192.168.20.20" }],
               gateway4: "100.100.100.4",

--- a/web/src/components/network/ConnectionForm.test.tsx
+++ b/web/src/components/network/ConnectionForm.test.tsx
@@ -66,7 +66,7 @@ const buildConnection = (id: string, overrides = {}) =>
   Connection.fromApi({
     id,
     status: ConnectionStatus.UP,
-    state: ConnectionState.activated,
+    state: ConnectionState.ACTIVATED,
     persistent: true,
     addresses: [],
     nameservers: [],

--- a/web/src/components/network/ConnectionPage.test.tsx
+++ b/web/src/components/network/ConnectionPage.test.tsx
@@ -32,7 +32,7 @@ jest.mock("~/hooks/model/progress", () => ({
 }));
 
 const mockConnection: Connection = new Connection("Network 1", {
-  state: ConnectionState.activated,
+  state: ConnectionState.ACTIVATED,
 });
 
 jest.mock("~/components/network/ConnectionDetails", () => () => <div>ConnectionDetails Mock</div>);

--- a/web/src/components/network/ConnectionsTable.test.tsx
+++ b/web/src/components/network/ConnectionsTable.test.tsx
@@ -24,7 +24,7 @@ import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender, mockNavigateFn } from "~/test-utils";
 import ConnectionsTable from "~/components/network/ConnectionsTable";
-import { Connection, ConnectionStatus } from "~/types/network";
+import { Connection, ConnectionState, ConnectionStatus } from "~/types/network";
 
 const mockMutateAsync = jest.fn();
 const mockConnections = [
@@ -32,17 +32,20 @@ const mockConnections = [
     iface: "eth0",
     addresses: [],
     status: ConnectionStatus.UP,
+    state: ConnectionState.ACTIVATED,
   }),
   new Connection("Wifi1", {
     iface: "wlan0",
     wireless: { ssid: "My Wifi", mode: "infrastructure" },
     addresses: [],
     status: ConnectionStatus.DOWN,
+    state: ConnectionState.DEACTIVATED,
   }),
   new Connection("MAC connection", {
     macAddress: "00:11:22:33:44:55",
     addresses: [],
     status: ConnectionStatus.DOWN,
+    state: ConnectionState.DEACTIVATED,
   }),
 ];
 
@@ -70,12 +73,12 @@ describe("ConnectionsTable", () => {
     expect(screen.getByText("MAC connection")).toBeInTheDocument();
   });
 
-  it("renders the Status column", () => {
+  it("renders the State column", () => {
     installerRender(<ConnectionsTable />);
-    // Wired connection 0 has status UP
-    expect(screen.getByText("Connected")).toBeInTheDocument();
-    // Wifi1 has status DOWN
-    expect(screen.getAllByText("Disconnected").length).toBeGreaterThan(0);
+    // Wired connection 0 has state activated
+    expect(screen.getByText("Activated")).toBeInTheDocument();
+    // Wifi1 has state deactivated
+    expect(screen.getAllByText("Deactivated").length).toBeGreaterThan(0);
   });
 
   it("shows the device name with a binding hint when a connection is bound by interface name", () => {
@@ -92,17 +95,17 @@ describe("ConnectionsTable", () => {
     within(row).getByText("(bound by MAC)");
   });
 
-  it("filters the connections by status", async () => {
+  it("filters the connections by state", async () => {
     const { user } = installerRender(<ConnectionsTable />);
-    // Select Status "Up"
-    await user.click(screen.getByLabelText("Status"));
-    await user.click(screen.getByRole("option", { name: "Up" }));
+    // Select State "Activated"
+    await user.click(screen.getByLabelText("State"));
+    await user.click(screen.getByRole("option", { name: "Activated" }));
     expect(screen.getByText("Wired connection 0")).toBeInTheDocument();
     expect(screen.queryByText("Wifi1")).not.toBeInTheDocument();
 
-    // Select Status "Down"
-    await user.click(screen.getByLabelText("Status"));
-    await user.click(screen.getByRole("option", { name: "Down" }));
+    // Select State "Deactivated"
+    await user.click(screen.getByLabelText("State"));
+    await user.click(screen.getByRole("option", { name: "Deactivated" }));
     expect(screen.queryByText("Wired connection 0")).not.toBeInTheDocument();
     expect(screen.getByText("Wifi1")).toBeInTheDocument();
     expect(screen.getByText("MAC connection")).toBeInTheDocument();

--- a/web/src/components/network/ConnectionsTable.test.tsx
+++ b/web/src/components/network/ConnectionsTable.test.tsx
@@ -62,7 +62,11 @@ jest.mock("~/hooks/model/config/network", () => ({
 jest.mock("~/hooks/model/system/network", () => ({
   useConnections: () => mockConnections,
   useDevices: () => mockDevices,
-  useSystem: () => ({ state: { wirelessEnabled: true } }),
+  useSystem: () => ({
+    connections: mockConnections,
+    devices: mockDevices,
+    state: { wirelessEnabled: true },
+  }),
 }));
 
 describe("ConnectionsTable", () => {

--- a/web/src/components/network/ConnectionsTable.test.tsx
+++ b/web/src/components/network/ConnectionsTable.test.tsx
@@ -56,11 +56,11 @@ const mockDevices = [
 ];
 
 jest.mock("~/hooks/model/config/network", () => ({
-  useConnections: () => mockConnections,
   useConnectionMutation: () => ({ mutateAsync: mockMutateAsync }),
 }));
 
 jest.mock("~/hooks/model/system/network", () => ({
+  useConnections: () => mockConnections,
   useDevices: () => mockDevices,
   useSystem: () => ({ state: { wirelessEnabled: true } }),
 }));

--- a/web/src/components/network/ConnectionsTable.tsx
+++ b/web/src/components/network/ConnectionsTable.tsx
@@ -42,12 +42,24 @@ import Text from "~/components/core/Text";
 import SelectableDataTable, { SortedBy } from "~/components/core/SelectableDataTable";
 import TextinputFilter from "~/components/storage/dasd/TextinputFilter";
 import SimpleSelector from "~/components/core/SimpleSelector";
-import { useConnections, useConnectionMutation } from "~/hooks/model/config/network";
+import { useConnectionMutation } from "~/hooks/model/config/network";
 import { useDevices, useSystem } from "~/hooks/model/system/network";
 import { sortCollection } from "~/utils";
-import { connectionType, CONNECTION_TYPE, connectionTypeLabel, formatIp } from "~/utils/network";
+import {
+  connectionType,
+  CONNECTION_TYPE,
+  connectionTypeLabel,
+  connectionStateLabel,
+  formatIp,
+} from "~/utils/network";
 import { _ } from "~/i18n";
-import { Connection, ConnectionStatus, ConnectionType, Device } from "~/types/network";
+import {
+  Connection,
+  ConnectionState,
+  ConnectionStatus,
+  ConnectionType,
+  Device,
+} from "~/types/network";
 import { NETWORK } from "~/routes/paths";
 
 /**
@@ -57,7 +69,7 @@ type ConnectionsFilters = {
   name?: string;
   device?: string;
   type?: "all" | ConnectionType;
-  status?: "all" | "up" | "down";
+  state?: "all" | ConnectionState;
 };
 
 /** Internal state shape for the connections table component. */
@@ -74,7 +86,7 @@ const initialState: TableState = {
     name: "",
     device: "",
     type: "all",
-    status: "all",
+    state: "all",
   },
 };
 
@@ -101,7 +113,7 @@ const filterConnections = (
   connections: Connection[],
   filters: ConnectionsFilters,
 ): Connection[] => {
-  const { name, device, type, status } = filters;
+  const { name, device, type, state } = filters;
 
   return connections.filter((c) => {
     if (!isEmpty(name) && !c.id.toLowerCase().includes(name.toLowerCase())) {
@@ -119,10 +131,8 @@ const filterConnections = (
       if (connectionType(c) !== type) return false;
     }
 
-    if (status && status !== "all") {
-      const isUp = c.status === ConnectionStatus.UP;
-      if (status === "up" && !isUp) return false;
-      if (status === "down" && isUp) return false;
+    if (state && state !== "all") {
+      if (c.state !== state) return false;
     }
 
     return true;
@@ -155,10 +165,9 @@ const createColumns = (devices: Device[]) => [
     sortingKey: (c: Connection) => connectionType(c),
   },
   {
-    name: _("Status"),
-    value: (c: Connection) =>
-      c.status === ConnectionStatus.UP ? _("Connected") : _("Disconnected"),
-    sortingKey: (c: Connection) => c.status,
+    name: _("State"),
+    value: (c: Connection) => connectionStateLabel(c.state),
+    sortingKey: (c: Connection) => c.state,
   },
   {
     name: _("Device"),
@@ -195,9 +204,8 @@ const createColumns = (devices: Device[]) => [
 
 export default function ConnectionsTable() {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const connections = useConnections();
   const devices = useDevices();
-  const { state: systemState } = useSystem();
+  const { state: systemState, connections } = useSystem();
   const { mutateAsync: mutateConnection } = useConnectionMutation();
   const navigate = useNavigate();
 
@@ -291,14 +299,19 @@ export default function ConnectionsTable() {
             </ToolbarItem>
             <ToolbarItem>
               <SimpleSelector
-                label={_("Status")}
-                value={state.filters.status}
+                label={_("State")}
+                value={state.filters.state}
                 options={{
                   all: _("All"),
-                  up: _("Up"),
-                  down: _("Down"),
+                  [ConnectionState.ACTIVATED]: connectionStateLabel(ConnectionState.ACTIVATED),
+                  [ConnectionState.DEACTIVATED]: connectionStateLabel(ConnectionState.DEACTIVATED),
+                  [ConnectionState.ACTIVATING]: connectionStateLabel(ConnectionState.ACTIVATING),
+                  [ConnectionState.DEACTIVATING]: connectionStateLabel(
+                    ConnectionState.DEACTIVATING,
+                  ),
+                  [ConnectionState.UNKNOWN]: connectionStateLabel(ConnectionState.UNKNOWN),
                 }}
-                onChange={(_, v) => onFilterChange("status", v)}
+                onChange={(_, v) => onFilterChange("state", v)}
               />
             </ToolbarItem>
           </ToolbarGroup>
@@ -329,8 +342,8 @@ export default function ConnectionsTable() {
         updateSorting={onSortingChange}
         itemActions={(c: Connection) => {
           const isWifi = !!c.wireless;
-          const isConnected = c.status === ConnectionStatus.UP;
-          const isDisconnected = c.status === ConnectionStatus.DOWN;
+          const isConnected = c.state === ConnectionState.ACTIVATED;
+          const isDisconnected = c.state === ConnectionState.DEACTIVATED;
           const canConnect = !isWifi || systemState.wirelessEnabled;
 
           return [

--- a/web/src/components/network/ConnectionsTable.tsx
+++ b/web/src/components/network/ConnectionsTable.tsx
@@ -205,7 +205,7 @@ const createColumns = (devices: Device[]) => [
 export default function ConnectionsTable() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const devices = useDevices();
-  const { state: systemState, connections } = useSystem();
+  const { state: systemState, connections = [] } = useSystem();
   const { mutateAsync: mutateConnection } = useConnectionMutation();
   const navigate = useNavigate();
 

--- a/web/src/components/network/InstallationOnlySwitch.test.tsx
+++ b/web/src/components/network/InstallationOnlySwitch.test.tsx
@@ -36,7 +36,7 @@ const mockConnection = (options: Partial<ConnectionOptions> = {}) =>
       ssid: "Network 2",
       mode: "infrastructure",
     },
-    state: ConnectionState.activating,
+    state: ConnectionState.ACTIVATING,
     ...options,
   });
 

--- a/web/src/components/network/NetworkPage.test.tsx
+++ b/web/src/components/network/NetworkPage.test.tsx
@@ -24,13 +24,14 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import NetworkPage from "~/components/network/NetworkPage";
+import { ConnectivityState } from "~/types/network";
 
 const mockProgressFn = jest.fn();
 const mockSystem = {
   connections: [],
   devices: [],
   state: {
-    connectivity: true,
+    connectivity: ConnectivityState.FULL,
     copyNetwork: true,
     networkingEnabled: true,
     wirelessEnabled: false,

--- a/web/src/components/network/WifiNetworksList.test.tsx
+++ b/web/src/components/network/WifiNetworksList.test.tsx
@@ -81,7 +81,7 @@ describe.skip("WifiNetworksList", () => {
             ssid: "Network 2",
             mode: "infrastructure",
           },
-          state: ConnectionState.activating,
+          state: ConnectionState.ACTIVATING,
         }),
       ];
 
@@ -158,7 +158,7 @@ describe.skip("WifiNetworksList", () => {
               ssid: "Network 2",
               mode: "infrastructure",
             },
-            state: ConnectionState.activating,
+            state: ConnectionState.ACTIVATING,
             persistent: true,
           }),
         ];
@@ -197,7 +197,7 @@ describe.skip("WifiNetworksList", () => {
               ssid: "Network 2",
               mode: "infrastructure",
             },
-            state: ConnectionState.activating,
+            state: ConnectionState.ACTIVATING,
             persistent: false,
           }),
         ];

--- a/web/src/components/network/WifiNetworksList.tsx
+++ b/web/src/components/network/WifiNetworksList.tsx
@@ -92,7 +92,7 @@ const NetworkSecurity = ({ id, security }) => {
 
 type ConnectingSpinnerProps = { ssid: WifiNetwork["ssid"]; state: ConnectionState | undefined };
 const ConnectingSpinner = ({ state, ssid }: ConnectingSpinnerProps) => {
-  if (state !== ConnectionState.activating) return;
+  if (state !== ConnectionState.ACTIVATING) return;
 
   // TRANSLATORS: %s will be replaced by Wi-Fi network SSID
   const label = sprintf(_("Connecting to %s"), ssid);
@@ -129,7 +129,7 @@ const NetworkListItem = ({ network, connection, showIp }: NetworkListItemProps) 
                   >
                     {network.ssid}
                   </Content>
-                  {connection?.state === ConnectionState.activated && (
+                  {connection?.state === ConnectionState.ACTIVATED && (
                     <Label id={statusId} isCompact color="green">
                       {_("Connected")}
                     </Label>

--- a/web/src/components/system/HostnamePage.test.tsx
+++ b/web/src/components/system/HostnamePage.test.tsx
@@ -24,6 +24,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import HostnamePage from "./HostnamePage";
+import { ConnectivityState } from "~/types/network";
 
 let mockStaticHostname: string;
 const mockPatchConfig = jest.fn();
@@ -46,7 +47,7 @@ jest.mock("~/hooks/model/proposal", () => ({
     network: {
       connections: [],
       state: {
-        connectivity: true,
+        connectivity: ConnectivityState.FULL,
         copyNetwork: true,
         networkingEnabled: false,
         wirelessEnabled: false,

--- a/web/src/hooks/model/system/network.test.ts
+++ b/web/src/hooks/model/system/network.test.ts
@@ -37,7 +37,7 @@ const createConnection = (
   return new Connection(id, {
     method4: ConnectionMethod.AUTO,
     method6: ConnectionMethod.AUTO,
-    state: ConnectionState.activated,
+    state: ConnectionState.ACTIVATED,
     persistent: true,
     ...overrides,
   });
@@ -72,7 +72,7 @@ describe("getNetworkStatus", () => {
     const nonPersistentConnection = createConnection("Network 2", {
       method4: ConnectionMethod.MANUAL,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       persistent: false,
     });
 
@@ -86,7 +86,7 @@ describe("getNetworkStatus", () => {
     const nonPersistentConnection = createConnection("Network 2", {
       method4: ConnectionMethod.MANUAL,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       persistent: false,
     });
 
@@ -99,7 +99,7 @@ describe("getNetworkStatus", () => {
     const nonPersistentConnection = createConnection("Network 1", {
       method4: ConnectionMethod.MANUAL,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       persistent: false,
     });
 
@@ -113,7 +113,7 @@ describe("getNetworkStatus", () => {
     const nonPersistentConnection = createConnection("Network 2", {
       method4: ConnectionMethod.MANUAL,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       persistent: false,
     });
 
@@ -126,7 +126,7 @@ describe("getNetworkStatus", () => {
 
   it("returns AUTO status when there are only connections with auto method and without static IP addresses", () => {
     const autoConnection = createConnection("Network 1", {
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       addresses: [],
     });
 
@@ -139,7 +139,7 @@ describe("getNetworkStatus", () => {
     const manualConnection = createConnection("Network 1", {
       method4: ConnectionMethod.MANUAL,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
     });
 
     const result = getNetworkStatus([manualConnection]);
@@ -151,7 +151,7 @@ describe("getNetworkStatus", () => {
     const manualWithStaticIp = createConnection("Network 1", {
       method4: ConnectionMethod.MANUAL,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       addresses: [{ address: "192.168.1.10", prefix: 24 }],
     });
 
@@ -164,7 +164,7 @@ describe("getNetworkStatus", () => {
     const mixedConnection = createConnection("Network 1", {
       method4: ConnectionMethod.AUTO,
       method6: ConnectionMethod.MANUAL,
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
     });
 
     const result = getNetworkStatus([mixedConnection]);
@@ -174,7 +174,7 @@ describe("getNetworkStatus", () => {
 
   it("returns MIXED status when there is an auto connection with static IP address", () => {
     const autoWithStaticIp = createConnection("Network 1", {
-      state: ConnectionState.activating,
+      state: ConnectionState.ACTIVATING,
       addresses: [{ address: "192.168.1.10", prefix: 24 }],
     });
 

--- a/web/src/types/network.ts
+++ b/web/src/types/network.ts
@@ -136,6 +136,14 @@ enum NetworkState {
   CONNECTED = "connected",
 }
 
+enum ConnectivityState {
+  UNKNOWN = "unknown",
+  NONE = "none",
+  PORTAL = "portal",
+  LIMITED = "limited",
+  FULL = "full",
+}
+
 enum SecurityProtocols {
   WEP = "WEP",
   WPA = "WPA1",
@@ -442,7 +450,7 @@ type WifiNetwork = AccessPoint & {
 
 type GeneralState = {
   copyNetwork: boolean;
-  connectivity: boolean;
+  connectivity: ConnectivityState;
   networkingEnabled: boolean;
   wirelessEnabled: boolean;
 };
@@ -580,6 +588,7 @@ export {
   ApSecurityFlags,
   BondMode,
   Connection,
+  ConnectivityState,
   ConnectionState,
   ConnectionStatus,
   ConnectionMethod,

--- a/web/src/types/network.ts
+++ b/web/src/types/network.ts
@@ -109,10 +109,11 @@ enum ConnectionStatus {
 
 // Current state of the connection.
 enum ConnectionState {
-  activating = "activating",
-  activated = "activated",
-  deactivating = "deactivating",
-  deactivated = "deactivated",
+  UNKNOWN = "unknown",
+  ACTIVATING = "activating",
+  ACTIVATED = "activated",
+  DEACTIVATING = "deactivating",
+  DEACTIVATED = "deactivated",
 }
 
 enum ConnectionMethod {
@@ -284,7 +285,7 @@ type APIConnection = {
   method6?: string;
   wireless?: Wireless;
   status: ConnectionStatus;
-  state: ConnectionState;
+  state?: ConnectionState;
   persistent: boolean;
 };
 
@@ -359,7 +360,7 @@ type ConnectionOptions = {
 class Connection {
   id: string;
   status: ConnectionStatus = ConnectionStatus.UP;
-  state: ConnectionState;
+  state?: ConnectionState;
   iface: string;
   macAddress?: string;
   addresses: IPAddress[] = [];
@@ -385,13 +386,12 @@ class Connection {
   }
 
   static fromApi(connection: APIConnection) {
-    const { id, status, interface: iface, ...options } = connection;
+    const { id, interface: iface, ...options } = connection;
     const nameservers = connection.nameservers || [];
     const dnsSearchList = connection.dnsSearchList || [];
     const addresses = connection.addresses?.map(buildAddress) || [];
     const conn = new Connection(id, {
       ...options,
-      status,
       // FIXME: try a better approach for methods/gateway and/or typecasting
       method4: options.method4 as ConnectionMethod,
       method6: options.method6 as ConnectionMethod,
@@ -416,7 +416,7 @@ class Connection {
   }
 
   toApi() {
-    const { iface, addresses, ...newConnection } = this;
+    const { iface, addresses, state, ...newConnection } = this;
     const result: APIConnection = {
       ...newConnection,
       interface: iface,

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -66,7 +66,8 @@ const CONNECTION_STATE_LABELS: Record<ConnectionState, string> = {
 /**
  * Returns the translated label for a connection state.
  */
-const connectionStateLabel = (state: ConnectionState): string => CONNECTION_STATE_LABELS[state];
+// eslint-disable-next-line agama-i18n/string-literals
+const connectionStateLabel = (state: ConnectionState): string => _(CONNECTION_STATE_LABELS[state]);
 
 /**
  * Returns true if the given connection type is virtual.

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -66,7 +66,6 @@ const CONNECTION_STATE_LABELS: Record<ConnectionState, string> = {
 /**
  * Returns the translated label for a connection state.
  */
-// eslint-disable-next-line agama-i18n/string-literals
 const connectionStateLabel = (state: ConnectionState): string => CONNECTION_STATE_LABELS[state];
 
 /**

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -29,6 +29,7 @@ import {
   Connection,
   ConnectionBindingMode,
   ConnectionType,
+  ConnectionState,
   Device,
   IPAddress,
   Route,
@@ -50,6 +51,23 @@ export const CONNECTION_TYPE = {
   VLAN: "vlan",
   UNKNOWN: "unknown",
 } as const;
+
+/**
+ * Translatable labels for connection states.
+ */
+const CONNECTION_STATE_LABELS: Record<ConnectionState, string> = {
+  unknown: N_("Unknown"),
+  activating: N_("Activating"),
+  activated: N_("Activated"),
+  deactivating: N_("Deactivating"),
+  deactivated: N_("Deactivated"),
+};
+
+/**
+ * Returns the translated label for a connection state.
+ */
+// eslint-disable-next-line agama-i18n/string-literals
+const connectionStateLabel = (state: ConnectionState): string => CONNECTION_STATE_LABELS[state];
 
 /**
  * Returns true if the given connection type is virtual.
@@ -397,6 +415,7 @@ export {
   buildRoutes,
   connectionAddresses,
   connectionBindingMode,
+  connectionStateLabel,
   connectionType,
   connectionTypeLabel,
   ensureIPPrefix,


### PR DESCRIPTION
In https://github.com/agama-project/agama/pull/3416 we did some fixes in the backend, and this PR is for adapting the UI in order to use the correct connectivity enum values as well as use the connections state instead of the status.

The current status is not correct enough, as when there are state changes the current status is not updated accordingly and therefore, it should false values. Therefore, this PR brings back the state value which was used in the past but was removed at some point when working only with the extended config or with the config which does not expose the value as it is not a configuration at all.

## Screenshot

<img width="1715" height="851" alt="image" src="https://github.com/user-attachments/assets/fe96f104-275f-421e-bff8-b603a06d0daa" />

