### PR TITLE
Make the JSON editor really read-only

### DIFF
--- a/web/src/components/core/ConfigDialog.tsx
+++ b/web/src/components/core/ConfigDialog.tsx
@@ -74,7 +74,6 @@ export default function ConfigDialog({ onClose }: ConfigDialogProps) {
         </Content>
         <CodeEditor
           isDarkTheme={isDark}
-          isReadOnly
           isCopyEnabled
           isDownloadEnabled
           copyButtonAriaLabel={_("Copy to the clipboard")}
@@ -94,6 +93,9 @@ export default function ConfigDialog({ onClose }: ConfigDialogProps) {
               hideCursorInOverviewRuler: true,
               contextmenu: false,
               minimap: { enabled: false },
+              readOnly: true,
+              // TRANSLATORS: error message displayed in the JSON editor when trying to change the read-only text
+              readOnlyMessage: { value: _("The configuration is read-only.") },
             },
             // Disable command palette, based on https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#example-interacting-with-the-editor-listening-to-key-events
             onMount: (editor, monaco) => {


### PR DESCRIPTION
## Problem

- When showing the JSON config the editor was not really read-only, although the `isReadOnly` flag was set.

## Solution

- It seems the read-only property needs to be set in the editor options when that is configured. After removing the whole `options` configuration the `isReadOnly` flag works. But we need that `options` so I moved the value there.

## Testing

- Tested manually, the editor does not allow to change the content, it shows a read-only hint when trying to do so.

## Note

- I added a custom message so it can be translated.

## Screenshots

<img width="579" height="286" alt="image" src="https://github.com/user-attachments/assets/7eba1d5b-cdfc-4377-99f3-85628c1916ec" />
