### PR TITLE
Fixed copying URL credentials to the target system (bsc#1267881)

### DIFF
--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -651,11 +651,13 @@ impl ZyppServer {
         Ok(())
     }
 
-    const ZYPP_DIRS: [&str; 4] = [
+    const ZYPP_DIRS: [&str; 5] = [
         "etc/zypp/services.d",
         "etc/zypp/repos.d",
         "etc/zypp/credentials.d",
         "var/cache/zypp",
+        // the credentials from URLs are stored in the ~/.zypp/credentials.cat file
+        "root/.zypp",
     ];
     fn copy_files(&self) -> ZyppServerResult<()> {
         for path in Self::ZYPP_DIRS {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jun 15 14:58:50 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed copying URL credentials to the target system (bsc#1267881)
+
+-------------------------------------------------------------------
 Mon Jun 15 08:05:06 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improve the "agama monitor" and "agama status" texts


### PR DESCRIPTION
## Problem

- When using a custom installation URL with a password (`inst.install_url=ftp://user:password@...`) then the password is not saved to the installed system.

## Solution

- Copy the `/root/.zypp/credentials.cat` file to the target system as well

## Details

- When libzypp finds any URL with password then the URL is saved without the password into the `/etc/zypp/repos.d/*.repo` file
-  The password is saved separately to `/root/.zypp/credentials.cat` file 
- The `*.repo` files are world readable, the `/root/.zypp/credentials.cat` file is root-only
- Let's copy the whole directory, whatever libzypp creates there it will be copied too

## Testing

- Tested manually
