### PR TITLE
fix(web): make installation pages look and behave as expected

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun  5 12:25:54 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Fix race condition in download success alert.
+- Do not show "Review and install" button in installation pages
+  (gh#agama-project/agama#3588).
+
+-------------------------------------------------------------------
 Thu Jun  4 14:56:26 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Improve the installation settings UI by showing and explaining the

--- a/web/src/components/core/DownloadFeedback.tsx
+++ b/web/src/components/core/DownloadFeedback.tsx
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   Alert,
   AlertActionCloseButton,
@@ -84,6 +84,7 @@ export default function DownloadFeedback({
 }: DownloadFeedbackProps) {
   const [alert, setAlert] = useState<"pending" | "success" | null>(null);
   const [filename, setFilename] = useState("");
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleDownload = async () => {
     const name = `${filenamePrefix}-${isoTimestamp()}.${extension}`;
@@ -95,13 +96,21 @@ export default function DownloadFeedback({
       await download(url, name);
       setAlert((value) => {
         if (value === "pending") {
-          setTimeout(() => setAlert(null), successTimeout);
+          timeoutRef.current = setTimeout(() => setAlert(null), successTimeout);
           return "success";
         }
       });
     } catch {
       setAlert(null);
     }
+  };
+
+  const handleSuccessClose = () => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setAlert(null);
   };
 
   const title = _("Installation logs download");
@@ -135,7 +144,7 @@ export default function DownloadFeedback({
           <Alert
             variant="success"
             title={title}
-            actionClose={<AlertActionCloseButton onClose={() => setAlert(null)} />}
+            actionClose={<AlertActionCloseButton onClose={handleSuccessClose} />}
           >
             <Stack hasGutter>
               <StackItem>

--- a/web/src/components/core/DownloadLogsButton.test.tsx
+++ b/web/src/components/core/DownloadLogsButton.test.tsx
@@ -25,23 +25,26 @@ import { screen } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
 import DownloadLogsButton from "./DownloadLogsButton";
 
+const mockDownload = jest.fn();
+jest.mock("~/utils", () => {
+  const original = jest.requireActual("~/utils");
+  return {
+    ...original,
+    download: (...args) => mockDownload(...args),
+  };
+});
+
 describe("DownloadLogsButton", () => {
   it("renders a button with 'Download logs' label", () => {
     plainRender(<DownloadLogsButton />);
-    screen.getByRole("link", { name: /Download logs/i });
+    screen.getByRole("button", { name: /Download logs/i });
   });
 
-  it("has correct download attributes", () => {
-    plainRender(<DownloadLogsButton />);
-    const button = screen.getByRole("link", { name: /Download logs/i });
-    expect(button).toHaveAttribute("href", "/api/private/download_logs");
-    expect(button).toHaveAttribute("download", "agama-logs.tar.gz");
-  });
-
-  it("renders as an anchor element", () => {
-    plainRender(<DownloadLogsButton />);
-    const button = screen.getByRole("link", { name: /Download logs/i });
-    expect(button.tagName).toBe("A");
+  it("triggers the download when clicked", async () => {
+    const { user } = plainRender(<DownloadLogsButton />);
+    const button = screen.getByRole("button", { name: /Download logs/i });
+    await user.click(button);
+    expect(mockDownload).toHaveBeenCalled();
   });
 
   it("accepts custom props", () => {
@@ -51,7 +54,7 @@ describe("DownloadLogsButton", () => {
 
   it("allows overriding size and variant", () => {
     plainRender(<DownloadLogsButton size="sm" variant="secondary" />);
-    const button = screen.getByRole("link", { name: /Download logs/i });
+    const button = screen.getByRole("button", { name: /Download logs/i });
     expect(button).toHaveClass("pf-m-secondary");
     expect(button).toHaveClass("pf-m-small");
   });

--- a/web/src/components/core/DownloadLogsButton.tsx
+++ b/web/src/components/core/DownloadLogsButton.tsx
@@ -23,6 +23,7 @@
 import React from "react";
 import { Button, ButtonProps, Flex } from "@patternfly/react-core";
 import Icon from "~/components/layout/Icon";
+import DownloadFeedback from "~/components/core/DownloadFeedback";
 import { ROOT } from "~/routes/paths";
 import { _ } from "~/i18n";
 
@@ -39,17 +40,16 @@ export default function DownloadLogsButton(
   props: Omit<ButtonProps, "onClick" | "href" | "download">,
 ) {
   return (
-    <Button
-      component="a"
-      variant="plain"
-      size="default"
-      {...props}
-      href={ROOT.logs}
-      download="agama-logs.tar.gz"
-    >
-      <Flex gap={{ default: "gapXs" }} alignItems={{ default: "alignItemsCenter" }}>
-        <Icon name="download" /> {_("Download logs")}
-      </Flex>
-    </Button>
+    <DownloadFeedback url={ROOT.logs} filenamePrefix="agama-logs" extension="tar.gz">
+      {({ download: downloadLogs }) => {
+        return (
+          <Button variant="plain" size="default" {...props} onClick={downloadLogs}>
+            <Flex gap={{ default: "gapXs" }} alignItems={{ default: "alignItemsCenter" }}>
+              <Icon name="download" /> {_("Download logs")}
+            </Flex>
+          </Button>
+        );
+      }}
+    </DownloadFeedback>
   );
 }

--- a/web/src/components/core/InstallationFailed.test.tsx
+++ b/web/src/components/core/InstallationFailed.test.tsx
@@ -48,6 +48,6 @@ describe("InstallationFailed", () => {
 
   it("shows a 'Download logs' button", () => {
     plainRender(<InstallationFailed />);
-    screen.getByRole("link", { name: /Download logs/i });
+    screen.getByRole("button", { name: /Download logs/i });
   });
 });

--- a/web/src/components/core/InstallationFinished.tsx
+++ b/web/src/components/core/InstallationFinished.tsx
@@ -69,7 +69,7 @@ function InstallationFinished() {
   const isGrub2WithTpm = useIsGrub2WithTpm();
 
   return (
-    <Page noDefaultProgressMonitor endSlot={<InstallerOptionsMenu hideLabel />}>
+    <Page noDefaultProgressMonitor noDefaultEndSlot endSlot={<InstallerOptionsMenu hideLabel />}>
       <Page.Content>
         <SplitInfoLayout
           icon="done_all"

--- a/web/src/components/core/InstallationProgress.tsx
+++ b/web/src/components/core/InstallationProgress.tsx
@@ -34,7 +34,7 @@ export default function InstallationProgress() {
   const product = useProductInfo();
 
   return (
-    <Page noDefaultProgressMonitor endSlot={<InstallerOptionsMenu hideLabel />}>
+    <Page noDefaultProgressMonitor noDefaultEndSlot endSlot={<InstallerOptionsMenu hideLabel />}>
       <Page.Content>
         <SplitInfoLayout
           icon="deployed_code_update"


### PR DESCRIPTION
`InstallationFinished` and `InstallationProgress` were displaying the "Review and install" button becuase "slot changes" made at https://github.com/agama-project/agama/pull/3560.

The `InstallationFailed`, in the other hand, was not updated to download logs feedback introduced in https://github.com/agama-project/agama/pull/3580.

While fixing these, also it was caught a random test failure that revealed the lack of a clearTimeout  in the component added in #3580.


Updated unit tests and testes manually too

---

Partial screenshot only for reference, you might miss the progress there but the important part is that "Review and Install" button does not appear in the header.


<img width="2048" height="1536" alt="localhost_8080_ - 2026-06-05T125820 222" src="https://github.com/user-attachments/assets/f481eba1-2957-4d4f-8c74-a908de9dc667" />

---


<img width="2048" height="1536" alt="localhost_8080_ - 2026-06-05T125731 655" src="https://github.com/user-attachments/assets/bd16ce49-f57e-487a-9bcf-1c0436915279" />

---

<img width="2048" height="1536" alt="localhost_8080_ - 2026-06-05T125315 094" src="https://github.com/user-attachments/assets/7dea889f-7f91-426a-ac03-a9478a2c5a8d" />
