### PR TITLE
Add optional cert_path second argument to rmt example

### DIFF
--- a/rust/suseconnect-agama/examples/rmt.rs
+++ b/rust/suseconnect-agama/examples/rmt.rs
@@ -1,4 +1,4 @@
-use std::{env, process::exit};
+use std::{env, fs, path::Path, process::{exit, Command}};
 
 use suseconnect_agama::{
     activate_product, announce_system, create_credentials_file, ConnectParams, ProductSpecification,
@@ -8,10 +8,18 @@ use url::Url;
 pub fn main() {
     tracing_subscriber::fmt::init();
     let args: Vec<String> = env::args().collect();
+
+    // Basic argument validation
+    if args.len() < 2 {
+        eprintln!("Usage: rmt <url> [<cert_path>]");
+        exit(1);
+    }
+
     let Some(url) = args.get(1) else {
         eprintln!("Provide url as first parameter");
         return;
     };
+    let cert_path = args.get(2).cloned();
 
     let params = ConnectParams {
         language: Some("en_US".to_string()),
@@ -19,6 +27,37 @@ pub fn main() {
         token: None,
         email: None,
     };
+
+    if let Some(cert) = &cert_path {
+        println!("Certificate path provided: {}. Processing...", cert);
+
+        let dest_dir = Path::new("/etc/pki/trust/anchors");
+        let cert_filename = Path::new(cert)
+            .file_name()
+            .expect("Invalid certificate path: missing filename");
+        let dest_path = dest_dir.join(cert_filename);
+
+        match fs::copy(cert, &dest_path) {
+            Ok(bytes) => println!("Copied {} bytes to {}", bytes, dest_path.display()),
+            Err(e) => {
+                eprintln!("Error copying certificate: {}", e);
+                exit(1);
+            }
+        }
+
+        println!("Running update-ca-certificates...");
+        let output = Command::new("update-ca-certificates")
+            .output()
+            .expect("Failed to execute update-ca-certificates");
+
+        if output.status.success() {
+            println!("CA certificates updated successfully.");
+        } else {
+            eprintln!("update-ca-certificates failed with status: {}", output.status);
+            eprintln!("Stderr: {}", String::from_utf8_lossy(&output.stderr));
+            exit(1);
+        }
+    }
 
     let result = announce_system(params.clone(), "sles16");
     println!("{:?}", result);

--- a/rust/suseconnect-agama/examples/rmt.rs
+++ b/rust/suseconnect-agama/examples/rmt.rs
@@ -9,17 +9,10 @@ pub fn main() {
     tracing_subscriber::fmt::init();
     let args: Vec<String> = env::args().collect();
 
-    // Basic argument validation
-    if args.len() < 2 {
+    let Some(url) = args.get(1) else {
         eprintln!("Usage: rmt <url> [<cert_path>]");
         exit(1);
-    }
-
-    let Some(url) = args.get(1) else {
-        eprintln!("Provide url as first parameter");
-        return;
     };
-    let cert_path = args.get(2).cloned();
 
     let params = ConnectParams {
         language: Some("en_US".to_string()),
@@ -28,7 +21,7 @@ pub fn main() {
         email: None,
     };
 
-    if let Some(cert) = &cert_path {
+    if let Some(cert) = &args.get(2) {
         println!("Certificate path provided: {}. Processing...", cert);
 
         let dest_dir = Path::new("/etc/pki/trust/anchors");

--- a/rust/suseconnect-agama/examples/rmt.rs
+++ b/rust/suseconnect-agama/examples/rmt.rs
@@ -1,4 +1,8 @@
-use std::{env, fs, path::Path, process::{exit, Command}};
+use std::{
+    env, fs,
+    path::Path,
+    process::{exit, Command},
+};
 
 use suseconnect_agama::{
     activate_product, announce_system, create_credentials_file, ConnectParams, ProductSpecification,
@@ -46,7 +50,10 @@ pub fn main() {
         if output.status.success() {
             println!("CA certificates updated successfully.");
         } else {
-            eprintln!("update-ca-certificates failed with status: {}", output.status);
+            eprintln!(
+                "update-ca-certificates failed with status: {}",
+                output.status
+            );
             eprintln!("Stderr: {}", String::from_utf8_lossy(&output.stderr));
             exit(1);
         }


### PR DESCRIPTION
## Problem

Exercise the agama-suseconnect use of libsuseconnect.so in a way that simulates registering against an RMT using a self-signed certificate. This helped identify and verify the fix for https://bugzilla.suse.com/show_bug.cgi?id=1268017 as proposed in SUSE/connect-ng#400.

## Solution

If the optional second argument specifying a cert path has been provided, install it in the system CA store before calling announce_system().

## Testing

- Leveraged in conjunction with SUSE/connect-ng#390 framework to test the SUSE/connect-ng#400 fix.