### PR TITLE
refactor(web): make DownloadFeedback reusable

### DIFF
--- a/web/src/components/core/DownloadFeedback.test.tsx
+++ b/web/src/components/core/DownloadFeedback.test.tsx
@@ -43,9 +43,18 @@ const TestTrigger = ({ download }: { download: () => void }) => (
   <button onClick={download}>Download</button>
 );
 
-const renderDownloadFeedback = (props = {}) => {
+const TestTitle = () => <>Installation logs download</>;
+const TestContent = ({ filename }: { filename?: string }) => <div>{filename}</div>;
+
+const renderDownloadFeedback = (successTimeout?: number) => {
   const { user } = plainRender(
-    <DownloadFeedback url="/api/logs" filenamePrefix="agama-logs" extension="tar.gz" {...props}>
+    <DownloadFeedback
+      url="/api/logs"
+      filenamePrefix="agama-logs"
+      extension="tar.gz"
+      info={{ title: TestTitle, content: TestContent }}
+      success={{ title: TestTitle, content: TestContent, timeout: successTimeout }}
+    >
       {({ download }) => <TestTrigger download={download} />}
     </DownloadFeedback>,
   );
@@ -106,7 +115,7 @@ describe("DownloadFeedback", () => {
 
   it("auto-dismisses the success alert after the timeout", async () => {
     mockDownload.mockResolvedValue(undefined);
-    const { user } = renderDownloadFeedback({ successTimeout: 10 });
+    const { user } = renderDownloadFeedback(10);
 
     await user.click(screen.getByRole("button", { name: "Download" }));
     await waitFor(() =>
@@ -165,7 +174,7 @@ describe("DownloadFeedback", () => {
 
   it("does not auto-dismiss if the user already closed the success alert", async () => {
     mockDownload.mockResolvedValue(undefined);
-    const { user } = renderDownloadFeedback({ successTimeout: 10 });
+    const { user } = renderDownloadFeedback(10);
 
     await user.click(screen.getByRole("button", { name: "Download" }));
     await waitFor(() =>

--- a/web/src/components/core/DownloadFeedback.tsx
+++ b/web/src/components/core/DownloadFeedback.tsx
@@ -21,18 +21,17 @@
  */
 
 import React, { useRef, useState } from "react";
-import {
-  Alert,
-  AlertActionCloseButton,
-  AlertGroup,
-  Divider,
-  Stack,
-  StackItem,
-} from "@patternfly/react-core";
-import Text from "~/components/core/Text";
-import Interpolate from "~/components/core/Interpolate";
+import { Alert, AlertActionCloseButton, AlertGroup } from "@patternfly/react-core";
 import { download, isoTimestamp } from "~/utils";
-import { _ } from "~/i18n";
+
+type FeedbackComponent = React.ComponentType<{ filename?: string }>;
+
+type AlertConfig = {
+  /** Alert title component. */
+  title: FeedbackComponent;
+  /** Alert content component. */
+  content: FeedbackComponent;
+};
 
 export type DownloadFeedbackProps = {
   /** URL of the resource to download. */
@@ -49,19 +48,14 @@ export type DownloadFeedbackProps = {
    * element such as a button or dropdown item.
    */
   children: (props: { download: () => void }) => React.ReactNode;
-  /** Milliseconds before the success alert auto-dismisses (e.g. 8000). */
-  successTimeout?: number;
+  /** Configuration for the info alert shown while preparing the download. */
+  info: AlertConfig;
+  /** Configuration for the success alert shown after download starts. */
+  success: AlertConfig & {
+    /** Milliseconds before the alert auto-dismisses (default: 8000). */
+    timeout?: number;
+  };
 };
-
-const MainText = ({ filename }) => (
-  <Interpolate
-    sentence={_(
-      "The file %s contains a record of the installer activity so far, useful to diagnose installation issues.",
-    )}
-  >
-    {() => <code>{filename}</code>}
-  </Interpolate>
-);
 
 /**
  * Wraps a downloadable resource with user feedback. Renders a toast alert
@@ -69,7 +63,21 @@ const MainText = ({ filename }) => (
  * starts, then delegates trigger rendering to its children via a render prop.
  *
  * @example
- * <DownloadFeedback url={ROOT.logs} filenamePrefix="agama-logs" extension="tar.gz">
+ * function Title() {
+ *   return <>{_("Download logs")}</>;
+ * }
+ *
+ * function Content({ filename }) {
+ *   return <div>Downloading {filename}...</div>;
+ * }
+ *
+ * <DownloadFeedback
+ *   url={ROOT.logs}
+ *   filenamePrefix="agama-logs"
+ *   extension="tar.gz"
+ *   info={{ title: Title, content: Content }}
+ *   success={{ title: Title, content: Content }}
+ * >
  *   {({ download }) => (
  *     <DropdownItem onClick={download}>{_("Download logs")}</DropdownItem>
  *   )}
@@ -79,7 +87,8 @@ export default function DownloadFeedback({
   url,
   filenamePrefix,
   extension,
-  successTimeout = 8000,
+  info: { title: InfoTitle, content: InfoContent },
+  success: { title: SuccessTitle, content: SuccessContent, timeout: successTimeout = 8000 },
   children,
 }: DownloadFeedbackProps) {
   const [alert, setAlert] = useState<"pending" | "success" | null>(null);
@@ -113,44 +122,26 @@ export default function DownloadFeedback({
     setAlert(null);
   };
 
-  const title = _("Installation logs download");
-
   return (
     <>
       <AlertGroup isToast>
         {alert === "pending" && (
           <Alert
             variant="info"
-            title={title}
+            title={<InfoTitle filename={filename} />}
             actionClose={<AlertActionCloseButton onClose={() => setAlert(null)} />}
           >
-            <Stack hasGutter>
-              <StackItem>
-                <MainText filename={filename} />
-              </StackItem>
-              <StackItem>
-                <Divider />
-                <Text textStyle="fontSizeXs">
-                  {_(
-                    "Data collection may take a while. The download will start automatically once the file is ready.",
-                  )}
-                </Text>
-              </StackItem>
-            </Stack>
+            <InfoContent filename={filename} />
           </Alert>
         )}
 
         {alert === "success" && (
           <Alert
             variant="success"
-            title={title}
+            title={<SuccessTitle filename={filename} />}
             actionClose={<AlertActionCloseButton onClose={handleSuccessClose} />}
           >
-            <Stack hasGutter>
-              <StackItem>
-                <MainText filename={filename} />
-              </StackItem>
-            </Stack>
+            <SuccessContent filename={filename} />
           </Alert>
         )}
       </AlertGroup>

--- a/web/src/components/core/DownloadLogsButton.tsx
+++ b/web/src/components/core/DownloadLogsButton.tsx
@@ -23,8 +23,7 @@
 import React from "react";
 import { Button, ButtonProps, Flex } from "@patternfly/react-core";
 import Icon from "~/components/layout/Icon";
-import DownloadFeedback from "~/components/core/DownloadFeedback";
-import { ROOT } from "~/routes/paths";
+import DownloadLogsFeedback from "~/components/core/DownloadLogsFeedback";
 import { _ } from "~/i18n";
 
 /**
@@ -40,16 +39,14 @@ export default function DownloadLogsButton(
   props: Omit<ButtonProps, "onClick" | "href" | "download">,
 ) {
   return (
-    <DownloadFeedback url={ROOT.logs} filenamePrefix="agama-logs" extension="tar.gz">
-      {({ download: downloadLogs }) => {
-        return (
-          <Button variant="plain" size="default" {...props} onClick={downloadLogs}>
-            <Flex gap={{ default: "gapXs" }} alignItems={{ default: "alignItemsCenter" }}>
-              <Icon name="download" /> {_("Download logs")}
-            </Flex>
-          </Button>
-        );
-      }}
-    </DownloadFeedback>
+    <DownloadLogsFeedback>
+      {({ download: downloadLogs }) => (
+        <Button variant="plain" size="default" {...props} onClick={downloadLogs}>
+          <Flex gap={{ default: "gapXs" }} alignItems={{ default: "alignItemsCenter" }}>
+            <Icon name="download" /> {_("Download logs")}
+          </Flex>
+        </Button>
+      )}
+    </DownloadLogsFeedback>
   );
 }

--- a/web/src/components/core/DownloadLogsFeedback.test.tsx
+++ b/web/src/components/core/DownloadLogsFeedback.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import DownloadLogsFeedback from "./DownloadLogsFeedback";
+import { plainRender } from "~/test-utils";
+
+const mockDownload = jest.fn();
+jest.mock("~/utils", () => {
+  const original = jest.requireActual("~/utils");
+  return {
+    ...original,
+    download: (...args) => mockDownload(...args),
+  };
+});
+
+const FIXED_DATE = "2026-06-03T10-30-00-000Z";
+jest
+  .spyOn(global, "Date")
+  .mockImplementation(() => ({ toISOString: () => "2026-06-03T10:30:00.000Z" }) as unknown as Date);
+
+const TestTrigger = ({ download }: { download: () => void }) => (
+  <button onClick={download}>Download logs</button>
+);
+
+const renderDownloadLogsFeedback = () => {
+  const { user } = plainRender(
+    <DownloadLogsFeedback>
+      {({ download }) => <TestTrigger download={download} />}
+    </DownloadLogsFeedback>,
+  );
+
+  return { user };
+};
+
+describe("DownloadLogsFeedback", () => {
+  beforeEach(() => {
+    mockDownload.mockReset();
+  });
+
+  it("renders the trigger children", () => {
+    renderDownloadLogsFeedback();
+    screen.getByRole("button", { name: "Download logs" });
+  });
+
+  it("shows installation logs download alert when download starts", async () => {
+    mockDownload.mockReturnValue(new Promise(() => {}));
+    const { user } = renderDownloadLogsFeedback();
+
+    await user.click(screen.getByRole("button", { name: "Download logs" }));
+
+    screen.getByRole("heading", { name: "Info alert: Installation logs download" });
+  });
+
+  it("passes the correct URL and filename to the download utility", async () => {
+    mockDownload.mockResolvedValue(undefined);
+    const { user } = renderDownloadLogsFeedback();
+
+    await user.click(screen.getByRole("button", { name: "Download logs" }));
+
+    expect(mockDownload).toHaveBeenCalledWith(
+      "/api/private/download_logs",
+      `agama-logs-${FIXED_DATE}.tar.gz`,
+    );
+  });
+
+  it("shows success alert after download completes", async () => {
+    mockDownload.mockResolvedValue(undefined);
+    const { user } = renderDownloadLogsFeedback();
+
+    await user.click(screen.getByRole("button", { name: "Download logs" }));
+
+    await waitFor(() =>
+      screen.getByRole("heading", { name: "Success alert: Installation logs download" }),
+    );
+  });
+
+  it("includes descriptive content about the logs file", async () => {
+    mockDownload.mockResolvedValue(undefined);
+    const { user } = renderDownloadLogsFeedback();
+
+    await user.click(screen.getByRole("button", { name: "Download logs" }));
+
+    await waitFor(() => screen.getByText(/contains a record of the installer activity so far/));
+  });
+});

--- a/web/src/components/core/DownloadLogsFeedback.tsx
+++ b/web/src/components/core/DownloadLogsFeedback.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Divider, Stack, StackItem } from "@patternfly/react-core";
+import DownloadFeedback from "~/components/core/DownloadFeedback";
+import Interpolate from "~/components/core/Interpolate";
+import Text from "~/components/core/Text";
+import { ROOT } from "~/routes/paths";
+import { _ } from "~/i18n";
+
+const MainText = ({ filename }: { filename?: string }) => (
+  <Interpolate
+    sentence={_(
+      "The file %s contains a record of the installer activity so far, useful to diagnose installation issues.",
+    )}
+  >
+    {() => <code>{filename}</code>}
+  </Interpolate>
+);
+
+export function LogsTitle() {
+  // TRANSLATORS: alert title for installation logs download
+  return <>{_("Installation logs download")}</>;
+}
+
+export function LogsInfoContent({ filename }: { filename?: string }) {
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <MainText filename={filename} />
+      </StackItem>
+      <StackItem>
+        <Divider />
+        <Text textStyle="fontSizeXs">
+          {_(
+            "Data collection may take a while. The download will start automatically once the file is ready.",
+          )}
+        </Text>
+      </StackItem>
+    </Stack>
+  );
+}
+
+export function LogsSuccessContent({ filename }: { filename?: string }) {
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <MainText filename={filename} />
+      </StackItem>
+    </Stack>
+  );
+}
+
+type DownloadLogsFeedbackProps = {
+  children: (props: { download: () => void }) => React.ReactNode;
+};
+
+/**
+ * Pre-configured DownloadFeedback for installation logs. Wraps the generic
+ * DownloadFeedback component with logs-specific content and configuration.
+ *
+ * @example
+ * <DownloadLogsFeedback>
+ *   {({ download }) => (
+ *     <Button onClick={download}>Download logs</Button>
+ *   )}
+ * </DownloadLogsFeedback>
+ */
+export default function DownloadLogsFeedback({ children }: DownloadLogsFeedbackProps) {
+  return (
+    <DownloadFeedback
+      url={ROOT.logs}
+      filenamePrefix="agama-logs"
+      extension="tar.gz"
+      info={{ title: LogsTitle, content: LogsInfoContent }}
+      success={{ title: LogsTitle, content: LogsSuccessContent }}
+    >
+      {children}
+    </DownloadFeedback>
+  );
+}

--- a/web/src/components/core/InstallerOptionsMenu.tsx
+++ b/web/src/components/core/InstallerOptionsMenu.tsx
@@ -32,8 +32,7 @@ import {
 import Icon from "~/components/layout/Icon";
 import ChangeProductOption from "~/components/core/ChangeProductOption";
 import ConfigDialog from "~/components/core/ConfigDialog";
-import DownloadFeedback from "~/components/core/DownloadFeedback";
-import { ROOT } from "~/routes/paths";
+import DownloadLogsFeedback from "~/components/core/DownloadLogsFeedback";
 import { _ } from "~/i18n";
 
 /**
@@ -66,14 +65,14 @@ export default function InstallerOptionsMenu({
   const toggle = () => setIsOpen(!isOpen);
   const toggleConfig = () => setIsConfigOpen(!isConfigOpen);
 
-  // DownloadFeedback must wrap the entire Dropdown rather than just the
+  // DownloadLogsFeedback must wrap the entire Dropdown rather than just the
   // DropdownItem. When the dropdown closes, PatternFly unmounts its children,
-  // which would reset DownloadFeedback's alert state and dismiss the pending
-  // toast prematurely. Keeping it as the outermost element ensures it stays
-  // mounted regardless of the dropdown lifecycle.
+  // which would reset the feedback alert state and dismiss the pending toast
+  // prematurely. Keeping it as the outermost element ensures it stays mounted
+  // regardless of the dropdown lifecycle.
   return (
     <>
-      <DownloadFeedback url={ROOT.logs} filenamePrefix="agama-logs" extension="tar.gz">
+      <DownloadLogsFeedback>
         {({ download: downloadLogs }) => (
           <Dropdown
             popperProps={{ position: "right", appendTo: () => document.body }}
@@ -107,7 +106,7 @@ export default function InstallerOptionsMenu({
             </DropdownList>
           </Dropdown>
         )}
-      </DownloadFeedback>
+      </DownloadLogsFeedback>
       {isConfigOpen && <ConfigDialog onClose={toggleConfig} />}
     </>
   );


### PR DESCRIPTION
While working on #3588, it was noticed that work done in #3580 made the `DownloadFeedback` component not fully reusable. This PR fixes it by decoupling it from logs-specific content. 

Logs feedback is now handled by `DownloadLogsFeedback` instead, built on top of `DownloadFeedback`, keeping the core component generic and easy to reuse.

Apart of testing it manually, missing unit tests has been added and existing updated.

This is just an internal web components refactor, with zero impact in the UI. Thus, no entry for the changes file needed.