### PR TITLE
Implement RFC 9457 Problem Details for HTTP error handling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "config",
  "futures-util",
  "gethostname",
+ "gettext-rs",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -113,26 +113,15 @@ pub async fn run(subcommand: ConfigCommands, opts: GlobalOpts) -> anyhow::Result
             let http_client = build_http_client(api_url, opts.insecure, true).await?;
             let response: api::Config = http_client.get("/config").await?;
             let json = serde_json::to_string_pretty(&response)?;
-
             let destination = output.unwrap_or(CliOutput::Stdout);
             destination.write(&json)?;
-
-            eprintln!();
-            validate(&http_client, CliInput::Full(json.clone()), false).await?;
         }
         ConfigCommands::Load { url_or_path } => {
             let (http_client, ws) = build_clients(api_url, opts.insecure).await?;
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
             let contents = url_or_path.read_to_string(opts.insecure)?;
-            let valid = validate(&http_client, CliInput::Full(contents.clone()), false).await?;
-
-            if !matches!(valid, ValidationOutcome::Valid) {
-                return Err(anyhow!("The profile is not valid"));
-            }
-
-            let model: api::Config = serde_json::from_str(&contents)?;
-            patch_config(&http_client, &model).await?;
-
+            let config = serde_json::from_str(&contents)?;
+            patch_config(&http_client, config).await?;
             monitor_progress(http_client, ws).await?;
         }
         ConfigCommands::Validate { url_or_path, local } => {
@@ -160,8 +149,7 @@ pub async fn run(subcommand: ConfigCommands, opts: GlobalOpts) -> anyhow::Result
                 .or_else(|| std::env::var("EDITOR").ok())
                 .unwrap_or(DEFAULT_EDITOR.to_string());
             let result = edit(&http_client, &response, &editor).await?;
-            patch_config(&http_client, &result).await?;
-
+            patch_config(&http_client, result).await?;
             monitor_progress(http_client, ws).await?;
         }
     }
