### PR TITLE
fix: remove trailing whitespace from translatable string

### DIFF
--- a/rust/agama-autoinstall/src/scripts.rs
+++ b/rust/agama-autoinstall/src/scripts.rs
@@ -131,9 +131,8 @@ impl ScriptsRunner {
 
     async fn should_retry(&self, url: &str, error: &str) -> anyhow::Result<Option<String>> {
         let msg = i18n_format!(
-            r#"
-                It was not possible to load the script from {0}. Do you want to try again?
-                "#,
+            // TRANSLATORS: {0} is a URL
+            "It was not possible to load the script from {0}. Do you want to try again?",
             url
         );
         self.questions.should_retry(&msg, error, url).await


### PR DESCRIPTION
## Problem

Looking at the POT file, Imo noticed a suspicious string:

```po
#: agama-autoinstall/src/scripts.rs:134
#, rust-format
msgid ""
"It was not possible to load the script from {0}. Do you want to try again?\n"
"                "
msgstr ""
```

https://github.com/agama-project/agama-weblate/blob/d822a3b0471373227cf5756a5cd112820af503ef/rust/agama.pot#L38

## Solution

Use a `"plain string"`,  not a `#""raw-quoted one""#`

## Testing

Ran `rust/build_pot --container` and inspected `rust/agama.pot` to look better.

## Screenshots

No

## Documentation

No