### PR TITLE
Unify "status" and "monitor" strings

### DIFF
--- a/rust/agama-cli/src/monitor/ui/content.rs
+++ b/rust/agama-cli/src/monitor/ui/content.rs
@@ -169,7 +169,7 @@ impl<'a> Content<'a> {
         });
 
         let lines = vec![Line::from(Span::styled(
-            gettext("Following issues needs to be addressed in the configuration:"),
+            gettext("Fix invalid settings before starting the installation:"),
             Style::default().add_modifier(Modifier::BOLD),
         ))];
         Paragraph::new(lines).render(title_area, buf);
@@ -190,8 +190,8 @@ impl<'a> Content<'a> {
         // This is called when there are no progresses, no issues, and no questions
         // So if we're in Configuring, we're ready to install
         let message = match self.status.status.stage {
-            Stage::Configuring => gettext("Ready for installation."),
-            Stage::Installing => gettext("Waiting to start installation..."),
+            Stage::Configuring => gettext("Ready to start the installation."),
+            Stage::Installing => gettext("Starting the installation."),
             _ => return,
         };
 

--- a/rust/agama-cli/src/monitor/ui/issues.rs
+++ b/rust/agama-cli/src/monitor/ui/issues.rs
@@ -18,31 +18,21 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use std::collections::HashMap;
-
-use agama_utils::api::{self, IssueWithScope, Scope};
-use gettextrs::gettext;
+use agama_utils::api::{self, IssueWithScope};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::{Modifier, Style},
-    text::{Line, Span},
+    text::Line,
     widgets::{Paragraph, Widget, Wrap},
 };
 
-use crate::monitor::ui::scope_to_string;
-
 pub struct IssuesList<'a> {
-    groups: HashMap<Scope, Vec<&'a api::Issue>>,
+    issues: &'a Vec<api::IssueWithScope>,
 }
 
 impl<'a> IssuesList<'a> {
     pub fn new(issues: &'a Vec<IssueWithScope>) -> Self {
-        let mut groups: HashMap<Scope, Vec<&api::Issue>> = HashMap::new();
-        for issue in issues {
-            groups.entry(issue.scope).or_default().push(&issue.issue);
-        }
-        Self { groups }
+        Self { issues }
     }
 }
 
@@ -50,20 +40,9 @@ impl<'a> Widget for IssuesList<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let mut lines = vec![];
 
-        for (scope, issues) in self.groups {
-            lines.push(Line::from(format!("  {}", scope_to_string(&scope))));
-            lines.push(Line::default());
-
-            for issue in issues {
-                lines.push(Line::from(format!("    - {}", &issue.description)));
-            }
-            lines.push(Line::default());
+        for issue in self.issues {
+            lines.push(Line::from(format!("- {}", &issue.issue.description)));
         }
-
-        lines.push(Line::from(Span::styled(
-            gettext("Waiting for these to be resolved."),
-            Style::default().add_modifier(Modifier::DIM),
-        )));
 
         Paragraph::new(lines)
             .wrap(Wrap { trim: false })

--- a/rust/agama-cli/src/status.rs
+++ b/rust/agama-cli/src/status.rs
@@ -314,7 +314,6 @@ mod tests {
         let report = StatusReport::new(status);
         let output = report.to_string();
         assert!(output.contains("Installation is ready to start."));
-        assert!(output.contains("Details:"));
         assert!(!output.contains("Open questions:"));
         assert!(!output.contains("Blocking issues:"));
     }
@@ -332,9 +331,9 @@ mod tests {
         ));
         let report = StatusReport::new(status);
         let output = report.to_string();
+        println!("{}", output);
         assert!(output.contains("There are unanswered questions."));
-        assert!(output.contains("Details:"));
-        assert!(output.contains("Open questions:\n  - What is your name?"));
-        assert!(output.contains("Blocking issues:\n  - This is a blocking issue."));
+        assert!(output.contains("  - What is your name?"));
+        assert!(output.contains("  - This is a blocking issue."));
     }
 }

--- a/rust/agama-cli/src/status.rs
+++ b/rust/agama-cli/src/status.rs
@@ -21,7 +21,6 @@
 use crate::api;
 use agama_lib::monitor::InstallationStatus;
 use agama_utils::api::status::Stage;
