### PR TITLE
Fix handling of AutoYaST rules

### DIFF
--- a/service/lib/agama/autoyast/profile_fetcher.rb
+++ b/service/lib/agama/autoyast/profile_fetcher.rb
@@ -55,6 +55,7 @@ module Agama
       # @return [ProfileHash,nil] an evaluated AutoYaST profile
       def fetch
         import_yast
+        replace_storage_manager
         read_profile
       end
 
@@ -162,6 +163,19 @@ module Agama
         Yast.import "AutoinstScripts"
         Yast.import "Profile"
         Yast.import "ProfileLocation"
+        require "agama/autoyast/report_patching"
+      end
+
+      def replace_storage_manager
+        require "y2storage/storage_manager"
+        require "agama/autoyast/storage_manager"
+        Y2Storage::StorageManager.define_singleton_method(:instance) do
+          return @storage_manager if @storage_manager
+
+          @storage_manager = Agama::AutoYaST::StorageManager.new
+          @storage_manager.probe
+          @storage_manager
+        end
       end
     end
   end

--- a/service/lib/agama/autoyast/profile_fetcher.rb
+++ b/service/lib/agama/autoyast/profile_fetcher.rb
@@ -21,6 +21,8 @@
 
 require "yast"
 require "agama/autoyast/pre_script"
+require "y2storage/storage_manager"
+require "agama/autoyast/storage_manager"
 
 # :nodoc:
 module Agama
@@ -55,8 +57,20 @@ module Agama
       # @return [ProfileHash,nil] an evaluated AutoYaST profile
       def fetch
         import_yast
-        replace_storage_manager
-        read_profile
+
+        original_instance = Y2Storage::StorageManager.method(:instance)
+        Y2Storage::StorageManager.define_singleton_method(:instance) do
+          return @storage_manager if @storage_manager
+
+          @storage_manager = Agama::AutoYaST::StorageManager.new
+          @storage_manager.probe
+          @storage_manager
+        end
+
+        result = read_profile
+        result
+      ensure
+        Y2Storage::StorageManager.define_singleton_method(:instance, original_instance)
       end
 
     private
@@ -164,18 +178,6 @@ module Agama
         Yast.import "Profile"
         Yast.import "ProfileLocation"
         require "agama/autoyast/report_patching"
-      end
-
-      def replace_storage_manager
-        require "y2storage/storage_manager"
-        require "agama/autoyast/storage_manager"
-        Y2Storage::StorageManager.define_singleton_method(:instance) do
-          return @storage_manager if @storage_manager
-
-          @storage_manager = Agama::AutoYaST::StorageManager.new
-          @storage_manager.probe
-          @storage_manager
-        end
       end
     end
   end

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -94,23 +94,22 @@ module UI
     end
 
     def run
-      # at first construct agama question to display.
-      text = @label
-      question = {
-        "class"         => "autoyast.password",
-        "text"          => text,
-        "options"       => ["ok", "cancel"],
-        "defaultOption" => "cancel",
-        "data"          => {}
-      }
-      data = { generic: question, withPassword: {} }.to_json
-      answer_json = Yast::Execute.locally!("agama", "questions", "ask", stdin: data,
-stdout: :capture)
-      answer = JSON.parse!(answer_json)
-      result = answer["generic"]["answer"].to_sym
-      return nil if result == :cancel
+      question = Agama::Question.new(
+        qclass:         "autoyast.password",
+        text:           @label,
+        field:          :password,
+        options:        [:ok, :cancel],
+        default_option: :cancel,
+        data:           {}
+      )
 
-      answer["withPassword"]["password"]
+      questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))
+
+      questions_client.ask(question) do |answer|
+        return nil if answer.action == :cancel
+
+        return answer.value
+      end
     end
   end
 end

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -29,6 +29,7 @@ require "json"
 require "yast"
 require "yast2/execute"
 require "ui/dialog"
+require "agama/http/clients/questions"
 
 # :nodoc:
 # rubocop:disable Metrics/ParameterLists
@@ -46,18 +47,20 @@ module Yast2
         text = message
         text += "\n\n" + details unless details.empty?
         options = generate_options(buttons)
