### PR TITLE
refactor(web): improve discoverability of "progress monitor"

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 28 14:05:33 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Improve discoverability of background tasks status
+  (gh#agama-project/agama#3560).
+
+-------------------------------------------------------------------
 Thu May 28 09:45:31 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Reset the configuration only when changing the product (bsc#1258032).

--- a/web/src/components/core/InstallationFinished.tsx
+++ b/web/src/components/core/InstallationFinished.tsx
@@ -69,7 +69,7 @@ function InstallationFinished() {
   const isGrub2WithTpm = useIsGrub2WithTpm();
 
   return (
-    <Page noDefaultStartSlot endSlot={<InstallerOptionsMenu hideLabel />}>
+    <Page noDefaultProgressMonitor endSlot={<InstallerOptionsMenu hideLabel />}>
       <Page.Content>
         <SplitInfoLayout
           icon="done_all"

--- a/web/src/components/core/InstallationProgress.tsx
+++ b/web/src/components/core/InstallationProgress.tsx
@@ -34,7 +34,7 @@ export default function InstallationProgress() {
   const product = useProductInfo();
 
   return (
-    <Page noDefaultStartSlot endSlot={<InstallerOptionsMenu hideLabel />}>
+    <Page noDefaultProgressMonitor endSlot={<InstallerOptionsMenu hideLabel />}>
       <Page.Content>
         <SplitInfoLayout
           icon="deployed_code_update"

--- a/web/src/components/core/Page.tsx
+++ b/web/src/components/core/Page.tsx
@@ -343,22 +343,18 @@ interface MinimalPageProps extends BasePageProps {
  */
 type PageProps = (StandardPageProps | MinimalPageProps) & {
   /**
-   * If true, the default component in the start slot
-   * (`<ProgressStatusMonitor />`) will not be rendered.
+   * If true, the ProgressStatusMonitor will not be automatically
+   * injected at the beginning of endSlot.
    *
-   * Pass a custom `startSlot` to render custom content instead.
-   *
-   * Default: `false` (renders default ProgressStatusMonitor if no `startSlot` provided)
+   * Default: `false` (ProgressStatusMonitor is injected)
    */
-  noDefaultStartSlot?: boolean;
+  noDefaultProgressMonitor?: boolean;
 
   /**
-   * If true, the default component in the end slot
-   * (`<ReviewAndInstallButton />`) will not be rendered.
+   * If true, the default ReviewAndInstallButton will not be
+   * automatically added to endSlot.
    *
-   * Pass a custom `endSlot` to render custom content instead.
-   *
-   * Default: `false` (renders default ReviewAndInstallButton if no `endSlot` provided)
+   * Default: `false` (ReviewAndInstallButton is added)
    */
   noDefaultEndSlot?: boolean;
 };
@@ -454,10 +450,9 @@ const StandardLayout = ({
  */
 const Page = ({
   variant = "standard",
-  startSlot,
   endSlot,
-  noDefaultStartSlot,
-  noDefaultEndSlot,
+  noDefaultProgressMonitor = false,
+  noDefaultEndSlot = false,
   children,
   ...props
 }: PageProps): React.ReactNode => {
@@ -465,11 +460,17 @@ const Page = ({
     return <MinimalLayout>{children}</MinimalLayout>;
   }
 
-  const startSlotContent = startSlot ?? (noDefaultStartSlot ? null : <ProgressStatusMonitor />);
-  const endSlotContent = endSlot ?? (noDefaultEndSlot ? null : <ReviewAndInstallButton />);
+  // Build endSlot content: [custom endSlot] [ReviewAndInstallButton] [ProgressStatusMonitor]
+  const endSlotContent = (
+    <>
+      {endSlot}
+      {!noDefaultEndSlot && <ReviewAndInstallButton />}
+      {!noDefaultProgressMonitor && <ProgressStatusMonitor />}
+    </>
+  );
 
   return (
-    <StandardLayout {...props} startSlot={startSlotContent} endSlot={endSlotContent}>
+    <StandardLayout {...props} endSlot={endSlotContent}>
       {children || <Outlet />}
     </StandardLayout>
   );

--- a/web/src/components/core/ProgressStatusMonitor.test.tsx
+++ b/web/src/components/core/ProgressStatusMonitor.test.tsx
@@ -27,18 +27,20 @@ import ProgressStatusMonitor from "./ProgressStatusMonitor";
 
 describe("ProgressStatusMonitor", () => {
   describe("when there are no tasks in background", () => {
-    it("renders a disabled button with no content", () => {
+    it("renders a button with list_alt_check icon", () => {
       installerRender(<ProgressStatusMonitor />);
-      const button = screen.getByRole("button");
-      expect(button).toBeDisabled();
-      expect(button).toBeEmptyDOMElement();
+      const button = screen.getByRole("button", { name: /idle/i });
+      expect(button).toBeEnabled();
+      // list_alt_check icon is rendered
+      expect(button.querySelector("svg")).toBeInTheDocument();
     });
 
-    it("does nothing when the button is clicked", async () => {
+    it("shows idle state in popover when clicked", async () => {
       const { user } = installerRender(<ProgressStatusMonitor />);
-      const button = screen.getByRole("button");
+      const button = screen.getByRole("button", { name: /idle/i });
       await user.click(button);
-      expect(screen.queryByRole("dialog")).toBeNull();
+      const popover = screen.getByRole("dialog", { name: /no pending tasks/i });
+      within(popover).getByText(/all background tasks completed/i);
     });
   });
 
@@ -59,16 +61,17 @@ describe("ProgressStatusMonitor", () => {
       ]);
     });
 
-    it("renders an enabled button with PatternFly 'in-progress' modifier", () => {
+    it("shows spinner immediately when tasks are active", () => {
       installerRender(<ProgressStatusMonitor />);
-      const button = screen.getByRole("button");
-      expect(button).toBeEnabled();
+      const button = screen.getByRole("button", { name: /1 task active/i });
+
+      // Shows spinner immediately
       expect(button.classList).toContain("pf-m-in-progress");
     });
 
     it("renders a popover with tasks details when the button is clicked", async () => {
       const { user } = installerRender(<ProgressStatusMonitor />);
-      const button = screen.getByRole("button");
+      const button = screen.getByRole("button", { name: /1 task active/i });
       await user.click(button);
       const popover = screen.getByRole("dialog", { name: "1 task active" });
       within(popover).getByText("Software");

--- a/web/src/components/core/ProgressStatusMonitor.tsx
+++ b/web/src/components/core/ProgressStatusMonitor.tsx
@@ -22,12 +22,12 @@
 
 import React from "react";
 import { Button, Divider, Flex, Popover, Stack } from "@patternfly/react-core";
+import Icon from "~/components/layout/Icon";
 import Text from "~/components/core/Text";
 import { useStatus } from "~/hooks/model/status";
 import { sprintf } from "sprintf-js";
 import { _, N_, n_ } from "~/i18n";
 import type { Progress as StatusProgress } from "~/model/status";
-import displayStyles from "@patternfly/react-styles/css/utilities/Display/display";
 
 type DetailProps = {
   tasks: StatusProgress[];
@@ -80,43 +80,78 @@ const DetailsBody = ({ tasks }: DetailProps) => {
 };
 
 /**
- * Displays a small status widget that indicates when background tasks (as
- * reported by `useStatus`) are running.
+ * Displays a progress status widget for monitoring background tasks.
  *
- * When tasks are active, the component shows a loading indicator inside a
- * button. Clicking this button opens a popover that presents details about the
- * ongoing work.
+ * The component shows two states:
  *
- * The popover shows:
+ *  - **Idle (list_alt_check icon)**: No background tasks running
+ *  - **Busy (spinner)**: Background tasks in progress
  *
- *  - The number of active tasks
- *  - A list of progress bars, one per task scope
+ * Clicking the button opens a popover showing:
  *
- * Intended as a lightweight monitor for background activity.
+ *  - When idle: "No pending tasks"
+ *  - When busy: Number of tasks and detailed progress for each scope
+ *
+ * The button remains always visible for discoverability and predictable UI,
+ * with appropriate aria-label updates for screen reader users.
  */
 export default function ProgressStatusMonitor() {
   const { progresses: tasks } = useStatus();
-
   const idle = tasks.length === 0;
+
+  // Determine icon and aria-label based on state
+  let icon: React.ReactNode;
+  let ariaLabel: string;
+
+  if (!idle) {
+    // Busy: show spinner
+    icon = undefined;
+    // TRANSLATORS: aria-label for background tasks status button when tasks are active
+    ariaLabel = sprintf(
+      n_("System status: %s task active", "System status: %s tasks active", tasks.length),
+      tasks.length,
+    );
+  } else {
+    // Idle: show list_alt_check
+    icon = <Icon name="list_alt_check" isMiddleAligned />;
+    // TRANSLATORS: aria-label for system status button when idle
+    ariaLabel = _("System status: Idle");
+  }
+
+  // Popover header and body depend on state
+  let headerContent: React.ReactNode;
+  let bodyContent: React.ReactNode;
+
+  if (!idle) {
+    // Busy: show task details
+    headerContent = <DetailsHeader tasks={tasks} />;
+    bodyContent = (
+      <Stack hasGutter>
+        <DetailsBody tasks={tasks} />
+      </Stack>
+    );
+  } else {
+    // Idle: show no tasks message
+    // TRANSLATORS: header when no background tasks are running
+    headerContent = _("No pending tasks");
+    // TRANSLATORS: message when all background tasks completed
+    bodyContent = <Text>{_("All background tasks completed")}</Text>;
+  }
 
   return (
     <Popover
       showClose={false}
       minWidth="400px"
       position="bottom-end"
-      headerContent={<DetailsHeader tasks={tasks} />}
-      bodyContent={
-        <Stack hasGutter>
-          <DetailsBody tasks={tasks} />
-        </Stack>
-      }
+      headerContent={headerContent}
+      bodyContent={bodyContent}
     >
-      <Button
-        variant="plain"
-        className={idle ? displayStyles.displayNone : displayStyles.displayBlock}
-        isDisabled={idle}
-        isLoading={!idle}
-      />
+      <Button variant="plain" isLoading={!idle} aria-label={ariaLabel}>
+        {icon}
+        <Text srOnly aria-live="polite" aria-atomic="true">
+          {!idle && ariaLabel}
+        </Text>
+      </Button>
     </Popover>
   );
 }

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -176,7 +176,9 @@ export default function Header({
             <ToolbarGroup align={{ default: "alignEnd" }} columnGap={{ default: "columnGapXs" }}>
               {startSlot && <ToolbarItem>{startSlot}</ToolbarItem>}
               {centerSlot && <ToolbarItem>{centerSlot}</ToolbarItem>}
-              {endSlot && <ToolbarItem>{endSlot}</ToolbarItem>}
+              {endSlot && (
+                <ToolbarItem columnGap={{ default: "columnGapXs" }}>{endSlot}</ToolbarItem>
+              )}
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>

--- a/web/src/components/layout/Icon.tsx
+++ b/web/src/components/layout/Icon.tsx
@@ -54,6 +54,7 @@ import Info from "@icons/info.svg?component";
 import Keyboard from "@icons/keyboard.svg?component";
 import Language from "@icons/language.svg?component";
 import ListAlt from "@icons/list_alt.svg?component";
+import ListAltCheck from "@icons/list_alt_check.svg?component";
 import Lock from "@icons/lock.svg?component";
 import ManageAccounts from "@icons/manage_accounts.svg?component";
 import Menu from "@icons/menu.svg?component";
@@ -75,6 +76,10 @@ import Visibility from "@icons/visibility.svg?component";
 import VisibilityOff from "@icons/visibility_off.svg?component";
 import Wifi from "@icons/wifi.svg?component";
 import WifiOff from "@icons/wifi_off.svg?component";
+import MoreTime from "@icons/more_time.svg?component";
+import TaskAlt from "@icons/task_alt.svg?component";
+import HourglassDisabled from "@icons/hourglass_disabled.svg?component";
+import Pending from "@icons/pending.svg?component";
 
 const icons = {
   add: Add,
@@ -105,6 +110,7 @@ const icons = {
   keyboard_arrow_down: KeyboardArrowDown,
   language: Language,
   list_alt: ListAlt,
+  list_alt_check: ListAltCheck,
   lock: Lock,
   manage_accounts: ManageAccounts,
   menu: Menu,
@@ -127,11 +133,26 @@ const icons = {
   warning: Warning,
   wifi: Wifi,
   wifi_off: WifiOff,
+  more_time: MoreTime,
+  task_alt: TaskAlt,
+  hourglass_disabled: HourglassDisabled,
+  pending: Pending,
 };
 
 export type IconProps = React.SVGAttributes<SVGElement> & {
   /** Name of the desired icon */
   name: keyof typeof icons;
+  /** Vertical alignment of the icon */
+  verticalAlign?: "baseline" | "middle" | "text-top" | "text-bottom" | "sub" | "super";
+  /**
+   * Shortcut for verticalAlign="text-top" to align icon with surrounding text.
+   *
+   * Use this when placing an icon inline with text in buttons, links, or labels.
+   * The `text-top` value aligns the icon's top edge with the tallest text in the
+   * line, which typically produces better visual alignment than `middle` when
+   * mixed with text content.
+   */
+  isMiddleAligned?: boolean;
 };
 
 /**
@@ -144,9 +165,21 @@ export type IconProps = React.SVGAttributes<SVGElement> & {
  * @example
  *   <Icon name="warning" />
  *
+ * @example
+ *   <Icon name="check_circle" isMiddleAligned />
+ *
+ * @example
+ *   <Icon name="check_circle" verticalAlign="text-top" />
+ *
  * @returns null if requested icon is not available or given a falsy value as name; JSX block otherwise.
  */
-export default function Icon({ name, ...otherProps }: IconProps): JSX.Element | null {
+export default function Icon({
+  name,
+  verticalAlign,
+  isMiddleAligned,
+  style,
+  ...otherProps
+}: IconProps): JSX.Element | null {
   // NOTE: Reaching this is unlikely, but let's be safe.
   if (!name || !icons[name]) {
     console.error(`Icon '${name}' not found.`);
@@ -155,5 +188,15 @@ export default function Icon({ name, ...otherProps }: IconProps): JSX.Element | 
 
   const IconComponent = icons[name];
 
-  return <IconComponent aria-hidden="true" data-icon-name={name} {...otherProps} />;
+  // isMiddleAligned shortcut takes precedence over verticalAlign
+  const align = isMiddleAligned ? "text-top" : verticalAlign;
+
+  const iconStyle = {
+    ...(align && { verticalAlign: align }),
+    ...style,
+  };
+
+  return (
+    <IconComponent aria-hidden="true" data-icon-name={name} {...otherProps} style={iconStyle} />
+  );
 }

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -45,6 +45,7 @@ import NoDesktopAlert from "~/components/software/NoDesktopAlert";
 import PotentialDataLossAlert from "~/components/storage/PotentialDataLossAlert";
 import InstallerL10nOptions from "~/components/core/InstallerL10nOptions";
 import InstallerOptionsMenu from "~/components/core/InstallerOptionsMenu";
+import ProgressStatusMonitor from "~/components/core/ProgressStatusMonitor";
 import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
 import ProductLogo from "~/components/product/ProductLogo";
@@ -157,9 +158,12 @@ const OverviewPageContent = ({ product }) => {
           <ProductLogo product={product} width="40px" /> {product.name}
         </>
       }
+      noDefaultEndSlot
+      noDefaultProgressMonitor
       endSlot={
         <>
           <InstallerL10nOptions />
+          <ProgressStatusMonitor />
           <InstallerOptionsMenu hideLabel showChangeProductOption />
         </>
       }

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -731,6 +731,7 @@ const ProductSelectionContent = () => {
         { label: <ProductSelectionTitle products={products} currentProduct={currentProduct} /> },
       ]}
       endSlot={<InstallerL10nOptions />}
+      noDefaultEndSlot
     >
       <Page.Content>
         <Flex gap={{ default: "gapXs" }} direction={{ default: "column" }}>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -321,7 +321,7 @@ export default function ProposalPage(): React.ReactNode {
   return (
     <Page
       breadcrumbs={[{ label: _("Storage") }]}
-      centerSlot={<ConnectedDevicesMenu />}
+      startSlot={<ConnectedDevicesMenu />}
       progress={{ scope: "storage", ensureRefetched: STORAGE_MODEL_KEY }}
     >
       <Page.Content>


### PR DESCRIPTION
## Summary

Refine `ProgressStatusMonitor` from a transient spinner into an always-visible progress status widget that communicates installer background activity consistently without implying overall system readiness.

Also adds vertical alignment controls to the `Icon` component to improve inline icon/text alignment across the UI.

## Background

Previously, `ProgressStatusMonitor` was hidden whenever no background tasks were running. This caused two UX issues:

*   Short-lived tasks caused the spinner to flash briefly and disappear
*   Users had no persistent indication that a background status widget even existed
    
## Solution

### Two States

#### Idle

*   Icon: `list_alt_check` - Neutral styling (no success color)

    The original proposal used a generic checkmark icon, but that visually suggested “everything is ready” even when blocking issues could still exist elsewhere in the installer. `list_alt_check`, however, communicates _task tracking_ and _completed activity_ without implying installation success or readiness    

*   Popover text:
    
    *   “No pending tasks”
    *   “All background tasks completed”
        

#### Busy

*   Spinner shown immediately while background tasks are running
*   Popover displays task count and progress details
    

## Layout Changes

`ProgressStatusMonitor` is now injected automatically at the layout level via `Page`.

### Default placement

Rightmost item in the header:

```text
[Review and Install] [ProgressStatusMonitor]
```

<img width="1213" height="692" alt="Screenshot 2026-05-28 at 14-50-09 Agama" src="https://github.com/user-attachments/assets/e9fe48b6-3039-4c1c-85b9-c6151f33bb40" />


<img width="1213" height="692" alt="Screenshot 2026-05-28 at 14-57-27 Agama" src="https://github.com/user-attachments/assets/392075b2-7559-4e9f-bb65-a3b97a39a40b" />


### Overview page override

The overview page manually positions the monitor between the language selector and options menu:

```text
[Language] [ProgressStatusMonitor] [Options]
```

<img width="1213" height="692" alt="Screenshot 2026-05-28 at 14-48-06 Agama" src="https://github.com/user-attachments/assets/0f4d7bae-2610-4376-bcc0-23cf09ab8347" />

<img width="1213" height="692" alt="Screenshot 2026-05-28 at 14-48-13 Agama" src="https://github.com/user-attachments/assets/4a83a789-1b44-4bcf-94f0-85f36850184c" />


