### PR TITLE
feat(storage): LVM policy for generating physical volumes

### DIFF
--- a/rust/agama-lib/share/storage.model.schema.json
+++ b/rust/agama-lib/share/storage.model.schema.json
@@ -98,6 +98,9 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "targetDevicesPolicy": {
+          "enum": ["useNeeded", "useAvailable"]
+        },
         "spacePolicy": { "$ref": "#/$defs/spacePolicy" },
         "logicalVolumes": {
           "type": "array",

--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -289,6 +289,11 @@
               "type": "array",
               "items": { "$ref": "#/$defs/alias" }
             },
+            "spacePolicy": {
+              "description": "Policy for creating physical volumes: either using all the available space or only the needed space for allocating the logical volumes.",
+              "enum": ["useNeeded", "useAvailable"],
+              "default": "useNeeded"
+            },
             "encryption": { "$ref": "#/$defs/encryption" }
           }
         }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  1 13:47:34 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Extend storage schemas to allow configuring the space policy for
+  creating new LVM physical volumes (jsc#PED-14153).
+
+-------------------------------------------------------------------
 Fri May 29 09:47:43 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Add "remoteAccess" key to profile to allow after installation

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/volume_group.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/volume_group.rb
@@ -62,6 +62,7 @@ module Agama
               search:                      convert_search,
               extent_size:                 convert_extent_size,
               physical_volumes_devices:    convert_physical_volumes_devices,
+              physical_volumes_policy:     convert_physical_volumes_policy,
               physical_volumes_encryption: convert_physical_volumes_encryption,
               physical_volumes:            convert_physical_volumes,
               logical_volumes:             convert_logical_volumes
@@ -82,6 +83,17 @@ module Agama
             return unless generate_json
 
             generate_json.is_a?(Array) ? generate_json : generate_json[:targetDevices]
+          end
+
+          # @return [:use_needed, :use_available]
+          def convert_physical_volumes_policy
+            generate_json = physical_volume_generate_json&.fetch(:generate)
+            return :use_needed unless generate_json.is_a?(Hash)
+
+            value = generate_json[:spacePolicy]
+            return :use_available if value == "useAvailable"
+
+            :use_needed
           end
 
           # @return [Configs::Encryption, nil]

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/volume_group.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/volume_group.rb
@@ -80,6 +80,7 @@ module Agama
               search:                      convert_search,
               extent_size:                 convert_extent_size,
               physical_volumes_devices:    convert_physical_volumes_devices,
+              physical_volumes_policy:     convert_physical_volumes_policy,
               physical_volumes_encryption: convert_physical_volumes_encryption,
               logical_volumes:             convert_volumes
             }
@@ -101,6 +102,16 @@ module Agama
             target_names
               .map { |n| target(n)&.ensure_alias }
               .compact
+          end
+
+          # @return [:use_needed, :use_available]
+          def convert_physical_volumes_policy
+            value = volume_group_model[:targetDevicesPolicy]
+
+            {
+              "useNeeded"    => :use_needed,
+              "useAvailable" => :use_available
+            }[value] || :use_available
           end
 
           # @return [Configs::Encryption, nil]

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/logical_volume.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/logical_volume.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_conversions/to_json_conversions/base"
+require "agama/storage/config_conversions/to_json_conversions/with_delete"
 require "agama/storage/config_conversions/to_json_conversions/with_encryption"
 require "agama/storage/config_conversions/to_json_conversions/with_filesystem"
 require "agama/storage/config_conversions/to_json_conversions/with_size"

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/volume_group.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/volume_group.rb
@@ -64,15 +64,21 @@ module Agama
             devices = config.physical_volumes_devices
             return if devices.empty?
 
+            space_policy = config.physical_volumes_policy
             encryption = config.physical_volumes_encryption
-            return { generate: devices } unless encryption
 
