### PR TITLE
adapt code for new suseconnect library

### DIFF
--- a/rust/agama-software/src/model/registration.rs
+++ b/rust/agama-software/src/model/registration.rs
@@ -402,7 +402,13 @@ impl RegistrationBuilder {
             config_files: vec![suseconnect_agama::GLOBAL_CREDENTIALS_FILE.into()],
         };
 
-        registration.activate_product(zypp, security, &self.product, &self.version, None)?;
+        registration.activate_product(
+            zypp,
+            security,
+            &self.product,
+            &self.version,
+            self.code.as_deref(),
+        )?;
         Ok(registration)
     }
 }

--- a/rust/suseconnect-agama/examples/activation.rs
+++ b/rust/suseconnect-agama/examples/activation.rs
@@ -1,8 +1,7 @@
 use std::{env, process::exit};
 
 use suseconnect_agama::{
-    activate_product, announce_system, create_credentials_file, ConnectParams,
-    ProductSpecification, DEFAULT_CONFIG_FILE,
+    activate_product, announce_system, create_credentials_file, ConnectParams, ProductSpecification,
 };
 
 pub fn main() {
@@ -28,7 +27,7 @@ pub fn main() {
     let result = create_credentials_file(
         &credentials.login,
         &credentials.password,
-        DEFAULT_CONFIG_FILE,
+        suseconnect_agama::GLOBAL_CREDENTIALS_FILE,
     );
     println!("{:?}", result);
     if result.is_err() {
@@ -39,6 +38,8 @@ pub fn main() {
         version: "16.0".to_string(),
         arch: "x86_64".to_string(),
     };
+    // uncomment to emulate original behavior which do not send token for base product
+    // params.token = None;
     let result = activate_product(product_spec, params, "");
     println!("{:?}", result);
 }

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri May 15 11:15:57 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt code to new suseconnect-ng version (bsc#1265239) 
+
+-------------------------------------------------------------------
 Thu May  7 12:11:45 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Import the ntp-client section from a AutoYaST profiles


### PR DESCRIPTION
## Problem

new suseconnect-ng library failed to register base product as it newly require registration code also for it.


## Solution

Use registration code beside for announce, also for base product registration.


## Testing

- *Added a new unit test*
- *Tested manually*