-        question = {
-          class:         "autoyast.popup",
-          text:          text,
-          options:       generate_options(buttons),
-          defaultOption: focus || options.first,
-          data:          {}
-        }
-        data = { generic: question }.to_json
-        answer_json = Yast::Execute.locally!("agama", "questions", "ask",
-          stdin: data, stdout: :capture)
-        answer = JSON.parse!(answer_json)
-        answer["generic"]["answer"].to_sym
+
+        questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))
+
+        question = Agama::Question.new(
+          qclass:         "autoyast.popup",
+          text:           text,
+          options:        generate_options(buttons),
+          default_option: focus || options.first,
+          data:           {}
+        )
+
+        questions_client.ask(question) do |answer|
+          return answer.action
+        end
       end
 
     private

--- a/service/lib/agama/autoyast/storage_manager.rb
+++ b/service/lib/agama/autoyast/storage_manager.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "json"
+require "y2storage/disk_size"
+require "yast2/execute"
+
+# :nodoc:
+module Agama
+  module AutoYaST
+    # Simplified storage manager to be used by AutoInstallRules.
+    #
+    # The AutoYaST compatibility layer cannot use the regular StorageManager because it conflicts
+    # with the one that Agama is using. The information from storage is used by the AutoInstallRules
+    # module. However, it only need a little of information about the storage layout.
+    #
+    # This class offers a tiny fraction of the StorageManager API, but enough for AutoInstallRules
+    # to work.
+    class StorageManager
+      attr_reader :probed
+
+      def initialize
+        @probed = nil
+        @disk_analyzer = nil
+      end
+
+      # Probes the storage information.
+      #
+      # Relies on lsblk to get the list of disks and partitions.
+      def probe
+        json = Yast::Execute.locally(
+          ["lsblk", "--json", "--output", "PATH,TYPE,FSTYPE,SIZE,MOUNTPOINTS", "--bytes"],
+          stdout: :capture
+        )
+        lshw = JSON.parse(json)
+        disks = lshw["blockdevices"].map do |disk|
+          next if disk["type"] != "disk" || disk.fetch("mountpoints", []).include?("[SWAP]")
+
+          partitions = disk.fetch("children", []).map do |part|
+            next if part.fetch("mountpoints", []).include?("[SWAP]")
+
+            Partition.new(part["path"], part["fstype"])
+          end
+
+          disk = Disk.new(disk["path"], Y2Storage::DiskSize.new(disk["size"]), partitions)
+        end.compact
+
+        @probed = Devicegraph.new(disks)
+      end
+
+      # Returns a disk analyzer for the probed data.
+      #
+      # It "replaces" the original Y2Storage::DiskAnalyzer offering just what the AutoInstallRules
+      # module needs.
+      #
+      # @return [DiskAnalyzer]
+      def probed_disk_analyzer
+        @disk_analyzer = DiskAnalyzer.new(@probed)
+      end
+    end
+
+    # Replacement for the Y2Storage::DiskAnalyzer class.
+    class DiskAnalyzer
+      def initialize(probed)
+        @probed = probed
+      end
+
+      # List of disks.
+      #
+      # @return [Array<Disk>]
+      def disks
+        @probed.disks
+      end
+
+      # List of Linux (non Windows) partitions.
+      #
+      # @return [Array<Partition>]
+      def linux_partitions
+        partitions.reject(&:windows?)
+      end
+
+      # List of Windows partitions.
+      #
+      # @return [Array<Partition>]
+      def windows_partitions
+        partitions.select(&:windows?)
+      end
+
+    private
+
+      def partitions
+        @probed.disks.map(&:partitions).flatten
+      end
+    end
+
+    # Replacement for the Y2Storage::Devicegraph class.
+    #
+    # It only holds the list of disks.
+    Devicegraph = Struct.new("Devicegraph", :disks)
+
+    # Replacement for the Y2Storage::Disk class.
+    #
+    # It only holds the name, the size and the list of partitions.
+    #
+    # rubocop:disable Lint/StructNewOverride
+    Disk = Struct.new("Disk", :name, :size, :partitions)
+    # rubocop:enable Lint/StructNewOverride
+
+    # Replacement for the Y2Storage::Partition class.
+    #
+    # It only holds the name and the type.
+    class Partition
+      attr_reader :name, :type
+
+      def initialize(name, type)
+        @name = name
+        @type = type
+      end
+
+      # Windows values from lsblk
+      WINDOWS_TYPES = ["vfat", "ntfs", "exfat", "msdos"].freeze
+
+      # Determine whether it is a Windows partition.
+      #
+      # The check is quite simplistic but hopefully good enough for AutoInstallRules.
+      def windows?
+        WINDOWS_TYPES.include?(@type)
+      end
+    end
+  end
+end

