### PR TITLE
Display the checkmedia result and wait on a key press on all consoles

### DIFF
--- a/live/live-root/usr/bin/checkmedia-service
+++ b/live/live-root/usr/bin/checkmedia-service
@@ -1,9 +1,79 @@
-#! /bin/sh
+#! /bin/bash
 
-# Note: the LIVE_MEDIUM_LABEL placeholder is replaced by the real label in config.sh script
+# get list of all system consoles from /proc/consoles
+get_consoles() {
+  if [ -f /proc/consoles ]; then
+    while read -r console _rest; do
+      if [ -c "/dev/$console" ]; then
+        echo "$console"
+      fi
+    done < /proc/consoles | sort -u
+  fi
+}
+
+readarray -t consoles < <(get_consoles)
+
+# print the specified message on all consoles
+broadcast() {
+  local msg="$1"
+
+  # trivial implementation for a single console
+  if [ ${#consoles[@]} -le 1 ]; then
+    echo -e "$msg"
+  else
+    for c in "${consoles[@]}"; do
+      echo -e "$msg" > "/dev/$c"
+    done
+  fi
+}
+
+# wait for a key press on any console
+wait_any_key() {
+  local msg="$1"
+  local tmpdir
+  local fifo
+  local -a pids
+
+  # trivial implementation for a single console
+  if [ ${#consoles[@]} -le 1 ]; then
+    read -r -n1 -s -p "$msg"
+    echo
+    return
+  fi
+
+  # use a fifo for synchronizing the processes
+  tmpdir=$(mktemp -d)
+  fifo="$tmpdir/fifo"
+  mkfifo "$fifo"
+
+  # spawn a read process for each console
+  for c in "${consoles[@]}"; do
+    echo -n "$msg" > "/dev/$c"
+    (
+      read -r -n1 -s < "/dev/$c"
+      echo "done" > "$fifo" 2> /dev/null
+    ) &
+    pids+=("$!")
+  done
+
+  # block until one of the background jobs receives a key press and writes to the fifo
+  read -r _ < "$fifo"
+
+  # cleanup, kill the other waiting processes
+  for pid in "${pids[@]}"; do
+    kill "$pid" 2> /dev/null
+  done
+  rm -rf "$tmpdir"
+
+  # finish the printed line
+  for c in "${consoles[@]}"; do
+    echo > "/dev/$c"
+  done
+}
 
 # get the partition where the live ISO is mounted, the real name is set by the
 # config.sh script which gets the live partition label name from KIWI
+# Note: the LIVE_MEDIUM_LABEL placeholder is replaced by the real label in config.sh script
 label="@@LIVE_MEDIUM_LABEL@@"
 disk="/dev/disk/by-label/$label"
 
@@ -15,22 +85,18 @@ if [ -b "$disk" ]; then
 fi
 
 if [ ! -b "$disk" ]; then
-  echo -e "\e[31mPartition \"$label\" not found, skipping media check\e[0m"
-  read -n1 -s -p "Press any key to continue... "
-  echo
+  broadcast "\e[31mPartition \"$label\" not found, skipping media check\e[0m"
+  wait_any_key "Press any key to continue... "
   exit 0
 fi
 
-echo "Checking data integrity of device $disk ($label))..."
+broadcast "Checking data integrity of device $disk ($label))..."
 
 if checkmedia -v "$disk"; then
-  echo -e "\e[32mMedium check succeeded\e[0m"
-  read -n1 -s -p "Press any key to continue... "
-  echo
+  broadcast "\e[32mMedium check succeeded\e[0m"
+  wait_any_key "Press any key to continue... "
 else
-  echo -e "\e[31mERROR: Medium check failed!\e[0m"
-  echo "The installation medium is broken, it should not be used for installation."
-  read -n1 -s -p "Press any key to halt the system... "
-  echo
+  broadcast "\e[31mERROR: Medium check failed!\e[0m\nThe installation medium is broken, it should not be used for installation."
+  wait_any_key "Press any key to halt the system... "
   halt
 fi

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  2 11:40:18 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Display the media check result and wait for a key press on all
+  system consoles to easily continue booting the installer system,
+  needed especially for openQA (bsc#1267263)
+
+-------------------------------------------------------------------
 Mon Jun  1 14:35:33 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Added "agama-screenshot" helper script to take screenshots


### PR DESCRIPTION
## Problem

- OpenQA has some troubles with pressing a key to continue when using the media check boot option with both normal console and serial console (when using the `console=tty console=ttyS0` boot options).
- https://bugzilla.suse.com/show_bug.cgi?id=1267263

## Solution

- Display the check media result on all configured consoles
- Wait for pressing a key on any console

## Testing

Tested manually, works fine in all these cases:

- System with a standard system console (no extra boot options provided)
- System with a standard console and a serial console
  - The standard console is the main console (booted with `console=ttyS0 console=tty`)
  - The serial console is the main console (booted with `console=tty console=ttyS0`)

## Screenshots

Tested with VirtualBox with a virtual serial port. The big window is the main VBox VM window, the small window is a virtual serial console attached to a virtual serial port of that VM. Booted with the `console=tty console=ttyS0` options. The checkmedia output is displayed only on the main console (ttyS0) but the result and the prompt is displayed on all consoles. Pressing a key on *any console* continues booting the system.

<img width="1276" height="1009" alt="image" src="https://github.com/user-attachments/assets/4cfd26b9-54bc-4432-9281-e1d45dcb29cf" />
