### PR TITLE
[SLE-16.0] Cache installed Ruby gems in CI

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Configure and refresh repositories
       # disable unused repositories to have faster refresh

--- a/.github/workflows/ci-devel.yml
+++ b/.github/workflows/ci-devel.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # checkout only the "devel" subdirectory
         sparse-checkout: |

--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Fix the file owner
       # fix the file owner
@@ -58,7 +58,7 @@ jobs:
            libxslt-devel libxml2-devel xmlstarlet 'rubygem(ruby-augeas)'
 
     - name: Cache RubyGems
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         key: "Gemfile-${{ hashFiles('service/Gemfile.lock') }}"
         path: service/vendor/bundle

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     # TODO: Cache the Ruby gems and node packages
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # fetch complete history with tags, agama.gemspec calls "git describe --tags"
         # that would fail with just last commit checked out
@@ -32,7 +32,7 @@ jobs:
         fetch-tags: true
 
     - name: Checkout integration tests
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: integration-tests
         repository: ${{ github.repository_owner }}/integration-tests

--- a/.github/workflows/ci-profile-schema.yml
+++ b/.github/workflows/ci-profile-schema.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # checkout only the directory with the schema
         sparse-checkout: |

--- a/.github/workflows/ci-rubocop.yml
+++ b/.github/workflows/ci-rubocop.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # cache the locally installed Ruby gems for the next invocation to speed up the run,
     # installing Rubocop from scratch takes about 1 minute, the cache is restored in about 2 seconds
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#using-the-cache-action
     - name: Rubygem cache
       id:   rubygem-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.local/share/gem

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -225,7 +225,7 @@ jobs:
         sudo apt-get -y install libclang-18-dev libpam0g-dev
         # uninstall the python3-jsonschema package, openapi-spec-validator wants
         # to install a newer version which would conflict with that
-        sudo apt-get purge python3-jsonschema
+        sudo apt-get purge python3-jsonschema python3-typing-extensions
         sudo pip install openapi-spec-validator
 
     - name: Installed packages

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Rust toolchain
       run: |
@@ -79,7 +79,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Rust toolchain
       run: |
@@ -95,7 +95,7 @@ jobs:
       run: apt list --installed
 
     - name: Rust cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo
@@ -119,7 +119,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Rust toolchain
       run: |
@@ -145,7 +145,7 @@ jobs:
 
     - name: Rust cache
       id: cache-tests
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo
@@ -205,7 +205,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Rust toolchain
       run: |
@@ -232,7 +232,7 @@ jobs:
       run: apt list --installed
 
     - name: Rust cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -96,6 +96,18 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v6
 
+    - name: Bundler cache
+      id: bundler-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          agama/service/.bundle
+          /usr/lib64/ruby/gems/*
+          !/usr/lib64/ruby/gems/*/gems
+          /usr/bin/rspec
+          /usr/bin/rxgettext
+        key: ${{ runner.os }}-ruby-bundler-16.0-${{ hashFiles('./service/Gemfile.lock') }}
+
     - name: Install RubyGems dependencies
       # install gems not included in openSUSE Leap 16.0
       run: bundle config set --local with 'development' && bundle install && bundle add gettext
@@ -131,7 +143,7 @@ jobs:
       working-directory: ./service
 
     - name: Upload coverage result
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage_service
         if-no-files-found: error
@@ -152,10 +164,10 @@ jobs:
 
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download coverage result
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: coverage_service
 

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -51,7 +51,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/.github/workflows/obs-service-shared.yml
+++ b/.github/workflows/obs-service-shared.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Git Checkout (full history)
         if: ${{ github.ref_type != 'tag' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # fetch all history, we need to find the latest tag and offset for the version number
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
         run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # fetch all history with tags, we need to find the latest version tag
           fetch-depth: 0

--- a/.github/workflows/obs-staging-live.yml
+++ b/.github/workflows/obs-staging-live.yml
@@ -33,7 +33,7 @@ jobs:
              findutils git make osc obs-service-format_spec_file
 
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure git
         run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -54,7 +54,7 @@ jobs:
              ${{ inputs.install_packages }}
 
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # fetch all history with tags, we need to find the latest version tag
           fetch-depth: 0

--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -44,7 +44,7 @@ jobs:
           gem install --no-format-exec gettext
 
       - name: Checkout Agama sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: agama
           # checkout the SLE-16 branch
@@ -60,7 +60,7 @@ jobs:
         run:  msgfmt --check-format agama/web/agama.pot
 
       - name: Checkout Weblate sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate


### PR DESCRIPTION
## Problems

- Old versions of GitHub Actions (they use old unsupported NodeJS v20,  GitHub prints a ["Node.js 20 actions are deprecated" ](https://github.com/agama-project/agama/actions/runs/26086960005) warning)
- Installing the needed Ruby gems takes quite long time (about [one and half minute](https://github.com/agama-project/agama/actions/runs/26175301761/job/77003739150#step:9:7))

## Solution

- Update the GitHub Action versions
- Cache the installed Ruby gems, restoring the cache and running Bundler now takes [just about 15 seconds](https://github.com/agama-project/agama/actions/runs/26182626931/job/77029525706#step:8:17). So the test run is it at least more than one minute faster!

## Testing

- Tested with the updated GitHub Actions