--- a/service/lib/agama/autoyast/storage_manager.rb
+++ b/service/lib/agama/autoyast/storage_manager.rb
@@ -52,7 +52,7 @@ module Agama
         )
         lshw = JSON.parse(json)
         disks = lshw["blockdevices"].map do |disk|
-          next if disk["type"] != "disk" || disk.fetch("mountpoints", []).include?("[SWAP]")
+          next if disk["type"].to_s != "disk" || disk.fetch("mountpoints", []).include?("[SWAP]")
 
           partitions = disk.fetch("children", []).map do |part|
             next if part.fetch("mountpoints", []).include?("[SWAP]")

--- a/service/lib/agama/question.rb
+++ b/service/lib/agama/question.rb
@@ -80,14 +80,16 @@ module Agama
           options:        hash["actions"].map { |a| a["id"].to_sym },
           default_option: hash["defaultAction"]&.to_sym,
           data:           hash["data"] || {},
-          answer:         answer
+          answer:         answer,
+          field:          hash["field"]
         )
         question.send(:id=, hash["id"])
         question
       end
     end
 
-    def initialize(qclass:, text:, options:, default_option: nil, data: {}, answer: nil)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(qclass:, text:, options:, default_option: nil, data: {}, answer: nil, field: nil)
       @id = nil
       @qclass = qclass
       @text = text
@@ -95,7 +97,9 @@ module Agama
       @default_option = default_option
       @data = data
       @answer = answer
+      @field = field
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Converts a question into a hash to be consumed by the HTTP API.
     def to_api
@@ -114,6 +118,9 @@ module Agama
         "defaultAction" => @default_option.to_s,
         "data"          => @data
       }
+
+      question["field"] = { "type" => @field } if @field
+      question
     end
 
   private

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,7 +1,12 @@
 -------------------------------------------------------------------
