### PR TITLE
Deprecate mkfsOptions in favor of mkfsExtraArguments

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -136,7 +136,6 @@ So it will be possible to define (or reuse) multi-device Btrfs file systems usin
   "metaDataRaidLevel": "..." ,
   "devices": [ ... ],
   "label": "...",
-  "mkfsOptions": { ... },
   "subvolumePrefix": "...",
   "subvolumes": [ ... ],
   "snapshots": ...,

--- a/rust/agama-lib/share/storage.model.schema.json
+++ b/rust/agama-lib/share/storage.model.schema.json
@@ -143,7 +143,7 @@
         "default": { "type": "boolean" },
         "type": { "$ref": "#/$defs/filesystemType" },
         "label": { "type": "string" },
-        "mkfsOptions": { "type": "array", "items": { "type": "string" } },
+        "mkfsExtraArguments": { "type": "string" },
         "mountOptions": { "type": "array", "items": { "type": "string" } }
       }
     },

--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -994,8 +994,13 @@
           "description": "How to mount the device.",
           "enum": ["device", "id", "label", "path", "uuid"]
         },
+        "mkfsExtraArguments": {
+          "description": "Additional arguments injected as-is to the mkfs command when creating the file system.",
+          "type": "string"
+        },
         "mkfsOptions": {
-          "description": "Options for creating the file system.",
+          "deprecated": true,
+          "description": "Deprecated in favor of mkfsExtraArguments",
           "type": "array",
           "items": {
             "type": "string"

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/filesystem.rb
@@ -48,7 +48,7 @@ module Agama
               label:         filesystem_json[:label],
               path:          filesystem_json[:path],
               mount_options: filesystem_json[:mountOptions],
-              mkfs_options:  filesystem_json[:mkfsOptions],
+              mkfs_args:     convert_mkfs_args,
               mount_by:      convert_mount_by,
               type:          convert_type
             }
@@ -68,6 +68,15 @@ module Agama
             return unless filesystem_type_json
 
             FromJSONConversions::FilesystemType.new(filesystem_type_json).convert
+          end
+
+          # @return [String, nil]
+          def convert_mkfs_args
+            fallback_value = (filesystem_json[:mkfsOptions] || []).join(" ")
+            value = filesystem_json[:mkfsExtraArguments] || fallback_value
+            return nil if value.empty?
+
+            value
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/filesystem.rb
@@ -45,7 +45,7 @@ module Agama
               path:          model_json[:mountPath],
               type:          convert_type,
               label:         model_json.dig(:filesystem, :label),
-              mkfs_options:  model_json.dig(:filesystem, :mkfsOptions),
+              mkfs_args:     model_json.dig(:filesystem, :mkfsExtraArguments),
               mount_options: model_json.dig(:filesystem, :mountOptions)
             }
           end

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/filesystem.rb
@@ -38,13 +38,13 @@ module Agama
           # @see Base#conversions
           def conversions
             {
-              reuseIfPossible: config.reuse?,
-              label:           config.label,
-              path:            config.path,
-              mountOptions:    config.mount_options,
-              mkfsOptions:     config.mkfs_options,
-              mountBy:         config.mount_by&.to_s,
-              type:            convert_type
+              reuseIfPossible:    config.reuse?,
+              label:              config.label,
+              path:               config.path,
+              mountOptions:       config.mount_options,
+              mkfsExtraArguments: config.mkfs_args,
+              mountBy:            config.mount_by&.to_s,
+              type:               convert_type
             }
           end
 

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
@@ -43,12 +43,12 @@ module Agama
           # @see Base#conversions
           def conversions
             {
-              reuse:        config.reuse?,
-              default:      convert_default,
-              type:         convert_type,
-              label:        config.label,
-              mkfsOptions:  convert_mkfs_options,
-              mountOptions: convert_mount_options
+              reuse:              config.reuse?,
+              default:            convert_default,
+              type:               convert_type,
+              label:              config.label,
+              mkfsExtraArguments: config.mkfs_args,
+              mountOptions:       convert_mount_options
             }
           end
 
@@ -69,13 +69,6 @@ module Agama
             end
 
             config.type.fs_type.to_s
-          end
-
-          # @return [Array<String>, nil]
-          def convert_mkfs_options
-            return if config.mkfs_options.empty?
-
-            config.mkfs_options
           end
 
           # @return [Array<String>, nil]

--- a/service/lib/agama/storage/configs/filesystem.rb
+++ b/service/lib/agama/storage/configs/filesystem.rb
@@ -42,8 +42,8 @@ module Agama
         # @return [String, nil]
         attr_accessor :label
 
-        # @return [Array<String>]
-        attr_accessor :mkfs_options
+        # @return [String, nil]
+        attr_accessor :mkfs_args
 
         # @return [Array<String>]
         attr_accessor :mount_options
@@ -54,7 +54,6 @@ module Agama
         def initialize
           @reuse = false
           @mount_options = []
-          @mkfs_options = []
         end
 
         # Whether the given path is equivalent to {#path}

--- a/service/lib/y2storage/proposal/agama_device_planner.rb
+++ b/service/lib/y2storage/proposal/agama_device_planner.rb
@@ -110,7 +110,7 @@ module Y2Storage
         planned.mount_point = config.path
         planned.mount_by = config.mount_by
         planned.fstab_options = config.mount_options
-        planned.mkfs_options = config.mkfs_options.join(",")
+        planned.mkfs_options = config.mkfs_args
         planned.label = config.label
         configure_filesystem_type(planned, config.type) if config.type
       end

