### PR TITLE
Add ignition and combustion to live image

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 21 15:39:19 UTC 2026 - Volkan OZTUZUN <volkan.oztuzun@suse.com>
+
+- Add ignition and combustion to the live image package list.
+
+-------------------------------------------------------------------
 Sat May 16 07:54:44 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 21

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -64,6 +64,8 @@
         <package name="avahi"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
+        <package name="ignition"/>
+        <package name="combustion >= 1.2"/> <!-- New firstboot mechanism -->
         <package name="procps"/>
         <package name="iputils"/>
         <package name="hyper-v" arch="aarch64,x86_64"/>


### PR DESCRIPTION
## Problem

The live image currently does not include the packages needed for the new firstboot mechanism.

## Solution

Add `ignition` and `combustion >= 1.2` to the Agama live image package list.

## Testing

- Tested manually by checking the generated diff.
- No unit tests added; this is a package list change.

## Screenshots

Not applicable.

## Documentation

Not applicable.