### PR TITLE
fix(deps): add @patternfly/react-styles as an explicit dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@patternfly/patternfly": "6.4.0",
         "@patternfly/react-code-editor": "6.4.1",
         "@patternfly/react-core": "6.4.1",
+        "@patternfly/react-styles": "6.4.0",
         "@patternfly/react-table": "6.4.1",
         "@tanstack/react-form": "^1.28.4",
         "@tanstack/react-query": "^5.90.21",
@@ -4248,9 +4249,9 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.5.1.tgz",
-      "integrity": "sha512-yQMzUbbf6qYM/v3JbPvaCJTgxRbOKoEw229XZmnnM8gDvp8ECiI7LqihrAOK/NA6T6M3DDgsRMd2JurUBhPDEw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.4.0.tgz",
+      "integrity": "sha512-EXmHA67s5sy+Wy/0uxWoUQ52jr9lsH2wV3QcgtvVc5zxpyBX89gShpqv4jfVqaowznHGDoL6fVBBrSe9BYOliQ==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {

--- a/web/package.json
+++ b/web/package.json
@@ -96,6 +96,7 @@
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/react-code-editor": "6.4.1",
     "@patternfly/react-core": "6.4.1",
+    "@patternfly/react-styles": "6.4.0",
     "@patternfly/react-table": "6.4.1",
     "@tanstack/react-form": "^1.28.4",
     "@tanstack/react-query": "^5.90.21",


### PR DESCRIPTION
## Problem

PR #3581 introduced `@patternfly/react-code-editor` and intentionally froze all PatternFly dependencies to `6.4.x` to avoid a known layout regression in `6.5.1`. However, `@patternfly/react-styles` was not added as an explicit dependency, leaving a gap.

## Root cause

`@patternfly/react-code-editor` lists `@patternfly/react-styles` as `workspace:^` inside the PatternFly monorepo. When published to npm, that becomes `^6.4.0`, which npm resolves to `6.5.1` (latest satisfying):

https://github.com/patternfly/patternfly-react/blob/189eb789fd314a5f787f0e81ed6341ed2c60de45/packages/react-code-editor/package.json#L36

```
@patternfly/react-code-editor@6.4.1
└── @patternfly/react-styles@^6.4.0  →  resolved to 6.5.1
```

Other PatternFly packages also pull `react-styles` as a transitive dependency, but at a different version. npm cannot flatten two different versions of the same package to the same root `node_modules`. With `react-styles` no longer in node_modules/@patternfly/ root, direct imports in the codebase break:

```ts
import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
import spacingStyles from "@patternfly/react-styles/css/utilities/Spacing/spacing";
```

## Fix

Added `@patternfly/react-styles@6.4.0` as an explicit dependency in `package.json` and pinned the resolved version in `package-lock.json`. This completes the freeze that #3581 started for all other PatternFly packages, and collapses all transitive resolutions of `react-styles` to the same version, giving npm a single version to hoist with no conflict.

## Impact

- Restores all PatternFly utility style imports broken after #3581.
- Keeps the entire PatternFly dependency set on a consistent `6.4.x` baseline, as originally intended.