@@ -171,7 +159,7 @@ pub async fn run(subcommand: ConfigCommands, opts: GlobalOpts) -> anyhow::Result
 
 async fn patch_config(
     http_client: &BaseHTTPClient,
-    model: &api::Config,
+    model: serde_json::Value,
 ) -> Result<(), anyhow::Error> {
     let patch = api::Patch::with_update(model)?;
     http_client.patch_void("/config", &patch).await?;
@@ -325,7 +313,7 @@ async fn from_json_or_jsonnet(
 
     match FileFormat::from_string(&any_profile) {
         FileFormat::Jsonnet => {
-            let full_profile = CliInput::Full(any_profile);
+            let full_profile = CliInput::Full(any_profile.to_string());
             let request = full_profile.to_map();
             let json_string = ProfileHTTPClient::new(client.clone())
                 .from_jsonnet(&request)
@@ -351,7 +339,7 @@ async fn edit(
     http_client: &BaseHTTPClient,
     model: &api::Config,
     editor: &str,
-) -> anyhow::Result<api::Config> {
+) -> anyhow::Result<serde_json::Value> {
     let original = serde_json::to_string_pretty(model)?;
     let mut file = Builder::new().suffix(".json").tempfile()?;
     let path = PathBuf::from(file.path());

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -30,6 +30,7 @@ use anyhow::{anyhow, Context};
 use clap::Subcommand;
 use console::style;
 use fluent_uri::Uri;
+use gettextrs::gettext;
 use tempfile::Builder;
 use tokio::time::sleep;
 
@@ -120,7 +121,9 @@ pub async fn run(subcommand: ConfigCommands, opts: GlobalOpts) -> anyhow::Result
             let (http_client, ws) = build_clients(api_url, opts.insecure).await?;
             let url_or_path = url_or_path.unwrap_or(CliInput::Stdin);
             let contents = url_or_path.read_to_string(opts.insecure)?;
-            let config = serde_json::from_str(&contents)?;
+            let Ok(config) = serde_json::from_str(&contents) else {
+                return Err(anyhow!(gettext("It is not a valid JSON file")));
+            };
             patch_config(&http_client, config).await?;
             monitor_progress(http_client, ws).await?;
         }
@@ -133,7 +136,7 @@ pub async fn run(subcommand: ConfigCommands, opts: GlobalOpts) -> anyhow::Result
             };
 
             if !matches!(validity, ValidationOutcome::Valid) {
-                return Err(anyhow!("The profile is not valid"));
+                return Err(anyhow!(gettext("The profile is not valid")));
             }
         }
         ConfigCommands::Generate { url_or_path } => {

--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -164,7 +164,7 @@ async fn patch_config(
     http_client: &BaseHTTPClient,
     model: serde_json::Value,
 ) -> Result<(), anyhow::Error> {
-    let patch = api::Patch::with_update(model)?;
+    let patch = api::Patch::with_update(model);
     http_client.patch_void("/config", &patch).await?;
     Ok(())
 }

--- a/rust/agama-lib/src/error.rs
+++ b/rust/agama-lib/src/error.rs
@@ -31,40 +31,17 @@ pub enum ServiceError {
     DBus(#[from] zbus::Error),
     #[error("Could not connect to Agama bus at '{0}': {1}")]
     DBusConnectionError(String, #[source] zbus::Error),
-    #[error("D-Bus protocol error: {0}")]
-    DBusProtocol(#[from] zbus::fdo::Error),
     #[error("Unexpected type on D-Bus '{0}'")]
     ZVariant(#[from] zvariant::Error),
     #[error(transparent)]
     HTTPError(#[from] reqwest::Error),
-    // it's fine to say only "Error" because the original
-    // specific error will be printed too
-    // `#` is std::fmt "Alternate form", anyhow::Error interprets as "include causes"
-    #[error("Error: {0:#}")]
-    Anyhow(#[from] anyhow::Error),
-    #[error("Failed to find these patterns: {0:?}")]
-    UnknownPatterns(Vec<String>),
     #[error("Passed json data is not correct: {0}")]
     InvalidJson(#[from] serde_json::Error),
-    #[error("Could not perform action '{0}'")]
-    UnsuccessfulAction(String),
-    #[error("Unknown installation phase: {0}")]
-    UnknownInstallationPhase(u32),
-    #[error("Question with id {0} does not exist")]
-    QuestionNotExist(u32),
-    #[error("Backend call failed with status {0} and text '{1}'")]
-    BackendError(u16, String),
     #[error("You are not logged in. Please use: agama auth login")]
     NotAuthenticated,
     // FIXME reroute the error to a better place
     #[error("Profile error: {0}")]
     Profile(#[from] ProfileError),
-    #[error("Unsupported SSL Fingerprint algorithm '#{0}'.")]
-    UnsupportedSSLFingerprintAlgorithm(String),
-    #[error("DASD with channel '#{0}' not found.")]
-    DASDChannelNotFound(String),
-    #[error("zFCP controller with channel '#{0}' not found.")]
-    ZFCPControllerNotFound(String),
 }
 
 #[derive(Error, Debug)]

--- a/rust/agama-lib/src/http/base_http_client.rs
+++ b/rust/agama-lib/src/http/base_http_client.rs
@@ -369,7 +369,7 @@ impl BaseHTTPClient {
             Err(_) => {
                 if let Ok(error_object) = serde_json::from_str::<serde_json::Value>(&text) {
                     if let Some(error) = error_object.get::<&str>("error") {
-                        ProblemDetails::internal_error(&error.to_string())
+                        ProblemDetails::internal_error(error.to_string())
                     } else {
                         ProblemDetails::internal_error(text)
                     }

--- a/rust/agama-lib/src/http/base_http_client.rs
+++ b/rust/agama-lib/src/http/base_http_client.rs
@@ -18,6 +18,7 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
+use agama_utils::api::ProblemDetails;
 use reqwest::{header, IntoUrl, Response};
 use serde::{de::DeserializeOwned, Serialize};
 use url::Url;
@@ -34,23 +35,8 @@ pub enum BaseHTTPClientError {
     InvalidURL(#[from] url::ParseError),
     #[error(transparent)]
     InvalidJSON(#[from] serde_json::Error),
-    #[error("Backend responded with code {} and the following message:\n\n{}", .0, format_backend_error(.1))]
-    BackendError(u16, String),
-}
-
-fn format_backend_error(error: &String) -> String {
-    let message: Result<serde_json::Value, _> = serde_json::from_str(error);
-
-    match message {
-        Ok(message) => {
-            if let Some(error) = message.get("error") {
-                error.to_string().replace("\\n", "\n")
-            } else {
-                format!("{:?}", error)
-            }
-        }
-        Err(_) => format!("{:?}", error),
-    }
+    #[error("{1}")]
+    Problem(u16, ProblemDetails),
 }
 
 /// Base that all HTTP clients should use.
@@ -377,6 +363,21 @@ impl BaseHTTPClient {
             .text()
             .await
             .unwrap_or_else(|_| Self::NO_TEXT.to_string());
-        BaseHTTPClientError::BackendError(code, text)
+
+        let problem = match serde_json::from_str::<ProblemDetails>(&text) {
+            Ok(problem) => problem,
+            Err(_) => {
+                if let Ok(error_object) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if let Some(error) = error_object.get::<&str>("error") {
+                        ProblemDetails::internal_error(&error.to_string())
+                    } else {
+                        ProblemDetails::internal_error(text)
+                    }
+                } else {
+                    ProblemDetails::internal_error(text)
+                }
+            }
+        };
+        BaseHTTPClientError::Problem(code, problem)
     }
 }

--- a/rust/agama-lib/src/http/base_http_client.rs
+++ b/rust/agama-lib/src/http/base_http_client.rs
@@ -368,8 +368,8 @@ impl BaseHTTPClient {
             Ok(problem) => problem,
             Err(_) => {
                 if let Ok(error_object) = serde_json::from_str::<serde_json::Value>(&text) {
-                    if let Some(error) = error_object.get::<&str>("error") {
-                        ProblemDetails::internal_error(error.to_string())
+                    if let Some(error) = error_object.get("error").and_then(|e| e.as_str()) {
+                        ProblemDetails::internal_error(error)
                     } else {
                         ProblemDetails::internal_error(text)
                     }

--- a/rust/agama-lib/src/questions/http_client.rs
+++ b/rust/agama-lib/src/questions/http_client.rs
@@ -101,7 +101,7 @@ impl HTTPClient {
             ..Default::default()
         };
 
-        let patch = Patch::with_update(&config)?;
+        let patch = Patch::with_config(&config)?;
 
         self.client.patch_void("/config", &patch).await?;
         Ok(())
@@ -120,7 +120,7 @@ impl HTTPClient {
             ..Default::default()
         };
 
-        let patch = Patch::with_update(&config)?;
+        let patch = Patch::with_config(&config)?;
         self.client.patch_void("/config", &patch).await?;
         Ok(())
     }

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -54,6 +54,7 @@ futures-util = { version = "0.3.30", default-features = false, features = [
 gethostname = "1.0.0"
 tokio-util = "0.7.12"
 url = "2.5.2"
+gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
 
 [[bin]]
 name = "agama-web-server"

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -36,14 +36,12 @@ pub enum Error {
 impl Error {
     /// Converts this error into RFC 9457 Problem Details
     pub fn into_problem_details(self) -> ProblemDetails {
-        match self {
-            Error::DBus(e) => {
-                // Try to extract service name from D-Bus error if possible
-                ProblemDetails::dbus_error("unknown", e.to_string())
-            }
-            Error::Anyhow(msg) => ProblemDetails::internal_error(msg),
-            Error::Service(e) => ProblemDetails::internal_error(e.to_string()),
-        }
+        let details = match self {
+            Error::DBus(e) => e.to_string(),
+            Error::Anyhow(msg) => msg,
+            Error::Service(e) => e.to_string(),
+        };
+        ProblemDetails::internal_error(details)
     }
 }
 

--- a/rust/agama-server/src/error.rs
+++ b/rust/agama-server/src/error.rs
@@ -18,13 +18,10 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
+use crate::web::error::ProblemDetailsExt;
 use agama_lib::error::ServiceError;
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    Json,
-};
-use serde_json::json;
+use agama_utils::api::ProblemDetails;
+use axum::response::{IntoResponse, Response};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -34,6 +31,20 @@ pub enum Error {
     Anyhow(String),
     #[error("Agama service error: {0}")]
     Service(#[from] ServiceError),
+}
+
+impl Error {
+    /// Converts this error into RFC 9457 Problem Details
+    pub fn into_problem_details(self) -> ProblemDetails {
+        match self {
+            Error::DBus(e) => {
+                // Try to extract service name from D-Bus error if possible
+                ProblemDetails::dbus_error("unknown", e.to_string())
+            }
+            Error::Anyhow(msg) => ProblemDetails::internal_error(msg),
+            Error::Service(e) => ProblemDetails::internal_error(e.to_string()),
+        }
+    }
 }
 
 // This would be nice, but using it for a return type
@@ -56,10 +67,6 @@ impl From<Error> for zbus::fdo::Error {
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        tracing::warn!("Server return error {}", self);
-        let body = json!({
-            "error": self.to_string()
-        });
-        (StatusCode::BAD_REQUEST, Json(body)).into_response()
+        self.into_problem_details().into_response()
     }
 }

--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -77,16 +77,21 @@ impl IntoResponse for ProfileError {
             ProfileError::Autoyast(AutoyastError::Execute(..)) => {
                 ProblemDetails::internal_error(self.to_string())
             }
-            // Client errors (400)
-            ProfileError::UrlRetrieval { .. }
-            | ProfileError::InvalidUtf8 { .. }
-            | ProfileError::FileRead { .. }
-            | ProfileError::ValidationError(_)
-            | ProfileError::EvaluationError(_)
-            | ProfileError::UrlParse(_)
-            | ProfileError::Autoyast(_)
-            | ProfileError::BadRequest(_) => {
-                ProblemDetails::generic(gettext("Could not process the profile"), self.to_string())
+            // Client errors (400) - specific titles for better UX
+            ProfileError::ValidationError(msg) | ProfileError::EvaluationError(msg) => {
+                ProblemDetails::generic(gettext("Profile validation failed"), msg)
+            }
+            ProfileError::UrlRetrieval { .. } | ProfileError::FileRead { .. } => {
+                ProblemDetails::generic(gettext("Could not retrieve profile"), self.to_string())
+            }
+            ProfileError::InvalidUtf8 { .. } => {
+                ProblemDetails::generic(gettext("Invalid profile encoding"), self.to_string())
+            }
+            ProfileError::UrlParse(_) | ProfileError::BadRequest(_) => {
+                ProblemDetails::generic(gettext("Invalid profile request"), self.to_string())
+            }
+            ProfileError::Autoyast(_) => {
+                ProblemDetails::generic(gettext("AutoYaST conversion failed"), self.to_string())
             }
         };
         problem.into_response()

--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -18,9 +18,10 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use crate::web::error::ErrorResponse;
+use crate::web::error::ProblemDetailsExt;
 use agama_lib::profile::AutoyastError;
 use agama_transfer::Transfer;
+use agama_utils::api::ProblemDetails;
 
 use agama_lib::profile::{
     AutoyastProfileImporter, ProfileEvaluator, ProfileValidator, ValidationOutcome,
@@ -69,11 +70,11 @@ enum ProfileError {
 
 impl IntoResponse for ProfileError {
     fn into_response(self) -> Response {
-        match self {
+        let problem = match self {
             // Server errors (500)
-            ProfileError::ValidatorSetup(_) => ErrorResponse::internal_server_error(self),
+            ProfileError::ValidatorSetup(_) => ProblemDetails::internal_error(self.to_string()),
             ProfileError::Autoyast(AutoyastError::Execute(..)) => {
-                ErrorResponse::internal_server_error(self)
+                ProblemDetails::internal_error(self.to_string())
             }
             // Client errors (400)
             ProfileError::UrlRetrieval { .. }
@@ -83,8 +84,11 @@ impl IntoResponse for ProfileError {
             | ProfileError::EvaluationError(_)
             | ProfileError::UrlParse(_)
             | ProfileError::Autoyast(_)
-            | ProfileError::BadRequest(_) => ErrorResponse::bad_request(self),
-        }
+            | ProfileError::BadRequest(_) => {
+                ProblemDetails::generic("Profile Error", self.to_string())
+            }
+        };
+        problem.into_response()
     }
 }
 

--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -22,6 +22,7 @@ use crate::web::error::ProblemDetailsExt;
 use agama_lib::profile::AutoyastError;
 use agama_transfer::Transfer;
 use agama_utils::api::ProblemDetails;
+use gettextrs::gettext;
 
 use agama_lib::profile::{
     AutoyastProfileImporter, ProfileEvaluator, ProfileValidator, ValidationOutcome,
@@ -85,7 +86,7 @@ impl IntoResponse for ProfileError {
             | ProfileError::UrlParse(_)
             | ProfileError::Autoyast(_)
             | ProfileError::BadRequest(_) => {
-                ProblemDetails::generic("Profile Error", self.to_string())
+                ProblemDetails::generic(gettext("Could not process the profile"), self.to_string())
             }
         };
         problem.into_response()

--- a/rust/agama-server/src/server/config_schema.rs
+++ b/rust/agama-server/src/server/config_schema.rs
@@ -27,8 +27,8 @@ use agama_lib::{
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("The config does not match the schema: {0}")]
-    Schema(String),
+    #[error("The config does not match the schema: {0:?}")]
+    Schema(Vec<String>),
     #[error(transparent)]
     ProfileValidator(#[from] ProfileError),
     #[error(transparent)]
@@ -40,6 +40,6 @@ pub fn check(json: &serde_json::Value) -> Result<(), Error> {
     let result = ProfileValidator::default_schema()?.validate_str(&raw_json)?;
     match result {
         ValidationOutcome::Valid => Ok(()),
-        ValidationOutcome::NotValid(reasons) => Err(Error::Schema(reasons.join(", "))),
+        ValidationOutcome::NotValid(reasons) => Err(Error::Schema(reasons)),
     }
 }

--- a/rust/agama-server/src/server/config_schema.rs
+++ b/rust/agama-server/src/server/config_schema.rs
@@ -24,15 +24,29 @@ use agama_lib::{
     error::ProfileError,
     profile::{ProfileValidator, ValidationOutcome},
 };
+use agama_utils::api::ProblemDetails;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("The config does not match the schema: {0:?}")]
+    #[error("The config does not match the schema")]
     Schema(Vec<String>),
     #[error(transparent)]
     ProfileValidator(#[from] ProfileError),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+}
+
+impl Error {
+    /// Converts this error into RFC 9457 Problem Details
+    pub fn into_problem_details(self) -> ProblemDetails {
+        match self {
+            Error::Schema(validation_errors) => {
+                ProblemDetails::schema_validation_failed(validation_errors)
+            }
+            Error::ProfileValidator(e) => ProblemDetails::internal_error(e.to_string()),
+            Error::Json(e) => ProblemDetails::invalid_json(e.to_string()),
+        }
+    }
 }
 
 pub fn check(json: &serde_json::Value) -> Result<(), Error> {

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -22,7 +22,7 @@
 
 use crate::profile::profile_service;
 use crate::server::config_schema;
-use crate::web::error::ProblemDetailsExt;
+use crate::web::error::{ProblemDetailsExt, ProblemDetailsResponse};
 use agama_lib::logs;
 use agama_manager::service::Error as ManagerError;
 use agama_manager::users::PasswordCheckResult;
@@ -192,7 +192,7 @@ fn get_status_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("System & Monitoring")
         .response_with::<200, Json<Status>, _>(|res| res.description("Status of the installation"))
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -219,7 +219,7 @@ fn get_system_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<SystemInfo>, _>(|res| {
             res.description("System information retrieved successfully")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -246,7 +246,7 @@ fn get_extended_config_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Config>, _>(|res| {
             res.description("Extended configuration retrieved successfully")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -269,7 +269,7 @@ fn get_config_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Config>, _>(|res| {
             res.description("Configuration retrieved successfully")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -304,10 +304,10 @@ fn put_config_docs(op: TransformOperation) -> TransformOperation {
         .tag("Configuration")
         .input::<Json<Config>>() // Override the auto-detected Json<Value> with Config schema
         .response::<200, ()>()
-        .response_with::<400, Json<ProblemDetails>, _>(|res| {
+        .response_with::<400, ProblemDetailsResponse, _>(|res| {
             res.description("Invalid configuration schema or malformed JSON")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -343,10 +343,10 @@ fn patch_config_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Configuration")
         .response::<200, ()>()
-        .response_with::<400, Json<ProblemDetails>, _>(|res| {
+        .response_with::<400, ProblemDetailsResponse, _>(|res| {
             res.description("Invalid configuration schema or malformed JSON")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -374,7 +374,7 @@ fn get_proposal_docs(op: TransformOperation) -> TransformOperation {
             res.description("Proposal successfully retrieved")
         })
         .response::<404, ()>()
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -414,7 +414,7 @@ fn get_issues_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Vec<IssueWithScope>>, _>(|res| {
             res.description("List of issues with their scopes")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -441,7 +441,7 @@ fn get_questions_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Vec<Question>>, _>(|res| {
             res.description("List of pending questions")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -470,8 +470,8 @@ fn ask_question_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Question>, _>(|res| {
             res.description("Question created successfully")
         })
-        .response_with::<400, Json<ProblemDetails>, _>(|res| res.description("Malformed JSON"))
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<400, ProblemDetailsResponse, _>(|res| res.description("Malformed JSON"))
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -509,8 +509,8 @@ fn update_question_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Issues & Questions")
         .response::<200, ()>()
-        .response_with::<400, Json<ProblemDetails>, _>(|res| res.description("Malformed JSON"))
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<400, ProblemDetailsResponse, _>(|res| res.description("Malformed JSON"))
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -568,11 +568,11 @@ fn get_license_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<LicenseContent>, _>(|res| {
             res.description("License retrieved successfully")
         })
-        .response_with::<400, Json<ProblemDetails>, _>(|res| {
+        .response_with::<400, ProblemDetailsResponse, _>(|res| {
             res.description("The specified language tag is not valid")
         })
         .response::<404, ()>()
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -605,10 +605,10 @@ fn run_action_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Actions")
         .response::<200, ()>()
-        .response_with::<422, Json<ProblemDetails>, _>(|res| {
+        .response_with::<422, ProblemDetailsResponse, _>(|res| {
             res.description("Action blocked by backend state (e.g., pending issues or system busy)")
         })
-        .response_with::<500, Json<ProblemDetails>, _>(|res| {
+        .response_with::<500, ProblemDetailsResponse, _>(|res| {
             res.description("Internal server error")
         })
 }

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -23,7 +23,7 @@
 use crate::profile::profile_service;
 use crate::server::config_schema;
 use crate::web::error::ErrorResponse;
-use agama_lib::{error::ServiceError, logs};
+use agama_lib::logs;
 use agama_manager::service::Error as ManagerError;
 use agama_manager::users::PasswordCheckResult;
 use agama_manager::{self as manager, message, users};
@@ -108,14 +108,11 @@ impl ServerState {
 pub async fn server_service(
     events: event::Sender,
     dbus: zbus::Connection,
-) -> Result<ApiRouter, ServiceError> {
-    let questions = question::start(events.clone())
-        .await
-        .map_err(anyhow::Error::msg)?;
+) -> Result<ApiRouter, Error> {
+    let questions = question::start(events.clone()).await?;
     let manager = manager::Service::starter(questions.clone(), events, dbus)
         .start()
-        .await
-        .map_err(anyhow::Error::msg)?;
+        .await?;
     let profile = profile_service().await;
     let state = ServerState::new(manager, questions);
     server_with_state(state, profile)
@@ -127,7 +124,7 @@ pub async fn server_service(
 pub fn server_with_state(
     state: ServerState,
     profile_routes: ApiRouter,
-) -> Result<ApiRouter, ServiceError> {
+) -> Result<ApiRouter, Error> {
     Ok(ApiRouter::new()
         .api_route("/status", get_with(get_status, get_status_docs))
         .api_route("/system", get_with(get_system, get_system_docs))

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -22,11 +22,12 @@
 
 use crate::profile::profile_service;
 use crate::server::config_schema;
-use crate::web::error::ErrorResponse;
+use crate::web::error::ProblemDetailsExt;
 use agama_lib::logs;
 use agama_manager::service::Error as ManagerError;
 use agama_manager::users::PasswordCheckResult;
 use agama_manager::{self as manager, message, users};
+use agama_utils::api::ProblemDetails;
 use agama_utils::{
     actor::Handler,
     api::{
@@ -70,19 +71,32 @@ pub enum Error {
 }
 
 impl Error {
+    /// Converts this error into RFC 9457 Problem Details
+    pub fn into_problem_details(self) -> ProblemDetails {
+        match self {
+            Error::ConfigSchema(e) => e.into_problem_details(),
+            Error::Json(e) => ProblemDetails::invalid_json(e.to_string()),
+            Error::Manager(e) => ProblemDetails::internal_error(e.to_string()),
+            Error::Questions(e) => ProblemDetails::internal_error(e.to_string()),
+            Error::MissingLanguageTag => {
+                ProblemDetails::generic("Missing Language Tag", "The language tag is required")
+            }
+        }
+    }
+
     /// Creates a BAD_REQUEST (400) response from this error.
     fn bad_request(self) -> Response {
-        ErrorResponse::bad_request(self)
+        self.into_problem_details().into_response()
     }
 
     /// Creates an INTERNAL_SERVER_ERROR (500) response from this error.
     fn internal_server_error(self) -> Response {
-        ErrorResponse::internal_server_error(self)
+        self.into_problem_details().into_response()
     }
 
     /// Creates an UNPROCESSABLE_ENTITY (422) response from this error.
     fn unprocessable_entity(self) -> Response {
-        ErrorResponse::unprocessable_entity(self)
+        self.into_problem_details().into_response()
     }
 }
 
@@ -178,7 +192,7 @@ fn get_status_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("System & Monitoring")
         .response_with::<200, Json<Status>, _>(|res| res.description("Status of the installation"))
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -205,7 +219,7 @@ fn get_system_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<SystemInfo>, _>(|res| {
             res.description("System information retrieved successfully")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -232,7 +246,7 @@ fn get_extended_config_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Config>, _>(|res| {
             res.description("Extended configuration retrieved successfully")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -255,7 +269,7 @@ fn get_config_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Config>, _>(|res| {
             res.description("Configuration retrieved successfully")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -290,10 +304,10 @@ fn put_config_docs(op: TransformOperation) -> TransformOperation {
         .tag("Configuration")
         .input::<Json<Config>>() // Override the auto-detected Json<Value> with Config schema
         .response::<200, ()>()
-        .response_with::<400, Json<ErrorResponse>, _>(|res| {
+        .response_with::<400, Json<ProblemDetails>, _>(|res| {
             res.description("Invalid configuration schema or malformed JSON")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -329,10 +343,10 @@ fn patch_config_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Configuration")
         .response::<200, ()>()
-        .response_with::<400, Json<ErrorResponse>, _>(|res| {
+        .response_with::<400, Json<ProblemDetails>, _>(|res| {
             res.description("Invalid configuration schema or malformed JSON")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -360,7 +374,7 @@ fn get_proposal_docs(op: TransformOperation) -> TransformOperation {
             res.description("Proposal successfully retrieved")
         })
         .response::<404, ()>()
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -400,7 +414,7 @@ fn get_issues_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Vec<IssueWithScope>>, _>(|res| {
             res.description("List of issues with their scopes")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -427,7 +441,7 @@ fn get_questions_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Vec<Question>>, _>(|res| {
             res.description("List of pending questions")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -456,8 +470,8 @@ fn ask_question_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<Question>, _>(|res| {
             res.description("Question created successfully")
         })
-        .response_with::<400, Json<ErrorResponse>, _>(|res| res.description("Malformed JSON"))
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<400, Json<ProblemDetails>, _>(|res| res.description("Malformed JSON"))
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -495,8 +509,8 @@ fn update_question_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Issues & Questions")
         .response::<200, ()>()
-        .response_with::<400, Json<ErrorResponse>, _>(|res| res.description("Malformed JSON"))
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<400, Json<ProblemDetails>, _>(|res| res.description("Malformed JSON"))
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -554,11 +568,11 @@ fn get_license_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<LicenseContent>, _>(|res| {
             res.description("License retrieved successfully")
         })
-        .response_with::<400, Json<ErrorResponse>, _>(|res| {
+        .response_with::<400, Json<ProblemDetails>, _>(|res| {
             res.description("The specified language tag is not valid")
         })
         .response::<404, ()>()
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }
@@ -591,10 +605,10 @@ fn run_action_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Actions")
         .response::<200, ()>()
-        .response_with::<422, Json<ErrorResponse>, _>(|res| {
+        .response_with::<422, Json<ProblemDetails>, _>(|res| {
             res.description("Action blocked by backend state (e.g., pending issues or system busy)")
         })
-        .response_with::<500, Json<ErrorResponse>, _>(|res| {
+        .response_with::<500, Json<ProblemDetails>, _>(|res| {
             res.description("Internal server error")
         })
 }

--- a/rust/agama-server/src/web.rs
+++ b/rust/agama-server/src/web.rs
@@ -24,7 +24,7 @@
 //! * Emit relevant events via websocket.
 //! * Serve the code for the web user interface (not implemented yet).
 
-use crate::server::server_service;
+use crate::server::{server_service, web::Error};
 use agama_utils::api::event;
 use aide::axum::ApiRouter;
 
@@ -37,7 +37,6 @@ mod service;
 mod state;
 mod ws;
 
-use agama_lib::error::ServiceError;
 pub use config::ServiceConfig;
 pub use service::MainServiceBuilder;
 use std::path::Path;
@@ -53,7 +52,7 @@ pub async fn service<P>(
     events: event::Sender,
     dbus: zbus::Connection,
     web_ui_dir: P,
-) -> Result<ApiRouter, ServiceError>
+) -> Result<ApiRouter, Error>
 where
     P: AsRef<Path>,
 {

--- a/rust/agama-server/src/web/auth.rs
+++ b/rust/agama-server/src/web/auth.rs
@@ -21,19 +21,20 @@
 //! Contains the code to handle access authorization.
 
 use super::state::ServiceState;
+use crate::web::error::ProblemDetailsExt;
 use agama_lib::auth::{AuthToken, AuthTokenError, TokenClaims};
+use agama_utils::api::ProblemDetails;
 use axum::{
     extract::FromRequestParts,
-    http::{request, StatusCode},
+    http::request,
     response::{IntoResponse, Response},
-    Json, RequestPartsExt,
+    RequestPartsExt,
 };
 use axum_extra::{
     headers::{self, authorization::Bearer},
     TypedHeader,
 };
 use pam::PamError;
-use serde_json::json;
 use thiserror::Error;
 
 /// Represents an authentication error.
@@ -52,10 +53,18 @@ pub enum AuthError {
 
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
-        let body = json!({
-            "error": self.to_string()
-        });
-        (StatusCode::UNAUTHORIZED, Json(body)).into_response()
+        let problem = match self {
+            AuthError::MissingToken => {
+                ProblemDetails::unauthorized("Authentication token is missing")
+            }
+            AuthError::InvalidToken(e) => {
+                ProblemDetails::unauthorized(format!("Invalid authentication token: {}", e))
+            }
+            AuthError::Failed(e) => {
+                ProblemDetails::unauthorized(format!("Authentication failed: {}", e))
+            }
+        };
+        problem.into_response()
     }
 }
 

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -32,8 +32,8 @@ use schemars::schema_for;
 use tokio::sync::broadcast;
 
 use crate::test_utils;
+use crate::web::error::ProblemDetailsResponse;
 use crate::web::http::{AuthResponse, LoginRequest};
-use agama_utils::api::ProblemDetails;
 
 /// Builds the unified OpenAPI specification for the Agama HTTP API using aide.
 ///
@@ -248,7 +248,7 @@ fn login_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<AuthResponse>, _>(|res| {
             res.description("Authentication successful, returns bearer token")
         })
-        .response_with::<401, Json<ProblemDetails>, _>(|res| {
+        .response_with::<401, ProblemDetailsResponse, _>(|res| {
             res.description("Authentication failed - invalid credentials")
         })
 }
@@ -264,7 +264,7 @@ fn session_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Authentication")
         .response::<200, ()>()
-        .response_with::<401, Json<ProblemDetails>, _>(|res| {
+        .response_with::<401, ProblemDetailsResponse, _>(|res| {
             res.description("Unauthorized - invalid or missing token")
         })
 }
@@ -279,7 +279,7 @@ fn logout_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Authentication")
         .response::<200, ()>()
-        .response_with::<401, Json<ProblemDetails>, _>(|res| {
+        .response_with::<401, ProblemDetailsResponse, _>(|res| {
             res.description("Unauthorized - invalid or missing token")
         })
 }

--- a/rust/agama-server/src/web/docs.rs
+++ b/rust/agama-server/src/web/docs.rs
@@ -32,8 +32,8 @@ use schemars::schema_for;
 use tokio::sync::broadcast;
 
 use crate::test_utils;
-use crate::web::error::ErrorResponse;
 use crate::web::http::{AuthResponse, LoginRequest};
+use agama_utils::api::ProblemDetails;
 
 /// Builds the unified OpenAPI specification for the Agama HTTP API using aide.
 ///
@@ -248,7 +248,7 @@ fn login_docs(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<AuthResponse>, _>(|res| {
             res.description("Authentication successful, returns bearer token")
         })
-        .response_with::<401, Json<ErrorResponse>, _>(|res| {
+        .response_with::<401, Json<ProblemDetails>, _>(|res| {
             res.description("Authentication failed - invalid credentials")
         })
 }
@@ -264,7 +264,7 @@ fn session_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Authentication")
         .response::<200, ()>()
-        .response_with::<401, Json<ErrorResponse>, _>(|res| {
+        .response_with::<401, Json<ProblemDetails>, _>(|res| {
             res.description("Unauthorized - invalid or missing token")
         })
 }
@@ -279,7 +279,7 @@ fn logout_docs(op: TransformOperation) -> TransformOperation {
         )
         .tag("Authentication")
         .response::<200, ()>()
-        .response_with::<401, Json<ErrorResponse>, _>(|res| {
+        .response_with::<401, Json<ProblemDetails>, _>(|res| {
             res.description("Unauthorized - invalid or missing token")
         })
 }

--- a/rust/agama-server/src/web/error.rs
+++ b/rust/agama-server/src/web/error.rs
@@ -47,11 +47,7 @@ impl ProblemDetailsExt for ProblemDetails {
         match self {
             ProblemDetails::SchemaValidationFailed { .. } => StatusCode::BAD_REQUEST,
             ProblemDetails::InvalidJson { .. } => StatusCode::BAD_REQUEST,
-            ProblemDetails::NetworkError { .. } => StatusCode::BAD_GATEWAY,
-            ProblemDetails::FileSystemError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            ProblemDetails::DBusError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ProblemDetails::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            ProblemDetails::NotFound { .. } => StatusCode::NOT_FOUND,
             ProblemDetails::Unauthorized { .. } => StatusCode::UNAUTHORIZED,
             ProblemDetails::Generic { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
@@ -114,38 +110,6 @@ mod tests {
         assert_eq!(json["errors"][0], "/network/hostname: is required");
         // Ensure status field is NOT in JSON
         assert!(json.get("status").is_none());
-    }
-
-    #[test]
-    fn test_network_error() {
-        let problem = ProblemDetails::network_error_with_status(
-            "https://example.com",
-            503,
-            "Connection timeout",
-        );
-
-        assert_eq!(problem.status_code(), StatusCode::BAD_GATEWAY);
-
-        let json = serde_json::to_value(&problem).unwrap();
-        assert_eq!(json["url"], "https://example.com");
-        assert_eq!(json["httpStatus"], 503);
-    }
-
-    #[test]
-    fn test_dbus_error() {
-        let problem = ProblemDetails::dbus_error_full(
-            "org.freedesktop.NetworkManager",
-            Some("/org/freedesktop/NetworkManager".to_string()),
-            Some("GetDevices".to_string()),
-            "Method call failed",
-        );
-
-        assert_eq!(problem.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
-
-        let json = serde_json::to_value(&problem).unwrap();
-        assert_eq!(json["service"], "org.freedesktop.NetworkManager");
-        assert_eq!(json["objectPath"], "/org/freedesktop/NetworkManager");
-        assert_eq!(json["method"], "GetDevices");
     }
 
     #[test]

--- a/rust/agama-server/src/web/error.rs
+++ b/rust/agama-server/src/web/error.rs
@@ -18,8 +18,12 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-//! Shared error handling utilities for HTTP API responses.
+//! Error handling utilities for HTTP API responses.
+//!
+//! This module provides server-specific functionality for RFC 9457 Problem Details.
+//! The core types and constructor methods are defined in `agama_utils::api::ProblemDetails`.
 
+use agama_utils::api::ProblemDetails;
 use aide::OperationIo;
 use axum::{
     http::StatusCode,
@@ -29,40 +33,127 @@ use axum::{
 use schemars::JsonSchema;
 use serde::Serialize;
 
-/// Error response returned by API endpoints
-#[derive(Serialize, JsonSchema, OperationIo)]
-#[aide(output)]
-pub struct ErrorResponse {
-    /// Error message
-    pub error: String,
+/// Extension trait for server-specific ProblemDetails functionality
+pub trait ProblemDetailsExt {
+    /// Returns the HTTP status code for this problem
+    fn status_code(&self) -> StatusCode;
+
+    /// Convert to HTTP response (convenience method)
+    fn into_response(self) -> Response;
 }
 
-impl ErrorResponse {
-    /// Creates a new error response with the given message.
-    pub fn new(error: impl std::error::Error) -> Self {
-        Self {
-            error: error.to_string(),
+impl ProblemDetailsExt for ProblemDetails {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ProblemDetails::SchemaValidationFailed { .. } => StatusCode::BAD_REQUEST,
+            ProblemDetails::InvalidJson { .. } => StatusCode::BAD_REQUEST,
+            ProblemDetails::NetworkError { .. } => StatusCode::BAD_GATEWAY,
+            ProblemDetails::FileSystemError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ProblemDetails::DBusError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ProblemDetails::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ProblemDetails::NotFound { .. } => StatusCode::NOT_FOUND,
+            ProblemDetails::Unauthorized { .. } => StatusCode::UNAUTHORIZED,
+            ProblemDetails::Generic { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
-    /// Creates an HTTP response with the given status code.
-    pub fn into_response_with_status(self, status: StatusCode) -> Response {
-        tracing::warn!("Server return error {} with status {}", self.error, status);
-        (status, Json(self)).into_response()
+    fn into_response(self) -> Response {
+        ProblemDetailsResponse::from(self).into_response()
+    }
+}
+
+/// Wrapper to make ProblemDetails work with aide's OpenAPI generation and axum responses
+#[derive(Debug, Clone, Serialize, JsonSchema, OperationIo)]
+#[aide(output)]
+#[serde(transparent)]
+#[schemars(transparent)]
+pub struct ProblemDetailsResponse(pub ProblemDetails);
+
+impl ProblemDetailsResponse {
+    /// Create a new ProblemDetailsResponse from ProblemDetails
+    pub fn new(problem: ProblemDetails) -> Self {
+        Self(problem)
+    }
+}
+
+impl From<ProblemDetails> for ProblemDetailsResponse {
+    fn from(problem: ProblemDetails) -> Self {
+        Self(problem)
+    }
+}
+
+impl IntoResponse for ProblemDetailsResponse {
+    fn into_response(self) -> Response {
+        let status = self.0.status_code();
+        (
+            status,
+            [(axum::http::header::CONTENT_TYPE, "application/problem+json")],
+            Json(self.0),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_schema_validation_failed() {
+        let problem = ProblemDetails::schema_validation_failed(vec![
+            "/network/hostname: is required".to_string(),
+        ]);
+
+        assert_eq!(problem.status_code(), StatusCode::BAD_REQUEST);
+
+        let json = serde_json::to_value(&problem).unwrap();
+        // Title is translated, so just check it's present and non-empty
+        assert!(json["title"].is_string());
+        assert!(!json["title"].as_str().unwrap().is_empty());
+        assert!(json["errors"].is_array());
+        assert_eq!(json["errors"][0], "/network/hostname: is required");
+        // Ensure status field is NOT in JSON
+        assert!(json.get("status").is_none());
     }
 
-    /// Creates a BAD_REQUEST (400) response.
-    pub fn bad_request(error: impl std::error::Error) -> Response {
-        Self::new(error).into_response_with_status(StatusCode::BAD_REQUEST)
+    #[test]
+    fn test_network_error() {
+        let problem = ProblemDetails::network_error_with_status(
+            "https://example.com",
+            503,
+            "Connection timeout",
+        );
+
+        assert_eq!(problem.status_code(), StatusCode::BAD_GATEWAY);
+
+        let json = serde_json::to_value(&problem).unwrap();
+        assert_eq!(json["url"], "https://example.com");
+        assert_eq!(json["httpStatus"], 503);
     }
 
-    /// Creates an INTERNAL_SERVER_ERROR (500) response.
-    pub fn internal_server_error(error: impl std::error::Error) -> Response {
-        Self::new(error).into_response_with_status(StatusCode::INTERNAL_SERVER_ERROR)
+    #[test]
+    fn test_dbus_error() {
+        let problem = ProblemDetails::dbus_error_full(
+            "org.freedesktop.NetworkManager",
+            Some("/org/freedesktop/NetworkManager".to_string()),
+            Some("GetDevices".to_string()),
+            "Method call failed",
+        );
+
+        assert_eq!(problem.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let json = serde_json::to_value(&problem).unwrap();
+        assert_eq!(json["service"], "org.freedesktop.NetworkManager");
+        assert_eq!(json["objectPath"], "/org/freedesktop/NetworkManager");
+        assert_eq!(json["method"], "GetDevices");
     }
 
-    /// Creates an UNPROCESSABLE_ENTITY (422) response.
-    pub fn unprocessable_entity(error: impl std::error::Error) -> Response {
-        Self::new(error).into_response_with_status(StatusCode::UNPROCESSABLE_ENTITY)
+    #[test]
+    fn test_generic_problem() {
+        let problem = ProblemDetails::generic("Custom Error", "Something unusual happened");
+
+        let json = serde_json::to_value(&problem).unwrap();
+        assert_eq!(json["type"], "about:blank"); // RFC 9457 standard generic type
+        assert_eq!(json["title"], "Custom Error");
     }
 }

--- a/rust/agama-server/src/web/error.rs
+++ b/rust/agama-server/src/web/error.rs
@@ -24,12 +24,17 @@
 //! The core types and constructor methods are defined in `agama_utils::api::ProblemDetails`.
 
 use agama_utils::api::ProblemDetails;
-use aide::OperationIo;
+use aide::generate::GenContext;
+use aide::openapi::{
+    MediaType, Operation, Response as OpenApiResponse, SchemaObject, StatusCode as ApiStatusCode,
+};
+use aide::operation::OperationOutput;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
+use indexmap::IndexMap;
 use schemars::JsonSchema;
 use serde::Serialize;
 
@@ -59,8 +64,7 @@ impl ProblemDetailsExt for ProblemDetails {
 }
 
 /// Wrapper to make ProblemDetails work with aide's OpenAPI generation and axum responses
-#[derive(Debug, Clone, Serialize, JsonSchema, OperationIo)]
-#[aide(output)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(transparent)]
 #[schemars(transparent)]
 pub struct ProblemDetailsResponse(pub ProblemDetails);
@@ -87,6 +91,51 @@ impl IntoResponse for ProblemDetailsResponse {
             Json(self.0),
         )
             .into_response()
+    }
+}
+
+impl OperationOutput for ProblemDetailsResponse {
+    type Inner = Self;
+
+    fn operation_response(
+        ctx: &mut GenContext,
+        _operation: &mut Operation,
+    ) -> Option<OpenApiResponse> {
+        // Get schema for ProblemDetails - aide will automatically register it in components
+        // and return a $ref if needed
+        let json_schema = ctx.schema.subschema_for::<ProblemDetails>();
+        let resolved_schema = ctx.resolve_schema(&json_schema);
+
+        Some(OpenApiResponse {
+            description: resolved_schema
+                .get("description")
+                .and_then(|d| d.as_str())
+                .map(String::from)
+                .unwrap_or_default(),
+            content: IndexMap::from_iter([(
+                "application/problem+json".to_string(),
+                MediaType {
+                    schema: Some(SchemaObject {
+                        json_schema,
+                        example: None,
+                        external_docs: None,
+                    }),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        })
+    }
+
+    fn inferred_responses(
+        ctx: &mut GenContext,
+        operation: &mut Operation,
+    ) -> Vec<(Option<ApiStatusCode>, OpenApiResponse)> {
+        if let Some(response) = Self::operation_response(ctx, operation) {
+            vec![(None, response)]
+        } else {
+            vec![]
+        }
     }
 }
 

--- a/rust/agama-utils/src/api.rs
+++ b/rust/agama-utils/src/api.rs
@@ -76,3 +76,6 @@ pub mod security;
 pub mod software;
 pub mod storage;
 pub mod users;
+
+pub mod problem_details;
+pub use problem_details::ProblemDetails;

--- a/rust/agama-utils/src/api/patch.rs
+++ b/rust/agama-utils/src/api/patch.rs
@@ -33,13 +33,13 @@ pub struct Patch {
 }
 
 impl Patch {
-    pub fn with_update(config: Value) -> Result<Self, serde_json::Error> {
-        Ok(Self {
+    pub fn with_update(config: Value) -> Self {
+        Self {
             update: Some(config),
-        })
+        }
     }
 
     pub fn with_config(config: &Config) -> Result<Self, serde_json::Error> {
-        Self::with_update(serde_json::to_value(config)?)
+        Ok(Self::with_update(serde_json::to_value(config)?))
     }
 }

--- a/rust/agama-utils/src/api/patch.rs
+++ b/rust/agama-utils/src/api/patch.rs
@@ -33,9 +33,13 @@ pub struct Patch {
 }
 
 impl Patch {
-    pub fn with_update(config: &Config) -> Result<Self, serde_json::Error> {
+    pub fn with_update(config: Value) -> Result<Self, serde_json::Error> {
         Ok(Self {
-            update: Some(serde_json::to_value(config)?),
+            update: Some(config),
         })
+    }
+
+    pub fn with_config(config: &Config) -> Result<Self, serde_json::Error> {
+        Self::with_update(serde_json::to_value(config)?)
     }
 }

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -1,0 +1,358 @@
+// Copyright (c) [2026] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+//! Problem Details for HTTP APIs (RFC 9457)
+//!
+//! This module defines the wire format for API errors following RFC 9457.
+//! These types are shared between the server and client.
+
+use gettextrs::gettext;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Problem Details for HTTP APIs (RFC 9457)
+///
+/// This enum represents different types of API errors following RFC 9457.
+/// Each variant contains only the fields relevant to that specific error type.
+///
+/// The `type` field (used for i18n) is determined by the enum variant,
+/// and the HTTP status code is determined by the server.
+///
+/// # Examples
+///
+/// Deserializing a schema validation error from JSON:
+///
+/// ```
+/// # use agama_utils::api::ProblemDetails;
+/// let json = r#"{
+///   "type": "tag:agama.opensuse.org,2026:problems/schema-validation-failed",
+///   "title": "Schema Validation Failed",
+///   "detail": "The provided configuration does not match the required schema",
+///   "errors": ["/network/hostname: is required"]
+/// }"#;
+///
+/// let problem: ProblemDetails = serde_json::from_str(json).unwrap();
+/// match problem {
+///     ProblemDetails::SchemaValidationFailed { errors, .. } => {
+///         assert_eq!(errors.len(), 1);
+///     }
+///     _ => panic!("Expected SchemaValidationFailed"),
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ProblemDetails {
+    /// Schema validation failed (HTTP 400)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/schema-validation-failed",
+        rename_all = "camelCase"
+    )]
+    SchemaValidationFailed {
+        /// Short summary
+        title: String,
+        /// Detailed explanation
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        /// List of validation error messages
+        errors: Vec<String>,
+    },
+
+    /// Invalid JSON in request body (HTTP 400)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/invalid-json",
+        rename_all = "camelCase"
+    )]
+    InvalidJson {
+        title: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+
+    /// Network error - upstream service unreachable (HTTP 502)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/network-error",
+        rename_all = "camelCase"
+    )]
+    NetworkError {
+        title: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        /// URL that failed
+        url: String,
+        /// HTTP status from upstream (if available)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        http_status: Option<u16>,
+    },
+
+    /// File system error (HTTP 500)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/file-system-error",
+        rename_all = "camelCase"
+    )]
+    FileSystemError {
+        title: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        /// File path
+        path: String,
+        /// Operation that failed (read, write, delete, etc.)
+        operation: String,
+    },
+
+    /// D-Bus service error (HTTP 500)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/dbus-error",
+        rename_all = "camelCase"
+    )]
+    DBusError {
+        title: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        /// D-Bus service name
+        service: String,
+        /// D-Bus object path
+        #[serde(skip_serializing_if = "Option::is_none")]
+        object_path: Option<String>,
+        /// D-Bus method name
+        #[serde(skip_serializing_if = "Option::is_none")]
+        method: Option<String>,
+    },
+
+    /// Internal server error (HTTP 500)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/internal-error",
+        rename_all = "camelCase"
+    )]
+    InternalError { title: String, detail: String },
+
+    /// Resource not found (HTTP 404)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/not-found",
+        rename_all = "camelCase"
+    )]
+    NotFound { title: String, detail: String },
+
+    /// Unauthorized - authentication required (HTTP 401)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/unauthorized",
+        rename_all = "camelCase"
+    )]
+    Unauthorized { title: String, detail: String },
+
+    /// Generic error without specific type (HTTP 500)
+    #[serde(rename = "about:blank", rename_all = "camelCase")]
+    Generic { title: String, detail: String },
+}
+
+impl ProblemDetails {
+    /// Creates a schema validation failed problem
+    pub fn schema_validation_failed(errors: Vec<String>) -> Self {
+        Self::SchemaValidationFailed {
+            title: gettext("Schema validation failed"),
+            detail: Some(gettext(
+                "The provided configuration does not match the required schema",
+            )),
+            errors,
+        }
+    }
+
+    /// Creates an invalid JSON problem
+    pub fn invalid_json(detail: impl Into<String>) -> Self {
+        Self::InvalidJson {
+            title: gettext("Invalid JSON"),
+            detail: Some(detail.into()),
+        }
+    }
+
+    /// Creates a network error problem
+    pub fn network_error(url: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::NetworkError {
+            title: gettext("Network error"),
+            detail: Some(detail.into()),
+            url: url.into(),
+            http_status: None,
+        }
+    }
+
+    /// Creates a network error problem with HTTP status
+    pub fn network_error_with_status(
+        url: impl Into<String>,
+        http_status: u16,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self::NetworkError {
+            title: gettext("Network error"),
+            detail: Some(detail.into()),
+            url: url.into(),
+            http_status: Some(http_status),
+        }
+    }
+
+    /// Creates a file system error problem
+    pub fn file_system_error(
+        path: impl Into<String>,
+        operation: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self::FileSystemError {
+            title: gettext("File system error"),
+            detail: Some(detail.into()),
+            path: path.into(),
+            operation: operation.into(),
+        }
+    }
+
+    /// Creates a D-Bus error problem
+    pub fn dbus_error(service: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::DBusError {
+            title: gettext("D-Bus service error"),
+            detail: Some(detail.into()),
+            service: service.into(),
+            object_path: None,
+            method: None,
+        }
+    }
+
+    /// Creates a D-Bus error problem with full context
+    pub fn dbus_error_full(
+        service: impl Into<String>,
+        object_path: Option<String>,
+        method: Option<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self::DBusError {
+            title: gettext("D-Bus service error"),
+            detail: Some(detail.into()),
+            service: service.into(),
+            object_path,
+            method,
+        }
+    }
+
+    /// Creates an internal error problem
+    pub fn internal_error(detail: impl Into<String>) -> Self {
+        Self::InternalError {
+            title: gettext("Internal server error"),
+            detail: detail.into(),
+        }
+    }
+
+    /// Creates a not found problem
+    pub fn not_found(resource: impl Into<String>) -> Self {
+        Self::NotFound {
+            title: gettext("Not Found"),
+            detail: format!("Resource not found: {}", resource.into()),
+        }
+    }
+
+    /// Creates an unauthorized problem
+    pub fn unauthorized(detail: impl Into<String>) -> Self {
+        Self::Unauthorized {
+            title: gettext("Unauthorized"),
+            detail: detail.into(),
+        }
+    }
+
+    /// Creates a generic problem
+    pub fn generic(title: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::Generic {
+            title: title.into(),
+            detail: detail.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_schema_validation_failed() {
+        let json = r#"{
+            "type": "tag:agama.opensuse.org,2026:problems/schema-validation-failed",
+            "title": "Schema Validation Failed",
+            "detail": "Config invalid",
+            "errors": ["/network/hostname: is required"]
+        }"#;
+
+        let problem: ProblemDetails = serde_json::from_str(json).unwrap();
+        match problem {
+            ProblemDetails::SchemaValidationFailed { title, errors, .. } => {
+                assert_eq!(title, "Schema Validation Failed");
+                assert_eq!(errors.len(), 1);
+                assert_eq!(errors[0], "/network/hostname: is required");
+            }
+            _ => panic!("Expected SchemaValidationFailed"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_network_error() {
+        let json = r#"{
+            "type": "tag:agama.opensuse.org,2026:problems/network-error",
+            "title": "Network Error",
+            "url": "https://example.com",
+            "httpStatus": 503
+        }"#;
+
+        let problem: ProblemDetails = serde_json::from_str(json).unwrap();
+        match problem {
+            ProblemDetails::NetworkError {
+                url, http_status, ..
+            } => {
+                assert_eq!(url, "https://example.com");
+                assert_eq!(http_status, Some(503));
+            }
+            _ => panic!("Expected NetworkError"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_generic() {
+        let json = r#"{
+            "type": "about:blank",
+            "title": "Something went wrong",
+            "detail": "An unexpected error occurred"
+        }"#;
+
+        let problem: ProblemDetails = serde_json::from_str(json).unwrap();
+        match problem {
+            ProblemDetails::Generic { title, detail, .. } => {
+                assert_eq!(title, "Something went wrong");
+                assert_eq!(detail, "An unexpected error occurred");
+            }
+            _ => panic!("Expected Generic"),
+        }
+    }
+
+    #[test]
+    fn test_serialize_and_deserialize_roundtrip() {
+        let original = ProblemDetails::SchemaValidationFailed {
+            title: "Test".to_string(),
+            detail: Some("Detail".to_string()),
+            errors: vec!["error1".to_string()],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: ProblemDetails = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(original, deserialized);
+    }
+}

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -164,12 +164,12 @@ impl Display for ProblemDetails {
                     .map(|e| format!("  - {e}"))
                     .collect::<Vec<_>>()
                     .join("\n");
-                write_problem(f, &title, detail.as_deref(), Some(&body))?
+                write_problem(f, title, detail.as_deref(), Some(&body))?
             }
 
             Self::Unauthorized { title, detail }
             | Self::InternalError { title, detail }
-            | Self::Generic { title, detail } => write_problem(f, title, Some(&detail), None)?,
+            | Self::Generic { title, detail } => write_problem(f, title, Some(detail), None)?,
 
             ProblemDetails::InvalidJson { title, detail } => {
                 write_problem(f, title, detail.as_deref(), None)?

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -23,6 +23,8 @@
 //! This module defines the wire format for API errors following RFC 9457.
 //! These types are shared between the server and client.
 
+use std::fmt::Display;
+
 use gettextrs::gettext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -277,6 +279,61 @@ impl ProblemDetails {
             detail: detail.into(),
         }
     }
+}
+
+impl Display for ProblemDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SchemaValidationFailed {
+                title,
+                detail,
+                errors,
+            } => {
+                let body = errors
+                    .iter()
+                    .map(|e| format!("  - {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                write_problem(f, &title, detail.as_deref(), Some(&body))?
+            }
+
+            Self::Unauthorized { title, detail }
+            | Self::InternalError { title, detail }
+            | Self::NotFound { title, detail }
+            | Self::Generic { title, detail } => write_problem(f, title, Some(&detail), None)?,
+
+            Self::DBusError { title, detail, .. } => {
+                write_problem(f, title, detail.as_deref(), None)?
+            }
+
+            ProblemDetails::InvalidJson { title, detail }
+            | ProblemDetails::NetworkError { title, detail, .. }
+            | ProblemDetails::FileSystemError { title, detail, .. } => {
+                write_problem(f, title, detail.as_deref(), None)?
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn write_problem(
+    f: &mut std::fmt::Formatter<'_>,
+    title: &str,
+    detail: Option<&str>,
+    body: Option<&str>,
+) -> std::fmt::Result {
+    write!(f, "An error ocurred: {title}")?;
+    if let Some(detail) = detail {
+        let label = gettext("Details:");
+        write!(f, "\n\n{label}\n{detail}")?;
+    }
+
+    if let Some(body) = body {
+        write!(f, "\n\n{body}")?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -186,15 +186,15 @@ pub fn write_problem(
     detail: Option<&str>,
     body: Option<&str>,
 ) -> std::fmt::Result {
-    write!(f, "{}\n", gettext("Error:"))?;
-    write!(f, "{}\n", title)?;
+    writeln!(f, "{}", gettext("Error:"))?;
+    writeln!(f, "{}", title)?;
     if let Some(detail) = detail {
         let label = gettext("Details:");
-        write!(f, "\n{label}\n{detail}")?;
+        writeln!(f, "\n{label}\n{detail}")?;
     }
 
     if let Some(body) = body {
-        write!(f, "\n\n{body}")?;
+        writeln!(f, "\n{body}")?;
     }
 
     Ok(())

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -186,7 +186,8 @@ pub fn write_problem(
     detail: Option<&str>,
     body: Option<&str>,
 ) -> std::fmt::Result {
-    write!(f, "An error ocurred: {title}")?;
+    let first_line = gettext("An error occurred: %s").replace("%s", title);
+    write!(f, "{}", first_line)?;
     if let Some(detail) = detail {
         let label = gettext("Details:");
         write!(f, "\n\n{label}\n{detail}")?;

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -87,69 +87,12 @@ pub enum ProblemDetails {
         detail: Option<String>,
     },
 
-    /// Network error - upstream service unreachable (HTTP 502)
-    #[serde(
-        rename = "tag:agama.opensuse.org,2026:problems/network-error",
-        rename_all = "camelCase"
-    )]
-    NetworkError {
-        title: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        detail: Option<String>,
-        /// URL that failed
-        url: String,
-        /// HTTP status from upstream (if available)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        http_status: Option<u16>,
-    },
-
-    /// File system error (HTTP 500)
-    #[serde(
-        rename = "tag:agama.opensuse.org,2026:problems/file-system-error",
-        rename_all = "camelCase"
-    )]
-    FileSystemError {
-        title: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        detail: Option<String>,
-        /// File path
-        path: String,
-        /// Operation that failed (read, write, delete, etc.)
-        operation: String,
-    },
-
-    /// D-Bus service error (HTTP 500)
-    #[serde(
-        rename = "tag:agama.opensuse.org,2026:problems/dbus-error",
-        rename_all = "camelCase"
-    )]
-    DBusError {
-        title: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        detail: Option<String>,
-        /// D-Bus service name
-        service: String,
-        /// D-Bus object path
-        #[serde(skip_serializing_if = "Option::is_none")]
-        object_path: Option<String>,
-        /// D-Bus method name
-        #[serde(skip_serializing_if = "Option::is_none")]
-        method: Option<String>,
-    },
-
     /// Internal server error (HTTP 500)
     #[serde(
         rename = "tag:agama.opensuse.org,2026:problems/internal-error",
         rename_all = "camelCase"
     )]
     InternalError { title: String, detail: String },
-
-    /// Resource not found (HTTP 404)
-    #[serde(
-        rename = "tag:agama.opensuse.org,2026:problems/not-found",
-        rename_all = "camelCase"
-    )]
-    NotFound { title: String, detail: String },
 
     /// Unauthorized - authentication required (HTTP 401)
     #[serde(
@@ -183,84 +126,11 @@ impl ProblemDetails {
         }
     }
 
-    /// Creates a network error problem
-    pub fn network_error(url: impl Into<String>, detail: impl Into<String>) -> Self {
-        Self::NetworkError {
-            title: gettext("Network error"),
-            detail: Some(detail.into()),
-            url: url.into(),
-            http_status: None,
-        }
-    }
-
-    /// Creates a network error problem with HTTP status
-    pub fn network_error_with_status(
-        url: impl Into<String>,
-        http_status: u16,
-        detail: impl Into<String>,
-    ) -> Self {
-        Self::NetworkError {
-            title: gettext("Network error"),
-            detail: Some(detail.into()),
-            url: url.into(),
-            http_status: Some(http_status),
-        }
-    }
-
-    /// Creates a file system error problem
-    pub fn file_system_error(
-        path: impl Into<String>,
-        operation: impl Into<String>,
-        detail: impl Into<String>,
-    ) -> Self {
-        Self::FileSystemError {
-            title: gettext("File system error"),
-            detail: Some(detail.into()),
-            path: path.into(),
-            operation: operation.into(),
-        }
-    }
-
-    /// Creates a D-Bus error problem
-    pub fn dbus_error(service: impl Into<String>, detail: impl Into<String>) -> Self {
-        Self::DBusError {
-            title: gettext("D-Bus service error"),
-            detail: Some(detail.into()),
-            service: service.into(),
-            object_path: None,
-            method: None,
-        }
-    }
-
-    /// Creates a D-Bus error problem with full context
-    pub fn dbus_error_full(
-        service: impl Into<String>,
-        object_path: Option<String>,
-        method: Option<String>,
-        detail: impl Into<String>,
-    ) -> Self {
-        Self::DBusError {
-            title: gettext("D-Bus service error"),
-            detail: Some(detail.into()),
-            service: service.into(),
-            object_path,
-            method,
-        }
-    }
-
     /// Creates an internal error problem
     pub fn internal_error(detail: impl Into<String>) -> Self {
         Self::InternalError {
             title: gettext("Internal server error"),
             detail: detail.into(),
-        }
-    }
-
-    /// Creates a not found problem
-    pub fn not_found(resource: impl Into<String>) -> Self {
-        Self::NotFound {
-            title: gettext("Not Found"),
-            detail: format!("Resource not found: {}", resource.into()),
         }
     }
 
@@ -299,16 +169,9 @@ impl Display for ProblemDetails {
 
             Self::Unauthorized { title, detail }
             | Self::InternalError { title, detail }
-            | Self::NotFound { title, detail }
             | Self::Generic { title, detail } => write_problem(f, title, Some(&detail), None)?,
 
-            Self::DBusError { title, detail, .. } => {
-                write_problem(f, title, detail.as_deref(), None)?
-            }
-
-            ProblemDetails::InvalidJson { title, detail }
-            | ProblemDetails::NetworkError { title, detail, .. }
-            | ProblemDetails::FileSystemError { title, detail, .. } => {
+            ProblemDetails::InvalidJson { title, detail } => {
                 write_problem(f, title, detail.as_deref(), None)?
             }
         }
@@ -357,27 +220,6 @@ mod tests {
                 assert_eq!(errors[0], "/network/hostname: is required");
             }
             _ => panic!("Expected SchemaValidationFailed"),
-        }
-    }
-
-    #[test]
-    fn test_deserialize_network_error() {
-        let json = r#"{
-            "type": "tag:agama.opensuse.org,2026:problems/network-error",
-            "title": "Network Error",
-            "url": "https://example.com",
-            "httpStatus": 503
-        }"#;
-
-        let problem: ProblemDetails = serde_json::from_str(json).unwrap();
-        match problem {
-            ProblemDetails::NetworkError {
-                url, http_status, ..
-            } => {
-                assert_eq!(url, "https://example.com");
-                assert_eq!(http_status, Some(503));
-            }
-            _ => panic!("Expected NetworkError"),
         }
     }
 

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -186,11 +186,11 @@ pub fn write_problem(
     detail: Option<&str>,
     body: Option<&str>,
 ) -> std::fmt::Result {
-    let first_line = gettext("An error occurred: %s").replace("%s", title);
-    write!(f, "{}", first_line)?;
+    write!(f, "{}\n", gettext("Error:"))?;
+    write!(f, "{}\n", title)?;
     if let Some(detail) = detail {
         let label = gettext("Details:");
-        write!(f, "\n\n{label}\n{detail}")?;
+        write!(f, "\n{label}\n{detail}")?;
     }
 
     if let Some(body) = body {

--- a/rust/agama-utils/src/question/start.rs
+++ b/rust/agama-utils/src/question/start.rs
@@ -24,13 +24,7 @@ use crate::{
     api::event,
 };
 
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
-    Service(#[from] service::Error),
-}
-
-pub async fn start(events: event::Sender) -> Result<Handler<Service>, Error> {
+pub async fn start(events: event::Sender) -> Result<Handler<Service>, service::Error> {
     let service = Service::new(events);
     let handler = actor::spawn(service);
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jun 12 10:17:34 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Implement the RFC9457 for error reporting (gh#agama-project/agama#3611).
+
+-------------------------------------------------------------------
 Wed Jun 10 06:18:24 UTC 2026 - Asish Kumar <officialasishkumar@gmail.com>
 
 - Honor extraRepositories repository priorities when adding software

--- a/rust/zypp-agama/zypp-agama-sys/src/bindings.rs
+++ b/rust/zypp-agama/zypp-agama-sys/src/bindings.rs
@@ -687,7 +687,7 @@ unsafe extern "C" {
     #[doc = " repository array in list.\n when no longer needed, use \\ref free_repository_list to release memory\n @param zypp see \\ref init_target\n @param[out] status (will overwrite existing contents)"]
     pub fn list_repositories(zypp: *mut Zypp, status: *mut Status) -> RepositoryList;
     pub fn free_repository_list(repo_list: *mut RepositoryList);
-    #[doc = " Adds repository to repo manager\n @param zypp see \\ref init_target\n @param alias have to be unique\n @param url can contain repo variables\n @param[out] status (will overwrite existing contents)\n @param callback pointer to function with callback or NULL\n @param user_data"]
+    #[doc = " Adds repository to repo manager\n @param zypp see \\ref init_target\n @param alias have to be unique\n @param url can contain repo variables\n @param priority repository priority, 0 uses libzypp's default\n @param[out] status (will overwrite existing contents)\n @param callback pointer to function with callback or NULL\n @param user_data"]
     pub fn add_repository(
         zypp: *mut Zypp,
         alias: *const ::std::os::raw::c_char,


### PR DESCRIPTION
Implements [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) Problem Details for HTTP APIs to improve error handling in Agama's HTTP API.

## Changes

- Replaces simple `{"error": "..."}` JSON responses with structured Problem Details format
- Uses tag URIs (`tag:agama.opensuse.org,2026:problems/...`) that don't require endpoints
- Enum-based approach for type safety with variant-specific fields
- Translation support via gettext for title and detail fields
- Shares types between client (agama-cli) and server (agama-utils::api)
- OpenAPI documentation with schemars and aide
- Status code only in HTTP response (not in JSON body) to avoid redundancy
- Do not validate the profile twice.

## Error Types

- `SchemaValidationFailed` (400) - with list of validation errors
- `InvalidJson` (400) - malformed JSON in request
- `Unauthorized` (401) - authentication failures
- `InternalError` (500) - generic server errors
- `Generic` - fallback using RFC 9457's `about:blank` type

## Follow-up

- Add a specific type for profile-related errors (e.g., AutoYaST conversion).
- Do all the checks on the server-side, even if it is not a valid JSON file.

## Example Response

```json
{
  "type": "tag:agama.opensuse.org,2026:problems/schema-validation-failed",
  "title": "Schema Validation Failed",
  "detail": "The provided configuration does not match the required schema",
  "errors": ["/network/hostname: is required"]
}
```

## Benefits

- **Localizable**: Error messages respect server locale (set via ConfigureL10n)
- **Structured**: Extension fields provide context (e.g., validation errors, file paths, D-Bus service names)
- **Type-safe**: Enum variants enforce correct fields for each error type
- **Consistent**: All API errors follow the same format
- **Standards-compliant**: Follows RFC 9457 with proper `application/problem+json` content type

## Examples

### Authenticating

Before:

```shell
% ./target/debug/agama -- --insecure --host 192.168.122.10 auth login
> Please enter the root password: ********
Backend responded with code 401 and the following message:

"Authentication via PAM failed: Auth_Err (7)"
```

After:

```shell
% ./target/debug/agama -- --insecure --host 192.168.122.10 auth login
Error:
Unauthorized

Details:
Authentication failed: Auth_Err (7)
```

### Wrong format

```shell
% ./target/debug/agama --insecure --host 192.168.122.10 config load /srv/www/htdocs/agama/wrong.jsonnet 
Backend responded with code 400 and the following message:

"Profile validation failed: The profile is not a well-formed JSON file"
```

After (it checks locally whether it is, at least, a valid JSON file). The real validation happens in the "config load". Check the "follow-up" section:

```shell
% ./target/debug/agama --insecure --host 192.168.122.10 config load wrong.jsonnet
It is not a valid JSON file
```

### Invalid schema

Before:

```shell
% ./target/debug/agama --insecure --host 192.168.122.10 config load /srv/www/htdocs/agama/wrong.json
✗ The profile is not valid. Please, check the following errors:

	* true is not of type "string". /product/id
	* 1 is not of type "string". /product/mode

The profile is not valid
```

After:

```shell
% ./target/debug/agama --insecure --host 192.168.122.10 config load wrong.json
Error:
Schema validation failed

Details:
The provided configuration does not match the required schema

  - true is not of type "string". /product/id
  - 1 is not of type "string". /product/mode
```