-            {
-              generate: {
-                targetDevices: devices,
-                encryption:    ToJSONConversions::Encryption.new(encryption).convert
-              }
-            }
+            # Only use advanced format if there's encryption or non-default space policy
+            if encryption.nil? && (space_policy.nil? || space_policy == :use_needed)
+              return { generate: devices }
+            end
+
+            generate = { targetDevices: devices }
+            generate[:spacePolicy] = "useAvailable" if space_policy == :use_available
+            if encryption
+              generate[:encryption] = ToJSONConversions::Encryption.new(encryption).convert
+            end
+
+            { generate: generate }
           end
 
           # @return [Array<Hash>]

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/with_delete.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/with_delete.rb
@@ -19,7 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "agama/storage/config_conversions/to_json_conversions/search"
+require "agama/storage/config_conversions/to_json_conversions/with_search"
+require "agama/storage/config_conversions/to_json_conversions/with_size"
 
 module Agama
   module Storage

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/volume_group.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/volume_group.rb
@@ -52,12 +52,13 @@ module Agama
           # @see Base#conversions
           def conversions
             {
-              name:           config.device_name,
-              vgName:         config.name,
-              extentSize:     config.extent_size&.to_i,
-              targetDevices:  convert_target_devices,
-              spacePolicy:    convert_space_policy,
-              logicalVolumes: convert_logical_volumes
+              name:                config.device_name,
+              vgName:              config.name,
+              extentSize:          config.extent_size&.to_i,
+              targetDevices:       convert_target_devices,
+              targetDevicesPolicy: convert_target_devices_policy,
+              spacePolicy:         convert_space_policy,
+              logicalVolumes:      convert_logical_volumes
             }
           end
 
@@ -68,6 +69,16 @@ module Agama
             config.physical_volumes_devices
               .map { |a| storage_config.partitionable(a)&.device_name }
               .compact
+          end
+
+          # Policy for creating physical volumes in the target devices.
+          #
+          # @return ["useNeeded", "useAvailable", nil]
+          def convert_target_devices_policy
+            {
+              use_needed:    "useNeeded",
+              use_available: "useAvailable"
+            }[config.physical_volumes_policy]
           end
 
           # @return [Array<Hash>]

--- a/service/lib/agama/storage/configs/volume_group.rb
+++ b/service/lib/agama/storage/configs/volume_group.rb
@@ -43,6 +43,17 @@ module Agama
         # @return [Array<String>]
         attr_accessor :physical_volumes_devices
 
+        # Space policy for automatically creating new physical volumes.
+        #
+        # Options:
+        # * :use_available The VG will be created to use all the available space of the target
+        #   devices, thus the VG size could be greater than the sum of LVs sizes.
+        # * :use_needed The created VG will match the requirements 1:1, so its size will be
+        #   exactly the sum of all the LVs sizes.
+        #
+        # @return [:use_needed, :use_available, nil]
+        attr_accessor :physical_volumes_policy
+
         # Encryption for the new physical volumes created at the {physical_volumes_devices}.
         #
         # @return [Encryption, nil]

--- a/service/lib/y2storage/proposal/agama_vg_planner.rb
+++ b/service/lib/y2storage/proposal/agama_vg_planner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -51,7 +51,7 @@ module Y2Storage
         Y2Storage::Planned::LvmVg.new(volume_group_name: vg_config.vg_name).tap do |planned|
           planned.extent_size = vg_config.extent_size
           planned.lvs = planned_lvs(vg_config)
