### PR TITLE
Add mkfsOptions and mountOptions to the forms

### DIFF
--- a/rust/agama-lib/share/storage.model.schema.json
+++ b/rust/agama-lib/share/storage.model.schema.json
@@ -142,7 +142,9 @@
         "reuse": { "type": "boolean" },
         "default": { "type": "boolean" },
         "type": { "$ref": "#/$defs/filesystemType" },
-        "label": { "type": "string" }
+        "label": { "type": "string" },
+        "mkfsOptions": { "type": "array", "items": { "type": "string" } },
+        "mountOptions": { "type": "array", "items": { "type": "string" } }
       }
     },
     "filesystemType": {

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/filesystem.rb
@@ -41,10 +41,12 @@ module Agama
           # @return [Hash]
           def conversions
             {
-              reuse: model_json.dig(:filesystem, :reuse),
-              path:  model_json[:mountPath],
-              type:  convert_type,
-              label: model_json.dig(:filesystem, :label)
+              reuse:         model_json.dig(:filesystem, :reuse),
+              path:          model_json[:mountPath],
+              type:          convert_type,
+              label:         model_json.dig(:filesystem, :label),
+              mkfs_options:  model_json.dig(:filesystem, :mkfsOptions),
+              mount_options: model_json.dig(:filesystem, :mountOptions)
             }
           end
 

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
@@ -43,10 +43,12 @@ module Agama
           # @see Base#conversions
           def conversions
             {
-              reuse:   config.reuse?,
-              default: convert_default,
-              type:    convert_type,
-              label:   config.label
+              reuse:        config.reuse?,
+              default:      convert_default,
+              type:         convert_type,
+              label:        config.label,
+              mkfsOptions:  convert_mkfs_options,
+              mountOptions: convert_mount_options
             }
           end
 
@@ -67,6 +69,20 @@ module Agama
             end
 
             config.type.fs_type.to_s
+          end
+
+          # @return [Array<String>, nil]
+          def convert_mkfs_options
+            return if config.mkfs_options.empty?
+
+            config.mkfs_options
+          end
+
+          # @return [Array<String>, nil]
+          def convert_mount_options
+            return if config.mount_options.empty?
+
+            config.mount_options
           end
 
           # @return [Boolean]

--- a/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
@@ -122,10 +122,12 @@ shared_examples "with filesystem" do
       expect(model_json[:mountPath]).to eq("/test")
       expect(model_json[:filesystem]).to eq(
         {
-          reuse:   true,
-          default: false,
-          type:    "xfs",
-          label:   "test"
+          reuse:        true,
+          default:      false,
+          type:         "xfs",
+          label:        "test",
+          mkfsOptions:  ["version=2"],
+          mountOptions: ["rw"]
         }
       )
     end

--- a/web/src/components/storage/partition-form/FilesystemAdditionalFields.tsx
+++ b/web/src/components/storage/partition-form/FilesystemAdditionalFields.tsx
@@ -23,8 +23,16 @@
 import React from "react";
 import LabelText from "~/components/form/LabelText";
 import { withForm } from "~/hooks/form";
-import { defaultOptions } from "./fields";
+import { defaultOptions, FILESYSTEM_ACTION } from "./fields";
 import { _ } from "~/i18n";
+import Interpolate from "~/components/core/Interpolate";
+
+/**
+ * Whether options for a new filesystem should be displayed.
+ */
+const isNewFilesystem = (filesystem: string): boolean => {
+  return filesystem !== FILESYSTEM_ACTION.REUSE;
+};
 
 /**
  * Additional filesystem settings fields.
@@ -35,11 +43,49 @@ const FilesystemAdditionalFields = withForm({
   ...defaultOptions,
   render: function Render({ form }) {
     return (
-      <form.AppField name="filesystemLabel">
-        {(field) => (
-          <field.TextField label={<LabelText suffix={_("(optional)")}>{_("Label")}</LabelText>} />
+      <form.Subscribe selector={(s) => ({ filesystem: s.values.filesystem })}>
+        {({ filesystem }) => (
+          <>
+            {isNewFilesystem(filesystem) && (
+              <form.AppField name="filesystemLabel">
+                {(field) => (
+                  <field.TextField
+                    label={<LabelText suffix={_("(optional)")}>{_("Label")}</LabelText>}
+                  />
+                )}
+              </form.AppField>
+            )}
+            <form.AppField name="mountOptions">
+              {(field) => (
+                <field.ArrayField
+                  label={<LabelText suffix={_("(optional)")}>{_("Mount options")}</LabelText>}
+                  helperText={_("E.g. rw, noatime, umask=0666")}
+                />
+              )}
+            </form.AppField>
+            {isNewFilesystem(filesystem) && (
+              <form.AppField name="mkfsOptions">
+                {(field) => (
+                  <field.ArrayField
+                    label={<LabelText suffix={_("(optional)")}>{_("Format options")}</LabelText>}
+                    splitPasteOn={/\r?\n/}
+                    helperText={
+                      <Interpolate
+                        sentence={
+                          // TRANSLATORS: %s is replaced by "mkfs" (command used to format devices)
+                          _("Additional arguments for the formatting command (%s).")
+                        }
+                      >
+                        {() => <code>{"mkfs"}</code>}
+                      </Interpolate>
+                    }
+                  />
+                )}
+              </form.AppField>
+            )}
+          </>
         )}
-      </form.AppField>
+      </form.Subscribe>
     );
   },
 });

--- a/web/src/components/storage/partition-form/FilesystemFields.test.tsx
+++ b/web/src/components/storage/partition-form/FilesystemFields.test.tsx
@@ -219,14 +219,14 @@ describe("FilesystemFields", () => {
   });
 
   describe("additional filesystem settings", () => {
-    it("shows checkbox for additional settings when filesystem supports it", async () => {
+    it("shows checkbox for additional settings", async () => {
       installerRender(<TestForm defaultValues={{ filesystem: FILESYSTEM_TYPE.AUTO }} />);
       screen.getByLabelText(/Define more file system settings/);
     });
 
-    it("does not show checkbox when reusing partition", () => {
+    it("shows checkbox even when reusing partition", () => {
       installerRender(<TestForm defaultValues={{ name: "vdd1", filesystem: "reuse" }} />);
-      expect(screen.queryByLabelText(/Define more file system settings/)).not.toBeInTheDocument();
+      screen.getByLabelText(/Define more file system settings/);
     });
   });
 });

--- a/web/src/components/storage/partition-form/FilesystemFields.tsx
+++ b/web/src/components/storage/partition-form/FilesystemFields.tsx
@@ -27,13 +27,7 @@ import { HelperText, HelperTextItem } from "@patternfly/react-core";
 import Text from "~/components/core/Text";
 import FieldNestedContent from "~/components/form/FieldNestedContent";
 import { withForm } from "~/hooks/form";
-import {
-  defaultOptions,
-  isReusingPartition,
-  FILESYSTEM_TYPE,
-  FILESYSTEM_ACTION,
-  supportsAdditionalConfig,
-} from "./fields";
+import { defaultOptions, isReusingPartition, FILESYSTEM_TYPE, FILESYSTEM_ACTION } from "./fields";
 import { useVolumeTemplate } from "~/hooks/model/system/storage";
 import { deviceLabel, filesystemLabel, formattedPath } from "~/components/storage/utils";
 import { _ } from "~/i18n";
@@ -281,18 +275,16 @@ const FilesystemFieldsContent = withForm({
           isFallback={isFallbackVolume}
         />
 
-        {supportsAdditionalConfig(filesystem) && (
-          <form.AppField name="showMoreFilesystemSettings">
-            {(field) => (
-              <field.CheckboxField
-                label={
-                  // TRANSLATORS: checkbox label for additional filesystem configuration options
-                  _("Define more file system settings")
-                }
-              />
-            )}
-          </form.AppField>
-        )}
+        <form.AppField name="showMoreFilesystemSettings">
+          {(field) => (
+            <field.CheckboxField
+              label={
+                // TRANSLATORS: checkbox label for additional filesystem configuration options
+                _("Define more file system settings")
+              }
+            />
+          )}
+        </form.AppField>
       </>
     );
   },

--- a/web/src/components/storage/partition-form/Form.test.tsx
+++ b/web/src/components/storage/partition-form/Form.test.tsx
@@ -264,6 +264,38 @@ describe("PartitionForm", () => {
       await user.click(screen.getByRole("option", { name: /vdd1/ }));
       expect(screen.getByLabelText("File system")).toHaveTextContent(/Current/);
     });
+
+    it("allows setting mount options when reusing partition", async () => {
+      const { user } = installerRender(<PartitionForm />);
+      await user.click(screen.getByLabelText("Partition"));
+      await user.click(screen.getByRole("option", { name: /vdd1/ }));
+      await user.type(screen.getByLabelText("Mount point"), "/data");
+      await user.click(screen.getByLabelText(/Define more file system settings/));
+      const mountOptionsInput = screen.getByLabelText(/Mount options.*optional/i);
+      await user.type(mountOptionsInput, "rw,noatime");
+      await user.click(screen.getByRole("button", { name: "Accept" }));
+      await waitFor(() =>
+        expect(mockAddPartition).toHaveBeenCalledWith(
+          "drives",
+          0,
+          expect.objectContaining({
+            filesystem: expect.objectContaining({
+              reuse: true,
+              mountOptions: ["rw,noatime"],
+            }),
+          }),
+        ),
+      );
+    });
+
+    it("does not allow to set the label when reusing partition", async () => {
+      const { user } = installerRender(<PartitionForm />);
+      await user.click(screen.getByLabelText("Partition"));
+      await user.click(screen.getByRole("option", { name: /vdd1/ }));
+      await user.type(screen.getByLabelText("Mount point"), "/data");
+      await user.click(screen.getByLabelText(/Define more file system settings/));
+      expect(screen.queryByLabelText(/Label.*optional/i)).not.toBeInTheDocument();
+    });
   });
 
   describe("filesystem selection", () => {
@@ -286,6 +318,58 @@ describe("PartitionForm", () => {
       const { user } = installerRender(<PartitionForm />);
       await user.click(screen.getByLabelText(/Define more file system settings/));
       screen.getByLabelText(/Label.*optional/i);
+    });
+
+    it("shows mount options field when additional settings are enabled", async () => {
+      const { user } = installerRender(<PartitionForm />);
+      await user.click(screen.getByLabelText(/Define more file system settings/));
+      screen.getByLabelText(/Mount options.*optional/i);
+    });
+
+    it("shows format options field when additional settings are enabled", async () => {
+      const { user } = installerRender(<PartitionForm />);
+      await user.click(screen.getByLabelText(/Define more file system settings/));
+      screen.getByLabelText(/Format options.*optional/i);
+    });
+
+    it("submits mkfsOptions when provided", async () => {
+      const { user } = installerRender(<PartitionForm />);
+      await user.type(screen.getByLabelText("Mount point"), "/data");
+      await user.click(screen.getByLabelText(/Define more file system settings/));
+      const mkfsOptionsInput = screen.getByLabelText(/Format options.*optional/i);
+      await user.type(mkfsOptionsInput, "-O ^64bit");
+      await user.click(screen.getByRole("button", { name: "Accept" }));
+      await waitFor(() =>
+        expect(mockAddPartition).toHaveBeenCalledWith(
+          "drives",
+          0,
+          expect.objectContaining({
+            filesystem: expect.objectContaining({
+              mkfsOptions: ["-O ^64bit"],
+            }),
+          }),
+        ),
+      );
+    });
+
+    it("submits mountOptions when provided", async () => {
+      const { user } = installerRender(<PartitionForm />);
+      await user.type(screen.getByLabelText("Mount point"), "/data");
+      await user.click(screen.getByLabelText(/Define more file system settings/));
+      const mountOptionsInput = screen.getByLabelText(/Mount options.*optional/i);
+      await user.type(mountOptionsInput, "rw,noatime");
+      await user.click(screen.getByRole("button", { name: "Accept" }));
+      await waitFor(() =>
+        expect(mockAddPartition).toHaveBeenCalledWith(
+          "drives",
+          0,
+          expect.objectContaining({
+            filesystem: expect.objectContaining({
+              mountOptions: ["rw,noatime"],
+            }),
+          }),
+        ),
+      );
     });
   });
 
@@ -381,7 +465,12 @@ describe("PartitionForm", () => {
         partitions: [
           {
             mountPath: "/home",
-            filesystem: { type: "xfs", label: "HomeData" },
+            filesystem: {
+              type: "xfs",
+              label: "HomeData",
+              mkfsOptions: [],
+              mountOptions: [],
+            },
             size: { min: 50 * 1024 * 1024 * 1024, max: 50 * 1024 * 1024 * 1024, default: false },
           },
         ],

--- a/web/src/components/storage/partition-form/Form.tsx
+++ b/web/src/components/storage/partition-form/Form.tsx
@@ -486,6 +486,11 @@ function PartitionFormContent({
           availablePartitions={availablePartitions}
         />
 
+        {/* Size (only for new partitions) */}
+        <form.Subscribe selector={(s) => s.values.name}>
+          {(name) => !isReusingPartition(name) && <SizeFields form={form} />}
+        </form.Subscribe>
+
         {/* Filesystem */}
         <FilesystemFields form={form} device={systemDevice} />
 