--- a/service/test/agama/storage/config_conversions/from_json_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/examples.rb
@@ -413,13 +413,13 @@ shared_examples "with filesystem" do
   context "if 'filesystem' is specified" do
     let(:filesystem) do
       {
-        reuseIfPossible: true,
-        type:            "xfs",
-        label:           "test",
-        path:            "/test",
-        mountBy:         "device",
-        mkfsOptions:     ["version=2"],
-        mountOptions:    ["rw"]
+        reuseIfPossible:    true,
+        type:               "xfs",
+        label:              "test",
+        path:               "/test",
+        mountBy:            "device",
+        mkfsExtraArguments: "-l version=2",
+        mountOptions:       ["rw"]
       }
     end
 
@@ -434,7 +434,7 @@ shared_examples "with filesystem" do
       expect(filesystem.label).to eq("test")
       expect(filesystem.path).to eq("/test")
       expect(filesystem.mount_by).to eq(Y2Storage::Filesystems::MountByType::DEVICE)
-      expect(filesystem.mkfs_options).to contain_exactly("version=2")
+      expect(filesystem.mkfs_args).to eq "-l version=2"
       expect(filesystem.mount_options).to contain_exactly("rw")
     end
 
@@ -460,7 +460,7 @@ shared_examples "with filesystem" do
         expect(filesystem.label).to be_nil
         expect(filesystem.path).to be_nil
         expect(filesystem.mount_by).to be_nil
-        expect(filesystem.mkfs_options).to eq([])
+        expect(filesystem.mkfs_args).to be_nil
         expect(filesystem.mount_options).to eq([])
       end
     end
@@ -477,9 +477,68 @@ shared_examples "with filesystem" do
         expect(filesystem.label).to be_nil
         expect(filesystem.path).to be_nil
         expect(filesystem.mount_by).to be_nil
-        expect(filesystem.mkfs_options).to eq([])
+        expect(filesystem.mkfs_args).to be_nil
         expect(filesystem.mount_options).to eq([])
       end
+    end
+  end
+
+  context "if 'filesystem' does not include mkfsExtraArguments or mkfsOptions" do
+    let(:filesystem) do
+      { path: "/test" }
+    end
+
+    it "sets #mkfs_args to nil" do
+      config = subject.convert
+      filesystem = config.filesystem
+      expect(filesystem.mkfs_args).to be_nil
+    end
+  end
+
+  context "if 'filesystem' includes both mkfsExtraArguments and mkfsOptions" do
+    let(:filesystem) do
+      {
+        path:               "/test",
+        mkfsExtraArguments: "-b 2k",
+        mkfsOptions:        ["noise", "to ignore"]
+      }
+    end
+
+    it "ignores mkfsOptions in favor of mkfsExtraArguments" do
+      config = subject.convert
+      filesystem = config.filesystem
+      expect(filesystem.mkfs_args).to eq "-b 2k"
+    end
+  end
+
+  context "if 'filesystem' includes empty mkfsExtraArguments and mkfsOptions" do
+    let(:filesystem) do
+      {
+        path:               "/test",
+        mkfsExtraArguments: "",
+        mkfsOptions:        []
+      }
+    end
+
+    it "sets #mkfs_args to nil" do
+      config = subject.convert
+      filesystem = config.filesystem
+      expect(filesystem.mkfs_args).to be_nil
+    end
+  end
+
+  context "if 'filesystem' includes a non-empty mkfsOptions but no mkfsExtraArguments" do
+    let(:filesystem) do
+      {
+        path:        "/test",
+        mkfsOptions: ["some", "-b content"]
+      }
+    end
+
+    it "sets #mkfs_args based on mkfsOptions" do
+      config = subject.convert
+      filesystem = config.filesystem
+      expect(filesystem.mkfs_args).to eq "some -b content"
     end
   end
 end

--- a/service/test/agama/storage/config_conversions/from_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/examples.rb
@@ -148,7 +148,7 @@ shared_examples "with mountPath" do
     expect(filesystem.label).to be_nil
     expect(filesystem.path).to eq("/test")
     expect(filesystem.mount_by).to be_nil
-    expect(filesystem.mkfs_options).to be_empty
+    expect(filesystem.mkfs_args).to be_nil
     expect(filesystem.mount_options).to be_empty
   end
 end
@@ -183,7 +183,7 @@ shared_examples "with filesystem" do
         expect(filesystem.label).to eq("test")
         expect(filesystem.path).to be_nil
         expect(filesystem.mount_by).to be_nil
-        expect(filesystem.mkfs_options).to be_empty
+        expect(filesystem.mkfs_args).to be_nil
         expect(filesystem.mount_options).to be_empty
       end
     end
@@ -238,7 +238,7 @@ shared_examples "with filesystem" do
         expect(filesystem.label).to eq("test")
         expect(filesystem.path).to be_nil
         expect(filesystem.mount_by).to be_nil
-        expect(filesystem.mkfs_options).to be_empty
+        expect(filesystem.mkfs_args).to be_nil
         expect(filesystem.mount_options).to be_empty
       end
     end
@@ -259,7 +259,7 @@ shared_examples "with filesystem" do
         expect(filesystem.label).to eq("test")
         expect(filesystem.path).to be_nil
         expect(filesystem.mount_by).to be_nil
-        expect(filesystem.mkfs_options).to be_empty
+        expect(filesystem.mkfs_args).to be_nil
         expect(filesystem.mount_options).to be_empty
       end
     end
@@ -314,7 +314,7 @@ shared_examples "with filesystem" do
         expect(filesystem.label).to eq("test")
         expect(filesystem.path).to be_nil
         expect(filesystem.mount_by).to be_nil
