### PR TITLE
fix(web): add redirects for refactored authentication and system routes

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  2 17:45:07 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Add redirections for legacy routes to preserve backward
+  compatibility after route refactors (gh#agama-project/agama#3578).
+
+-------------------------------------------------------------------
 Mon Jun  1 13:51:58 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Create new LVM volume groups using all the availabe space on the

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { createHashRouter, Outlet } from "react-router";
+import { createHashRouter, Navigate, Outlet } from "react-router";
 import App from "~/App";
 import Protected from "~/Protected";
 import ErrorPage from "~/components/core/ErrorPage";
@@ -38,8 +38,36 @@ import registrationRoutes from "~/routes/registration";
 import storageRoutes from "~/routes/storage";
 import softwareRoutes from "~/routes/software";
 import usersRoutes from "~/routes/users";
-import { SYSTEM, ROOT as PATHS } from "./routes/paths";
+import { SYSTEM, USER, ROOT as PATHS } from "./routes/paths";
 import { N_ } from "~/i18n";
+
+// Redirects for legacy routes that have been consolidated or renamed. These
+// help prevent 404s for bookmarked URLs or external links after route
+// refactors. While direct access to these routes is not a fully supported or
+// common use case, maintaining redirects preserves backward compatibility.
+//
+// Using `replace` prevents unnecessary browser history entries, ensuring
+// expected back-button behavior. These redirects are intended as a temporary
+// compatibility measure and should be retained for some time to allow
+// bookmarked URLs and external links to naturally transition.
+const legacyRedirects = () => [
+  {
+    path: "/hostname",
+    element: <Navigate to={SYSTEM.root} replace />,
+  },
+  {
+    path: "/users/first",
+    element: <Navigate to={USER.root} replace />,
+  },
+  {
+    path: "/users/first/edit",
+    element: <Navigate to={USER.root} replace />,
+  },
+  {
+    path: "/users/root/edit",
+    element: <Navigate to={USER.root} replace />,
+  },
+];
 
 const rootRoutes = () => [
   {
@@ -57,6 +85,7 @@ const rootRoutes = () => [
   storageRoutes(),
   softwareRoutes(),
   usersRoutes(),
+  ...legacyRedirects(),
 ];
 
 const protectedRoutes = () => [


### PR DESCRIPTION
## Summary

This PR introduces redirects for legacy routes that were consolidated in recent refactoring (_System_ in #3482, _Authentication_ in #3531). Without these redirects, accessing the old URLs would result in 404 errors. While direct access to these URLs is not a common scenario at this stage of development, maintaining redirects improves robustness, preserves user experience, and follows good routing practices.

## Changes

Uses `<Navigate>` with `replace`  option to avoid polluting browser history, ensuring that the back button behaves intuitively after a redirect. 

- /hostname -> /system  (`HostnamePage` merged into `SystemPage`)
- /users/first, /users/first/edit, /users/root/edit ->  `/users` (`FirstUserForm` and `RootUserForm` unified into `AuthenticationForm`)

## Future Considerations

- This pattern should be reused for any future route change/consolidation.
- After certain time, these redirects can be safely removed.  