+Fri May 15 11:41:34 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix handling of AutoYaST rules (gh#agama-project/agama#3502).
+
+-------------------------------------------------------------------
 Fri May 15 11:15:57 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
-- Adapt code to new suseconnect-ng version (bsc#1265239) 
+- Adapt code to new suseconnect-ng version (bsc#1265239)
 
 -------------------------------------------------------------------
 Thu May  7 12:11:45 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/service/test/agama/autoyast/profile_fetcher_test.rb
+++ b/service/test/agama/autoyast/profile_fetcher_test.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require "agama/http/clients/questions"
 require "agama/autoyast/profile_fetcher"
 require "json"
 require "tmpdir"
@@ -55,6 +56,14 @@ describe Agama::AutoYaST::ProfileFetcher do
     instance_double(Y2Storage::DiskAnalyzer, windows_partitions: [], linux_partitions: [])
   end
 
+  let(:questions_client) do
+    instance_double(Agama::HTTP::Clients::Questions).as_null_object
+  end
+
+  let(:lsblk) do
+    File.read(File.join(FIXTURES_PATH, "lsblk.json"))
+  end
+
   before do
     stub_const("Y2Autoinstallation::XmlChecks::ERRORS_PATH", File.join(tmpdir, "errors"))
     stub_const("Agama::AutoYaST::PreScript::SCRIPTS_DIR", File.join(tmpdir, "scripts"))
@@ -67,7 +76,8 @@ describe Agama::AutoYaST::ProfileFetcher do
     allow(Yast::AutoinstConfig).to receive(:modified_profile)
       .and_return(File.join(tmpdir, "profile", "modified.xml"))
     allow(Y2Autoinstallation::XmlValidator).to receive(:new).and_return(xml_validator)
-    allow(Y2Storage::StorageManager).to receive(:instance).and_return(storage_manager)
+    allow(Agama::HTTP::Clients::Questions).to receive(:new).and_return(questions_client)
+    allow(Yast::Execute).to receive(:locally).and_return(lsblk)
   end
 
   after do

--- a/service/test/agama/autoyast/storage_manager_test.rb
+++ b/service/test/agama/autoyast/storage_manager_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "yast"
+require "agama/autoyast/storage_manager"
+
+describe Agama::AutoYaST::StorageManager do
+  before do
+    allow(Yast::Execute).to receive(:locally).and_return(lsblk)
+  end
+
+  let(:lsblk) do
+    File.read(File.join(FIXTURES_PATH, "lsblk.json"))
+  end
+
+  describe "#probe" do
+    it "reads the storage information" do
+      subject.probe
+      probed = subject.probed
+
+      expect(probed.disks).to contain_exactly(
+        an_object_having_attributes(name: "/dev/sda"),
+        an_object_having_attributes(name: "/dev/vda"),
+        an_object_having_attributes(name: "/dev/vdb")
+      )
+    end
+  end
+
+  describe "#probed_disk_analyzer" do
+    before do
+      subject.probe
+    end
+
+    it "return the disk analyzer" do
+      analyzer = subject.probed_disk_analyzer
+      expect(analyzer.linux_partitions).to contain_exactly(
+        an_object_having_attributes(name: "/dev/vda1"),
+        an_object_having_attributes(name: "/dev/vda2")
+      )
+
+      expect(analyzer.windows_partitions).to contain_exactly(
+        an_object_having_attributes(name: "/dev/vda3")
+      )
+    end
+  end
+end

--- a/service/test/fixtures/lsblk.json
+++ b/service/test/fixtures/lsblk.json
@@ -1,0 +1,120 @@
+{
+   "blockdevices": [
+      {
+         "name": "loop0",
+         "fstype": "squashfs",
+         "type": "loop",
+         "path": "/dev/loop0",
+         "size": 679739392,
+         "mountpoints": []
+      },{
+         "name": "loop1",
+         "fstype": "ext4",
+         "type": "loop",
+         "path": "/dev/loop1",
+         "size": 6861881344,
+         "mountpoints": [],
+         "children": [
+            {
+               "name": "live-rw",
+               "fstype": "ext4",
+               "type": "dm",
+               "path": "/dev/mapper/live-rw",
+               "size": 6861881344,
+               "mountpoints": [
+                   "/"
+               ]
+            },{
+               "name": "live-base",
+               "fstype": "ext4",
+               "type": "dm",
+               "path": "/dev/mapper/live-base",
+               "size": 6861881344,
+               "mountpoints": []
+            }
+         ]
+      },{
+         "name": "loop2",
+         "fstype": "DM_snapshot_cow",
+         "type": "loop",
+         "path": "/dev/loop2",
+         "size": 34359738368,
+         "mountpoints": [],
+         "children": [
+            {
+               "name": "live-rw",
+               "fstype": "ext4",
+               "type": "dm",
+               "path": "/dev/mapper/live-rw",
+               "size": 6861881344,
+               "mountpoints": [
+                   "/"
+               ]
+            }
+         ]
+      },{
+         "name": "sda",
+         "fstype": null,
+         "type": "disk",
+         "path": "/dev/sda",
+         "size": 1073741824,
+         "mountpoints": []
+      },{
+         "name": "sr0",
+         "fstype": "iso9660",
+         "type": "rom",
+         "path": "/dev/sr0",
+         "size": 855382016,
+         "mountpoints": [
+             "/run/initramfs/live"
+         ]
+      },{
+         "name": "zram0",
+         "fstype": null,
+         "type": "disk",
+         "path": "/dev/zram0",
+         "size": 4105306112,
+         "mountpoints": [
+             "[SWAP]"
+         ]
+      },{
+         "name": "vda",
+         "fstype": null,
+         "type": "disk",
+         "path": "/dev/vda",
+         "size": 42949672960,
+         "mountpoints": [],
+         "children": [
+            {
+               "name": "vda1",
+               "fstype": null,
+               "type": "part",
+               "path": "/dev/vda1",
+               "size": 8388608,
+               "mountpoints": []
+            },{
+               "name": "vda2",
+               "fstype": "btrfs",
+               "type": "part",
+               "path": "/dev/vda2",
+               "size": 40791703552,
+               "mountpoints": []
+            },{
+               "name": "vda3",
+               "fstype": "ntfs",
+               "type": "part",
+               "path": "/dev/vda3",
+               "size": 2148515328,
+               "mountpoints": []
+            }
+         ]
+      },{
+         "name": "vdb",
+         "fstype": null,
+         "type": "disk",
+         "path": "/dev/vdb",
+         "size": 21474836480,
+         "mountpoints": []
+      }
+   ]
+}


### PR DESCRIPTION
## Problem

Agama is not able to import AutoYaST profiles using rules. Some limitations are expected (e.g., when working with dialogs), but in this case the `agama-autoyast` script just crashes without the user noticing.

The problem is that the Agama D-Bus service holds the libstorage-ng lock and, even if it was not the case, the storage probing is not done.

## Solution

Fortunately, the `AutoInstallRules` module needs to know just a little bit of information about storage. So this solution implements a minimal `StorageManager` which should suffice for most common use cases.

Additionally, this PR fixes the communication using the patched `Yast2::Popup.show` method and the `UI::Password` dialog.

## Testing

- Added a new unit test
- Tested manually