### PR TITLE
Improve check of software service availability

### DIFF
--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -600,10 +600,16 @@ impl Service {
     ///
     /// Consider the service as available if there is no pending progress.
     async fn is_software_available(&self) -> Result<bool, Error> {
-        let is_empty = self
-            .progress
-            .call(progress::message::IsEmpty::with_scope(Scope::Software))
-            .await?;
+        let status = self.progress.call(progress::message::GetStatus).await?;
+        if status.stage == Stage::Installing {
+            return Ok(false);
+        }
+
+        let is_empty = status
+            .progresses
+            .iter()
+            .find(|p| p.scope == Scope::Software)
+            .is_none();
         Ok(is_empty)
     }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sat May 16 00:43:49 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider the software service as not busy during the "installation"
+  phase to prevent potential deadlocks (gh#agama-project/agama#3508).
+
+-------------------------------------------------------------------
 Fri May 15 14:34:41 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Support new boot section in product definition (jsc#PED-10703).


### PR DESCRIPTION
## Problem

During installation, the `GET /api/system` might not be available. It is reproducible most of the time, but not at 100%.

## Solution

It seems that the condition to check whether the software service is not enough. I have added another condition and now it seems to work (manually tested). The patch is as small as possible. In a future iteration we should most probably get rid of the `IsEmpty` message.

## Testing

- Tested manually