### PR TITLE
fix(storage): activate devices

### DIFF
--- a/rust/agama-storage-client/src/service.rs
+++ b/rust/agama-storage-client/src/service.rs
@@ -106,6 +106,36 @@ pub struct Service {
     zfcp_proxy: Option<ZFCPProxy<'static>>,
 }
 
+impl Service {
+    /// Runs the probe action in a separate task.
+    ///
+    /// There are chances to block the service if a probing is requested. For example, if the D-Bus
+    /// service is waiting for a question and the probe action is called, then this service task
+    /// keeps blocked until the question is answered. This typically happens when setting a config
+    /// and a monitor (e.g., iSCSI monitor) requests a storage probe.
+    ///
+    /// It is important to avoid blocking the service task, otherwise no info can be retrieved from
+    /// D-Bus, even though the info is cached by the proxy.
+    ///
+    /// Theoretically, this same problem could happen by calling to activate or setting the locale,
+    /// but the UI does not allow those options if there are questions.
+    ///
+    /// TODO: Decide how to behave when there are questions and a new change is requested to D-Bus
+    /// (exit with error, call D-Bus without waiting, ...).
+    async fn probe(&mut self) -> Result<(), Error> {
+        let proxy = self.storage_proxy.clone();
+
+        tokio::spawn(async move {
+            let result = proxy.probe().await;
+            if let Err(error) = &result {
+                tracing::error!("Failed to probe storage: {error}");
+            }
+        });
+
+        Ok(())
+    }
+}
+
 impl Actor for Service {
     type Error = Error;
 }
@@ -115,7 +145,7 @@ impl MessageHandler<message::CallAction> for Service {
     async fn handle(&mut self, message: message::CallAction) -> Result<(), Error> {
         match message.action.as_str() {
             "Activate" => self.storage_proxy.activate().await?,
-            "Probe" => self.storage_proxy.probe().await?,
+            "Probe" => self.probe().await?,
             "Install" => self.storage_proxy.install().await?,
             "Finish" => self.storage_proxy.finish().await?,
             "Umount" => self.storage_proxy.umount().await?,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 19 12:27:20 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Perform storage probing in a separate task to avoid blocking the
+  service (related to bsc#1265302).
+
+-------------------------------------------------------------------
 Mon May 18 10:58:44 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Detect when the WebSocket gets disconnected (bsc#1265431).

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -121,7 +121,7 @@ module Agama
             logger.info("Probing storage")
 
             start_progress(3, ACTIVATING_STEP)
-            manager.activate unless manager.activated?
+            manager.activate
 
             next_progress_step(PROBING_STEP)
             perform_probe(force: true)

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 19 12:28:48 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Always activate storage devices in order to detect multipath and
+  new encryptions (bsc#1265302).
+
+-------------------------------------------------------------------
 Sat May 16 07:54:41 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 21

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -1175,8 +1175,8 @@ describe Agama::DBus::Storage::Manager do
     end
 
     context "when storage devices are already activated" do
-      it "does not activate devices" do
-        expect(backend).to_not receive(:activate)
+      it "activates the devices" do
+        expect(backend).to receive(:activate)
         subject.probe
       end
     end


### PR DESCRIPTION
## Problem

After configuring iSCSI, DASD or ZFCP, the storage activation is not performed, so new multipath or encryptions are not properly detected.

https://bugzilla.suse.com/show_bug.cgi?id=1265302

## Solution

Always request storage activation as part of the reprobing. The LUKS answers already provided by the user are not requested again thanks to the libstorage-ng cache.
