### PR TITLE
Remove a TODO note that slipped into translatable CLI help

### DIFF
--- a/rust/agama-cli/src/commands.rs
+++ b/rust/agama-cli/src/commands.rs
@@ -44,8 +44,7 @@ pub fn build_probe_cmd() -> Command {
     let long_about = make_long(&about, &gettext("\
         In Agama's jargon, the term 'probing' refers to the process of 'analyzing' the system. This \
         includes reading software repositories, analyzing storage devices, and more. The 'probe' \
-        command initiates this analysis process and returns immediately. \
-        TODO: do we really need a \"probe\" action?"));
+        command initiates this analysis process and returns immediately."));
     Command::new("probe").about(&about).long_about(long_about)
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 16 14:01:07 UTC 2026 - Martin Vidner <mvidner@suse.com>
+
+- Remove a TODO note that slipped into translatable CLI help
+  (gh#agama-project/agama#3639).
+
+-------------------------------------------------------------------
 Mon Jun 15 15:45:28 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 22


### PR DESCRIPTION
## Problem

A "TODO" comment was accidentally part of the CLI help, so we let it slip into the translatable texts in #3594.

## Solution

Remove the TODO part of the string.

The question is implicitly resolved as: yes, we do want the `probe` action.

## Testing

None

## Screenshots

No

## Documentation

No