### PR TITLE
Print the status after the exiting the monitor

### DIFF
--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -29,16 +29,14 @@ mod ui;
 
 use agama_lib::{
     http::{BaseHTTPClient, WebSocketClient},
-    monitor::{InstallationStatus, Monitor, MonitorUpdate},
+    monitor::{Monitor, MonitorUpdate},
 };
-use agama_utils::api::status::Stage;
 use anyhow::Result;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use gettextrs::gettext;
 use ratatui::{backend::CrosstermBackend, Terminal, TerminalOptions, Viewport};
 use std::io::{self, IsTerminal};
 
-use crate::monitor::app::MonitorAppBuilder;
+use crate::{monitor::app::MonitorAppBuilder, status::StatusReport};
 
 const MONITOR_HEIGHT: u16 = 20;
 
@@ -153,7 +151,8 @@ pub async fn run(
     // Handle result
     match result {
         Ok(status) => {
-            print_status(status);
+            let report = StatusReport::new(status);
+            println!("{}", report);
         }
         Err(e) => {
             eprintln!("{e}");
@@ -162,24 +161,4 @@ pub async fn run(
 
     // Forces crossterm loop to finish.
     std::process::exit(0);
-}
-
-fn print_status(status: InstallationStatus) {
-    let message = match &status.status.stage {
-        Stage::Configuring => {
-            if !status.questions.is_empty() {
-                gettext("There are pending questions you need to answer")
-            } else if status.issues.is_empty() {
-                gettext("There are invalid settings. You need to fix them before proceeding with the installation.")
-            } else if !status.status.progresses.is_empty() || !status.status.tasks.is_empty() {
-                gettext("The installer is reading the configuration.")
-            } else {
-                gettext("The system is ready for installation.")
-            }
-        }
-        Stage::Installing => gettext("The system is being installed."),
-        Stage::Finished => gettext("The installation has finished successfully."),
-        Stage::Failed => gettext("The installation has failed."),
-    };
-    println!("{message}");
 }

--- a/rust/agama-cli/src/monitor.rs
+++ b/rust/agama-cli/src/monitor.rs
@@ -29,10 +29,12 @@ mod ui;
 
 use agama_lib::{
     http::{BaseHTTPClient, WebSocketClient},
-    monitor::{Monitor, MonitorUpdate},
+    monitor::{InstallationStatus, Monitor, MonitorUpdate},
 };
+use agama_utils::api::status::Stage;
 use anyhow::Result;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use gettextrs::gettext;
 use ratatui::{backend::CrosstermBackend, Terminal, TerminalOptions, Viewport};
 use std::io::{self, IsTerminal};
 
@@ -150,8 +152,8 @@ pub async fn run(
 
     // Handle result
     match result {
-        Ok(()) => {
-            // Normal finish (idle or user quit)
+        Ok(status) => {
+            print_status(status);
         }
         Err(e) => {
             eprintln!("{e}");
@@ -160,4 +162,24 @@ pub async fn run(
 
     // Forces crossterm loop to finish.
     std::process::exit(0);
+}
+
+fn print_status(status: InstallationStatus) {
+    let message = match &status.status.stage {
+        Stage::Configuring => {
+            if !status.questions.is_empty() {
+                gettext("There are pending questions you need to answer")
+            } else if status.issues.is_empty() {
+                gettext("There are invalid settings. You need to fix them before proceeding with the installation.")
+            } else if !status.status.progresses.is_empty() || !status.status.tasks.is_empty() {
+                gettext("The installer is reading the configuration.")
+            } else {
+                gettext("The system is ready for installation.")
+            }
+        }
+        Stage::Installing => gettext("The system is being installed."),
+        Stage::Finished => gettext("The installation has finished successfully."),
+        Stage::Failed => gettext("The installation has failed."),
+    };
+    println!("{message}");
 }

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -285,7 +285,7 @@ impl MonitorApp {
                         if let Event::Key(key_event) = event {
                             if self.handle_key_event(key_event) {
                                 terminal_handle.abort();
-                                return Ok(());
+                                return Ok(self.status.clone());
                             }
                         }
                     }

--- a/rust/agama-cli/src/monitor/app.rs
+++ b/rust/agama-cli/src/monitor/app.rs
@@ -187,7 +187,7 @@ impl MonitorApp {
     pub async fn run(
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    ) -> Result<(), MonitorError> {
+    ) -> Result<InstallationStatus, MonitorError> {
         let (tx, mut rx) = mpsc::channel(16);
 
         // Take ownership of the monitor updates receiver
@@ -238,7 +238,7 @@ impl MonitorApp {
                 Message::StatusUpdate(status) => self.update_status(status),
                 Message::Finished => {
                     terminal_handle.abort();
-                    return Ok(());
+                    return Ok(self.status.clone());
                 }
                 Message::Disconnected => {
                     terminal_handle.abort();
@@ -256,7 +256,7 @@ impl MonitorApp {
                             && key_event.modifiers == KeyModifiers::CONTROL
                         {
                             terminal_handle.abort();
-                            return Ok(());
+                            return Ok(self.status.clone());
                         }
                     }
 

--- a/rust/agama-cli/src/monitor/ui/question.rs
+++ b/rust/agama-cli/src/monitor/ui/question.rs
@@ -218,10 +218,10 @@ impl QuestionUiState {
                 let mut answer = Answer::new(&selected_action.id);
 
                 match &question.spec.field {
-                    QuestionField::String | QuestionField::Password => {
-                        if !self.input_text.is_empty() {
-                            answer = answer.with_value(&self.input_text);
-                        }
+                    QuestionField::String | QuestionField::Password
+                        if !self.input_text.is_empty() =>
+                    {
+                        answer = answer.with_value(&self.input_text);
                     }
                     QuestionField::Select { options } => {
                         if let Some(opt) = options.get(self.field_selection_idx) {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Jun 12 12:37:58 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Print the status after running the "monitor", "config load" and
-  "install" commands (gh#agama-project/agama#3615).
+- Print the status after running the "monitor", "config load",
+  "config edit" and "install" commands (gh#agama-project/agama#3615).
 
 -------------------------------------------------------------------
 Fri Jun 12 12:19:51 UTC 2026 - Josef Reidinger <jreidinger@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 12 12:37:58 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Print the status after running the "monitor", "config load" and
+  "install" commands (gh#agama-project/agama#3615).
+
+-------------------------------------------------------------------
 Fri Jun 12 12:19:51 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Add to `agama monitor` ability to answer questions


### PR DESCRIPTION
Print the output of the "agama status" comment after exiting the monitor. The idea is that the  user knows what is going on after the last command. Take into account that the monitor runs when loading the configuration or when performing the installation.