### PR TITLE
Fix "config validate" command

### DIFF
--- a/rust/agama-lib/src/profile/http_client.rs
+++ b/rust/agama-lib/src/profile/http_client.rs
@@ -19,7 +19,6 @@
 // find current contact information at www.suse.com.
 
 use crate::http::{BaseHTTPClient, BaseHTTPClientError};
-use crate::profile::ValidationOutcome;
 use fluent_uri::Uri;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -34,11 +33,11 @@ impl ProfileHTTPClient {
     }
 
     /// Validate a JSON profile, by doing a HTTP client request.
-    pub async fn validate(&self, request: &impl Serialize) -> anyhow::Result<ValidationOutcome> {
-        Ok(self
-            .client
-            .post("private/profile/validate", request)
-            .await?)
+    pub async fn validate(&self, request: &impl Serialize) -> anyhow::Result<()> {
+        self.client
+            .post_void("private/profile/validate", request)
+            .await?;
+        Ok(())
     }
 
     /// Evaluate a Jsonnet profile, by doing a HTTP client request.

--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -18,20 +18,20 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use crate::web::error::ProblemDetailsExt;
+use crate::{
+    server::{config_schema, web::Error},
+    web::error::ProblemDetailsExt,
+};
 use agama_lib::profile::AutoyastError;
 use agama_transfer::Transfer;
 use agama_utils::api::ProblemDetails;
 use gettextrs::gettext;
 
-use agama_lib::profile::{
-    AutoyastProfileImporter, ProfileEvaluator, ProfileValidator, ValidationOutcome,
-};
+use agama_lib::profile::{AutoyastProfileImporter, ProfileEvaluator};
 use aide::axum::ApiRouter;
 use axum::{
     response::{IntoResponse, Response},
     routing::post,
-    Json,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -39,7 +39,7 @@ use thiserror::Error;
 use url::Url;
 
 #[derive(Error, Debug)]
-enum ProfileError {
+pub enum ProfileError {
     #[error("Failed to retrieve profile from URL {url}: {source}")]
     UrlRetrieval {
         url: String,
@@ -160,19 +160,19 @@ impl ProfileBody {
     }
 }
 
-async fn validate(body: String) -> Result<Json<ValidationOutcome>, ProfileError> {
+async fn validate(body: String) -> Result<(), Response> {
     let profile = ProfileBody::from_string(body);
-    let profile_string = match profile.retrieve_profile()? {
+    let profile_content = profile
+        .retrieve_profile()
+        .map_err(|e| Error::from(e).bad_request())?;
+    let profile_string = match profile_content {
         Some(retrieved) => retrieved,
         None => profile.json.expect("Missing profile"),
     };
-    let validator = ProfileValidator::default_schema()
-        .map_err(|e| ProfileError::ValidatorSetup(e.to_string()))?;
-    let result = validator
-        .validate_str(&profile_string)
-        .map_err(|e| ProfileError::ValidationError(e.to_string()))?;
-
-    Ok(Json(result))
+    let json: serde_json::Value =
+        serde_json::from_str(&profile_string).map_err(|e| Error::from(e).bad_request())?;
+    config_schema::check(&json).map_err(|e| Error::from(e).bad_request())?;
+    Ok(())
 }
 
 async fn evaluate(body: String) -> Result<String, ProfileError> {

--- a/rust/agama-server/src/server.rs
+++ b/rust/agama-server/src/server.rs
@@ -21,4 +21,4 @@
 pub mod web;
 pub use web::{server_service, server_with_state};
 
-mod config_schema;
+pub(crate) mod config_schema;

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -21,6 +21,7 @@
 //! This module implements Agama's HTTP API.
 
 use crate::profile::profile_service;
+use crate::profile::web::ProfileError;
 use crate::server::config_schema;
 use crate::web::error::{ProblemDetailsExt, ProblemDetailsResponse};
 use agama_lib::logs;
@@ -50,6 +51,7 @@ use axum::{
     routing::{get, post},
     Json,
 };
+use gettextrs::gettext;
 use hyper::{header, HeaderMap, StatusCode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -68,6 +70,8 @@ pub enum Error {
     Json(#[from] serde_json::Error),
     #[error("Missing language tag")]
     MissingLanguageTag,
+    #[error(transparent)]
+    Profile(#[from] ProfileError),
 }
 
 impl Error {
@@ -78,24 +82,26 @@ impl Error {
             Error::Json(e) => ProblemDetails::invalid_json(e.to_string()),
             Error::Manager(e) => ProblemDetails::internal_error(e.to_string()),
             Error::Questions(e) => ProblemDetails::internal_error(e.to_string()),
-            Error::MissingLanguageTag => {
-                ProblemDetails::generic("Missing Language Tag", "The language tag is required")
-            }
+            Error::MissingLanguageTag => ProblemDetails::generic(
+                gettext("Missing Language Tag"),
+                "The language tag is required",
+            ),
+            Error::Profile(e) => ProblemDetails::generic(gettext("Profile error"), e.to_string()),
         }
     }
 
     /// Creates a BAD_REQUEST (400) response from this error.
-    fn bad_request(self) -> Response {
+    pub fn bad_request(self) -> Response {
         self.into_problem_details().into_response()
     }
 
     /// Creates an INTERNAL_SERVER_ERROR (500) response from this error.
-    fn internal_server_error(self) -> Response {
+    pub fn internal_server_error(self) -> Response {
         self.into_problem_details().into_response()
     }
 
     /// Creates an UNPROCESSABLE_ENTITY (422) response from this error.
-    fn unprocessable_entity(self) -> Response {
+    pub fn unprocessable_entity(self) -> Response {
         self.into_problem_details().into_response()
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 17 13:30:47 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the "agama config validate" command to work with the
+  server (gh#agama-project/agama#3641).
+
+-------------------------------------------------------------------
 Mon Jun 15 15:45:28 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 22


### PR DESCRIPTION
## Problem

The "agama config validate" only works locally. However, an "agama config load" does the validation just fine.

## Solution

Fix the `/private/profile/validate` to use the same logic than `config load` (including the problem details API).