### PR TITLE
Support the old location in the `agama-scripts` service (SLE-16)

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  4 12:01:27 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider the old init scripts location for backward compatibility
+  (gh#agama-project/agama#3564).
+
+-------------------------------------------------------------------
 Wed May  6 15:50:46 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update "time" crate to prevent CVE-2026-25727 (bsc#1257930).

--- a/rust/share/agama-scripts.sh
+++ b/rust/share/agama-scripts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,7 +22,20 @@
 
 # This script runs the user-defined Agama init scripts.
 
-: "${SCRIPTS_DIR:=/var/lib/agama/scripts/init}"
+NEW_SCRIPTS_DIR="/var/lib/agama/scripts/init"
+OLD_SCRIPTS_DIR="/var/log/agama-installation/scripts/init"
+
+# Use SCRIPTS_DIR from environment if set, otherwise try the new location
+# first, then fall back to the old location for backward compatibility.
+if [ -z "$SCRIPTS_DIR" ]; then
+    if [ -d "$NEW_SCRIPTS_DIR" ]; then
+        SCRIPTS_DIR="$NEW_SCRIPTS_DIR"
+    elif [ -d "$OLD_SCRIPTS_DIR" ]; then
+        SCRIPTS_DIR="$OLD_SCRIPTS_DIR"
+    else
+        SCRIPTS_DIR="$NEW_SCRIPTS_DIR"
+    fi
+fi
 
 systemctl disable agama-scripts.service
 


### PR DESCRIPTION
- Fix the `agama-scripts.sh` to check the new location first and fall back to the old location for backward compatibility
- Addresses the issue where #3372 only changed to the new location without providing a fallback

The script now:

1. Respects SCRIPTS_DIR if set from the environment
2. Tries /var/lib/agama/scripts/init (new location) first
3. Falls back to /var/log/agama-installation/scripts/init (old location)
4. Defaults to the new location if neither exists

This ensures backward compatibility with the Agama version included in SLES 16.0 and Leap 16.0.