### PR TITLE
[SLE-16.0] Added `plymouth.ignore-serial-consoles` boot option on ppc64le

### DIFF
--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -97,7 +97,7 @@ fi
 
 menuentry "Install $label" --class os --unrestricted {
   echo 'Loading kernel...'
-  linux /boot/ppc64le/linux splash=silent
+  linux /boot/ppc64le/linux splash=silent plymouth.ignore-serial-consoles
   echo 'Loading initrd...'
   initrd /boot/ppc64le/initrd
 }
@@ -111,7 +111,7 @@ menuentry "Check Installation Medium" --class os --unrestricted {
 
 menuentry "Rescue System" --class os --unrestricted {
   echo 'Loading kernel...'
-  linux /boot/ppc64le/linux $RESCUE_SYSTEM_BOOT_SETTINGS
+  linux /boot/ppc64le/linux $RESCUE_SYSTEM_BOOT_SETTINGS plymouth.ignore-serial-consoles
   echo 'Loading initrd...'
   initrd /boot/ppc64le/initrd
 }

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun  5 13:42:42 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Added "plymouth.ignore-serial-consoles" boot option on ppc64le
+  (bsc#1249569)
+
+-------------------------------------------------------------------
 Tue May 19 13:57:18 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Removed the "Boot from Hard Disk" boot menu option, the "Install"


### PR DESCRIPTION
## Problem

- Unable to login if both plymouth and gdm are installed
- https://bugzilla.suse.com/show_bug.cgi?id=1249569

## Solution

- It was suggested to add the `plymouth.ignore-serial-consoles` boot option on Power

## Testing

- Unfortunately not tested because of lack of hardware