### PR TITLE
refactor(web): simplify IssuesAlert component content

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 26 15:39:38 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Simplify alert for issues (gh#agama-project/agama#3550).
+
+-------------------------------------------------------------------
 Mon May 25 12:36:17 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update shell-quote dependency (CVE-2026-9277, bsc#1266256).

--- a/web/src/components/core/IssuesAlert.test.tsx
+++ b/web/src/components/core/IssuesAlert.test.tsx
@@ -24,28 +24,44 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { IssuesAlert } from "~/components/core";
-import { SOFTWARE } from "~/routes/paths";
 import type { Issue } from "~/model/issue";
 
-describe("IssueAlert", () => {
-  it("renders a list of issues", () => {
-    const issue: Issue = {
-      description: "A generic issue",
-      class: "generic",
-      scope: "software",
-    };
-    installerRender(<IssuesAlert issues={[issue]} />);
-    expect(screen.getByText(issue.description)).toBeInTheDocument();
+const genericIssue: Issue = {
+  description: "A generic issue",
+  class: "generic",
+  scope: "software",
+};
+
+const anotherIssue: Issue = {
+  description: "Another issue",
+  class: "generic",
+  scope: "software",
+};
+
+describe("IssuesAlert", () => {
+  it("renders nothing when there are no issues", () => {
+    const { container } = installerRender(<IssuesAlert issues={[]} />);
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders a link to conflict resolution when there is a 'solver' issue", () => {
-    const issue: Issue = {
-      description: "Conflicts found",
-      class: "solver",
-      scope: "software",
-    };
-    installerRender(<IssuesAlert issues={[issue]} />);
-    const link = screen.getByRole("link", { name: "Review and fix" });
-    expect(link).toHaveAttribute("href", SOFTWARE.conflicts);
+  describe("when there is a single issue", () => {
+    it("renders the issue description as the alert title", () => {
+      installerRender(<IssuesAlert issues={[genericIssue]} />);
+      screen.getByRole("heading", { name: /A generic issue/ });
+    });
+
+    it("does not render a list", () => {
+      installerRender(<IssuesAlert issues={[genericIssue]} />);
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when there are multiple issues", () => {
+    it("renders a generic alert title and a list of issue descriptions", () => {
+      installerRender(<IssuesAlert issues={[genericIssue, anotherIssue]} />);
+      screen.getByRole("heading", { name: /The following issues need to be addressed/ });
+      screen.getByText(genericIssue.description);
+      screen.getByText(anotherIssue.description);
+    });
   });
 });

--- a/web/src/components/core/IssuesAlert.test.tsx
+++ b/web/src/components/core/IssuesAlert.test.tsx
@@ -59,7 +59,7 @@ describe("IssuesAlert", () => {
   describe("when there are multiple issues", () => {
     it("renders a generic alert title and a list of issue descriptions", () => {
       installerRender(<IssuesAlert issues={[genericIssue, anotherIssue]} />);
-      screen.getByRole("heading", { name: /The following issues need to be addressed/ });
+      screen.getByRole("heading", { name: /You must fix these issues/ });
       screen.getByText(genericIssue.description);
       screen.getByText(anotherIssue.description);
     });

--- a/web/src/components/core/IssuesAlert.tsx
+++ b/web/src/components/core/IssuesAlert.tsx
@@ -21,34 +21,25 @@
  */
 
 import React from "react";
-import { Alert, List, ListItem } from "@patternfly/react-core";
+import { isEmpty } from "radashi";
+import { Alert, AlertProps, List, ListItem } from "@patternfly/react-core";
 import { _ } from "~/i18n";
-import Link from "./Link";
-import { PATHS } from "~/routes/software";
+
 import type { Issue } from "~/model/issue";
 
-export default function IssuesAlert({ issues }) {
-  if (issues === undefined || issues.length === 0) return;
+export default function IssuesAlert({ issues }: { issues: Issue[] }) {
+  if (isEmpty(issues)) return;
+  const props: Partial<AlertProps> = { isInline: true, variant: "warning" };
+
+  if (issues.length === 1) {
+    return <Alert {...props} title={issues[0].description} />;
+  }
 
   return (
-    <Alert
-      isInline
-      variant="warning"
-      title={_("Before starting the installation, you need to address the following problems:")}
-    >
+    <Alert {...props} title={_("The following issues need to be addressed")}>
       <List>
-        {issues.map((i: Issue, idx: number) => (
-          <ListItem key={idx}>
-            {i.description}{" "}
-            {i.class === "solver" && (
-              <Link to={PATHS.conflicts} variant="link" isInline>
-                {
-                  // TRANSLATORS: Clickable link to show and resolve package dependency conflicts
-                  _("Review and fix")
-                }
-              </Link>
-            )}
-          </ListItem>
+        {issues.map((i, idx) => (
+          <ListItem key={idx}>{i.description}</ListItem>
         ))}
       </List>
     </Alert>

--- a/web/src/components/core/IssuesAlert.tsx
+++ b/web/src/components/core/IssuesAlert.tsx
@@ -36,7 +36,7 @@ export default function IssuesAlert({ issues }: { issues: Issue[] }) {
   }
 
   return (
-    <Alert {...props} title={_("The following issues need to be addressed")}>
+    <Alert {...props} title={_("You must fix these issues")}>
       <List>
         {issues.map((i, idx) => (
           <ListItem key={idx}>{i.description}</ListItem>


### PR DESCRIPTION
The _Before starting the installation, you need to address the following problems:_ alert title appeared in each section of the Agama web UI. 

This made sense in the former interface, where users could land directly on a section without prior context. It no longer does: users now see the overview first, where installation is clearly blocked with _You need to fix any invalid settings before proceeding with the installation._ and each invalid section is already flagged, inviting users to visit it for details.

Repeating the installation preamble inside each section is therefore redundant and noisy. This PR simplifies `IssuesAlert` to:

- Show the issue description directly as the alert title when there is only one issue.
- Show a concise list of issues under a shorter title when there are more than one.

> [!NOTE]
> Besides reducing noise, this makes the actual problem more immediately visible to the user and saves vertical space by avoiding the extra bullet list when only one issue is present.

The `solver` issue class (now known as  `software_conflict`) and its associated _Review and fix_ link to the conflict resolution page have also been dropped. Conflict resolution is not yet available in the UI following the API changes,
and is expected to be handled differently going forward.


| Before | After |
|-|-|
| <img width="2048" height="1536" alt="localhost_8080_ (96)" src="https://github.com/user-attachments/assets/d3c26d8a-c462-4b7f-8e9e-2aaa1023e6de" /> | <img width="2048" height="1536" alt="localhost_8080_ (95)" src="https://github.com/user-attachments/assets/330cc83a-b61e-46bf-b724-6f8c66715f1d" /> |
