### PR TITLE
[SLE-16] Fix boot menu

### DIFF
--- a/live/README.md
+++ b/live/README.md
@@ -111,6 +111,12 @@ To build a SLE image using the internal OBS instance run
 make build OBS_API=https://api.suse.de OBS_PROJECT=Devel:YaST:Agama:Head OBS_PACKAGE=agama-installer FLAVOR=SUSE_SLE_16
 ```
 
+To build the SLE-16.0 maintenance image (for QU) run
+
+```shell
+make build OBS_API=https://api.suse.de OBS_PROJECT=Devel:YaST:Agama:Maintenance:SLE-16 OBS_PACKAGE=agama-installer FLAVOR=SUSE_SLE_16
+```
+
 #### Using locally built RPM packages
 
 If you have a locally built RPM which you want to include in the ISO instead of the RPM from the

--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -76,9 +76,6 @@ if [ -f (\$root)/boot/grub2/themes/$theme/theme.txt ];then
 fi
 terminal_input console
 terminal_output gfxterm
-menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
-  exit
-}
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...

--- a/live/config-cdroot/fix_bootconfig.aarch64
+++ b/live/config-cdroot/fix_bootconfig.aarch64
@@ -45,7 +45,7 @@ fi
 if [ -n "\${iso_path}" ]; then
     isoboot="iso-scan/filename=\${iso_path}"
 fi
-set timeout=10
+set timeout=60
 set timeout_style=menu
 if [ "\${grub_platform}" = "efi" ]; then
     echo "Please press 't' to show the boot menu on this console"

--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -87,17 +87,13 @@ cat >$dst/boot/grub2/grub.cfg <<XXX
 
 gfxmode=auto
 
-set default="Boot from Hard Disk"
+set default=0
 
 insmod gettext
 
 if sleep --interruptible 0 ; then
   timeout=60
 fi
-
-menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
-  exit
-}
 
 menuentry "Install $label" --class os --unrestricted {
   echo 'Loading kernel...'

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -45,7 +45,7 @@ fi
 if [ -n "\${iso_path}" ]; then
     isoboot="iso-scan/filename=\${iso_path}"
 fi
-set timeout=10
+set timeout=60
 set timeout_style=menu
 if [ "\${grub_platform}" = "efi" ]; then
     echo "Please press 't' to show the boot menu on this console"

--- a/live/config-cdroot/fix_bootconfig.x86_64
+++ b/live/config-cdroot/fix_bootconfig.x86_64
@@ -76,17 +76,11 @@ if [ -f (\$root)/boot/grub2/themes/$theme/theme.txt ];then
 fi
 terminal_input console
 terminal_output gfxterm
-menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
-  if search --no-floppy --file /efi/boot/fallback.efi --set ; then
-    for os in opensuse sles leap suse; do
-      if [ -f /efi/\$os/grub.efi ] ; then
-        chainloader /efi/\$os/grub.efi
-        boot
-      fi
-    done
-  fi
-  exit
-}
+if [ "\${grub_platform}" != "efi" ]; then
+  menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu --class os {
+    exit
+  }
+fi
 menuentry "Install $label" --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue May 19 13:57:18 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Removed the "Boot from Hard Disk" boot menu option, the "Install"
+  menu item is now the default (bsc#1259601, jsc#PED-13766)
+  (kept only in legacy BIOS boot mode)
+- Increased the timeout for booting the default menu item from
+  10 seconds to 60 seconds (jsc#PED-14986)
+
+-------------------------------------------------------------------
 Wed May 13 13:14:26 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Restore back the checkmedia option in the *.kiwi file


### PR DESCRIPTION
## Problem

- The default boot menu item is "Boot from Hard Disk"
- https://bugzilla.suse.com/show_bug.cgi?id=1259601

## Solution

- Backport the 16.1 boot menu fixes to 16.0 (from https://github.com/agama-project/agama/pull/3185)

## Testing

- Tested manually in a locally built ISO, see below

## Screenshots

The boot menu in the locally built ISO booted in the UEFI mode:
- No "Boot from Hard Disk" menu option
- The "Install" option is the default
- The default timeout is 60 seconds

<img width="1024" height="768" alt="agama-16 0-updated-bootmenu" src="https://github.com/user-attachments/assets/51b19599-b318-4647-ae9d-75a825fa52ec" />
