### PR TITLE
Fix new susereg

### DIFF
--- a/service/lib/agama/registration.rb
+++ b/service/lib/agama/registration.rb
@@ -119,9 +119,8 @@ module Agama
         # TODO: check if we can do it in memory for libzypp
         SUSE::Connect::YaST.create_credentials_file(@login, @password, GLOBAL_CREDENTIALS_PATH)
 
-        activate_params = { token: code }
         @logger.info "Activating product #{base_target_product.inspect}"
-        service = SUSE::Connect::YaST.activate_product(base_target_product, activate_params, email)
+        service = SUSE::Connect::YaST.activate_product(base_target_product, reg_params, email)
         process_service(service)
         @registered = true
       end
@@ -155,8 +154,8 @@ module Agama
           identifier: name,
           version:    register_version
         )
-        activate_params = { token: code }
-        service = SUSE::Connect::YaST.activate_product(target_product, activate_params, @email)
+        reg_params = connect_params(token: code)
+        service = SUSE::Connect::YaST.activate_product(target_product, reg_params, @email)
         process_service(service)
 
         @registered_addons << RegisteredAddon.new(name, register_version, !version.empty?, code)

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 10 13:43:42 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- always send all params to product activation as new
+  suseconnect-ng do not transfer it from announce system (bsc#1268015) 
+
+-------------------------------------------------------------------
 Fri Jun  5 06:37:05 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed using a custom password-protected installation repository

--- a/service/test/agama/registration_test.rb
+++ b/service/test/agama/registration_test.rb
@@ -154,7 +154,7 @@ describe Agama::Registration do
           expect(SUSE::Connect::YaST).to receive(:activate_product).with(
             an_object_having_attributes(
               arch: "x86_64", identifier: "test", version: "5.0"
-            ), { token: "11112222" }, "test@test.com"
+            ), hash_including(token: "11112222"), "test@test.com"
           )
 
           subject.register("11112222", email: "test@test.com")
@@ -347,7 +347,7 @@ describe Agama::Registration do
 
       it "registers addon" do
         expect(SUSE::Connect::YaST).to receive(:activate_product).with(
-          addon, { token: code }, anything
+          addon, hash_including(token: code), anything
         )
 
         subject.register_addon(addon.identifier, addon.version, code)
@@ -355,7 +355,7 @@ describe Agama::Registration do
 
       it "registers addon only once" do
         expect(SUSE::Connect::YaST).to receive(:activate_product).with(
-          addon, { token: code }, anything
+          addon, hash_including(token: code), anything
         ).once
 
         subject.register_addon(addon.identifier, addon.version, code)
@@ -365,7 +365,7 @@ describe Agama::Registration do
       context "the requested addon version is not specified" do
         it "finds the version automatically" do
           expect(SUSE::Connect::YaST).to receive(:activate_product).with(
-            addon, { token: code }, anything
+            addon, hash_including(token: code), anything
           )
 
           expect(SUSE::Connect::YaST).to receive(:show_product).and_return(


### PR DESCRIPTION
## Problem

additional url is not respected when registering product with new suseconnect-ng version.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1268015

## Solution

Always send all parameters like we do in 16.1


## Testing

- ENOTIME to test. Setup is not trivial.