-          planned.size_strategy = :use_needed
+          planned.size_strategy = vg_config.physical_volumes_policy || :use_needed
           planned.pvs_candidate_devices = devices_for_pvs(vg_config)
           configure_pvs_encryption(planned, vg_config)
           configure_reuse(planned, vg_config)

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  1 13:49:08 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Allow configuring the space policy for creating LVM physical
+  volumes (jsc#PED-14153).
+
+-------------------------------------------------------------------
 Thu May 28 15:59:07 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - When proposing a booting partition, try with the desired size

--- a/service/test/agama/storage/config_conversions/from_json_conversions/volume_group_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/volume_group_test.rb
@@ -199,6 +199,7 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::VolumeGroup do
             {
               generate: {
                 targetDevices: target_devices,
+                spacePolicy:   space_policy,
                 encryption:    encryption
               }
             },
@@ -207,6 +208,8 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::VolumeGroup do
         end
 
         let(:target_devices) { nil }
+
+        let(:space_policy) { nil }
 
         let(:encryption) { nil }
 
@@ -221,6 +224,15 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::VolumeGroup do
           it "sets #physical_volumes_devices to the expected value" do
             volume_group = subject.convert
             expect(volume_group.physical_volumes_devices).to eq([])
+          end
+        end
+
+        context "if the physical volume does not specify 'spacePolicy'" do
+          let(:space_policy) { nil }
+
+          it "sets #physical_volumes_policy to the default value" do
+            volume_group = subject.convert
+            expect(volume_group.physical_volumes_policy).to eq(:use_needed)
           end
         end
 
@@ -239,6 +251,28 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::VolumeGroup do
           it "sets #physical_volumes_devices to the expected value" do
             volume_group = subject.convert
             expect(volume_group.physical_volumes_devices).to contain_exactly("disk1")
+          end
+        end
+
+        context "if the physical volume specifies 'spacePolicy'" do
+          let(:target_devices) { ["disk1"] }
+
+          context "with 'useNeeded'" do
+            let(:space_policy) { "useNeeded" }
+
+            it "sets #physical_volumes_policy to the expected value" do
+              volume_group = subject.convert
+              expect(volume_group.physical_volumes_policy).to eq(:use_needed)
+            end
+          end
+
+          context "with 'useAvailable'" do
+            let(:space_policy) { "useAvailable" }
+
+            it "sets #physical_volumes_policy to the expected value" do
+              volume_group = subject.convert
+              expect(volume_group.physical_volumes_policy).to eq(:use_available)
+            end
           end
         end
 

--- a/service/test/agama/storage/config_conversions/from_model_conversions/volume_group_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/volume_group_test.rb
@@ -77,6 +77,15 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::VolumeGroup do
       end
     end
 
+    context "if 'targetDevicesPolicy' is not specified" do
+      let(:model_json) { {} }
+
+      it "sets #physical_volumes_policy to :use_available" do
+        config = subject.convert
+        expect(config.physical_volumes_policy).to eq(:use_available)
+      end
+    end
+
     context "if 'logicalVolumes' is not specified" do
       let(:model_json) { {} }
 
@@ -135,6 +144,35 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::VolumeGroup do
       it "sets #physical_volumes_devices to the expected value" do
         config = subject.convert
         expect(config.physical_volumes_devices).to eq([drive.alias, md_raid.alias])
+      end
+    end
+
+    context "if 'targetDevicesPolicy' is specified" do
+      context "with 'useNeeded'" do
+        let(:model_json) { { targetDevicesPolicy: "useNeeded" } }
+
+        it "sets #physical_volumes_policy to :use_needed" do
+          config = subject.convert
+          expect(config.physical_volumes_policy).to eq(:use_needed)
+        end
+      end
+
+      context "with 'useAvailable'" do
+        let(:model_json) { { targetDevicesPolicy: "useAvailable" } }
+
+        it "sets #physical_volumes_policy to :use_available" do
+          config = subject.convert
+          expect(config.physical_volumes_policy).to eq(:use_available)
+        end
+      end
+
+      context "with an unknown value" do
+        let(:model_json) { { targetDevicesPolicy: "unknownValue" } }
+
+        it "sets #physical_volumes_policy to :use_available" do
+          config = subject.convert
+          expect(config.physical_volumes_policy).to eq(:use_available)
+        end
       end
     end
 

--- a/service/test/agama/storage/config_conversions/to_json_conversions/volume_group_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/volume_group_test.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../../../test_helper"
+require "agama/storage/bootloader_config"
 require "agama/storage/config_conversions/from_json_conversions/volume_group"
 require "agama/storage/config_conversions/to_json_conversions/volume_group"
 require "y2storage/refinements"
@@ -148,6 +149,37 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::VolumeGroup do
           )
         end
 
+        context "and #physical_volumes_policy is configured" do
+          let(:physical_volumes) do
+            [
+              "pv1",
+              "pv2",
+              {
+                generate: {
+                  targetDevices: ["disk1"],
+                  spacePolicy:   "useAvailable"
+                }
+              }
+            ]
+          end
+
+          it "generates the expected JSON" do
+            config_json = subject.convert
+            expect(config_json[:physicalVolumes]).to eq(
+              [
+                "pv1",
+                "pv2",
+                {
+                  generate: {
+                    targetDevices: ["disk1"],
+                    spacePolicy:   "useAvailable"
+                  }
+                }
+              ]
+            )
+          end
+        end
+
         context "and #physical_volumes_encryption is configured" do
           let(:physical_volumes) do
             [
@@ -180,6 +212,43 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::VolumeGroup do
                 }
               ]
             )
