### PR TITLE
Fix monitor initialization in "config load"

### DIFF
--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -125,10 +125,14 @@ pub struct MonitorApp {
 impl MonitorApp {
     /// Updates the installation status.
     pub fn update_status(&mut self, new_status: InstallationStatus) {
-        if self.stop_on_idle && new_status.is_idle() {
+        self.status = new_status;
+        if self.should_exit() {
             self.exit = true;
         }
-        self.status = new_status;
+    }
+
+    fn should_exit(&self) -> bool {
+        self.stop_on_idle && self.status.is_idle()
     }
 
     /// Runs the monitor TUI event loop.
@@ -146,6 +150,10 @@ impl MonitorApp {
         let (tx, mut rx) = mpsc::channel(16);
         let tx_clone = tx.clone();
         let mut updates = self.monitor.subscribe();
+
+        if self.should_exit() {
+            return Ok(());
+        }
 
         tokio::task::spawn(async move {
             while let Ok(new_status) = updates.recv().await {

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 15 16:37:52 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the monitor initialization when "agama config load" happens
+  too fast (gh#agama-project/agama#3507).
+
+-------------------------------------------------------------------
 Fri May 15 14:27:47 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added support for installing systemd-boot and grub2-bls,


### PR DESCRIPTION
## Problem

If "agama config load" does not cause any update or the update happens to fast, it stays in the monitor.

## Solution

Check whether the system is already idle when starting the monitor.

## Testing

- Tested manually