-use crossterm::style::Stylize;
 use gettextrs::gettext;
 use serde::Serialize;
 use std::fmt;
@@ -75,20 +74,18 @@ impl fmt::Display for InstallationEnum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let text = match self {
             Self::Failed => gettext(
-                "Installation failed. Use the \"agama logs store\" command to get the logs to \
+                "The installation failed. Use the \"agama logs store\" command to get the logs to \
                 troubleshoot or share with support.",
             ),
-            Self::Succeeded => gettext("Installation finished successfully."),
-            Self::Ready => gettext("Installation is ready to start."),
-            Self::Installing => gettext("Installation is in progress."),
+            Self::Succeeded => gettext("The installation finished successfully."),
+            Self::Ready => gettext("Ready to start the installation."),
+            Self::Installing => gettext("The installation is in progress."),
             Self::Proposing => gettext("The installer is preparing an installation proposal."),
             Self::Question => gettext(
                 "There are unanswered questions. Use the \"agama monitor\" command or the \
-                web user interface to answer them.",
+                web user interface to answer them:",
             ),
-            Self::Issues => {
-                gettext("There are issues in configuration that are blocking the installation.")
-            }
+            Self::Issues => gettext("Fix invalid settings before starting the installation:"),
         };
         write!(f, "{}", text)
     }
@@ -122,21 +119,18 @@ impl StatusReport {
 
 impl fmt::Display for StatusReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{}", self.installation)?;
+        writeln!(f, "{}\n", self.installation)?;
 
         if !self.questions.is_empty() {
-            writeln!(f, "\n{}", gettext("Open questions:").bold())?;
             for q in &self.questions {
                 writeln!(f, "  - {}", q.spec.text)?;
             }
-        }
-
-        if !self.issues.is_empty() {
-            writeln!(f, "\n{}", gettext("Blocking issues:").bold())?;
+        } else if !self.issues.is_empty() {
             for i in &self.issues {
                 writeln!(f, "  - {}", i.issue.description)?;
             }
         }
+
         Ok(())
     }
 }
@@ -313,9 +307,7 @@ mod tests {
         let status = default_status();
         let report = StatusReport::new(status);
         let output = report.to_string();
-        assert!(output.contains("Installation is ready to start."));
-        assert!(!output.contains("Open questions:"));
-        assert!(!output.contains("Blocking issues:"));
+        assert!(output.contains("Ready to start the installation"));
     }
 
     #[test]
@@ -331,7 +323,6 @@ mod tests {
         ));
         let report = StatusReport::new(status);
         let output = report.to_string();
-        println!("{}", output);
         assert!(output.contains("There are unanswered questions."));
         assert!(output.contains("  - What is your name?"));
         assert!(output.contains("  - This is a blocking issue."));

--- a/rust/agama-cli/src/status.rs
+++ b/rust/agama-cli/src/status.rs
@@ -325,6 +325,18 @@ mod tests {
         let output = report.to_string();
         assert!(output.contains("There are unanswered questions."));
         assert!(output.contains("  - What is your name?"));
-        assert!(output.contains("  - This is a blocking issue."));
+        assert!(!output.contains("This is a blocking issue."));
+    }
+
+    #[test]
+    fn test_status_report_display_with_issues() {
+        let mut status = default_status();
+        status.issues.push(IssueWithScope {
+            scope: Scope::Manager,
+            issue: Issue::new("class1", "This is a blocking issue."),
+        });
+        let report = StatusReport::new(status);
+        let output = report.to_string();
+        assert!(output.contains("This is a blocking issue."));
     }
 }

--- a/rust/agama-cli/src/status.rs
+++ b/rust/agama-cli/src/status.rs
@@ -21,6 +21,7 @@
 use crate::api;
 use agama_lib::monitor::InstallationStatus;
 use agama_utils::api::status::Stage;
+use crossterm::style::Stylize;
 use gettextrs::gettext;
 use serde::Serialize;
 use std::fmt;
