### PR TITLE
Ignition + combustion workaround, always force the first boot mode

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/95initrd-firstboot/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/95initrd-firstboot/module-setup.sh
@@ -18,7 +18,7 @@ install() {
   #
   # The problem is that the first boot detection fails because of the
   # complicated Live ISO setup which uses the device mapper for creating
-  # writable overlay over the squashfs read-only image.)
+  # writable overlay over the squashfs read-only image.
 	$SYSTEMCTL -q --root "$initdir" disable firstboot-detect.service
 	$SYSTEMCTL -q --root "$initdir" enable firstboot.target
 }

--- a/live/live-root/usr/lib/dracut/modules.d/95initrd-firstboot/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/95initrd-firstboot/module-setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# workaround for failing first boot detection in the Live ISO system
+
+check() {
+  # always include this dracut module in the initramfs
+	return 0
+}
+
+depends() {
+	echo bash systemd
+}
+
+install() {
+  # Do not try detecting whether this is the first boot or not, consider every
+  # boot as the first boot. That's true for the installer, we always start with
+  # the same read-only root filesystem image from scratch.
+  #
+  # The problem is that the first boot detection fails because of the
+  # complicated Live ISO setup which uses the device mapper for creating
+  # writable overlay over the squashfs read-only image.)
+	$SYSTEMCTL -q --root "$initdir" disable firstboot-detect.service
+	$SYSTEMCTL -q --root "$initdir" enable firstboot.target
+}

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 25 15:25:49 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Enable back ignition and combustion, apply a workaround for
+  detecting the first boot (disable detection, consider every boot
+  as the first boot) (related to bsc#1266257)
+
+-------------------------------------------------------------------
 Mon May 25 12:06:55 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Temporarily disabled ignition and combustion because they cannot

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -64,9 +64,8 @@
         <package name="avahi"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
-        <!-- Temporarily disabled, see bsc#1266257
         <package name="ignition"/>
-        <package name="combustion"/> -->
+        <package name="combustion"/>
         <package name="procps"/>
         <package name="iputils"/>
         <package name="hyper-v" arch="aarch64,x86_64"/>

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -53,6 +53,9 @@ else
 sed -i -e "s/^\s*#\s*download.connect_timeout\s*=\s*.*$/download.connect_timeout = 20/" /etc/zypp/zypp.conf
 fi
 
+# combustion requires fstab file, create a dummy one
+touch /etc/fstab
+
 # activate services
 systemctl enable sshd.service
 systemctl enable NetworkManager.service


### PR DESCRIPTION
## Problem

- Ignition and combustion do not start properly in the Live ISO
- https://bugzilla.suse.com/show_bug.cgi?id=1266257

## Solution

- It turned out that the `firstboot-detect.service` which should detect whether the current boot is the first boot or not does not work properly in the Live ISO environment.
- The workaround is to disable the first boot detection and always behave like in the first boot. That's actually true for the installer, we always start with the same read-only root filesystem image from scratch.

## Testing

- Tested manually
- The ISO builds and boots fine
- Tested with a simple combustion script
  - Remote script: boot with the `rd.neednet=1 ip=dhcp combustion.url=http://.../script rd.break` boot options
  - Local script: create disk partition with label `COMBUSTION`, place the script into `/combustion/script` file (do not forget to make it executable)
  - In both cases the script was correctly executed by Combustion .

