### PR TITLE
mark properly autoinst question as the one that needs string data

### DIFF
--- a/rust/agama-autoinstall/src/questions.rs
+++ b/rust/agama-autoinstall/src/questions.rs
@@ -48,6 +48,7 @@ impl UserQuestions {
                 ("Retry", localized_retry.as_str()),
                 ("Manual", localized_manual.as_str()),
             ])
+            .as_string()
             .with_default_action("Manual")
             .with_data(&[("error", error), ("originalValue", url)]);
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 15 07:33:59 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- Mark properly autoinst retry question as the one that should
+  return value for new url (gh#agama-project/agama#3623)
+
+-------------------------------------------------------------------
 Fri Jun 12 16:35:53 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Adapt storate schemas to allow configuring filesystem options

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,5 +1,4 @@
 -------------------------------------------------------------------
-
 Mon Jun 15 07:33:59 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Mark properly autoinst retry question as the one that should


### PR DESCRIPTION
## Problem

Failed load of autoinst profile is does not ask in monitor for new URL.

## Solution

Mark properly question as the one that needs string value back.