### PR TITLE
Try boot partitions with desired and min sizes

### DIFF
--- a/service/lib/y2storage/agama_proposal.rb
+++ b/service/lib/y2storage/agama_proposal.rb
@@ -134,11 +134,40 @@ module Y2Storage
 
       configure_ptable_types(devicegraph)
       devicegraph = clean_graph(devicegraph)
-      complete_planned(devicegraph)
       return if issues?
 
-      result = create_devices(devicegraph)
+      result = create_devices_with_boot(devicegraph)
       result.devicegraph
+    end
+
+    # Creates the devices doing several attempts, each one for a different set of boot partitions
+    #
+    # @raise [NoDiskSpaceError] if there is no enough space to perform the installation
+    # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
+    def create_devices_with_boot(devicegraph)
+      initial_devicegraph = devicegraph.dup
+      possible_boot_sets = Proposal::BootPlanner.new(devicegraph, config, bootloader_config)
+        .plans(planned_devices.mountable_devices)
+
+      result = nil
+      while !result && possible_boot_sets.any?
+        begin
+          boot_devices = possible_boot_sets.shift
+          planned_with_boot = planned_devices.prepend(boot_devices)
+          # Although this can affect the planned devices in the collection, that is not a problem
+          # because the different "boot plans" are almost equal (only the sizes change) so there is
+          # no difference in shadowing.
+          remove_shadowed_subvols(planned_with_boot)
+          result = create_devices(devicegraph, planned_with_boot)
+          @planned_devices = planned_with_boot
+        rescue NoDiskSpaceError
+          raise if possible_boot_sets.empty?
+
+          devicegraph = initial_devicegraph.dup
+        end
+      end
+
+      result
     end
 
     # Fills the list of planned devices, excluding partitions from the boot requirements checker
@@ -173,26 +202,6 @@ module Y2Storage
       end
     end
 
-    # Modifies the list of planned devices, removing shadowed subvolumes and adding any planned
-    # partition needed for booting the new target system
-    #
-    # @param devicegraph [Devicegraph]
-    def complete_planned(devicegraph)
-      if config.boot.configure?
-        @planned_devices = planned_devices.prepend(boot_partitions(devicegraph))
-      end
-
-      remove_shadowed_subvols(planned_devices)
-    end
-
-    # @see #complete_planned
-    #
-    # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
-    def boot_partitions(devicegraph)
-      planner = Proposal::BootPlanner.new(devicegraph, config, bootloader_config)
-      planner.partitions(planned_devices.mountable_devices)
-    end
-
     # Removes partition tables from candidate devices with empty partition table
     #
     # @param devicegraph [Devicegraph] the graph gets modified
@@ -222,9 +231,9 @@ module Y2Storage
     # Creates the planned devices on a given devicegraph
     #
     # @param devicegraph [Devicegraph] the graph gets modified
-    def create_devices(devicegraph)
+    def create_devices(devicegraph, all_devices)
       devices_creator = Proposal::AgamaDevicesCreator.new(devicegraph, issues_list)
-      result = devices_creator.populated_devicegraph(planned_devices, space_maker)
+      result = devices_creator.populated_devicegraph(all_devices, space_maker)
     end
 
     # Name of the boot device.

--- a/service/lib/y2storage/proposal/boot_planner.rb
+++ b/service/lib/y2storage/proposal/boot_planner.rb
@@ -42,21 +42,23 @@ module Y2Storage
         @bootloader_config = bootloader_config
       end
 
-      # Partitions needed in order to be able to boot the system
+      # Candidate sets of partitions needed in order to be able to boot the system
       #
       # @raise [NotBootableError] if adding partitions is not enough to make the system bootable
       #
       # @param planned_devices [Array<Planned::Device>] devices that are already planned to be
       #   added to the starting devicegraph.
-      # @return [Array<Planned::Partition>]
-      def partitions(planned_devices)
+      # @return [Array<Array<Planned::Partition>>]
+      def plans(planned_devices)
+        return [[]] unless config.boot.configure?
+
         checker = BootRequirementsChecker.new(
           devicegraph,
           planned_devices: planned_devices,
           boot_disk_name:  boot_device_name,
           bootloader:      bootloader_config.type
         )
-        checker.needed_partitions(:min)
+        different_plans(checker)
       rescue BootRequirementsChecker::Error => e
         raise NotBootableError, e.message
       end
@@ -77,6 +79,31 @@ module Y2Storage
       # @return [String, nil]
       def boot_device_name
         config.boot_device&.found_device&.name
+      end
+
+      # @see #plans
+      #
+      # This ensures that only one attempt is done if the plans for desired and min size are the
+      # same, which happens with some boot requirement strategies.
+      #
+      # @return [Array<Array<Planned::Partition>>]
+      def different_plans(checker)
+        plans = [:desired, :min].map do |target|
+          checker.needed_partitions(target)
+        end
+
+        return plans[0, 1] if equivalent_plans?(plans.first, plans.last)
+
+        plans
+      end
+
+      # @see #different_plans
+      #
+      # @return [Boolean]
+      def equivalent_plans?(plan_a, plan_b)
+        # The only possible difference between two plans for the same situation (:desired vs :min)
+        # is the size of the boot partitions
+        plan_a.map(&:min_size) == plan_b.map(&:min_size)
       end
     end
   end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 28 15:59:07 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- When proposing a booting partition, try with the desired size
