### PR TITLE
Improve monitor reliability and API

### DIFF
--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -43,7 +43,7 @@ use std::io::{self, IsTerminal};
 
 use theme::Theme;
 
-use crate::monitor::app::{MonitorAppBuilder, StopInfo};
+use crate::monitor::app::MonitorAppBuilder;
 
 /// Sets up the terminal for fullscreen TUI mode
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
@@ -99,15 +99,14 @@ async fn run_headless(
                 );
             }
             MonitorUpdate::Finished => {
-                println!("Monitoring finished: installation became idle");
                 break;
             }
             MonitorUpdate::Disconnected => {
-                println!("Monitoring finished: connection was closed");
+                eprintln!("Connection to the server was closed.");
                 break;
             }
             MonitorUpdate::Error(e) => {
-                println!("Monitoring finished with error: {}", e);
+                eprintln!("{e}");
                 break;
             }
         }
@@ -154,17 +153,20 @@ pub async fn run(
 
     if let Err(error) = result {
         eprintln!("Error running the monitor: {error}");
-    } else if let Some(info) = app.stop_info() {
+    } else if let Some(update) = app.stop_update() {
         // Report why monitoring stopped
-        match info {
-            StopInfo::Finished => {
+        match update {
+            MonitorUpdate::Finished => {
                 // Silent success - finished is expected when stop_on_idle is true
             }
-            StopInfo::Disconnected => {
-                eprintln!("Connection to the server was closed");
+            MonitorUpdate::Disconnected => {
+                eprintln!("Connection to the server was closed.");
             }
-            StopInfo::Error(e) => {
-                eprintln!("Monitoring stopped with error: {}", e);
+            MonitorUpdate::Error(e) => {
+                eprintln!("{e}");
+            }
+            MonitorUpdate::Status(_) => {
+                // Should not happen - status updates don't cause stopping
             }
         }
     }

--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -43,7 +43,7 @@ use std::io::{self, IsTerminal};
 
 use theme::Theme;
 
-use crate::monitor::app::{Message, MonitorAppBuilder};
+use crate::monitor::app::MonitorAppBuilder;
 
 /// Sets up the terminal for fullscreen TUI mode
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
@@ -151,23 +151,13 @@ pub async fn run(
     // Cleanup
     restore_terminal(&mut terminal)?;
 
-    if let Err(error) = result {
-        eprintln!("Error running the monitor: {error}");
-    } else if let Some(message) = app.stop_message() {
-        // Report why monitoring stopped
-        match message {
-            Message::Finished => {
-                // Silent success - finished is expected when stop_on_idle is true
-            }
-            Message::Disconnected => {
-                eprintln!("Connection to the server was closed.");
-            }
-            Message::Error(e) => {
-                eprintln!("{e}");
-            }
-            Message::StatusUpdate(_) | Message::Terminal(_) => {
-                // Should not happen - these don't cause stopping
-            }
+    // Handle result
+    match result {
+        Ok(()) => {
+            // Normal finish (idle or user quit)
+        }
+        Err(e) => {
+            eprintln!("{e}");
         }
     }
 

--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -87,7 +87,7 @@ async fn run_headless(
     println!("Initial stage: {:?}", status.status.stage);
 
     // Listen to updates
-    while let Ok(update) = updates.recv().await {
+    while let Some(update) = updates.recv().await {
         match update {
             MonitorUpdate::Status(status) => {
                 println!(

--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -30,7 +30,7 @@ mod ui;
 
 use agama_lib::{
     http::{BaseHTTPClient, WebSocketClient},
-    monitor::Monitor,
+    monitor::{Monitor, MonitorUpdate},
 };
 use anyhow::Result;
 use crossterm::{
@@ -43,7 +43,7 @@ use std::io::{self, IsTerminal};
 
 use theme::Theme;
 
-use crate::monitor::app::MonitorAppBuilder;
+use crate::monitor::app::{MonitorAppBuilder, StopInfo};
 
 /// Sets up the terminal for fullscreen TUI mode
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
@@ -86,18 +86,33 @@ async fn run_headless(
     println!("Agama monitor started (headless mode)");
     println!("Initial stage: {:?}", status.status.stage);
 
-    // Listen to updates until channel closes
-    while let Ok(status) = updates.recv().await {
-        println!(
-            "Stage: {:?}, Active tasks: {}, Issues: {}, Questions: {}",
-            status.status.stage,
-            status.status.progresses.len(),
-            status.issues.len(),
-            status.questions.len()
-        );
+    // Listen to updates
+    while let Ok(update) = updates.recv().await {
+        match update {
+            MonitorUpdate::Status(status) => {
+                println!(
+                    "Stage: {:?}, Active tasks: {}, Issues: {}, Questions: {}",
+                    status.status.stage,
+                    status.status.progresses.len(),
+                    status.issues.len(),
+                    status.questions.len()
+                );
+            }
+            MonitorUpdate::Finished => {
+                println!("Monitoring finished: installation became idle");
+                break;
+            }
+            MonitorUpdate::Disconnected => {
+                println!("Monitoring finished: connection was closed");
+                break;
+            }
+            MonitorUpdate::Error(e) => {
+                println!("Monitoring finished with error: {}", e);
+                break;
+            }
+        }
     }
 
-    println!("Monitoring finished");
     Ok(())
 }
 
@@ -139,6 +154,19 @@ pub async fn run(
 
     if let Err(error) = result {
         eprintln!("Error running the monitor: {error}");
+    } else if let Some(info) = app.stop_info() {
+        // Report why monitoring stopped
+        match info {
+            StopInfo::Finished => {
+                // Silent success - finished is expected when stop_on_idle is true
+            }
+            StopInfo::Disconnected => {
+                eprintln!("Connection to the server was closed");
+            }
+            StopInfo::Error(e) => {
+                eprintln!("Monitoring stopped with error: {}", e);
+            }
+        }
     }
 
     // Forces crossterm loop to finish.

--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -43,7 +43,7 @@ use std::io::{self, IsTerminal};
 
 use theme::Theme;
 
-use crate::monitor::app::MonitorAppBuilder;
+use crate::monitor::app::{Message, MonitorAppBuilder};
 
 /// Sets up the terminal for fullscreen TUI mode
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
@@ -153,20 +153,20 @@ pub async fn run(
 
     if let Err(error) = result {
         eprintln!("Error running the monitor: {error}");
-    } else if let Some(update) = app.stop_update() {
+    } else if let Some(message) = app.stop_message() {
         // Report why monitoring stopped
-        match update {
-            MonitorUpdate::Finished => {
+        match message {
+            Message::Finished => {
                 // Silent success - finished is expected when stop_on_idle is true
             }
-            MonitorUpdate::Disconnected => {
+            Message::Disconnected => {
                 eprintln!("Connection to the server was closed.");
             }
-            MonitorUpdate::Error(e) => {
+            Message::Error(e) => {
                 eprintln!("{e}");
             }
-            MonitorUpdate::Status(_) => {
-                // Should not happen - status updates don't cause stopping
+            Message::StatusUpdate(_) | Message::Terminal(_) => {
+                // Should not happen - these don't cause stopping
             }
         }
     }

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -98,7 +98,7 @@ impl MonitorAppBuilder {
             theme: self.theme,
             exit: false,
             product_names,
-            stop_info: None,
+            stop_update: None,
         })
     }
 
@@ -113,17 +113,6 @@ impl MonitorAppBuilder {
     }
 }
 
-/// Stop information
-#[derive(Clone, Debug)]
-pub enum StopInfo {
-    /// Installation became idle
-    Finished,
-    /// Connection was lost
-    Disconnected,
-    /// An error occurred
-    Error(String),
-}
-
 /// Application state for the monitor TUI
 pub struct MonitorApp {
     /// Monitor updates receiver (taken when run() is called)
@@ -136,8 +125,8 @@ pub struct MonitorApp {
     theme: Theme,
     /// Exit in the next iteration
     exit: bool,
-    /// Stop information (if stopped)
-    stop_info: Option<StopInfo>,
+    /// Stop update (if stopped)
+    stop_update: Option<MonitorUpdate>,
 }
 
 impl MonitorApp {
@@ -146,9 +135,9 @@ impl MonitorApp {
         self.status = new_status;
     }
 
-    /// Returns information about why the monitor stopped, if it stopped.
-    pub fn stop_info(&self) -> Option<&StopInfo> {
-        self.stop_info.as_ref()
+    /// Returns the monitor update that caused stopping, if stopped.
+    pub fn stop_update(&self) -> Option<&MonitorUpdate> {
+        self.stop_update.as_ref()
     }
 
     /// Runs the monitor TUI event loop.
@@ -218,15 +207,15 @@ impl MonitorApp {
             match message {
                 Message::StatusUpdate(status) => self.update_status(status),
                 Message::Finished => {
-                    self.stop_info = Some(StopInfo::Finished);
+                    self.stop_update = Some(MonitorUpdate::Finished);
                     self.exit = true;
                 }
                 Message::Disconnected => {
-                    self.stop_info = Some(StopInfo::Disconnected);
+                    self.stop_update = Some(MonitorUpdate::Disconnected);
                     self.exit = true;
                 }
                 Message::Error(e) => {
-                    self.stop_info = Some(StopInfo::Error(e));
+                    self.stop_update = Some(MonitorUpdate::Error(e));
                     self.exit = true;
                 }
                 Message::Terminal(event) => {

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -96,7 +96,6 @@ impl MonitorAppBuilder {
             updates: Some(updates),
             status,
             theme: self.theme,
-            exit: false,
             product_names,
             stop_update: None,
         })
@@ -123,8 +122,6 @@ pub struct MonitorApp {
     product_names: HashMap<String, String>,
     /// UI color theme
     theme: Theme,
-    /// Exit in the next iteration
-    exit: bool,
     /// Stop update (if stopped)
     stop_update: Option<MonitorUpdate>,
 }
@@ -196,7 +193,7 @@ impl MonitorApp {
         });
 
         // Main event loop
-        while !self.exit {
+        while self.stop_update.is_none() {
             terminal.draw(|f| f.render_widget(&mut *self, f.area()))?;
 
             let message = rx
@@ -208,15 +205,12 @@ impl MonitorApp {
                 Message::StatusUpdate(status) => self.update_status(status),
                 Message::Finished => {
                     self.stop_update = Some(MonitorUpdate::Finished);
-                    self.exit = true;
                 }
                 Message::Disconnected => {
                     self.stop_update = Some(MonitorUpdate::Disconnected);
-                    self.exit = true;
                 }
                 Message::Error(e) => {
                     self.stop_update = Some(MonitorUpdate::Error(e));
-                    self.exit = true;
                 }
                 Message::Terminal(event) => {
                     if let Event::Key(key_event) = event {
@@ -238,7 +232,7 @@ impl MonitorApp {
 
         match (key_event.code, key_event.modifiers) {
             (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => {
-                self.exit = true;
+                self.stop_update = Some(MonitorUpdate::Finished);
             }
             _ => {}
         }

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -243,10 +243,10 @@ impl MonitorApp {
             return false;
         }
 
-        match (key_event.code, key_event.modifiers) {
-            (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => true,
-            _ => false,
-        }
+        matches!(
+            (key_event.code, key_event.modifiers),
+            (KeyCode::Char('q'), _) | (KeyCode::Esc, _)
+        )
     }
 }
 

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -24,7 +24,6 @@ use agama_lib::{
 };
 use anyhow::{anyhow, Result};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
-use gettextrs::gettext;
 use ratatui::{backend::CrosstermBackend, buffer::Buffer, layout::Rect, widgets::Widget, Terminal};
 use serde::Deserialize;
 use std::{collections::HashMap, io, time::Duration};
@@ -32,9 +31,9 @@ use tokio::sync::mpsc;
 
 use super::{theme::Theme, ui};
 
-/// Application messages.
+/// Application messages (internal).
 #[derive(Clone, Debug)]
-pub enum Message {
+enum Message {
     /// Status update from monitor
     StatusUpdate(InstallationStatus),
     /// Monitor finished (installation became idle)
@@ -45,6 +44,23 @@ pub enum Message {
     Error(String),
     /// Terminal event.
     Terminal(Event),
+}
+
+/// Errors that can occur while running the monitor.
+#[derive(Debug, thiserror::Error)]
+pub enum MonitorError {
+    /// Connection to the server was closed.
+    #[error("Connection to the server was closed")]
+    Disconnected,
+    /// An error occurred during monitoring.
+    #[error("{0}")]
+    MonitoringError(String),
+    /// I/O error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Other error.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 // FIXME: find a better place
@@ -98,7 +114,6 @@ impl MonitorAppBuilder {
             status,
             theme: self.theme,
             product_names,
-            stop_message: None,
         })
     }
 
@@ -123,19 +138,12 @@ pub struct MonitorApp {
     product_names: HashMap<String, String>,
     /// UI color theme
     theme: Theme,
-    /// Stop message (if stopped)
-    stop_message: Option<Message>,
 }
 
 impl MonitorApp {
     /// Updates the installation status.
     fn update_status(&mut self, new_status: InstallationStatus) {
         self.status = new_status;
-    }
-
-    /// Returns the message that caused stopping, if stopped.
-    pub fn stop_message(&self) -> Option<&Message> {
-        self.stop_message.as_ref()
     }
 
     /// Runs the monitor TUI event loop.
@@ -146,11 +154,14 @@ impl MonitorApp {
     ///
     /// The main loop reacts to events from both sources.
     ///
+    /// Returns `Ok(())` when monitoring finishes normally (idle or user quit).
+    /// Returns `Err(MonitorError)` when an error occurs (disconnection or monitoring error).
+    ///
     /// * `terminal` - The terminal to draw on
     pub async fn run(
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    ) -> Result<()> {
+    ) -> Result<(), MonitorError> {
         let (tx, mut rx) = mpsc::channel(16);
 
         // Take ownership of the monitor updates receiver
@@ -194,42 +205,47 @@ impl MonitorApp {
         });
 
         // Main event loop
-        while self.stop_message.is_none() {
+        loop {
             terminal.draw(|f| f.render_widget(&mut *self, f.area()))?;
 
-            let message = rx
-                .recv()
-                .await
-                .ok_or(anyhow!(gettext("Lost the connection with the server.")))?;
+            let message = rx.recv().await.ok_or(MonitorError::Disconnected)?;
 
             match message {
                 Message::StatusUpdate(status) => self.update_status(status),
-                msg @ Message::Finished | msg @ Message::Disconnected | msg @ Message::Error(_) => {
-                    self.stop_message = Some(msg);
+                Message::Finished => {
+                    terminal_handle.abort();
+                    return Ok(());
+                }
+                Message::Disconnected => {
+                    terminal_handle.abort();
+                    return Err(MonitorError::Disconnected);
+                }
+                Message::Error(e) => {
+                    terminal_handle.abort();
+                    return Err(MonitorError::MonitoringError(e));
                 }
                 Message::Terminal(event) => {
                     if let Event::Key(key_event) = event {
-                        self.handle_key_event(key_event);
+                        if self.handle_key_event(key_event) {
+                            terminal_handle.abort();
+                            return Ok(());
+                        }
                     }
                 }
             }
         }
-
-        terminal_handle.abort();
-        Ok(())
     }
 
     /// Handle terminal key events.
-    fn handle_key_event(&mut self, key_event: KeyEvent) {
+    /// Returns true if the application should exit.
+    fn handle_key_event(&mut self, key_event: KeyEvent) -> bool {
         if key_event.kind != KeyEventKind::Press {
-            return;
+            return false;
         }
 
         match (key_event.code, key_event.modifiers) {
-            (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => {
-                self.stop_message = Some(Message::Finished);
-            }
-            _ => {}
+            (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => true,
+            _ => false,
         }
     }
 }

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -20,7 +20,7 @@
 
 use agama_lib::{
     http::{BaseHTTPClient, WebSocketClient},
-    monitor::{InstallationStatus, Monitor},
+    monitor::{InstallationStatus, Monitor, MonitorUpdate},
 };
 use anyhow::{anyhow, Result};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
@@ -37,8 +37,12 @@ use super::{theme::Theme, ui};
 enum Message {
     /// Status update from monitor
     StatusUpdate(InstallationStatus),
-    /// Monitor has finished (channel closed)
-    MonitorFinished,
+    /// Monitor finished (installation became idle)
+    Finished,
+    /// Monitor disconnected (connection lost)
+    Disconnected,
+    /// Monitor stopped with error
+    Error(String),
     /// Terminal event.
     Terminal(Event),
 }
@@ -95,6 +99,7 @@ impl MonitorAppBuilder {
             theme: self.theme,
             exit: false,
             product_names,
+            stop_info: None,
         })
     }
 
@@ -109,10 +114,21 @@ impl MonitorAppBuilder {
     }
 }
 
+/// Stop information
+#[derive(Clone, Debug)]
+pub enum StopInfo {
+    /// Installation became idle
+    Finished,
+    /// Connection was lost
+    Disconnected,
+    /// An error occurred
+    Error(String),
+}
+
 /// Application state for the monitor TUI
 pub struct MonitorApp {
-    /// Status updates receiver
-    updates: broadcast::Receiver<InstallationStatus>,
+    /// Monitor updates receiver
+    updates: broadcast::Receiver<MonitorUpdate>,
     /// Current installation status
     status: InstallationStatus,
     /// Product names
@@ -121,12 +137,19 @@ pub struct MonitorApp {
     theme: Theme,
     /// Exit in the next iteration
     exit: bool,
+    /// Stop information (if stopped)
+    stop_info: Option<StopInfo>,
 }
 
 impl MonitorApp {
     /// Updates the installation status.
     fn update_status(&mut self, new_status: InstallationStatus) {
         self.status = new_status;
+    }
+
+    /// Returns information about why the monitor stopped, if it stopped.
+    pub fn stop_info(&self) -> Option<&StopInfo> {
+        self.stop_info.as_ref()
     }
 
     /// Runs the monitor TUI event loop.
@@ -147,23 +170,24 @@ impl MonitorApp {
         // Resubscribe to get a new receiver for the task
         let mut status_updates = self.updates.resubscribe();
 
-        // Spawn task to forward status updates
+        // Spawn task to forward monitor updates
         let tx_monitor = tx.clone();
         tokio::task::spawn(async move {
             loop {
                 match status_updates.recv().await {
-                    Ok(status) => {
-                        if tx_monitor
-                            .send(Message::StatusUpdate(status))
-                            .await
-                            .is_err()
-                        {
+                    Ok(update) => {
+                        let message = match update {
+                            MonitorUpdate::Status(status) => Message::StatusUpdate(status),
+                            MonitorUpdate::Finished => Message::Finished,
+                            MonitorUpdate::Disconnected => Message::Disconnected,
+                            MonitorUpdate::Error(e) => Message::Error(e),
+                        };
+                        if tx_monitor.send(message).await.is_err() {
                             break;
                         }
                     }
                     Err(_) => {
-                        // Channel closed - monitoring finished
-                        _ = tx_monitor.send(Message::MonitorFinished).await;
+                        // Channel closed unexpectedly
                         break;
                     }
                 }
@@ -199,7 +223,18 @@ impl MonitorApp {
 
             match message {
                 Message::StatusUpdate(status) => self.update_status(status),
-                Message::MonitorFinished => self.exit = true,
+                Message::Finished => {
+                    self.stop_info = Some(StopInfo::Finished);
+                    self.exit = true;
+                }
+                Message::Disconnected => {
+                    self.stop_info = Some(StopInfo::Disconnected);
+                    self.exit = true;
+                }
+                Message::Error(e) => {
+                    self.stop_info = Some(StopInfo::Error(e));
+                    self.exit = true;
+                }
                 Message::Terminal(event) => {
                     if let Event::Key(key_event) = event {
                         self.handle_key_event(key_event);

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -23,10 +23,11 @@ use agama_lib::{
     monitor::{InstallationStatus, Monitor, MonitorUpdate},
 };
 use anyhow::{anyhow, Result};
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind};
+use futures_util::StreamExt;
 use ratatui::{backend::CrosstermBackend, buffer::Buffer, layout::Rect, widgets::Widget, Terminal};
 use serde::Deserialize;
-use std::{collections::HashMap, io, time::Duration};
+use std::{collections::HashMap, io};
 use tokio::sync::mpsc;
 
 use super::{theme::Theme, ui};
@@ -189,17 +190,15 @@ impl MonitorApp {
         // Spawn task to read terminal events
         let tx_terminal = tx.clone();
         let terminal_handle = tokio::task::spawn(async move {
-            loop {
-                match crossterm::event::poll(Duration::from_millis(100)) {
-                    Ok(true) => {
-                        if let Ok(event) = crossterm::event::read() {
-                            if tx_terminal.send(Message::Terminal(event)).await.is_err() {
-                                break;
-                            }
+            let mut event_stream = EventStream::new();
+            while let Some(event) = event_stream.next().await {
+                match event {
+                    Ok(event) => {
+                        if tx_terminal.send(Message::Terminal(event)).await.is_err() {
+                            break;
                         }
                     }
                     Err(_) => break,
-                    _ => {}
                 }
             }
         });

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -175,23 +175,15 @@ impl MonitorApp {
         // Spawn task to forward monitor updates
         let tx_monitor = tx.clone();
         tokio::task::spawn(async move {
-            loop {
-                match status_updates.recv().await {
-                    Some(update) => {
-                        let message = match update {
-                            MonitorUpdate::Status(status) => Message::StatusUpdate(status),
-                            MonitorUpdate::Finished => Message::Finished,
-                            MonitorUpdate::Disconnected => Message::Disconnected,
-                            MonitorUpdate::Error(e) => Message::Error(e),
-                        };
-                        if tx_monitor.send(message).await.is_err() {
-                            break;
-                        }
-                    }
-                    None => {
-                        // Channel closed
-                        break;
-                    }
+            while let Some(update) = status_updates.recv().await {
+                let message = match update {
+                    MonitorUpdate::Status(status) => Message::StatusUpdate(status),
+                    MonitorUpdate::Finished => Message::Finished,
+                    MonitorUpdate::Disconnected => Message::Disconnected,
+                    MonitorUpdate::Error(e) => Message::Error(e),
+                };
+                if tx_monitor.send(message).await.is_err() {
+                    break;
                 }
             }
         });

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -33,7 +33,8 @@ use tokio::sync::mpsc;
 use super::{theme::Theme, ui};
 
 /// Application messages.
-enum Message {
+#[derive(Clone, Debug)]
+pub enum Message {
     /// Status update from monitor
     StatusUpdate(InstallationStatus),
     /// Monitor finished (installation became idle)
@@ -97,7 +98,7 @@ impl MonitorAppBuilder {
             status,
             theme: self.theme,
             product_names,
-            stop_update: None,
+            stop_message: None,
         })
     }
 
@@ -122,8 +123,8 @@ pub struct MonitorApp {
     product_names: HashMap<String, String>,
     /// UI color theme
     theme: Theme,
-    /// Stop update (if stopped)
-    stop_update: Option<MonitorUpdate>,
+    /// Stop message (if stopped)
+    stop_message: Option<Message>,
 }
 
 impl MonitorApp {
@@ -132,9 +133,9 @@ impl MonitorApp {
         self.status = new_status;
     }
 
-    /// Returns the monitor update that caused stopping, if stopped.
-    pub fn stop_update(&self) -> Option<&MonitorUpdate> {
-        self.stop_update.as_ref()
+    /// Returns the message that caused stopping, if stopped.
+    pub fn stop_message(&self) -> Option<&Message> {
+        self.stop_message.as_ref()
     }
 
     /// Runs the monitor TUI event loop.
@@ -193,7 +194,7 @@ impl MonitorApp {
         });
 
         // Main event loop
-        while self.stop_update.is_none() {
+        while self.stop_message.is_none() {
             terminal.draw(|f| f.render_widget(&mut *self, f.area()))?;
 
             let message = rx
@@ -203,14 +204,8 @@ impl MonitorApp {
 
             match message {
                 Message::StatusUpdate(status) => self.update_status(status),
-                Message::Finished => {
-                    self.stop_update = Some(MonitorUpdate::Finished);
-                }
-                Message::Disconnected => {
-                    self.stop_update = Some(MonitorUpdate::Disconnected);
-                }
-                Message::Error(e) => {
-                    self.stop_update = Some(MonitorUpdate::Error(e));
+                msg @ Message::Finished | msg @ Message::Disconnected | msg @ Message::Error(_) => {
+                    self.stop_message = Some(msg);
                 }
                 Message::Terminal(event) => {
                     if let Event::Key(key_event) = event {
@@ -232,7 +227,7 @@ impl MonitorApp {
 
         match (key_event.code, key_event.modifiers) {
             (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => {
-                self.stop_update = Some(MonitorUpdate::Finished);
+                self.stop_message = Some(Message::Finished);
             }
             _ => {}
         }

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -28,7 +28,6 @@ use gettextrs::gettext;
 use ratatui::{backend::CrosstermBackend, buffer::Buffer, layout::Rect, widgets::Widget, Terminal};
 use serde::Deserialize;
 use std::{collections::HashMap, io, time::Duration};
-use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 
 use super::{theme::Theme, ui};
@@ -94,7 +93,7 @@ impl MonitorAppBuilder {
             Monitor::connect(self.websocket_client, &self.http_client, self.stop_on_idle).await?;
 
         Ok(MonitorApp {
-            updates,
+            updates: Some(updates),
             status,
             theme: self.theme,
             exit: false,
@@ -127,8 +126,8 @@ pub enum StopInfo {
 
 /// Application state for the monitor TUI
 pub struct MonitorApp {
-    /// Monitor updates receiver
-    updates: broadcast::Receiver<MonitorUpdate>,
+    /// Monitor updates receiver (taken when run() is called)
+    updates: Option<mpsc::Receiver<MonitorUpdate>>,
     /// Current installation status
     status: InstallationStatus,
     /// Product names
@@ -167,15 +166,18 @@ impl MonitorApp {
     ) -> Result<()> {
         let (tx, mut rx) = mpsc::channel(16);
 
-        // Resubscribe to get a new receiver for the task
-        let mut status_updates = self.updates.resubscribe();
+        // Take ownership of the monitor updates receiver
+        let mut status_updates = self
+            .updates
+            .take()
+            .ok_or(anyhow!("Monitor receiver already taken"))?;
 
         // Spawn task to forward monitor updates
         let tx_monitor = tx.clone();
         tokio::task::spawn(async move {
             loop {
                 match status_updates.recv().await {
-                    Ok(update) => {
+                    Some(update) => {
                         let message = match update {
                             MonitorUpdate::Status(status) => Message::StatusUpdate(status),
                             MonitorUpdate::Finished => Message::Finished,
@@ -186,8 +188,8 @@ impl MonitorApp {
                             break;
                         }
                     }
-                    Err(_) => {
-                        // Channel closed unexpectedly
+                    None => {
+                        // Channel closed
                         break;
                     }
                 }

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -227,10 +227,12 @@ impl Monitor {
     ///
     /// Returns a receiver for monitor updates and the initial status.
     /// The monitor runs on a separate Tokio task and emits MonitorUpdate messages:
+    ///
     /// - `MonitorUpdate::Status(status)` for status changes
     /// - `MonitorUpdate::Finished` when the installation becomes idle (if stop_on_idle is true)
     /// - `MonitorUpdate::Disconnected` when the WebSocket connection is closed
     /// - `MonitorUpdate::Error(msg)` when an error occurs during monitoring
+    ///
     /// After a terminal message (Finished, Disconnected, or Error), the channel will close.
     pub async fn connect(
         websocket_client: WebSocketClient,

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -43,7 +43,7 @@
 //! println!("Current stage: {:?}", status.status.stage);
 //!
 //! // Receive monitor updates
-//! while let Ok(update) = updates.recv().await {
+//! while let Some(update) = updates.recv().await {
 //!     match update {
 //!         MonitorUpdate::Status(status) => {
 //!             println!("Status updated! Issues count: {}", status.issues.len());

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -27,7 +27,7 @@
 //!
 //! ```no_run
 //! use agama_lib::http::{BaseHTTPClient, WebSocketClient};
-//! use agama_lib::monitor::Monitor;
+//! use agama_lib::monitor::{Monitor, MonitorUpdate};
 //! use agama_lib::auth::AuthToken;
 //! use url::Url;
 //!
@@ -42,9 +42,25 @@
 //! let (mut updates, status) = Monitor::connect(ws_client, &http_client, stop_on_idle).await?;
 //! println!("Current stage: {:?}", status.status.stage);
 //!
-//! // Receive status updates (channel closes when monitoring stops)
-//! while let Ok(status) = updates.recv().await {
-//!     println!("Status updated! Issues count: {}", status.issues.len());
+//! // Receive monitor updates
+//! while let Ok(update) = updates.recv().await {
+//!     match update {
+//!         MonitorUpdate::Status(status) => {
+//!             println!("Status updated! Issues count: {}", status.issues.len());
+//!         }
+//!         MonitorUpdate::Finished => {
+//!             println!("Installation became idle");
+//!             break;
+//!         }
+//!         MonitorUpdate::Disconnected => {
+//!             println!("Connection lost");
+//!             break;
+//!         }
+//!         MonitorUpdate::Error(e) => {
+//!             println!("Error: {}", e);
+//!             break;
+//!         }
+//!     }
 //! }
 //! println!("Monitoring finished");
 //! # Ok(())
@@ -131,6 +147,19 @@ pub struct InstallationStatus {
     pub system_info: SystemInfo,
 }
 
+/// Monitor update message
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub enum MonitorUpdate {
+    /// Status update during monitoring
+    Status(InstallationStatus),
+    /// Installation became idle (when stop_on_idle is enabled)
+    Finished,
+    /// WebSocket connection was closed or lost
+    Disconnected,
+    /// An error occurred during monitoring
+    Error(String),
+}
+
 impl InstallationStatus {
     pub fn has_product(&self) -> bool {
         self.system_info.product_id.is_some()
@@ -158,7 +187,7 @@ pub struct Monitor {
     /// A mutex is needed to avoid race conditions.
     status: Mutex<InstallationStatus>,
     /// Channel to broadcast status updates to subscribers.
-    updates: broadcast::Sender<InstallationStatus>,
+    updates: broadcast::Sender<MonitorUpdate>,
     /// Whether to stop monitoring when the installation goes idle.
     stop_on_idle: bool,
 }
@@ -193,15 +222,18 @@ impl Monitor {
     /// * `http_client`: HTTP client to talk to the service.
     /// * `stop_on_idle`: whether to automatically stop monitoring when the installation goes idle.
     ///
-    /// Returns a receiver for status updates and the initial status.
-    /// The monitor runs on a separate Tokio task and emits InstallationStatus updates.
-    /// When stop_on_idle is true, monitoring will stop when the installation becomes idle.
-    /// When the monitor stops (connection lost or stop_on_idle), the channel will close.
+    /// Returns a receiver for monitor updates and the initial status.
+    /// The monitor runs on a separate Tokio task and emits MonitorUpdate messages:
+    /// - `MonitorUpdate::Status(status)` for status changes
+    /// - `MonitorUpdate::Finished` when the installation becomes idle (if stop_on_idle is true)
+    /// - `MonitorUpdate::Disconnected` when the WebSocket connection is closed
+    /// - `MonitorUpdate::Error(msg)` when an error occurs during monitoring
+    /// After a terminal message (Finished, Disconnected, or Error), the channel will close.
     pub async fn connect(
         websocket_client: WebSocketClient,
         http_client: &BaseHTTPClient,
         stop_on_idle: bool,
-    ) -> Result<(broadcast::Receiver<InstallationStatus>, InstallationStatus), MonitorError> {
+    ) -> Result<(broadcast::Receiver<MonitorUpdate>, InstallationStatus), MonitorError> {
         let (tx, rx) = broadcast::channel(100);
 
         let initial_status = Self::get_installation_status(http_client).await?;
@@ -278,22 +310,28 @@ impl Monitor {
     /// - A critical error occurs
     /// - stop_on_idle is true and the installation becomes idle
     ///
+    /// Before exiting, sends a terminal message (Finished, Disconnected, or Error).
     /// When the loop exits, the broadcast sender is dropped, closing the channel.
     async fn run(&mut self) {
-        loop {
+        let final_message = loop {
             let event = self.ws_client.receive().await;
             match self.handle_event(event).await {
-                Ok(should_exit) => {
-                    if should_exit {
-                        break;
-                    }
+                Ok(Some(msg)) => {
+                    // Received an explicit stop signal
+                    break msg;
+                }
+                Ok(None) => {
+                    // Continue monitoring
                 }
                 Err(err) => {
                     tracing::error!("Critical error happen during event handling: {:?}", err);
-                    break;
+                    break MonitorUpdate::Error(err.to_string());
                 }
             }
-        }
+        };
+
+        // Send final message
+        let _ = self.updates.send(final_message);
         // Channel closes automatically when self.updates is dropped
     }
 
@@ -304,12 +342,19 @@ impl Monitor {
     ///
     /// * `event`: Agama event.
     ///
-    /// Returns `Ok(true)` if the monitor should exit, `Ok(false)` to continue.
+    /// Returns `Ok(Some(message))` if the monitor should exit with the given terminal message,
+    /// `Ok(None)` to continue monitoring.
     async fn handle_event(
         &mut self,
         event: Result<Event, crate::http::WebSocketError>,
-    ) -> Result<bool, crate::http::WebSocketError> {
-        let event = event?;
+    ) -> Result<Option<MonitorUpdate>, crate::http::WebSocketError> {
+        let event = match event {
+            Ok(e) => e,
+            Err(crate::http::WebSocketError::Closed) => {
+                return Ok(Some(MonitorUpdate::Disconnected));
+            }
+            Err(e) => return Err(e),
+        };
 
         let mut g = self.status.lock().await;
         let status = &mut *g;
@@ -325,7 +370,7 @@ impl Monitor {
                 let issues = manager.issues().await;
                 let Ok(issues) = issues else {
                     tracing::error!("Failed to get list of issues: {:?}", issues);
-                    return Ok(false);
+                    return Ok(None);
                 };
                 status.issues = issues;
 
@@ -342,7 +387,7 @@ impl Monitor {
                 let questions = questions.get_questions().await;
                 let Ok(questions) = questions else {
                     tracing::error!("Failed to get list of questions: {:?}", questions);
-                    return Ok(false);
+                    return Ok(None);
                 };
                 let questions = questions
                     .into_iter()
@@ -370,15 +415,18 @@ impl Monitor {
             }
             _ => {
                 // other events are not interesting for monitor
-                return Ok(false);
+                return Ok(None);
             }
         }
 
         // Send update (ignore if send failed to avoid flooding logs)
-        let _ = self.updates.send(g.clone());
+        let _ = self.updates.send(MonitorUpdate::Status(g.clone()));
 
         // Check if we should exit
-        let should_exit = self.stop_on_idle && g.is_idle();
-        Ok(should_exit)
+        if self.stop_on_idle && g.is_idle() {
+            Ok(Some(MonitorUpdate::Finished))
+        } else {
+            Ok(None)
+        }
     }
 }

--- a/rust/agama-lib/src/monitor.rs
+++ b/rust/agama-lib/src/monitor.rs
@@ -71,7 +71,7 @@ use std::fmt;
 
 use agama_utils::api::{self, Config, Event};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{mpsc, Mutex};
 
 use crate::{
     http::{BaseHTTPClient, WebSocketClient},
@@ -186,10 +186,13 @@ pub struct Monitor {
     ///
     /// A mutex is needed to avoid race conditions.
     status: Mutex<InstallationStatus>,
-    /// Channel to broadcast status updates to subscribers.
-    updates: broadcast::Sender<MonitorUpdate>,
+    /// Channel to send status updates to the subscriber.
+    updates: mpsc::Sender<MonitorUpdate>,
     /// Whether to stop monitoring when the installation goes idle.
     stop_on_idle: bool,
+    /// Whether we've seen the system become busy (at least one progress event).
+    /// Used with stop_on_idle to avoid exiting before work starts.
+    seen_busy: bool,
 }
 
 impl Monitor {
@@ -233,8 +236,8 @@ impl Monitor {
         websocket_client: WebSocketClient,
         http_client: &BaseHTTPClient,
         stop_on_idle: bool,
-    ) -> Result<(broadcast::Receiver<MonitorUpdate>, InstallationStatus), MonitorError> {
-        let (tx, rx) = broadcast::channel(100);
+    ) -> Result<(mpsc::Receiver<MonitorUpdate>, InstallationStatus), MonitorError> {
+        let (tx, rx) = mpsc::channel(100);
 
         let initial_status = Self::get_installation_status(http_client).await?;
 
@@ -244,6 +247,7 @@ impl Monitor {
             status: Mutex::new(initial_status.clone()),
             updates: tx,
             stop_on_idle,
+            seen_busy: !initial_status.is_idle(), // If starting busy, mark as seen
         };
 
         tokio::spawn(async move { monitor.run().await });
@@ -311,8 +315,15 @@ impl Monitor {
     /// - stop_on_idle is true and the installation becomes idle
     ///
     /// Before exiting, sends a terminal message (Finished, Disconnected, or Error).
-    /// When the loop exits, the broadcast sender is dropped, closing the channel.
+    /// When the loop exits, the sender is dropped, closing the channel.
     async fn run(&mut self) {
+        // Send initial status so the UI renders immediately
+        let initial_status = self.status.lock().await.clone();
+        let _ = self
+            .updates
+            .send(MonitorUpdate::Status(initial_status))
+            .await;
+
         let final_message = loop {
             let event = self.ws_client.receive().await;
             match self.handle_event(event).await {
@@ -331,7 +342,7 @@ impl Monitor {
         };
 
         // Send final message
-        let _ = self.updates.send(final_message);
+        let _ = self.updates.send(final_message).await;
         // Channel closes automatically when self.updates is dropped
     }
 
@@ -399,6 +410,9 @@ impl Monitor {
                 status.questions.retain(|q| q.id != id);
             }
             Event::ProgressChanged { progress } => {
+                // Mark that we've seen activity
+                self.seen_busy = true;
+
                 let index = status
                     .status
                     .progresses
@@ -420,10 +434,12 @@ impl Monitor {
         }
 
         // Send update (ignore if send failed to avoid flooding logs)
-        let _ = self.updates.send(MonitorUpdate::Status(g.clone()));
+        let _ = self.updates.send(MonitorUpdate::Status(g.clone())).await;
 
         // Check if we should exit
-        if self.stop_on_idle && g.is_idle() {
+        // Only exit on idle if we've seen the system become busy first.
+        // This prevents exiting before work starts (e.g., when config load is about to begin).
+        if self.stop_on_idle && self.seen_busy && g.is_idle() {
             Ok(Some(MonitorUpdate::Finished))
         } else {
             Ok(None)

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 21 15:53:10 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Prevent the monitor from blocking (related to bsc#1265431).
+
+-------------------------------------------------------------------
 Mon May 18 10:58:44 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Detect when the WebSocket gets disconnected (bsc#1265431).


### PR DESCRIPTION
Fixes monitor issues with `agama config load` and improves the API.

**Changes:**

- Distinguish between different monitor stop reasons (Finished, Disconnected, Error)
- Use mpsc channel instead of broadcast to avoid race conditions
- Track activity to prevent premature exit when system is idle at startup
- Simplify MonitorApp API to return errors instead of exposing internal state
- Use crossterm EventStream to read key events in a non-blocking way.

**Status:** Work in progress - testing needed

Fixes the issue where monitor would exit immediately or only appear at the end during config loading.