@@ -73,13 +74,21 @@ impl InstallationEnum {
 impl fmt::Display for InstallationEnum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let text = match self {
-            Self::Failed => gettext("Installation failed."),
+            Self::Failed => gettext(
+                "Installation failed. Use the \"agama logs store\" command to get the logs to \
+                troubleshoot or share with support.",
+            ),
             Self::Succeeded => gettext("Installation finished successfully."),
             Self::Ready => gettext("Installation is ready to start."),
             Self::Installing => gettext("Installation is in progress."),
-            Self::Proposing => gettext("Installation is being proposed."),
-            Self::Question => gettext("There are unanswered questions. Use `agama monitor` command or the web user interface to answer them."),
-            Self::Issues => gettext("There are issues in configuration that are blocking the installation."),
+            Self::Proposing => gettext("The installer is preparing an installation proposal."),
+            Self::Question => gettext(
+                "There are unanswered questions. Use the \"agama monitor\" command or the \
+                web user interface to answer them.",
+            ),
+            Self::Issues => {
+                gettext("There are issues in configuration that are blocking the installation.")
+            }
         };
         write!(f, "{}", text)
     }
@@ -114,18 +123,18 @@ impl StatusReport {
 impl fmt::Display for StatusReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.installation)?;
-        writeln!(f)?;
-        write!(f, "{}", gettext("Details:"))?;
+
         if !self.questions.is_empty() {
-            write!(f, "\n{}", gettext("Open questions:"))?;
+            writeln!(f, "\n{}", gettext("Open questions:").bold())?;
             for q in &self.questions {
-                write!(f, "\n  - {}", q.spec.text)?;
+                writeln!(f, "  - {}", q.spec.text)?;
             }
         }
+
         if !self.issues.is_empty() {
-            write!(f, "\n{}", gettext("Blocking issues:"))?;
+            writeln!(f, "\n{}", gettext("Blocking issues:").bold())?;
             for i in &self.issues {
-                write!(f, "\n  - {}", i.issue.description)?;
+                writeln!(f, "  - {}", i.issue.description)?;
             }
         }
         Ok(())

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jun 15 06:27:29 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improve the "agama status" format (gh#agama-project/agama#3621).
+
+-------------------------------------------------------------------
 Fri Jun 12 16:35:53 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Adapt storate schemas to allow configuring filesystem options

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Mon Jun 15 08:05:06 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Improve the "agama status" format (gh#agama-project/agama#3621).
+- Improve the "agama monitor" and "agama status" texts
+  (gh#agama-project/agama#3621).
 
 -------------------------------------------------------------------
 Mon Jun 15 07:33:59 UTC 2026 - Josef Reidinger <jreidinger@suse.com>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 15 13:57:52 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Minor text update in the dialog to retry loading the configuration
+  (gh#agama-project/agama#3621).
+
+-------------------------------------------------------------------
 Fri Jun 12 15:34:50 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Redesing storage forms (format disk, partition and logical

--- a/web/src/components/questions/LoadConfigRetryQuestion.tsx
+++ b/web/src/components/questions/LoadConfigRetryQuestion.tsx
@@ -76,7 +76,7 @@ export default function RetryLoadConfigQuestion({
         <Content>
           <Text isBold>
             {/* TRANSLATORS: help text in popup to clarify what user should do */}
-            {_("Verify that the location is correct and the configuration is valid.")}
+            {_("Make sure the location is correct and the configuration is valid.")}
           </Text>
         </Content>
         {error && (


### PR DESCRIPTION
The output of the "agama status" and "agama monitor" command can be improved with better texts and some additional formatting.

* Improve and unify tests.
* `agama status` does not display issues if there are pending questions.
* Remove the "titles" ("Details", "Blocking issues", and "Open questions").
* Do not display the scope of the issues.
* Adjust text of the LoadConfigRetryQuestion dialog.

# Screenshots

<img width="1070" height="190" alt="image" src="https://github.com/user-attachments/assets/f9b1a1ca-5935-4ee7-857a-291defe28642" />

<img width="1070" height="190" alt="image" src="https://github.com/user-attachments/assets/41d00185-63cf-4d64-aa7c-00654856cc53" />

<img width="944" height="262" alt="image" src="https://github.com/user-attachments/assets/014e8800-70ae-40ad-9ec8-d77e45fc5ea7" />

