### PR TITLE
Updated CI caching

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -191,6 +191,10 @@ jobs:
       run: rpm -qa
 
     - name: Rust cache
+      # cache only the master branch (it is shared in pull requests), the Rust
+      # cache for unit tests is HUGE (about 3GB!) and we would quickly reach the
+      # 10GB limit for just few branches/pull requests
+      if: github.ref_name == 'master'
       id: cache-tests
       uses: actions/cache@v5
       with:

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -103,6 +103,18 @@ jobs:
         "rubygem(ruby:$RUBY_VERSION:gettext)" \
         which
 
+    - name: Bundler cache
+      id: bundler-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          agama/service/.bundle
+          /usr/lib64/ruby/gems/*
+          !/usr/lib64/ruby/gems/*/gems
+          /usr/bin/rspec
+          /usr/bin/rxgettext
+        key: ${{ runner.os }}-ruby-bundler-master-${{ hashFiles('./service/Gemfile.lock') }}
+
     - name: Install RubyGems dependencies
       run: bundle config set --local with 'development' && bundle install
 


### PR DESCRIPTION
## Problem

- The Ruby gems are not cached in unit tests, installing them takes like 90 seconds.
- The Rust unit test cache is huge (~3GB!!), saving the cache for each branch causes reaching the 10GB storage GitHub limit. When the limit is reached then GitHub starts removing the other Ruby, NPM, Rubocop...  caches which are much smaller. The result is that the Rust cache causes the caching in other Actions pointless as the caches are usually not present (have been deleted).

## Solution

- Port the Ruby gem caching from #3528 to master branch
- Enable the Rust unit test cache only in the master branch. (That is also inherited to pull requests open against master so that should help a bit also in the other branches.)

## Testing

- Tested by running the modified GitHub Action, see the results for this pull request.