### PR TITLE
[SLE-16.0] Do not loose the repository password (bsc#1258701)

### DIFF
--- a/service/lib/agama/software/repository.rb
+++ b/service/lib/agama/software/repository.rb
@@ -60,7 +60,13 @@ module Agama
             "priority" => priority
           )
 
-          repo_id ? find(repo_id) : nil
+          return nil unless repo_id
+
+          repo = find(repo_id)
+          # set the original URL, the Pkg.SourceGeneralData() used in Y2Packager::Repository.find
+          # returns the URL without the user password so it would be lost
+          repo.url = url if repo
+          repo
         end
       end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun  5 06:37:05 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed using a custom password-protected installation repository
+  (bsc#1258701)
+
+-------------------------------------------------------------------
 Fri May 15 11:14:54 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt code to new suseconnect-ng version (bsc#1265239) 


### PR DESCRIPTION
## Problem

- A custom password-protected installation repository cannot be used, libzypp fails to log in to the remote server.
- https://bugzilla.suse.com/show_bug.cgi?id=1258701


## Solution

- When creating the `Repository` object in Ruby the password in the URL is lost. Using that URL later causes failures.

## Testing

- Tested manually
- The system can be properly installed from a password protected FTP server
- The password is also correctly saved into the target system, the password-protected repository can be accessed also in the installed system