-        expect(filesystem.mkfs_options).to be_empty
+        expect(filesystem.mkfs_args).to be_nil
         expect(filesystem.mount_options).to be_empty
       end
     end
@@ -334,7 +334,7 @@ shared_examples "with filesystem" do
       expect(filesystem.label).to eq("test")
       expect(filesystem.path).to be_nil
       expect(filesystem.mount_by).to be_nil
-      expect(filesystem.mkfs_options).to be_empty
+      expect(filesystem.mkfs_args).to be_nil
       expect(filesystem.mount_options).to be_empty
     end
   end
@@ -353,7 +353,7 @@ shared_examples "with filesystem" do
       expect(filesystem.label).to eq("test")
       expect(filesystem.path).to be_nil
       expect(filesystem.mount_by).to be_nil
-      expect(filesystem.mkfs_options).to eq([])
+      expect(filesystem.mkfs_args).to be_nil
       expect(filesystem.mount_options).to eq([])
     end
   end
@@ -372,7 +372,7 @@ shared_examples "with filesystem" do
       expect(filesystem.label).to be_nil
       expect(filesystem.path).to be_nil
       expect(filesystem.mount_by).to be_nil
-      expect(filesystem.mkfs_options).to eq([])
+      expect(filesystem.mkfs_args).to be_nil
       expect(filesystem.mount_options).to eq([])
     end
   end
@@ -400,7 +400,7 @@ shared_examples "with mountPath and filesystem" do
     expect(filesystem.label).to eq("test")
     expect(filesystem.path).to eq("/test")
     expect(filesystem.mount_by).to be_nil
-    expect(filesystem.mkfs_options).to be_empty
+    expect(filesystem.mkfs_args).to be_nil
     expect(filesystem.mount_options).to be_empty
   end
 end

--- a/service/test/agama/storage/config_conversions/to_json_conversions/config_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/config_test.rb
@@ -116,7 +116,6 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Config do
                 max:        1
               },
               filesystem: {
-                mkfsOptions:     [],
                 mountOptions:    [],
                 path:            "/",
                 reuseIfPossible: false

--- a/service/test/agama/storage/config_conversions/to_json_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/examples.rb
@@ -306,13 +306,13 @@ shared_examples "with filesystem" do
   context "if #encryption is configured" do
     let(:filesystem) do
       {
-        reuseIfPossible: true,
-        type:            "xfs",
-        label:           "test",
-        path:            "/test",
-        mountBy:         "device",
-        mkfsOptions:     ["version=2"],
-        mountOptions:    ["rw"]
+        reuseIfPossible:    true,
+        type:               "xfs",
+        label:              "test",
+        path:               "/test",
+        mountBy:            "device",
+        mkfsExtraArguments: "-l version=2",
+        mountOptions:       ["rw"]
       }
     end
 
@@ -322,13 +322,13 @@ shared_examples "with filesystem" do
 
       expect(filesystem_json).to eq(
         {
-          reuseIfPossible: true,
-          type:            "xfs",
-          label:           "test",
-          path:            "/test",
-          mountBy:         "device",
-          mkfsOptions:     ["version=2"],
-          mountOptions:    ["rw"]
+          reuseIfPossible:    true,
+          type:               "xfs",
+          label:              "test",
+          path:               "/test",
+          mountBy:            "device",
+          mkfsExtraArguments: "-l version=2",
+          mountOptions:       ["rw"]
         }
       )
     end
@@ -354,7 +354,6 @@ shared_examples "with filesystem" do
             type:            {
               btrfs: { snapshots: true }
             },
-            mkfsOptions:     [],
             mountOptions:    []
           }
         )
@@ -371,7 +370,6 @@ shared_examples "with filesystem" do
         expect(filesystem_json).to eq(
           {
             reuseIfPossible: false,
-            mkfsOptions:     [],
             mountOptions:    []
           }
         )

