### PR TITLE
Use PATCH when selecting initial product, PUT when changing

### DIFF
--- a/web/src/components/product/ProductSelectionPage.test.tsx
+++ b/web/src/components/product/ProductSelectionPage.test.tsx
@@ -68,6 +68,7 @@ const productWithModes: Product = {
 };
 
 const mockPutConfigFn = jest.fn();
+const mockPatchConfigFn = jest.fn();
 const mockUseSystemFn: jest.Mock<ReturnType<typeof useSystem>> = jest.fn();
 const mockUseSystemSoftwareFn: jest.Mock<ReturnType<typeof useSystemSoftware>> = jest.fn();
 
@@ -81,6 +82,7 @@ jest.mock("~/components/product/LicenseDialog", () => () => <div>LicenseDialog M
 jest.mock("~/api", () => ({
   ...jest.requireActual("~/api"),
   putConfig: (payload) => mockPutConfigFn(payload),
+  patchConfig: (payload) => mockPatchConfigFn(payload),
 }));
 
 jest.mock("~/hooks/model/system", () => ({
@@ -253,18 +255,32 @@ describe("ProductSelectionPage", () => {
     const selectButton = screen.getByRole("button", { name: "Select" });
     await user.click(productOption);
     await user.click(selectButton);
-    expect(mockPutConfigFn).toHaveBeenCalledWith({ product: { id: tumbleweed.id } });
+    expect(mockPatchConfigFn).toHaveBeenCalledWith({ product: { id: tumbleweed.id } });
+    expect(mockPutConfigFn).not.toHaveBeenCalled();
   });
 
-  it("does not trigger the product selection if user selects a product but clicks o cancel button", async () => {
-    mockProduct(microOs);
-    const { user } = installerRender(<ProductSelectionPage />);
-    const productOption = screen.getByRole("radio", { name: tumbleweed.name });
-    const cancel = screen.getByRole("link", { name: "Cancel" });
-    expect(cancel).toHaveAttribute("href", ROOT.overview);
-    await user.click(productOption);
-    await user.click(cancel);
-    expect(mockPutConfigFn).not.toHaveBeenCalled();
+  describe("when a product is selected", () => {
+    it("triggers the product selection (reset) when user clicks the submission button", async () => {
+      mockProduct(microOs);
+      const { user } = installerRender(<ProductSelectionPage />);
+      const productOption = screen.getByRole("radio", { name: tumbleweed.name });
+      const selectButton = screen.getByRole("button", { name: /Change/ });
+      await user.click(productOption);
+      await user.click(selectButton);
+      expect(mockPutConfigFn).toHaveBeenCalledWith({ product: { id: tumbleweed.id } });
+      expect(mockPatchConfigFn).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the product selection if user selects a product but clicks o cancel button", async () => {
+      mockProduct(microOs);
+      const { user } = installerRender(<ProductSelectionPage />);
+      const productOption = screen.getByRole("radio", { name: tumbleweed.name });
+      const cancel = screen.getByRole("link", { name: "Cancel" });
+      expect(cancel).toHaveAttribute("href", ROOT.overview);
+      await user.click(productOption);
+      await user.click(cancel);
+      expect(mockPutConfigFn).not.toHaveBeenCalled();
+    });
   });
 
   it.todo("make navigation test work");
@@ -346,8 +362,31 @@ describe("ProductSelectionPage", () => {
       const selectButton = screen.getByRole("button", { name: /Select/ });
       await user.click(selectButton);
 
-      expect(mockPutConfigFn).toHaveBeenCalledWith({
+      expect(mockPatchConfigFn).toHaveBeenCalledWith({
         product: { id: productWithModes.id, mode: "standard" },
+      });
+      expect(mockPutConfigFn).not.toHaveBeenCalled();
+    });
+
+    describe("when a product is selected", () => {
+      it("triggers the product selection (reset) with mode", async () => {
+        mockProduct(tumbleweed);
+        mockUseSystemFn.mockReturnValue({ products: [productWithModes, tumbleweed] });
+        const { user } = installerRender(<ProductSelectionPage />);
+
+        const productOption = screen.getByRole("radio", { name: productWithModes.name });
+        await user.click(productOption);
+
+        const standardMode = screen.getByRole("radio", { name: "Standard" });
+        await user.click(standardMode);
+
+        const selectButton = screen.getByRole("button", { name: /Change/ });
+        await user.click(selectButton);
+
+        expect(mockPutConfigFn).toHaveBeenCalledWith({
+          product: { id: productWithModes.id, mode: "standard" },
+        });
+        expect(mockPatchConfigFn).not.toHaveBeenCalled();
       });
     });
 

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -55,7 +55,7 @@ import { InstallerL10nOptions, Link, Page, SubtleContent } from "~/components/co
 import ProductLogo from "~/components/product/ProductLogo";
 import LicenseDialog from "~/components/product/LicenseDialog";
 import Text from "~/components/core/Text";
-import { putConfig } from "~/api";
+import { patchConfig, putConfig } from "~/api";
 import { useProduct, useProductInfo } from "~/hooks/model/config/product";
 import { useSystem } from "~/hooks/model/system";
 import { useSystem as useSystemSoftware } from "~/hooks/model/system/software";
@@ -702,8 +702,14 @@ const ProductSelectionContent = () => {
   const onSubmit = async (selectedProduct: Product, selectedMode: string) => {
     setIsSubmmited(true);
     setSubmmitedSelection(selectedProduct);
-    // Put product and mode only in order to reset the rest of the config, which can depend on the selected product and mode (bsc#1264438)
-    putConfig({ product: { id: selectedProduct.id, mode: selectedMode } });
+    const productConfig = { product: { id: selectedProduct.id, mode: selectedMode } };
+    if (currentProduct) {
+      // Use PUT to reset the config when changing product (bsc#1264438)
+      putConfig(productConfig);
+    } else {
+      // Use PATCH to preserve initial settings when no product was selected yet
+      patchConfig(productConfig);
+    }
   };
 
   return (


### PR DESCRIPTION
When no product is selected yet, use PATCH to preserve initial settings that may have been loaded from CLI. When changing from one product to another, use PUT to reset the configuration.


## Problem

*Short description of the original problem.*

- *Bugzilla link*
- *openQA link*
- *Links to other related pull requests*


## Solution

*Short description of the fix.*


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

## Documentation

*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
*other times they need advertisement and explanation.*

*Look for relevant sections and adjust:*
- The `*.changes` files. For ALL affected packages.
- The description parts of the [JSON schema][profile.schema.json]
- Is the CLI affected? See [cli.md][] for a complete overview,
  change the `///` comments (rust doc)
  and update the .md with `cargo xtask markdown`
- <https://agama-project.github.io/> ([source][gh.io])
- Run: `git ls-files '*.md'`

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/cli.md
[profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
[gh.io]: https://github.com/agama-project/agama-project.github.io/