+  before falling back to the minimal (gh#agama-project/agama#3559).
+
+-------------------------------------------------------------------
 Tue May 19 12:28:48 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Always activate storage devices in order to detect multipath and

--- a/service/test/y2storage/agama_proposal_boot_sizes_test.rb
+++ b/service/test/y2storage/agama_proposal_boot_sizes_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../agama/storage/storage_helpers"
+require "agama/config"
+require "agama/storage/config"
+require "agama/storage/config_conversions"
+require "agama/storage/system"
+require "y2storage"
+require "y2storage/agama_proposal"
+
+describe Y2Storage::AgamaProposal do
+  using Y2Storage::Refinements::SizeCasts
+  include Agama::RSpec::StorageHelpers
+
+  subject(:proposal) do
+    described_class.new(config, storage_system, bootloader_config: bootloader_config)
+  end
+
+  let(:bootloader_config) { instance_double(Agama::Storage::BootloaderConfig, type: bootloader) }
+
+  let(:storage_system) { Agama::Storage::System.new }
+
+  let(:config) { config_from_json }
+
+  let(:config_from_json) do
+    Agama::Storage::ConfigConversions::FromJSON.new(config_json).convert
+  end
+
+  describe "#propose (when existing partitions need to be resized)" do
+    before do
+      mock_storage(devicegraph: scenario)
+      allow_any_instance_of(Y2Storage::Arch).to receive(:efiboot?).and_return(true)
+      allow(Yast::Arch).to receive(:x86_64).and_return(true)
+      allow(Yast::Arch).to receive(:i386).and_return(false)
+      allow(Yast::Arch).to receive(:aarch64).and_return(false)
+      allow_any_instance_of(Y2Storage::Partition)
+        .to(receive(:detect_resize_info))
+        .and_return(resize_info)
+    end
+
+    let(:scenario) { "disks.yaml" }
+
+    let(:resize_info) do
+      instance_double(Y2Storage::ResizeInfo, resize_ok?: true, min_size: 5.GiB, max_size: 10.GiB)
+    end
+
+    let(:config_json) do
+      {
+        boot:   { configure: true },
+        drives: [
+          {
+            search:     "/dev/vda",
+            partitions: [
+              # Shrink vda3 to make room
+              { search: "/dev/vda3", size: { min: 0, max: "current" } },
+              # Request root partition that requires some resizing
+              { size: { min: root_min }, filesystem: { path: "/" } }
+            ]
+          }
+        ]
+      }
+    end
+
+    context "if the desired and min sizes are different" do
+      let(:bootloader) { Y2Storage::BootloaderType::GRUB2 }
+
+      context "and it is possible to resize enough to get the desired boot partitions" do
+        let(:root_min) { "24 GiB" }
+
+        it "creates boot partitions with the desired sizes" do
+          devicegraph = proposal.propose
+          boot_partition = devicegraph.partitions.find { |p| p.id.is?(:esp) }
+          expect(boot_partition.size).to eq 256.MiB
+        end
+      end
+
+      context "and it is not possible to resize enough to get the desired boot partitions" do
+        let(:root_min) { "24.75 GiB" }
+
+        it "creates boot partitions with the min sizes if possible" do
+          devicegraph = proposal.propose
+          boot_partition = devicegraph.partitions.find { |p| p.id.is?(:esp) }
+          expect(boot_partition.size).to eq 128.MiB
+        end
+      end
+
+      context "and it is not possible to resize enough to get the minimal boot partitions" do
+        let(:root_min) { "25 GiB" }
+
+        it "raises a NoDiskSpaceError" do
+          expect { proposal.propose }.to raise_error Y2Storage::NoDiskSpaceError
+        end
+      end
+    end
+
+    context "if the desired and min sizes are equal" do
+      let(:bootloader) { Y2Storage::BootloaderType::SYSTEMD_BOOT }
+
+      context "and it is possible to resize enough to get the desired boot partitions" do
+        let(:root_min) { "23.5 GiB" }
+
+        it "creates boot partitions with the desired sizes" do
+          devicegraph = proposal.propose
+          boot_partition = devicegraph.partitions.find { |p| p.id.is?(:esp) }
+          expect(boot_partition.size).to eq 1.GiB
+        end
+      end
+
+      context "and it is not possible to resize enough to get the desired boot partitions" do
+        let(:root_min) { "25 GiB" }
+
+        it "raises a NoDiskSpaceError" do
+          expect { proposal.propose }.to raise_error Y2Storage::NoDiskSpaceError
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The logic to calculate boot-related partitions in yast2-storage-ng defines three sizes for each partition: min, desired and max.

When using that in Agama, desired is ignored and only min and max are taken into account. That's something we always wanted to re-evaluate (together with several other aspects related to proposing boot partitions).

When installing with enough available space (let's say in an empty disk or allowing the installer to delete partitions) then there is often no practical difference. The distance between min, desired and max is so small in comparison with the rest of partitions to create that any attempt (starting with either min or desired) always produces the same result. See #3394 for the whole rationale.

But the result is non-optimal when resizing existing partitions just as much as needed to make space for the new installation. In those case Agama is creating partitions with min sizes that where intended for extreme cases, not really as the best practice.

## Solution

This introduces a new approach in which several different sets of boot-related partitions are calculated and tried. In this case, it makes a first attempt using the desired sizes as starting point and, if that fails, a second attempt using the min size as starting point.

This results in more reasonable proposal in most cases, without introducing the risk of failing in edge cases that used to work when using the min sizes.

## Testing

- Added a new unit tests

## Note

This is a "resurrection" of #3394, which was archived for the wrong reasons.