@@ -504,11 +509,6 @@ function PartitionFormContent({
               </NestedContent>
             )
           }
-        </form.Subscribe>
-
-        {/* Size (only for new partitions) */}
-        <form.Subscribe selector={(s) => s.values.name}>
-          {(name) => !isReusingPartition(name) && <SizeFields form={form} />}
         </form.Subscribe>
 
         <ActionGroup>

--- a/web/src/components/storage/partition-form/Form.tsx
+++ b/web/src/components/storage/partition-form/Form.tsx
@@ -42,6 +42,7 @@ import configModel from "~/model/storage/config-model";
 import { STORAGE } from "~/routes/paths";
 import { compact } from "~/utils";
 import { _ } from "~/i18n";
+import { isEmpty } from "radashi";
 
 import PartitionFields from "./PartitionFields";
 import FilesystemFields from "./FilesystemFields";
@@ -51,7 +52,6 @@ import {
   defaultOptions,
   validate,
   isReusingPartition,
-  supportsAdditionalConfig,
   FILESYSTEM_TYPE,
   FILESYSTEM_ACTION,
   SIZE_MODE,
@@ -127,23 +127,41 @@ function useUnusedPartitions(): System.Device[] {
 function buildPayload(values: typeof defaultOptions.defaultValues): ConfigModelType.Partition {
   const isReuse = isReusingPartition(values.name);
 
+  const fsExtraSetting = (attr) => {
+    if (!values.showMoreFilesystemSettings) return;
+    if (isEmpty(values[attr])) return;
+
+    return values[attr];
+  };
+
   // Filesystem configuration
   const filesystem = (): ConfigModelType.Filesystem | undefined => {
     // Reuse existing filesystem (filesystem field holds REUSE sentinel)
     if (values.filesystem === FILESYSTEM_ACTION.REUSE) {
-      return { reuse: true, default: true };
+      return {
+        reuse: true,
+        default: true,
+        mountOptions: fsExtraSetting("mountOptions") || undefined,
+      };
     }
 
     // Automatic filesystem selection
     if (values.filesystem === FILESYSTEM_TYPE.AUTO) {
-      return undefined;
+      return {
+        default: true,
+        label: fsExtraSetting("filesystemLabel") || undefined,
+        mkfsOptions: fsExtraSetting("mkfsOptions") || undefined,
+        mountOptions: fsExtraSetting("mountOptions") || undefined,
+      };
     }
 
     // Explicit filesystem type
     return {
       default: false,
       type: values.filesystem as ConfigModelType.FilesystemType,
-      label: values.filesystemLabel || undefined,
+      label: fsExtraSetting("filesystemLabel") || undefined,
+      mkfsOptions: fsExtraSetting("mkfsOptions") || undefined,
+      mountOptions: fsExtraSetting("mountOptions") || undefined,
     };
   };
 
@@ -268,6 +286,10 @@ function toFormValues(
 
   const mountPoint = partitionConfig.mountPath || "";
   const filesystemLabel = fsConfig?.label || "";
+  const mkfsOptions = fsConfig?.mkfsOptions || [];
+  const mountOptions = fsConfig?.mountOptions || [];
+  const showMoreFilesystemSettings =
+    filesystemLabel !== "" || !!mkfsOptions.length || !!mountOptions.length;
   return {
     mountPoint,
     committedMountPoint: mountPoint,
@@ -276,7 +298,9 @@ function toFormValues(
     filesystem: shouldKeepFilesystem ? FILESYSTEM_ACTION.REUSE : fsConfigValue(fsConfig),
     filesystemAction: shouldKeepFilesystem ? FILESYSTEM_ACTION.REUSE : FILESYSTEM_ACTION.FORMAT,
     filesystemLabel,
-    showMoreFilesystemSettings: filesystemLabel !== "",
+    mkfsOptions,
+    mountOptions,
+    showMoreFilesystemSettings,
     ...inferSizeFields(partitionConfig),
   };
 }
@@ -501,9 +525,8 @@ function PartitionFormContent({
             filesystem: s.values.filesystem,
           })}
         >
-          {({ showMore, filesystem }) =>
-            showMore &&
-            supportsAdditionalConfig(filesystem) && (
+          {({ showMore }) =>
+            showMore && (
               <NestedContent margin="mxLg">
                 <FilesystemAdditionalFields form={form} />
               </NestedContent>

--- a/web/src/components/storage/partition-form/fields.test.ts
+++ b/web/src/components/storage/partition-form/fields.test.ts
@@ -22,7 +22,6 @@
 
 import {
   isReusingPartition,
-  supportsAdditionalConfig,
   validate,
   FILESYSTEM_ACTION,
   FILESYSTEM_TYPE,
@@ -43,19 +42,6 @@ describe("fields", () => {
     });
   });
 
-  describe("supportsAdditionalConfig", () => {
-    it("returns false for REUSE action", () => {
-      expect(supportsAdditionalConfig(FILESYSTEM_ACTION.REUSE)).toBe(false);
-    });
-
-    it("returns true for other filesystem types", () => {
-      expect(supportsAdditionalConfig("xfs")).toBe(true);
-      expect(supportsAdditionalConfig("btrfs")).toBe(true);
-      expect(supportsAdditionalConfig("ext4")).toBe(true);
-      expect(supportsAdditionalConfig(FILESYSTEM_TYPE.AUTO)).toBe(true);
-    });
-  });
-
   describe("validate", () => {
     const createBaseFields = (): PartitionFormData => ({
       mountPoint: "/home",
@@ -64,6 +50,8 @@ describe("fields", () => {
       filesystem: FILESYSTEM_TYPE.AUTO,
       filesystemAction: FILESYSTEM_ACTION.REUSE,
       filesystemLabel: "",
+      mkfsOptions: [],
+      mountOptions: [],
       showMoreFilesystemSettings: false,
       sizeMode: SIZE_MODE.AUTO,
       fixedSize: "",

--- a/web/src/components/storage/partition-form/fields.ts
+++ b/web/src/components/storage/partition-form/fields.ts
@@ -72,16 +72,6 @@ export function isReusingPartition(name: string): boolean {
   return name !== "";
 }
 
-/**
- * Checks if a filesystem value supports additional configuration.
- *
- * Returns false for "reuse", althought this will change in future work when
- * adding more config apart of the Filesystem Label.
- */
-export const supportsAdditionalConfig = (filesystem: string): boolean => {
-  return filesystem !== FILESYSTEM_ACTION.REUSE;
-};
-
 /** Form field types */
 
 export type SizeMode = (typeof SIZE_MODE)[keyof typeof SIZE_MODE];
@@ -135,6 +125,8 @@ type FilesystemFields = {
   filesystem: string; // "auto" | concrete type like "xfs", "btrfs", "ext4"
   filesystemAction: string; // "reuse" | "format"
   filesystemLabel: string;
+  mkfsOptions: string[];
+  mountOptions: string[];
   showMoreFilesystemSettings: boolean;
 };
 
@@ -162,6 +154,8 @@ const defaultValues: FormFields = {
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
+  mkfsOptions: [],
+  mountOptions: [],
   showMoreFilesystemSettings: false,
   sizeMode: SIZE_MODE.AUTO,
   fixedSize: "",

--- a/web/src/openapi/storage/config-model.ts
+++ b/web/src/openapi/storage/config-model.ts
@@ -64,6 +64,8 @@ export interface Filesystem {
   default: boolean;
   type?: FilesystemType;
   label?: string;
+  mkfsOptions?: string[];
+  mountOptions?: string[];
 }
 export interface Partition {
   name?: string;


### PR DESCRIPTION
This is how the form looks initially.
<img width="1259" height="787" alt="nada" src="https://github.com/user-attachments/assets/d9305e9f-7658-46d8-9544-a66bddf69b00" />

This is how it looks for a new filesystem.
<img width="1269" height="785" alt="new" src="https://github.com/user-attachments/assets/008fbac7-fdad-4930-b605-3654af537a55" />

And this how it would look like when mounting an existing filesystem.
<img width="1265" height="787" alt="reused" src="https://github.com/user-attachments/assets/a3e0a0bf-c515-4892-af82-102827a8307b" />

## TODO

- Fix the "blinking" in which the initial values are visible while submitting.
- Ensure the options (especially the `mkfs` ones) are correctly used by libstorage-ng during commit.


