### PR TITLE
Make sure bootloader is installed before final storage steps

### DIFF
--- a/service/lib/agama/storage/finisher.rb
+++ b/service/lib/agama/storage/finisher.rb
@@ -68,9 +68,9 @@ module Agama
       def possible_steps
         [
           CopyFilesStep.new(logger),
+          BootloaderStep.new(logger),
           StorageStep.new(logger),
           IscsiStep.new(logger),
-          BootloaderStep.new(logger),
           SnapshotsStep.new(logger)
         ]
       end

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -22,7 +22,7 @@
     Requires:       yast2-iscsi-client >= 5.0.11
     Requires:       yast2-network
     Requires:       yast2-proxy
-    Requires:       yast2-storage-ng >= 5.0.46
+    Requires:       yast2-storage-ng >= 5.0.47
     %ifarch s390 s390x
     Requires:       yast2-s390 >= 4.6.4
     Requires:       yast2-reipl


### PR DESCRIPTION
## Problem

The final steps of some encryption processes need to be performed once the bootloader is already configured.


## Solution

Reorder the steps in the storage finish process.

Bonus: update dependency on yast2-storage-ng since we also need some corrections there.

## Testing

Tested manually
