### PR TITLE
refactor(web): UI fixes and improvements

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 11 23:52:08 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Standardize form Cancel actions across the application, add a
+  link back to the installation summary in the form submission
+  alerts, and fix empty toast containers blocking the header
+  toolbar (gh#agama-project/agama#3613).
+
+-------------------------------------------------------------------
 Wed Jun 10 12:07:34 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Redesign the installer header: replace the "Review and Install"

--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -75,6 +75,13 @@
 
 .pf-v6-c-alert-group.pf-m-toast {
   padding: var(--pf-t--global--spacer--xl);
+  // Prevent empty toast container from blocking clicks on elements below
+  pointer-events: none;
+
+  // Re-enable pointer events for actual alert items
+  > * {
+    pointer-events: auto;
+  }
 }
 
 .pf-v6-c-alert__title {

--- a/web/src/components/core/ConfigDialog.tsx
+++ b/web/src/components/core/ConfigDialog.tsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState } from "react";
 import { Content, Flex, Spinner } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import Popup from "~/components/core/Popup";
+import { useAppearance } from "~/context/appearance";
 import { ROOT } from "~/routes/paths";
 import { isoTimestamp } from "~/utils";
 import { _ } from "~/i18n";
@@ -37,6 +38,7 @@ type ConfigDialogProps = {
  * options to copy or download the content.
  */
 export default function ConfigDialog({ onClose }: ConfigDialogProps) {
+  const { isDark } = useAppearance();
   const [config, setConfig] = useState<string | undefined>(undefined);
   const [downloadFileName, setDownloadFileName] = useState("agama-config.json");
 
@@ -71,6 +73,7 @@ export default function ConfigDialog({ onClose }: ConfigDialogProps) {
           )}
         </Content>
         <CodeEditor
+          isDarkTheme={isDark}
           isReadOnly
           isCopyEnabled
           isDownloadEnabled

--- a/web/src/components/product/ProductSelectionPage.test.tsx
+++ b/web/src/components/product/ProductSelectionPage.test.tsx
@@ -233,7 +233,7 @@ describe("ProductSelectionPage", () => {
     it("renders the Cancel button", () => {
       mockProduct(microOs);
       installerRender(<ProductSelectionPage />);
-      screen.getByRole("link", { name: "Cancel" });
+      screen.getByRole("button", { name: "Cancel" });
     });
 
     it("triggers the product selection (reset) when user clicks the submission button", async () => {
@@ -253,7 +253,7 @@ describe("ProductSelectionPage", () => {
   it("does not render the Cancel button if product no selected yet", () => {
     mockProduct(undefined);
     installerRender(<ProductSelectionPage />);
-    expect(screen.queryByRole("link", { name: "Cancel" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
   });
 
   it("triggers the product selection when user select a product and click submission button", async () => {
@@ -271,10 +271,10 @@ describe("ProductSelectionPage", () => {
     mockProduct(microOs);
     const { user } = installerRender(<ProductSelectionPage />);
     const productOption = screen.getByRole("radio", { name: tumbleweed.name });
-    const cancel = screen.getByRole("link", { name: "Cancel" });
-    expect(cancel).toHaveAttribute("href", ROOT.overview);
+    const cancel = screen.getByRole("button", { name: "Cancel" });
     await user.click(productOption);
     await user.click(cancel);
+    expect(mockNavigateFn).toHaveBeenCalledWith(-1);
     expect(mockPutConfigFn).not.toHaveBeenCalled();
   });
 

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -51,7 +51,7 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
-import { Link, Page, SubtleContent } from "~/components/core";
+import { Page, SubtleContent } from "~/components/core";
 import ProductLogo from "~/components/product/ProductLogo";
 import LicenseDialog from "~/components/product/LicenseDialog";
 import Text from "~/components/core/Text";
@@ -544,11 +544,7 @@ const ProductForm = ({
                 selectedMode={selectedMode}
               />
             </Page.Submit>
-            {currentProduct && !isSubmitted && (
-              <Link to={ROOT.overview} size="lg" variant="link">
-                {_("Cancel")}
-              </Link>
-            )}
+            {currentProduct && !isSubmitted && <Page.Back size="lg">{_("Cancel")}</Page.Back>}
           </Split>
         </StackItem>
         <StackItem>

--- a/web/src/components/product/registration-form/Form.tsx
+++ b/web/src/components/product/registration-form/Form.tsx
@@ -222,6 +222,7 @@ export default function ProductRegistrationForm() {
               </HelperText>
             )}
           </Stack>
+          <form.CancelButton />
         </ActionGroup>
       </Form>
     </form.AppForm>

--- a/web/src/components/system/SystemPage.tsx
+++ b/web/src/components/system/SystemPage.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) [2025-2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Page } from "~/components/core";
+import SystemForm from "~/components/system/system-form/Form";
+import { _ } from "~/i18n";
+
+/**
+ * Page for configuring system settings (hostname and NTP).
+ */
+export default function SystemPage() {
+  return (
+    <Page breadcrumbs={[{ label: _("System") }]}>
+      <Page.Content>
+        <SystemForm />
+      </Page.Content>
+    </Page>
+  );
+}

--- a/web/src/components/system/system-form/Form.test.tsx
+++ b/web/src/components/system/system-form/Form.test.tsx
@@ -23,7 +23,7 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
-import SystemPage from "./Form";
+import SystemForm from "./Form";
 
 let mockStaticHostname: string;
 const mockPatchConfig = jest.fn();
@@ -57,7 +57,7 @@ jest.mock("~/hooks/model/proposal", () => ({
   }),
 }));
 
-describe("SystemPage", () => {
+describe("SystemForm", () => {
   beforeEach(() => {
     mockSystem.mockReturnValue({});
     mockStaticHostname = "";
@@ -65,25 +65,25 @@ describe("SystemPage", () => {
   });
 
   it("renders hostname and NTP settings sections", () => {
-    installerRender(<SystemPage />);
+    installerRender(<SystemForm />);
     screen.getByRole("group", { name: "Hostname" });
     screen.getByRole("group", { name: "Time Synchronization Servers" });
   });
 
   describe("form submission", () => {
     it("does not send config when nothing changed", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const acceptButton = screen.getByRole("button", { name: "Accept" });
       await user.click(acceptButton);
 
       expect(mockPatchConfig).not.toHaveBeenCalled();
-      screen.getByText("No changes detected. System settings are already up to date.");
+      screen.getByText("No changes to apply");
     });
 
     it("only sends hostname config when hostname changed", async () => {
       mockStaticHostname = "my-server";
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const hostnameInput = screen.getByRole("textbox", { name: "Name" });
       await user.clear(hostnameInput);
@@ -98,7 +98,7 @@ describe("SystemPage", () => {
     });
 
     it("only sends NTP config when NTP settings changed", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const modeButtons = screen.getAllByLabelText("Mode");
       const ntpModeButton = modeButtons[1];
@@ -128,7 +128,7 @@ describe("SystemPage", () => {
     });
 
     it("does not send config when switching back to initial state", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       // Switch to custom mode
       const modeButtons = screen.getAllByLabelText("Mode");
@@ -151,11 +151,11 @@ describe("SystemPage", () => {
 
       // No config should be sent because we're back to the initial state
       expect(mockPatchConfig).not.toHaveBeenCalled();
-      screen.getByText("No changes detected. System settings are already up to date.");
+      await screen.findByText("No changes to apply");
     });
 
     it("sends both hostname and NTP config when both changed", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       // Change hostname mode to static
       const modeButtons = screen.getAllByLabelText("Mode");
@@ -198,7 +198,7 @@ describe("SystemPage", () => {
     });
 
     it("shows success alert after successful update", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       // Make a change to trigger an update
       const modeButtons = screen.getAllByLabelText("Mode");
@@ -214,12 +214,12 @@ describe("SystemPage", () => {
       const acceptButton = screen.getByRole("button", { name: "Accept" });
       await user.click(acceptButton);
 
-      screen.getByText("System settings successfully updated");
+      await screen.findByText("Changes successfully applied");
     });
 
     it("shows error alert when update fails", async () => {
       mockPatchConfig.mockRejectedValue({ message: "Network error" });
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       // Change something to trigger API call
       const modeButtons = screen.getAllByLabelText("Mode");
@@ -242,7 +242,7 @@ describe("SystemPage", () => {
 
   describe("validation", () => {
     it("shows error when static hostname is empty", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const modeButtons = screen.getAllByLabelText("Mode");
       const hostnameModeButton = modeButtons[0];
@@ -262,7 +262,7 @@ describe("SystemPage", () => {
     });
 
     it("shows error when custom NTP mode has no servers", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const modeButtons = screen.getAllByLabelText("Mode");
       const ntpModeButton = modeButtons[1];
@@ -279,7 +279,7 @@ describe("SystemPage", () => {
     });
 
     it("shows error when NTP servers are invalid", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const modeButtons = screen.getAllByLabelText("Mode");
       const ntpModeButton = modeButtons[1];
@@ -302,7 +302,7 @@ describe("SystemPage", () => {
     });
 
     it("accepts valid NTP server hostnames", async () => {
-      const { user } = installerRender(<SystemPage />);
+      const { user } = installerRender(<SystemForm />);
 
       const modeButtons = screen.getAllByLabelText("Mode");
       const ntpModeButton = modeButtons[1];

--- a/web/src/components/system/system-form/Form.tsx
+++ b/web/src/components/system/system-form/Form.tsx
@@ -20,13 +20,13 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useRef } from "react";
+import React from "react";
 import { isEmpty, isNullish, shake } from "radashi";
 import { ActionGroup, Alert, Form } from "@patternfly/react-core";
-import Page from "~/components/core/Page";
 import { patchConfig } from "~/api";
 import { useConfig } from "~/hooks/model/config";
 import { useProposal } from "~/hooks/model/proposal";
+import { useFormSubmit } from "~/hooks/use-form-submit";
 import { anyFieldChanged, useAppForm } from "~/hooks/form";
 import { _ } from "~/i18n";
 
@@ -82,30 +82,37 @@ function buildNtpConfig(
 }
 
 /**
- * Page for configuring system settings.
+ * Form for configuring system settings.
  *
  * Allows the user to configure:
  * - Hostname: choose between a transient hostname (provided by the network) or
  *   a static one (set manually)
  * - NTP: choose between default NTP servers or custom ones
  */
-export default function SystemPage() {
-  /**
-   * Tracks whether the backend config was actually patched during the last submit.
-   *
-   * Used to distinguish between two successful submit scenarios:
-   * - true: form had changes, backend was updated via patchConfig()
-   * - false: form validated successfully but no changes needed persisting
-   *
-   * This determines the alert variant (success vs info) and message shown to the user.
-   */
-  const configWasPatched = useRef(false);
+export default function SystemForm() {
   const { ntp } = useConfig();
   const { hostname } = useProposal();
   const { hostname: transientHostname, static: staticHostname } = hostname;
 
   const ntpServers = ntp?.sources?.map((s) => s.address) || [];
   const usingTransientHostname = isEmpty(staticHostname) || isNullish(staticHostname);
+
+  // useFormSubmit is initialized before useAppForm so we can pass onSubmitAsync
+  // directly into the validators option — no mutation, no two-phase wiring.
+  const { onSubmitAsync, AlertSubscribe, formSubmitHandler } = useFormSubmit<SystemFormValues>({
+    onSubmit: async (formValues, fieldMeta) => {
+      const config = shake({
+        hostname: buildHostnameConfig(formValues, fieldMeta),
+        ntp: buildNtpConfig(formValues, fieldMeta),
+      });
+
+      if (isEmpty(config)) return { noChanges: true };
+
+      return patchConfig(config)
+        .then(() => ({ patched: true as const }))
+        .catch(({ message }) => ({ error: message }));
+    },
+  });
 
   const form = useAppForm({
     ...defaultOptions,
@@ -116,102 +123,50 @@ export default function SystemPage() {
       ntpServers,
     },
     validators: {
-      onSubmitAsync: async ({ value: formValues, formApi }) => {
-        configWasPatched.current = false;
-
-        // Form pristine, nothing has changed for sure, skip everything
-        if (!formApi.state.isDirty) return undefined;
-
-        const fieldErrors = validate(formValues);
+      onSubmitAsync: async (ctx) => {
+        // Field validation runs first. If it fails, TanStack Form surfaces
+        // errors per field and onSubmitAsync (business logic) is not called.
+        const fieldErrors = validate(ctx.value);
         if (fieldErrors) return fieldErrors;
 
-        const { fieldMeta } = formApi.state;
-
-        const config = shake({
-          hostname: buildHostnameConfig(formValues, fieldMeta),
-          ntp: buildNtpConfig(formValues, fieldMeta),
-        });
-
-        // Form dirty but no actual changes nor backend patches needed
-        if (isEmpty(config)) {
-          form.reset(formValues);
-          return undefined;
-        }
-
-        return await patchConfig(config)
-          .then(() => {
-            configWasPatched.current = true;
-            form.reset(formValues);
-            return undefined;
-          })
-          .catch(({ message: errorMessage }) => ({
-            form: errorMessage,
-          }));
+        // Business logic: patch building + API call.
+        return onSubmitAsync(ctx, form);
       },
     },
   });
 
   return (
-    <Page breadcrumbs={[{ label: _("System") }]}>
-      <Page.Content>
-        <form.AppForm>
-          <Form
-            id="systemForm"
-            onSubmit={(e) => {
-              e.preventDefault();
-              form.setErrorMap({ onSubmit: { fields: {} } });
-              form.handleSubmit();
-            }}
-          >
-            <form.Subscribe selector={(s) => s.errorMap.onSubmit?.form}>
-              {(serverError) =>
-                serverError && (
-                  <Alert
-                    isInline
-                    variant="danger"
-                    title={
-                      // TRANSLATORS: error message when system settings update request fails
-                      _("System settings could not be updated")
-                    }
-                  >
-                    {serverError}
-                  </Alert>
-                )
-              }
-            </form.Subscribe>
+    <form.AppForm>
+      <Form id="systemForm" onSubmit={formSubmitHandler(form)}>
+        {/* Server error alert */}
+        <form.Subscribe selector={(s) => s.errorMap.onSubmit?.form}>
+          {(serverError) =>
+            serverError && (
+              <Alert
+                isInline
+                variant="danger"
+                title={
+                  // TRANSLATORS: error message when system settings update request fails
+                  _("System settings could not be updated")
+                }
+              >
+                {serverError}
+              </Alert>
+            )
+          }
+        </form.Subscribe>
 
-            <form.Subscribe
-              selector={(s) =>
-                s.isSubmitted && !s.isSubmitting && !s.errorMap.onSubmit?.form && !s.isDirty
-              }
-            >
-              {(showResult) =>
-                showResult && (
-                  <Alert
-                    isInline
-                    variant={configWasPatched.current ? "success" : "info"}
-                    title={
-                      configWasPatched.current
-                        ? // TRANSLATORS: success message shown after system settings are updated
-                          _("System settings successfully updated")
-                        : // TRANSLATORS: info message shown when submitting the form with no changes
-                          _("No changes detected. System settings are already up to date.")
-                    }
-                  />
-                )
-              }
-            </form.Subscribe>
+        {/* Success / no-changes / validation error alerts — managed by useFormSubmit */}
+        <AlertSubscribe form={form} />
 
-            <HostnameFields form={form} />
-            <NtpFields form={form} />
+        <HostnameFields form={form} />
+        <NtpFields form={form} />
 
-            <ActionGroup>
-              {/* TRANSLATORS: button to save system settings changes */}
-              <form.SubmitButton label={_("Accept")} />
-            </ActionGroup>
-          </Form>
-        </form.AppForm>
-      </Page.Content>
-    </Page>
+        <ActionGroup>
+          {/* TRANSLATORS: button to save system settings changes */}
+          <form.SubmitButton label={_("Accept")} />
+        </ActionGroup>
+      </Form>
+    </form.AppForm>
   );
 }

--- a/web/src/components/system/system-form/Form.tsx
+++ b/web/src/components/system/system-form/Form.tsx
@@ -165,6 +165,7 @@ export default function SystemForm() {
         <ActionGroup>
           {/* TRANSLATORS: button to save system settings changes */}
           <form.SubmitButton label={_("Accept")} />
+          <form.CancelButton />
         </ActionGroup>
       </Form>
     </form.AppForm>

--- a/web/src/components/users/authentication-form/Form.test.tsx
+++ b/web/src/components/users/authentication-form/Form.test.tsx
@@ -170,6 +170,8 @@ describe("AuthenticationForm", () => {
 
       expect(mockPutConfig).not.toHaveBeenCalled();
       screen.getByText("No changes to apply");
+      const link = screen.getByRole("link", { name: "installation" });
+      expect(link).toHaveAttribute("href", "/overview");
     });
 
     it("creates first user when checkbox is checked", async () => {
@@ -383,6 +385,8 @@ describe("AuthenticationForm", () => {
       await user.click(screen.getByRole("button", { name: "Accept" }));
 
       await screen.findByText("Changes successfully applied");
+      const link = screen.getByRole("link", { name: "installation" });
+      expect(link).toHaveAttribute("href", "/overview");
     });
   });
 });

--- a/web/src/components/users/authentication-form/Form.tsx
+++ b/web/src/components/users/authentication-form/Form.tsx
@@ -274,6 +274,7 @@ function AuthenticationForm({ user, root }: AuthenticationFormProps) {
 
         <ActionGroup>
           <form.SubmitButton label={_("Accept")} />
+          <form.CancelButton />
         </ActionGroup>
       </Form>
     </form.AppForm>

--- a/web/src/hooks/use-form-submit.tsx
+++ b/web/src/hooks/use-form-submit.tsx
@@ -23,6 +23,9 @@
 import React, { useRef } from "react";
 import { Alert } from "@patternfly/react-core";
 import Page from "~/components/core/Page";
+import Interpolate from "~/components/core/Interpolate";
+import Link from "~/components/core/Link";
+import { ROOT } from "~/routes/paths";
 import { _ } from "~/i18n";
 
 // Minimal interface describing the form instance methods and state that
@@ -267,7 +270,20 @@ export function useFormSubmit<TValues>({
               isInline
               variant={wasPatched.current ? "success" : "info"}
               title={wasPatched.current ? successTitle : noChangesTitle}
-            />
+            >
+              <Interpolate
+                sentence={
+                  /* TRANSLATORS: Link shown in the alert after submitting a form. Text in [brackets] becomes a link. Keep the brackets. */
+                  _("Go to [installation] summary")
+                }
+              >
+                {(linkText) => (
+                  <Link isInline variant="link" to={ROOT.overview}>
+                    {linkText}
+                  </Link>
+                )}
+              </Interpolate>
+            </Alert>
           );
         }}
       </form.Subscribe>

--- a/web/src/hooks/use-form-submit.tsx
+++ b/web/src/hooks/use-form-submit.tsx
@@ -274,7 +274,7 @@ export function useFormSubmit<TValues>({
               <Interpolate
                 sentence={
                   /* TRANSLATORS: Link shown in the alert after submitting a form. Text in [brackets] becomes a link. Keep the brackets. */
-                  _("Go to [installation] summary")
+                  _("Go to [installation] summary.")
                 }
               >
                 {(linkText) => (

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -30,7 +30,7 @@ import InstallationFinished from "~/components/core/InstallationFinished";
 import InstallationProgress from "~/components/core/InstallationProgress";
 import LoginPage from "~/components/core/LoginPage";
 import OverviewPage from "~/components/overview/OverviewPage";
-import SystemPage from "~/components/system/system-form/Form";
+import SystemPage from "~/components/system/SystemPage";
 import l10nRoutes from "~/routes/l10n";
 import networkRoutes from "~/routes/network";
 import productsRoutes from "~/routes/products";


### PR DESCRIPTION
This PR improves form consistency, navigation, and user guidance across the web UI. It standardizes form actions, provides clearer feedback after submission, and fixes a minor UI issue with the header.

As part of an effort to unify form behavior across the application, form-level **Cancel** actions now consistently navigate back to the previous page. This pattern applies also to pages that are themselves forms (system, authentication, registration, product selection, etc.), rather than summary or overview pages that serve as navigation hubs to other sections.

## Changes

* **Refactor system settings form**

  * Uses shared form handling for consistency with other forms
  * Keeps the form testable independently from the page wrapper

* **Improve post-submit feedback**
  * Success and no-changes alerts now include a link back to the installation summary
  * 
  | Success | No changes |
  |-|-|
  | <img width="334" height="173" alt="Screenshot_2026-06-12_00-57-01" src="https://github.com/user-attachments/assets/d82c6a9d-241f-4a4c-8aa5-57e067f6f176" /> | <img width="334" height="173" alt="Screenshot_2026-06-12_00-56-54" src="https://github.com/user-attachments/assets/1760dffc-102c-47a4-8c79-9acd8a6d7f0d" /> |


* **Standardize form Cancel actions**

  * Add Cancel buttons to the system, authentication, and registration forms
  * Use back navigation for the product selection Cancel action
  * Align form navigation behavior across the application

  | System | Authentication | Registration |
  |-|-|-|
  | <img width="2048" height="1536" alt="localhost_8080_ - 2026-06-11T235425 354" src="https://github.com/user-attachments/assets/13e1a83c-5ccf-4549-9c64-2bc1ea153022" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-06-11T235527 023" src="https://github.com/user-attachments/assets/40c90cbb-d3b9-4e03-9466-78fd1f4f9e8c" /> | <img width="2052" height="1536" alt="localhost_8080_ - 2026-06-11T235554 681" src="https://github.com/user-attachments/assets/6d230263-95d5-4f4c-8eac-ec7b002249f6" /> |

* **Fix color scheme leftover in the config dialog**

    * The JSON code editor now uses its dark theme when dark mode is active

    | Before | After |
    |-|-|
    | <img width="2048" height="1536" alt="localhost_8080_ - 2026-06-12T010401 788" src="https://github.com/user-attachments/assets/99bb0f42-efcb-4472-8087-705e9d899bfb" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-06-12T010052 274" src="https://github.com/user-attachments/assets/36ab0694-0999-49c2-b1d9-5517bcd03f6a" /> |




* **Fix header toolbar interaction**

  * Prevents empty toast containers from blocking clicks on header actions