+          end
+
+          context "and #physical_volumes_policy is also configured" do
+            let(:physical_volumes) do
+              [
+                "pv1",
+                "pv2",
+                {
+                  generate: {
+                    targetDevices: ["disk1"],
+                    spacePolicy:   "useAvailable",
+                    encryption:    {
+                      luks1: { password: "12345" }
+                    }
+                  }
+                }
+              ]
+            end
+
+            it "generates the expected JSON" do
+              config_json = subject.convert
+              expect(config_json[:physicalVolumes]).to eq(
+                [
+                  "pv1",
+                  "pv2",
+                  {
+                    generate: {
+                      targetDevices: ["disk1"],
+                      spacePolicy:   "useAvailable",
+                      encryption:    {
+                        luks1: { password: "12345" }
+                      }
+                    }
+                  }
+                ]
+              )
+            end
           end
         end
       end

--- a/service/test/agama/storage/config_conversions/to_model_conversions/config_test.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/config_test.rb
@@ -207,10 +207,11 @@ describe Agama::Storage::ConfigConversions::ToModelConversions::Config do
         expect(config_model[:volumeGroups]).to eq(
           [
             {
-              vgName:         "vg0",
-              spacePolicy:    "keep",
-              targetDevices:  [],
-              logicalVolumes: [
+              vgName:              "vg0",
+              spacePolicy:         "keep",
+              targetDevices:       [],
+              targetDevicesPolicy: "useNeeded",
+              logicalVolumes:      [
                 {
                   delete:         false,
                   deleteIfNeeded: false,

--- a/service/test/agama/storage/config_conversions/to_model_conversions/volume_group_test.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/volume_group_test.rb
@@ -135,6 +135,48 @@ describe Agama::Storage::ConfigConversions::ToModelConversions::VolumeGroup do
       it "generates the expected JSON" do
         model_json = subject.convert
         expect(model_json[:targetDevices]).to eq(["/dev/vda", "/dev/vdb"])
+        expect(model_json[:targetDevicesPolicy]).to eq("useNeeded")
+      end
+
+      context "with 'useNeeded' policy" do
+        let(:physical_volumes) do
+          [{ generate: { targetDevices: ["disk1", "disk2"], spacePolicy: "useNeeded" } }]
+        end
+
+        it "generates the expected JSON" do
+          model_json = subject.convert
+          expect(model_json[:targetDevices]).to eq(["/dev/vda", "/dev/vdb"])
+          expect(model_json[:targetDevicesPolicy]).to eq("useNeeded")
+        end
+      end
+
+      context "with 'useAvailable' policy" do
+        let(:physical_volumes) do
+          [{ generate: { targetDevices: ["disk1", "disk2"], spacePolicy: "useAvailable" } }]
+        end
+
+        it "generates the expected JSON" do
+          model_json = subject.convert
+          expect(model_json[:targetDevices]).to eq(["/dev/vda", "/dev/vdb"])
+          expect(model_json[:targetDevicesPolicy]).to eq("useAvailable")
+        end
+      end
+
+      context "without any specific policy" do
+        let(:physical_volumes) do
+          [{ generate: { targetDevices: ["disk1", "disk2"] } }]
+        end
+
+        before do
+          vg = config.volume_groups.first
+          vg.physical_volumes_policy = nil
+        end
+
+        it "generates the expected JSON" do
+          model_json = subject.convert
+          expect(model_json[:targetDevices]).to eq(["/dev/vda", "/dev/vdb"])
+          expect(model_json[:targetDevicesPolicy]).to be_nil
+        end
       end
     end
 

--- a/service/test/agama/storage/config_conversions/to_model_test.rb
+++ b/service/test/agama/storage/config_conversions/to_model_test.rb
@@ -114,11 +114,12 @@ describe Agama::Storage::ConfigConversions::ToModel do
           ],
           volumeGroups: [
             {
-              name:           "/dev/test",
-              vgName:         "test",
-              targetDevices:  ["/dev/vda"],
-              spacePolicy:    "keep",
-              logicalVolumes: [
+              name:                "/dev/test",
+              vgName:              "test",
+              targetDevices:       ["/dev/vda"],
+              targetDevicesPolicy: "useNeeded",
+              spacePolicy:         "keep",
+              logicalVolumes:      [
                 {
                   name:           "/dev/test/lv1",
                   filesystem:     {

--- a/service/test/y2storage/agama_proposal_lvm_test.rb
+++ b/service/test/y2storage/agama_proposal_lvm_test.rb
@@ -824,5 +824,76 @@ describe Y2Storage::AgamaProposal do
         expect(vg.lvm_lvs.map { |lv| lv.mount_point.path }).to contain_exactly("/")
       end
     end
+
+    context "when a volume group has generated physical volumes with useAvailable space policy" do
+      let(:scenario) { "disks.yaml" }
+
+      let(:config_json) do
+        {
+          drives:       [
+            { alias: "vda" },
+            { alias: "vdb" }
+          ],
+          volumeGroups: [
+            {
+              name:            "system",
+              physicalVolumes: [
+                {
+                  generate: {
+                    targetDevices: ["vda", "vdb"],
+                    spacePolicy:   "useAvailable"
+                  }
+                }
+              ],
+              logicalVolumes:  [
+                {
+                  name:       "root",
+                  size:       "10 GiB",
+                  filesystem: {
+                    path: "/",
+                    type: "btrfs"
+                  }
+                },
+                {
+                  name:       "home",
+                  size:       { min: "20 GiB" },
+                  filesystem: {
+                    path: "/home",
+                    type: "xfs"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "proposes the expected devices" do
+        devicegraph = proposal.propose
+
+        system = devicegraph.find_by_name("/dev/system")
+        expect(system.lvm_lvs.size).to eq 2
+
+        root = system.lvm_lvs.find { |lv| lv.lv_name == "root" }
+        home = system.lvm_lvs.find { |lv| lv.lv_name == "home" }
+
+        expect(root.size).to eq 10.GiB
+        expect(root.filesystem.type).to eq Y2Storage::Filesystems::Type::BTRFS
+        expect(root.filesystem.mount_path).to eq "/"
+
+        expect(home.size).to be > 20.GiB
+        expect(home.filesystem.type).to eq Y2Storage::Filesystems::Type::XFS
+        expect(home.filesystem.mount_path).to eq "/home"
+
+        # With useAvailable policy, PVs should use all available space on the target disks. There
+        # is ~20 GiB in vda and ~50 GiB in vdb.
+        expect(system.size).to be > 69.GiB
+
+        vda_pv = system.lvm_pvs.find { |pv| pv.plain_blk_device.partitionable.name == "/dev/vda" }
+        vdb_pv = system.lvm_pvs.find { |pv| pv.plain_blk_device.partitionable.name == "/dev/vdb" }
+        expect(vda_pv.plain_blk_device.size).to be > 19.GiB
+        expect(vdb_pv.plain_blk_device.size).to be > 49.GiB
+      end
+    end
   end
 end

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  1 13:51:58 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Create new LVM volume groups using all the availabe space on the
+  selected disks (jsc#PED-14153).
+
+-------------------------------------------------------------------
 Thu May 28 18:38:34 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Added support for configuring a VLAN using the UI

--- a/web/src/components/storage/LvmPage.test.tsx
+++ b/web/src/components/storage/LvmPage.test.tsx
@@ -295,6 +295,29 @@ describe("LvmPage", () => {
       mockUseVolumeGroup.mockReturnValue(mockRootVolumeGroup);
     });
 
+    it("shows helper text when targetDevicesPolicy is useNeeded", () => {
+      const vgWithUseNeeded = {
+        ...mockRootVolumeGroup,
+        targetDevicesPolicy: "useNeeded" as const,
+      };
+      mockUseVolumeGroup.mockReturnValue(vgWithUseNeeded);
+
+      installerRender(<LvmPage />);
+
+      screen.getByText(/This volume group only occupies the space required by its logical volumes/);
+      screen.getByText(/To expand it to cover all available disk space, recreate the volume group/);
+    });
+
+    it("does not show helper text when targetDevicesPolicy is not useNeeded", () => {
+      installerRender(<LvmPage />);
+
+      expect(
+        screen.queryByText(
+          /This volume group only occupies the space required by its logical volumes/,
+        ),
+      ).toBeNull();
+    });
+
     it("performs basic validations", async () => {
       const { user } = installerRender(<LvmPage />);
       const name = screen.getByRole("textbox", { name: "Name" });

--- a/web/src/components/storage/LvmPage.tsx
+++ b/web/src/components/storage/LvmPage.tsx
@@ -35,6 +35,7 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 import { Page, SubtleContent } from "~/components/core";
+import { Icon } from "~/components/layout";
 import { useAvailableDevices } from "~/hooks/model/system/storage";
 import { deviceLabel } from "./utils";
 import { contentDescription, filesystemLabels, typeDescription } from "./utils/device";
@@ -51,6 +52,7 @@ import {
 } from "~/hooks/model/storage/config-model";
 import type { ConfigModel, Data } from "~/model/storage/config-model";
 import type { Storage as System } from "~/model/system";
+import Text from "~/components/core/Text";
 
 /**
  * Hook that returns the devices that can be selected as target to automatically create LVM PVs.
@@ -84,6 +86,22 @@ function vgNameError(
 
 function targetDevicesError(targetDevices: System.Device[]): string | undefined {
   if (!targetDevices.length) return _("Select at least one disk.");
+}
+
+function UseNeededHelperText() {
+  return (
+    <Content>
+      <Flex gap={{ default: "gapXs" }} alignItems={{ default: "alignItemsCenter" }}>
+        <Icon name="emergency" />
+        <Text component="span">
+          {_(
+            "This volume group only occupies the space required by its logical volumes. " +
+              "To expand it to cover all available disk space, recreate the volume group.",
+          )}
+        </Text>
+      </Flex>
+    </Content>
+  );
 }
 
 /**
@@ -218,6 +236,7 @@ export default function LvmPage() {
                 />
               ))}
             </Gallery>
+            {volumeGroup?.targetDevicesPolicy === "useNeeded" && <UseNeededHelperText />}
           </FormGroup>
           {!volumeGroup && (
             <FormGroup label={_("Move mount points")} isStack>

--- a/web/src/openapi/config/storage.ts
+++ b/web/src/openapi/config/storage.ts
@@ -299,6 +299,14 @@ export interface EncryptionLuks2 {
 export interface EncryptionPervasiveLuks2 {
   pervasiveLuks2: {
     password: EncryptionPassword;
+    /**
+     * List of APQNs used to generate secure keys.
+     */
+    apqns?: string[];
+    /**
+     * Type of the generated secure key.
+     */
+    keyType?: "EP11-AES" | "CCA-AESCIPHER" | "CCA-AESDATA";
   };
 }
 /**
@@ -454,6 +462,10 @@ export interface SimplePhysicalVolumesGenerator {
 export interface AdvancedPhysicalVolumesGenerator {
   generate: {
     targetDevices: Alias[];
+    /**
+     * Policy for creating physical volumes: either using all the available space or only the needed space for allocating the logical volumes.
+     */
+    spacePolicy?: "useNeeded" | "useAvailable";
     encryption?: Encryption;
   };
 }

--- a/web/src/openapi/storage/config-model.ts
+++ b/web/src/openapi/storage/config-model.ts
@@ -94,6 +94,7 @@ export interface VolumeGroup {
   vgName: string;
   extentSize?: number;
   targetDevices?: string[];
+  targetDevicesPolicy?: "useNeeded" | "useAvailable";
   spacePolicy?: SpacePolicy;
   logicalVolumes?: LogicalVolume[];
 }


### PR DESCRIPTION
New LVM volume groups use the needed space to allocate its logical volumes. For example, if two disks are selected as target devices for creating physical volumes and everything fits into the first disk, then the second disk is not used at all.

This behaviour could be unexpected, so now Agama allows configuring the policy for creating new physical volumes:

## `useNeeded` policy

This is the policy for the current behaviour. Only needed space is used. It is the default value to keep backward compatibility with old profiles.

~~~json
{
  "physicalVolumes": [
    { 
      "generate": {
        "targetDevices": ["disk1", "disk2"],
        "spacePolicy": "useNeeded"
      }
    }
  ]
}
~~~

If a config is loaded using the CLI and `useNeeded` is used, then the UI will inform to the user, but it does not allow changing the policy. In this case, the volume group has to be removed and created again in order to use `useAvailable` policy. 

<img width="2024" height="1630" alt="localhost_8080__" src="https://github.com/user-attachments/assets/118b6fc7-500a-4d72-8d63-9c8d991eb4d5" />

## `useAvailable` policy

Creates the volume group using all the space available in the target devices. Volume groups created through the UI will always use this policy. 

~~~json
{
  "physicalVolumes": [
    { 
      "generate": {
        "targetDevices": ["disk1", "disk2"],
        "spacePolicy": "useAvailable"
      }
    }
  ]
}
~~~
