### PR TITLE
Editorconfig fixes, fixed problems reported by the `shfmt` tool

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,19 @@ root = true
 [*.sh]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
+
+# A special non-standard configuration for the `shfmt` tool which matches any
+# file with a shell hashbang on the first line, it does not need the *.sh
+# extension in the file name (needs shfmt >= 3.8.0).
+#
+# To reformat all files run `shfmt -w -l .` at the top-level directory.
+[[shell]]
+indent_style = space
+indent_size = 2
+switch_case_indent = true
+space_redirects    = true
+trim_trailing_whitespace = true
 
 [*.{c,h,cxx,hxx}]
 indent_style = space

--- a/live/live-root/usr/bin/live-password
+++ b/live/live-root/usr/bin/live-password
@@ -132,7 +132,7 @@ random_password() {
     # so make the password easy to type (it cannot be copy pasted)
     #
     # TODO: check this with the security team
-    PASSWD=$((base64 -w 0 < /dev/random | tr -d "+/0OolI1" | head -c 8) 2>/dev/null)
+    PASSWD=$( (base64 -w 0 < /dev/random | tr -d "+/0OolI1" | head -c 8) 2> /dev/null)
 
     if [ -n "$PASSWD" ]; then
       echo "$PASSWD" | passwd --stdin

--- a/live/live-root/usr/lib/dracut/modules.d/98dracut-menu/dracut-cmdline-menu.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/98dracut-menu/dracut-cmdline-menu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -d /sysroot  ] ; then
   type getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh

--- a/service/.editorconfig
+++ b/service/.editorconfig
@@ -1,8 +1,5 @@
 # EditorConfig is awesome: https://EditorConfig.org
 
-# top-most EditorConfig file
-root = true
-
 # 2 space indentation
 [{*.rb,bin/agamactl}]
 indent_style = space

--- a/setup-services.sh
+++ b/setup-services.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
 # Using a git checkout in the current directory and set up the services, so that it can be used by:
 # - the web frontend (as set up by setup-web.sh)

--- a/web/.editorconfig
+++ b/web/.editorconfig
@@ -1,5 +1,4 @@
 # https://editorconfig.org
-root = true
 
 [*]
 charset = utf-8


### PR DESCRIPTION
## Problem

- The shell formatting options are not used in the `web/` and `service/` subdirectories.

## Solution

- Remove `root = true` option from the `.editorconfig` files in subdirectories, that prevents from using the shared rules from the top-level `.editorconfig` file, like the `*.sh` definition.
- Added a special `[[shell]]` section for formatting the shell files using the `shfmt` tool, it can autodetect shell files even without the `*.sh` extension (it checks the hashbang on the first line). See the [shfmt documentation](https://manpages.debian.org/testing/shfmt/shfmt.1.en.html).

## Notes

- Additionally I fixed the most severe issues found by the `shfmt` tool.
- It can be used to reformat the sources into an unified style but to make only the minimal changes before RC I'm postponing that fixes after the release. Mostly there is just inconsistent indentation, extra `;` separators , trailing spaces or similar minor issues. The potentially serious issues are already fixed in this pull request.

## Testing

- Tested manually, the shell formatting options are correctly applied also in the `web/` and `service/` subdirectories.

## TODO

- Later I'd like to run the `shfmt` check in the CI, but again, after the release...