--- a/service/test/agama/storage/config_conversions/to_json_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_test.rb
@@ -134,7 +134,6 @@ describe Agama::Storage::ConfigConversions::ToJSON do
               logicalVolumes:  [
                 {
                   filesystem: {
-                    mkfsOptions:     [],
                     mountOptions:    [],
                     path:            "/",
                     reuseIfPossible: false

--- a/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
@@ -107,13 +107,13 @@ shared_examples "with filesystem" do
   context "if #filesystem is configured" do
     let(:filesystem) do
       {
-        reuseIfPossible: true,
-        type:            "xfs",
-        label:           "test",
-        path:            "/test",
-        mountBy:         "device",
-        mkfsOptions:     ["version=2"],
-        mountOptions:    ["rw"]
+        reuseIfPossible:    true,
+        type:               "xfs",
+        label:              "test",
+        path:               "/test",
+        mountBy:            "device",
+        mkfsExtraArguments: "-l version=2",
+        mountOptions:       ["rw"]
       }
     end
 
@@ -122,12 +122,12 @@ shared_examples "with filesystem" do
       expect(model_json[:mountPath]).to eq("/test")
       expect(model_json[:filesystem]).to eq(
         {
-          reuse:        true,
-          default:      false,
-          type:         "xfs",
-          label:        "test",
-          mkfsOptions:  ["version=2"],
-          mountOptions: ["rw"]
+          reuse:              true,
+          default:            false,
+          type:               "xfs",
+          label:              "test",
+          mkfsExtraArguments: "-l version=2",
+          mountOptions:       ["rw"]
         }
       )
     end

--- a/service/test/agama/storage/proposal_test.rb
+++ b/service/test/agama/storage/proposal_test.rb
@@ -188,7 +188,6 @@ describe Agama::Storage::Proposal do
                         reuseIfPossible: false,
                         path:            "/",
                         type:            "btrfs",
-                        mkfsOptions:     [],
                         mountOptions:    []
                       },
                       size:       {

--- a/web/src/components/storage/formattable-device-form/Form.test.tsx
+++ b/web/src/components/storage/formattable-device-form/Form.test.tsx
@@ -164,7 +164,7 @@ describe("FormattableDeviceForm", () => {
       await user.type(screen.getByLabelText("Mount point"), "/home");
       await user.click(screen.getByLabelText(/Define more file system settings/));
       await user.type(screen.getByLabelText(/Mount options.*optional/i), "rw,noatime");
-      await user.type(screen.getByLabelText(/Format options.*optional/i), "-O ^64bit");
+      await user.type(screen.getByLabelText(/Additional format.*optional/i), "-O ^64bit");
       await user.click(screen.getByRole("button", { name: "Accept" }));
       await waitFor(() =>
         expect(mockSetFilesystem).toHaveBeenCalledWith(
@@ -173,7 +173,7 @@ describe("FormattableDeviceForm", () => {
           expect.objectContaining({
             filesystem: expect.objectContaining({
               mountOptions: ["rw,noatime"],
-              mkfsOptions: ["-O ^64bit"],
+              mkfsExtraArguments: "-O ^64bit",
             }),
           }),
         ),

--- a/web/src/components/storage/formattable-device-form/fields.ts
+++ b/web/src/components/storage/formattable-device-form/fields.ts
@@ -51,7 +51,7 @@ const defaultValues: FormFields = {
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
-  mkfsOptions: [],
+  mkfsExtraArguments: "",
   mountOptions: [],
   showMoreFilesystemSettings: false,
 };

--- a/web/src/components/storage/formattable-device-form/transformations.test.ts
+++ b/web/src/components/storage/formattable-device-form/transformations.test.ts
@@ -41,7 +41,7 @@ describe("buildPayload", () => {
       filesystem: {
         default: true,
         label: undefined,
-        mkfsOptions: undefined,
+        mkfsExtraArguments: undefined,
         mountOptions: undefined,
       },
     });
@@ -62,7 +62,7 @@ describe("buildPayload", () => {
         default: false,
         type: "xfs",
         label: undefined,
-        mkfsOptions: undefined,
+        mkfsExtraArguments: undefined,
         mountOptions: undefined,
       },
     });
@@ -74,7 +74,7 @@ describe("buildPayload", () => {
       mountPoint: "/data",
       filesystem: "ext4",
       filesystemLabel: "my-data",
-      mkfsOptions: ["-O", "dir_index"],
+      mkfsExtraArguments: "-O dir_index",
       mountOptions: ["noatime"],
       showMoreFilesystemSettings: true,
     };
@@ -85,7 +85,7 @@ describe("buildPayload", () => {
       default: false,
       type: "ext4",
       label: "my-data",
-      mkfsOptions: ["-O", "dir_index"],
+      mkfsExtraArguments: "-O dir_index",
       mountOptions: ["noatime"],
     });
   });
@@ -96,7 +96,7 @@ describe("buildPayload", () => {
       mountPoint: "/data",
       filesystem: "ext4",
       filesystemLabel: "my-data",
-      mkfsOptions: ["-O", "dir_index"],
+      mkfsExtraArguments: "-O dir_index",
       mountOptions: ["noatime"],
       showMoreFilesystemSettings: false,
     };
@@ -107,7 +107,7 @@ describe("buildPayload", () => {
       default: false,
       type: "ext4",
       label: undefined,
-      mkfsOptions: undefined,
+      mkfsExtraArguments: undefined,
       mountOptions: undefined,
     });
   });
@@ -168,7 +168,7 @@ describe("toFormValues", () => {
       // No stored config means formatting is not a deliberate choice yet.
       filesystemAction: "reuse",
       filesystemLabel: "",
-      mkfsOptions: [],
+      mkfsExtraArguments: "",
       mountOptions: [],
       showMoreFilesystemSettings: false,
     });
@@ -224,7 +224,7 @@ describe("toFormValues", () => {
         default: false,
         type: "xfs",
         mountOptions: ["noatime", "nodiratime"],
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
       },
       partitions: [],
     };
@@ -233,7 +233,7 @@ describe("toFormValues", () => {
 
     expect(result).toMatchObject({
       mountOptions: ["noatime", "nodiratime"],
-      mkfsOptions: ["-O", "dir_index"],
+      mkfsExtraArguments: "-O dir_index",
       showMoreFilesystemSettings: true,
     });
   });

--- a/web/src/components/storage/formattable-device-form/transformations.ts
+++ b/web/src/components/storage/formattable-device-form/transformations.ts
@@ -128,7 +128,7 @@ export function buildPayload(values: typeof defaultOptions.defaultValues): Data.
  * ## Extra Filesystem Settings
  *
  * The showMoreFilesystemSettings checkbox is pre-checked when any of label,
- * mkfsOptions, or mountOptions are non-empty in the stored config.
+ * mkfsExtraArguments, or mountOptions are non-empty in the stored config.
  *
  * @param deviceModel - Drive or MD RAID config from the backend
  * @returns Partial form values to merge with defaults
@@ -168,10 +168,10 @@ export function toFormValues(
 
   const mountPoint = deviceModel.mountPath || "";
   const filesystemLabel = fsConfig?.label || "";
-  const mkfsOptions = fsConfig?.mkfsOptions || [];
+  const mkfsExtraArguments = fsConfig?.mkfsExtraArguments || "";
   const mountOptions = fsConfig?.mountOptions || [];
   const showMoreFilesystemSettings =
-    filesystemLabel !== "" || !!mkfsOptions.length || !!mountOptions.length;
+    filesystemLabel !== "" || mkfsExtraArguments !== "" || !!mountOptions.length;
 
   return {
     mountPoint,
@@ -179,7 +179,7 @@ export function toFormValues(
     filesystem: keepsFilesystem ? FILESYSTEM_ACTION.REUSE : fsConfigValue(fsConfig),
     filesystemAction: formatsFilesystem ? FILESYSTEM_ACTION.FORMAT : FILESYSTEM_ACTION.REUSE,
     filesystemLabel,
-    mkfsOptions,
+    mkfsExtraArguments,
     mountOptions,
     showMoreFilesystemSettings,
   };

--- a/web/src/components/storage/formattable-device-form/validations.test.ts
+++ b/web/src/components/storage/formattable-device-form/validations.test.ts
@@ -30,7 +30,7 @@ const createBaseFields = (): FormattableDeviceFormData => ({
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
-  mkfsOptions: [],
+  mkfsExtraArguments: "",
   mountOptions: [],
   showMoreFilesystemSettings: false,
 });

--- a/web/src/components/storage/logical-volume-form/fields.ts
+++ b/web/src/components/storage/logical-volume-form/fields.ts
@@ -97,7 +97,7 @@ const defaultValues: FormFields = {
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
-  mkfsOptions: [],
+  mkfsExtraArguments: "",
   mountOptions: [],
   showMoreFilesystemSettings: false,
   sizeMode: SIZE_MODE.AUTO,

--- a/web/src/components/storage/logical-volume-form/transformations.test.ts
+++ b/web/src/components/storage/logical-volume-form/transformations.test.ts
@@ -78,7 +78,7 @@ describe("buildPayload", () => {
         filesystem: {
           default: true,
           label: undefined,
-          mkfsOptions: undefined,
+          mkfsExtraArguments: undefined,
           mountOptions: undefined,
         },
         size: {
@@ -111,7 +111,7 @@ describe("buildPayload", () => {
           default: false,
           type: "xfs",
           label: undefined,
-          mkfsOptions: undefined,
+          mkfsExtraArguments: undefined,
           mountOptions: undefined,
         },
         size: {
@@ -130,7 +130,7 @@ describe("buildPayload", () => {
         lvName: "data",
         filesystem: "btrfs",
         filesystemLabel: "data-vol",
-        mkfsOptions: ["-m", "dup"],
+        mkfsExtraArguments: "-m dup",
         mountOptions: ["compress=zstd"],
         showMoreFilesystemSettings: true,
         sizeMode: "auto",
@@ -142,7 +142,7 @@ describe("buildPayload", () => {
         default: false,
         type: "btrfs",
         label: "data-vol",
-        mkfsOptions: ["-m", "dup"],
+        mkfsExtraArguments: "-m dup",
         mountOptions: ["compress=zstd"],
       });
     });
@@ -341,14 +341,14 @@ describe("toFormValues", () => {
         lvName: "root",
         filesystem: {
           type: "ext4",
-          mkfsOptions: ["-O", "dir_index"],
+          mkfsExtraArguments: "-O dir_index",
         },
       };
 
       const result = toFormValues(config as ConfigModel.LogicalVolume);
 
       expect(result).toMatchObject({
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         showMoreFilesystemSettings: true,
       });
     });

--- a/web/src/components/storage/logical-volume-form/transformations.ts
+++ b/web/src/components/storage/logical-volume-form/transformations.ts
@@ -231,7 +231,7 @@ export function buildPayload(
  * ## Extra Filesystem Settings
  *
  * The showMoreFilesystemSettings checkbox is pre-checked when any of label,
- * mkfsOptions, or mountOptions are non-empty in the stored config.
+ * mkfsExtraArguments, or mountOptions are non-empty in the stored config.
  *
  * @param logicalVolumeConfig - LV config from backend, or null for new LV
  * @returns Partial form values to merge with defaults
@@ -281,10 +281,10 @@ export function toFormValues(
 
   const mountPoint = logicalVolumeConfig.mountPath || "";
   const filesystemLabel = fsConfig?.label || "";
-  const mkfsOptions = fsConfig?.mkfsOptions || [];
+  const mkfsExtraArguments = fsConfig?.mkfsExtraArguments || "";
   const mountOptions = fsConfig?.mountOptions || [];
   const showMoreFilesystemSettings =
-    filesystemLabel !== "" || !!mkfsOptions.length || !!mountOptions.length;
+    filesystemLabel !== "" || mkfsExtraArguments !== "" || !!mountOptions.length;
 
   return {
     mountPoint,
@@ -294,7 +294,7 @@ export function toFormValues(
     filesystem: shouldKeepFilesystem ? FILESYSTEM_ACTION.REUSE : fsConfigValue(fsConfig),
     filesystemAction: shouldKeepFilesystem ? FILESYSTEM_ACTION.REUSE : FILESYSTEM_ACTION.FORMAT,
     filesystemLabel,
-    mkfsOptions,
+    mkfsExtraArguments,
     mountOptions,
     showMoreFilesystemSettings,
     ...inferSizeFields(logicalVolumeConfig),

--- a/web/src/components/storage/logical-volume-form/validations.test.ts
+++ b/web/src/components/storage/logical-volume-form/validations.test.ts
@@ -32,7 +32,7 @@ const createBaseFields = (): LogicalVolumeFormData => ({
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
-  mkfsOptions: [],
+  mkfsExtraArguments: "",
   mountOptions: [],
   showMoreFilesystemSettings: false,
   sizeMode: SIZE_MODE.AUTO,

--- a/web/src/components/storage/partition-form/Form.test.tsx
+++ b/web/src/components/storage/partition-form/Form.test.tsx
@@ -361,14 +361,14 @@ describe("PartitionForm", () => {
     it("shows format options field when additional settings are enabled", async () => {
       const { user } = installerRender(<PartitionForm />);
       await user.click(screen.getByLabelText(/Define more file system settings/));
-      screen.getByLabelText(/Format options.*optional/i);
+      screen.getByLabelText(/Additional format.*optional/i);
     });
 
     it("submits mkfsOptions when provided", async () => {
       const { user } = installerRender(<PartitionForm />);
       await user.type(screen.getByLabelText("Mount point"), "/data");
       await user.click(screen.getByLabelText(/Define more file system settings/));
-      const mkfsOptionsInput = screen.getByLabelText(/Format options.*optional/i);
+      const mkfsOptionsInput = screen.getByLabelText(/Additional format.*optional/i);
       await user.type(mkfsOptionsInput, "-O ^64bit");
       await user.click(screen.getByRole("button", { name: "Accept" }));
       await waitFor(() =>
@@ -377,7 +377,7 @@ describe("PartitionForm", () => {
           0,
           expect.objectContaining({
             filesystem: expect.objectContaining({
-              mkfsOptions: ["-O ^64bit"],
+              mkfsExtraArguments: "-O ^64bit",
             }),
           }),
         ),
@@ -500,7 +500,7 @@ describe("PartitionForm", () => {
             filesystem: {
               type: "xfs",
               label: "HomeData",
-              mkfsOptions: [],
+              mkfsExtraArguments: "",
               mountOptions: [],
             },
             size: { min: 50 * 1024 * 1024 * 1024, max: 50 * 1024 * 1024 * 1024, default: false },

--- a/web/src/components/storage/partition-form/fields.ts
+++ b/web/src/components/storage/partition-form/fields.ts
@@ -81,7 +81,7 @@ const defaultValues: FormFields = {
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
-  mkfsOptions: [],
+  mkfsExtraArguments: "",
   mountOptions: [],
   showMoreFilesystemSettings: false,
   sizeMode: SIZE_MODE.AUTO,

--- a/web/src/components/storage/partition-form/transformations.test.ts
+++ b/web/src/components/storage/partition-form/transformations.test.ts
@@ -46,7 +46,7 @@ describe("buildPayload", () => {
         filesystem: {
           default: true,
           label: undefined,
-          mkfsOptions: undefined,
+          mkfsExtraArguments: undefined,
           mountOptions: undefined,
         },
         size: {
@@ -77,7 +77,7 @@ describe("buildPayload", () => {
           default: false,
           type: "xfs",
           label: undefined,
-          mkfsOptions: undefined,
+          mkfsExtraArguments: undefined,
           mountOptions: undefined,
         },
         size: {
@@ -95,7 +95,7 @@ describe("buildPayload", () => {
         name: "",
         filesystem: "ext4",
         filesystemLabel: "my-data",
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         mountOptions: ["noatime"],
         showMoreFilesystemSettings: true,
         sizeMode: "auto",
@@ -107,7 +107,7 @@ describe("buildPayload", () => {
         default: false,
         type: "ext4",
         label: "my-data",
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         mountOptions: ["noatime"],
       });
     });
@@ -119,7 +119,7 @@ describe("buildPayload", () => {
         name: "",
         filesystem: "ext4",
         filesystemLabel: "my-data",
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         mountOptions: ["noatime"],
         showMoreFilesystemSettings: false,
       };
@@ -130,7 +130,7 @@ describe("buildPayload", () => {
         default: false,
         type: "ext4",
         label: undefined,
-        mkfsOptions: undefined,
+        mkfsExtraArguments: undefined,
         mountOptions: undefined,
       });
     });
@@ -288,14 +288,14 @@ describe("toFormValues", () => {
         mountPath: "/",
         filesystem: {
           type: "ext4",
-          mkfsOptions: ["-O", "dir_index"],
+          mkfsExtraArguments: "-O dir_index",
         },
       };
 
       const result = toFormValues(config as ConfigModel.Partition);
 
       expect(result).toMatchObject({
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         showMoreFilesystemSettings: true,
       });
     });

--- a/web/src/components/storage/partition-form/transformations.ts
+++ b/web/src/components/storage/partition-form/transformations.ts
@@ -161,7 +161,7 @@ export function buildPayload(values: typeof defaultOptions.defaultValues): Confi
  * ## Extra Filesystem Settings
  *
  * The showMoreFilesystemSettings checkbox is pre-checked when any of label,
- * mkfsOptions, or mountOptions are non-empty in the stored config.
+ * mkfsExtraArguments, or mountOptions are non-empty in the stored config.
  *
  * @param partitionConfig - Partition config from backend, or null for new partition
  * @returns Partial form values to merge with defaults
@@ -209,10 +209,10 @@ export function toFormValues(
 
   const mountPoint = partitionConfig.mountPath || "";
   const filesystemLabel = fsConfig?.label || "";
-  const mkfsOptions = fsConfig?.mkfsOptions || [];
+  const mkfsExtraArguments = fsConfig?.mkfsExtraArguments || "";
   const mountOptions = fsConfig?.mountOptions || [];
   const showMoreFilesystemSettings =
-    filesystemLabel !== "" || !!mkfsOptions.length || !!mountOptions.length;
+    filesystemLabel !== "" || mkfsExtraArguments !== "" || !!mountOptions.length;
 
   return {
     mountPoint,
@@ -221,7 +221,7 @@ export function toFormValues(
     filesystem: shouldKeepFilesystem ? FILESYSTEM_ACTION.REUSE : fsConfigValue(fsConfig),
     filesystemAction: shouldKeepFilesystem ? FILESYSTEM_ACTION.REUSE : FILESYSTEM_ACTION.FORMAT,
     filesystemLabel,
-    mkfsOptions,
+    mkfsExtraArguments,
     mountOptions,
     showMoreFilesystemSettings,
     ...inferSizeFields(partitionConfig),

--- a/web/src/components/storage/partition-form/validations.test.ts
+++ b/web/src/components/storage/partition-form/validations.test.ts
@@ -33,7 +33,7 @@ describe("validations", () => {
       filesystem: FILESYSTEM_TYPE.AUTO,
       filesystemAction: FILESYSTEM_ACTION.REUSE,
       filesystemLabel: "",
-      mkfsOptions: [],
+      mkfsExtraArguments: "",
       mountOptions: [],
       showMoreFilesystemSettings: false,
       sizeMode: SIZE_MODE.AUTO,

--- a/web/src/components/storage/shared/FilesystemAdditionalFields.tsx
+++ b/web/src/components/storage/shared/FilesystemAdditionalFields.tsx
@@ -57,16 +57,19 @@ const FilesystemAdditionalFields = withForm({
               )}
             </form.AppField>
             {isNewFilesystem(filesystem) && (
-              <form.AppField name="mkfsOptions">
+              <form.AppField name="mkfsExtraArguments">
                 {(field) => (
-                  <field.ArrayField
-                    label={<LabelText suffix={_("(optional)")}>{_("Format options")}</LabelText>}
-                    splitPasteOn={/\r?\n/}
+                  <field.TextField
+                    label={
+                      <LabelText suffix={_("(optional)")}>
+                        {_("Additional format arguments")}
+                      </LabelText>
+                    }
                     helperText={
                       <Interpolate
                         sentence={
                           // TRANSLATORS: %s is replaced by "mkfs" (command used to format devices)
-                          _("Additional arguments for the formatting command (%s).")
+                          _("This will be injected to the command to create the file system (%s).")
                         }
                       >
                         {() => <code>{"mkfs"}</code>}

--- a/web/src/components/storage/shared/fields.ts
+++ b/web/src/components/storage/shared/fields.ts
@@ -111,7 +111,7 @@ export type FilesystemFields = {
    */
   filesystemAction: string;
   filesystemLabel: string;
-  mkfsOptions: string[];
+  mkfsExtraArguments: string;
   mountOptions: string[];
   /**
    * Whether the optional filesystem settings (label, mkfs and mount options)
@@ -153,7 +153,7 @@ export const sharedDefaultValues: MountPointFields & FilesystemFields & SizeFiel
   filesystem: FILESYSTEM_TYPE.AUTO,
   filesystemAction: FILESYSTEM_ACTION.REUSE,
   filesystemLabel: "",
-  mkfsOptions: [],
+  mkfsExtraArguments: "",
   mountOptions: [],
   showMoreFilesystemSettings: false,
   sizeMode: SIZE_MODE.AUTO,

--- a/web/src/components/storage/shared/transformations.test.ts
+++ b/web/src/components/storage/shared/transformations.test.ts
@@ -35,7 +35,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "reuse",
         filesystemLabel: "",
-        mkfsOptions: [],
+        mkfsExtraArguments: "",
         mountOptions: [],
         showMoreFilesystemSettings: false,
       });
@@ -51,7 +51,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "reuse",
         filesystemLabel: "",
-        mkfsOptions: [],
+        mkfsExtraArguments: "",
         mountOptions: ["noatime", "rw"],
         showMoreFilesystemSettings: true,
       });
@@ -67,7 +67,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "reuse",
         filesystemLabel: "",
-        mkfsOptions: [],
+        mkfsExtraArguments: "",
         mountOptions: [],
         showMoreFilesystemSettings: true,
       });
@@ -85,7 +85,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "auto",
         filesystemLabel: "",
-        mkfsOptions: [],
+        mkfsExtraArguments: "",
         mountOptions: [],
         showMoreFilesystemSettings: false,
       });
@@ -93,7 +93,7 @@ describe("buildFilesystemConfig", () => {
       expect(result).toEqual({
         default: true,
         label: undefined,
-        mkfsOptions: undefined,
+        mkfsExtraArguments: undefined,
         mountOptions: undefined,
       });
     });
@@ -102,7 +102,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "auto",
         filesystemLabel: "my-data",
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         mountOptions: ["noatime"],
         showMoreFilesystemSettings: true,
       });
@@ -110,7 +110,7 @@ describe("buildFilesystemConfig", () => {
       expect(result).toEqual({
         default: true,
         label: "my-data",
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         mountOptions: ["noatime"],
       });
     });
@@ -119,7 +119,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "auto",
         filesystemLabel: "my-data",
-        mkfsOptions: ["-O", "dir_index"],
+        mkfsExtraArguments: "-O dir_index",
         mountOptions: ["noatime"],
         showMoreFilesystemSettings: false,
       });
@@ -127,7 +127,7 @@ describe("buildFilesystemConfig", () => {
       expect(result).toEqual({
         default: true,
         label: undefined,
-        mkfsOptions: undefined,
+        mkfsExtraArguments: undefined,
         mountOptions: undefined,
       });
     });
@@ -138,7 +138,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "xfs",
         filesystemLabel: "",
-        mkfsOptions: [],
+        mkfsExtraArguments: "",
         mountOptions: [],
         showMoreFilesystemSettings: false,
       });
@@ -147,7 +147,7 @@ describe("buildFilesystemConfig", () => {
         default: false,
         type: "xfs",
         label: undefined,
-        mkfsOptions: undefined,
+        mkfsExtraArguments: undefined,
         mountOptions: undefined,
       });
     });
@@ -156,7 +156,7 @@ describe("buildFilesystemConfig", () => {
       const result = buildFilesystemConfig({
         filesystem: "btrfs",
         filesystemLabel: "root-fs",
-        mkfsOptions: ["-m", "dup"],
+        mkfsExtraArguments: "-m dup",
         mountOptions: ["compress=zstd"],
         showMoreFilesystemSettings: true,
       });
@@ -165,7 +165,7 @@ describe("buildFilesystemConfig", () => {
         default: false,
         type: "btrfs",
         label: "root-fs",
-        mkfsOptions: ["-m", "dup"],
+        mkfsExtraArguments: "-m dup",
         mountOptions: ["compress=zstd"],
       });
     });

--- a/web/src/components/storage/shared/transformations.ts
+++ b/web/src/components/storage/shared/transformations.ts
@@ -76,9 +76,9 @@ type FilesystemConfigFields = Omit<FilesystemFields, "filesystemAction">;
  * 2. **AUTO**: Let installer choose filesystem type, allow all options
  * 3. **Explicit type**: User-selected filesystem type, allow all options
  *
- * Optional filesystem settings (label, mkfsOptions, mountOptions) are only
- * included when the showMoreFilesystemSettings checkbox is checked AND the
- * field is non-empty.
+ * Optional filesystem settings (label, mkfsExtraArguments, mountOptions) are
+ * only included when the showMoreFilesystemSettings checkbox is checked AND
+ * the field is non-empty.
  *
  * @param values - Form field values containing filesystem configuration
  * @returns Filesystem config for ConfigModel, or undefined for "no filesystem"
@@ -107,11 +107,11 @@ type FilesystemConfigFields = Omit<FilesystemFields, "filesystemAction">;
  * // Explicit XFS with mkfs options
  * buildFilesystemConfig({
  *   filesystem: "xfs",
- *   mkfsOptions: ["-m", "crc=1"],
+ *   mkfsExtraArguments: "-m crc=1",
  *   showMoreFilesystemSettings: true,
  *   ...
  * })
- * // → { default: false, type: "xfs", mkfsOptions: ["-m", "crc=1"] }
+ * // → { default: false, type: "xfs", mkfsExtraArguments: "-m crc=1" }
  */
 export function buildFilesystemConfig(
   values: FilesystemConfigFields,
@@ -139,7 +139,7 @@ export function buildFilesystemConfig(
     return {
       default: true,
       label: (extraSetting("filesystemLabel") as string) || undefined,
-      mkfsOptions: (extraSetting("mkfsOptions") as string[]) || undefined,
+      mkfsExtraArguments: (extraSetting("mkfsExtraArguments") as string) || undefined,
       mountOptions: (extraSetting("mountOptions") as string[]) || undefined,
     };
   }
@@ -149,7 +149,7 @@ export function buildFilesystemConfig(
     default: false,
     type: values.filesystem as ConfigModel.FilesystemType,
     label: (extraSetting("filesystemLabel") as string) || undefined,
-    mkfsOptions: (extraSetting("mkfsOptions") as string[]) || undefined,
+    mkfsExtraArguments: (extraSetting("mkfsExtraArguments") as string) || undefined,
     mountOptions: (extraSetting("mountOptions") as string[]) || undefined,
   };
 }

--- a/web/src/openapi/config/storage.ts
+++ b/web/src/openapi/config/storage.ts
@@ -336,7 +336,7 @@ export interface Filesystem {
   /**
    * Options for creating the file system.
    */
-  mkfsOptions?: string[];
+  mkfsExtraArguments?: string[];
   /**
    * Options to add to the fourth field of fstab.
    */

--- a/web/src/openapi/config/storage.ts
+++ b/web/src/openapi/config/storage.ts
@@ -334,9 +334,9 @@ export interface Filesystem {
   path?: string;
   mountBy?: MountBy;
   /**
-   * Options for creating the file system.
+   * Additional arguments injected as-is to the mkfs command when creating the file system.
    */
-  mkfsExtraArguments?: string[];
+  mkfsExtraArguments?: string;
   /**
    * Options to add to the fourth field of fstab.
    */

--- a/web/src/openapi/storage/config-model.ts
+++ b/web/src/openapi/storage/config-model.ts
@@ -64,7 +64,7 @@ export interface Filesystem {
   default: boolean;
   type?: FilesystemType;
   label?: string;
-  mkfsOptions?: string[];
+  mkfsExtraArguments?: string;
   mountOptions?: string[];
 }
 export interface Partition {


### PR DESCRIPTION
## Problem

- https://trello.com/c/lt6dOvXm/5779-2-storage-form-2-format-options-mount-options-in-the-form-to-create-mount-a-partition

We find out the field `mkfsOptions` in the JSON API was highly confusing and not really translated into the correct actions.

## Solution

Deprecate the confusing field in favor of a new one that is more obvious and should work almost out of the box and without introducing ambiguities.

<img width="879" height="792" alt="mkfsExtraArgs" src="https://github.com/user-attachments/assets/09d21e50-98d4-46c1-85d0-94541ab08dbc" />


## Testing

- Added a new unit tests
- Tested manually

## ToDo

- Open the corresponding pull request for documentation