### PR TITLE
Fixed Kiwi file

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 25 12:06:55 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Temporarily disabled ignition and combustion because they cannot
+  start properly in the Live ISO environment (bsc#1266257)
+
+-------------------------------------------------------------------
 Thu May 21 15:39:19 UTC 2026 - Volkan OZTUZUN <volkan.oztuzun@suse.com>
 
 - Add ignition and combustion to the live image package list.

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -64,8 +64,9 @@
         <package name="avahi"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
+        <!-- Temporarily disabled, see bsc#1266257
         <package name="ignition"/>
-        <package name="combustion"/>
+        <package name="combustion"/> -->
         <package name="procps"/>
         <package name="iputils"/>
         <package name="hyper-v" arch="aarch64,x86_64"/>

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -65,7 +65,7 @@
         <package name="bind-utils"/>
         <package name="systemd"/>
         <package name="ignition"/>
-        <package name="combustion >= 1.2"/> <!-- New firstboot mechanism -->
+        <package name="combustion &gt;= 1.2"/> <!-- New firstboot mechanism -->
         <package name="procps"/>
         <package name="iputils"/>
         <package name="hyper-v" arch="aarch64,x86_64"/>

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -65,7 +65,7 @@
         <package name="bind-utils"/>
         <package name="systemd"/>
         <package name="ignition"/>
-        <package name="combustion &gt;= 1.2"/> <!-- New firstboot mechanism -->
+        <package name="combustion"/>
         <package name="procps"/>
         <package name="iputils"/>
         <package name="hyper-v" arch="aarch64,x86_64"/>


### PR DESCRIPTION
## Problem

- Kiwi does not build the Live image and prints error " could not parse build description (kiwi)  element 'packages' closes, but I expected 'package'"


## Solution

- The `>` character in an attribute string must be escaped.
- Replace `combustion >= 1.2` with `combustion &gt;= 1.2`
- Related to #3529

## Testing

- Tested manually, the image can be now built locally

## Note

Later it turned out that both ignition and combustion do not start properly in the Live ISO environment.
See https://bugzilla.suse.com/show_bug.cgi?id=1266257.

As a temporary workaround to fix the booting problem both services have been disabled.
