### PR TITLE
Translatable texts for the terminal feature

### DIFF
--- a/web/src/terminal-texts.js
+++ b/web/src/terminal-texts.js
@@ -1,0 +1,36 @@
+/**
+ * This is just a dummy file to have translatable texts for implementing
+ * an embedded terminal later. Delete this file when not needed anymore.
+ */
+
+import { _ } from "~/i18n";
+
+/**
+ * Dummy function just for defining translatable texts.
+ * @returns Array of translated texts
+ */
+function dummy() {
+  return [
+    // TRANSLATORS: menu item for opening a terminal session in browser
+    _("Terminal"),
+    // TRANSLATORS: label for closing the terminal
+    _("Close terminal"),
+    // alternative message if we can only hide the terminal (keeping the current
+    // session running)
+    // TRANSLATORS: label for hiding the terminal
+    _("Hide terminal"),
+    // TRANSLATORS: error message
+    _("Error: Cannot open a terminal session"),
+    // TRANSLATORS: page header
+    _("Terminal session"),
+    // take the host name from document.location.host, display only when
+    // connected remotely, i.e. the host is not "localhost"
+    // TRANSLATORS:
+    _("Connected to %s"),
+    // TRANSLATORS: %s is keyboard shortcut for switching the browser tabs,
+    // usually Ctrl+Tab
+    _("Use %s keyboard shortcut to switch between the terminal and the installer."),
+  ];
+}
+
+export default dummy;


### PR DESCRIPTION
## Problem

- Because of the translation text freeze we need the translatable texts for the terminal feature ASAP

## Solution

- Add the texts into a separate not used file
- Move the texts later and delete the file when not needed

## Proposal

When using the terminal you will most likely need to often switch between the terminal and the installer. You run a command, check the result in the web UI, click something there, run another command in terminal to see what has changed, etc...

Opening a terminal in a popup would probably require closing and opening it again too many times. Therefore I propose opening the terminal in a separate tab so you easily switch between then.

But switching back to installer might not be easy esp. when running a fullscreen mode. Let's display a short help.


Simple text mockup:

---
### Terminal session &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;X

Connected to 192.168.42

> [!NOTE]
>
> Use Ctrl+Tab keyboard shortcut to switch between the terminal and the installer.


```console
agama:~ #














```

---
