### PR TITLE
Fixed starting the nmtui and self-update services

### DIFF
--- a/live/live-root/usr/bin/live-self-update
+++ b/live/live-root/usr/bin/live-self-update
@@ -118,6 +118,9 @@ cleanup_chroot() {
     findmnt "$NEWROOT"/proc > /dev/null && umount "$NEWROOT"/proc
     findmnt "$NEWROOT"/dev > /dev/null && umount "$NEWROOT"/dev
   fi
+
+  # return the original exit value
+  exit "$result"
 }
 
 # read the data from /etc/os-release file (source it)

--- a/live/live-root/usr/lib/dracut/modules.d/99initrd-nmtui/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99initrd-nmtui/module-setup.sh
@@ -20,12 +20,15 @@ installkernel() {
 
 # install hook for dracut
 install() {
+  # fail if any install command fails (cannot be used globally as this file is sourced by dracut)
+  set -e
   # install the hook for processing the boot parameters and enabling network support in dracut
   inst_hook cmdline 99 "$moddir/initrd-nmtui-cmdline.sh"
 
   # install the systemd service and the self-update script to the initramfs
-  inst_multiple "$systemdsystemunitdir"/initrd-nmtui.service initrd-network-setup.sh dialog nmtui nmcli kill tput clear
+  inst_multiple /etc/systemd/system/initrd-nmtui.service initrd-network-setup.sh dialog nmtui nmcli kill tput clear
 
   # enable the self-update service in the initramfs
   $SYSTEMCTL -q --root "$initdir" enable initrd-nmtui.service
+  set +e
 }

--- a/live/live-root/usr/lib/dracut/modules.d/99live-self-update/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99live-self-update/module-setup.sh
@@ -20,6 +20,8 @@ installkernel() {
 
 # install hook for dracut
 install() {
+  # fail if any install command fails (cannot be used globally as this file is sourced by dracut)
+  set -e
   # install the hook for processing the boot parameters
   inst_hook cmdline 99 "$moddir/live-self-update-parser.sh"
 
@@ -27,7 +29,7 @@ install() {
   inst_multiple systemd-cat dirname /usr/lib/live-self-update/conf.sh jq
 
   # install the systemd service and the self-update script to the initramfs
-  inst_multiple "$systemdsystemunitdir"/live-self-update.service live-self-update
+  inst_multiple /etc/systemd/system/live-self-update.service live-self-update
 
   # needed by the live-self-update script
   inst_multiple grep tail sed
@@ -47,4 +49,5 @@ install() {
 
   # enable the self-update service in the initramfs
   $SYSTEMCTL -q --root "$initdir" enable live-self-update.service
+  set +e
 }

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 15 14:16:33 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed starting the initrd-nmtui and live-self-update services
+  in the initrd (gh#agama-project/agama#3504)
+
+-------------------------------------------------------------------
 Thu May 14 03:45:16 UTC 2026 - Asish Kumar <officialasishkumar@gmail.com>
 
 - Install dracut systemd service units via the unit directory variable


### PR DESCRIPTION
## Problem

- The self-update service is not started at boot

## Details

- The service files have been moved from `/usr/lib/systemd/system` to `/etc/systemd/system`
- The dracut complains:
```
dracut[I]: *** Including module: live-self-update ***
dracut-install: ERROR: installing '/usr/lib/systemd/system/live-self-update.service'
dracut[E]: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.AltRpF/initramfs -a /usr/lib/systemd/system/live-self-update.service live-self-update
Failed to enable unit: Unit live-self-update.service does not exist
```
- Unfortunately dracut continues and ignores the error, that's the reason nobody noticed the problem


## Solution

- Fix the service file location
- The same problem was found in the `initrd-nmtui.service` file
- Use `set -e` to avoid similar problems in the future
-  Return the original exit value so the `systemctl status live-self-update.service` does not report a failure

## Testing

- Tested with a locally built ISO, the self-update service starts properly
