### PR TITLE
Use the "monitor" icon for the "System" group in the web UI

### DIFF
--- a/web/src/components/layout/Icon.tsx
+++ b/web/src/components/layout/Icon.tsx
@@ -35,6 +35,7 @@ import Backspace from "@icons/backspace.svg?component";
 import CheckCircle from "@icons/check_circle.svg?component";
 import ChevronLeft from "@icons/chevron_left.svg?component";
 import ChevronRight from "@icons/chevron_right.svg?component";
+import Monitor from "@icons/monitor.svg?component";
 import Delete from "@icons/delete.svg?component";
 import DoneAll from "@icons/done_all.svg?component";
 import DeployedCodeUpdate from "@icons/deployed_code_update.svg?component";
@@ -107,6 +108,7 @@ const icons = {
   lock: Lock,
   manage_accounts: ManageAccounts,
   menu: Menu,
+  monitor: Monitor,
   more_horiz: MoreHoriz,
   more_vert: MoreVert,
   network_wifi: NetworkWifi,

--- a/web/src/components/overview/SystemSummary.tsx
+++ b/web/src/components/overview/SystemSummary.tsx
@@ -137,7 +137,7 @@ export default function SystemSummary() {
 
   return (
     <Summary
-      icon="fingerprint"
+      icon="monitor"
       title={
         <Link to={SYSTEM.root} variant="link" isInline>
           {_("System")}


### PR DESCRIPTION
## Problem

- Weird icon for the "System" group

<img width="715" height="358" alt="agama-system-icon-old" src="https://github.com/user-attachments/assets/af32e846-a024-4bf2-b6fe-550960591443" />


## Solution

- Use the "monitor" icon instead of "fingerprint"

## Testing

- Tested manually

## Screenshots

<img width="715" height="358" alt="agama-system-icon-new" src="https://github.com/user-attachments/assets/bb502525-d01a-449b-aa61-4a91d3c46e07" />
