### PR TITLE
Do not download the Monaco editor parts from CDN

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -74,6 +74,7 @@
         "jest-environment-jsdom": "^30.2.0",
         "jest-transform-stub": "^2.0.0",
         "mini-css-extract-plugin": "^2.10.0",
+        "monaco-editor-webpack-plugin": "^7.1.1",
         "neostandard": "^0.13.0",
         "prettier": "^3.8.1",
         "react-refresh": "^0.18.0",
@@ -7019,6 +7020,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -8678,6 +8689,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -13474,6 +13495,21 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -13886,6 +13922,20 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor-webpack-plugin": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.1.1.tgz",
+      "integrity": "sha512-WxdbFHS3Wtz4V9hzhe/Xog5hQRSMxmDLkEEYZwqMDHgJlkZo00HVFZR0j5d0nKypjTUkkygH3dDSXERLG4757A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.31.0",
+        "webpack": "^4.5.0 || 5.x"
       }
     },
     "node_modules/ms": {

--- a/web/package.json
+++ b/web/package.json
@@ -69,6 +69,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-transform-stub": "^2.0.0",
     "mini-css-extract-plugin": "^2.10.0",
+    "monaco-editor-webpack-plugin": "^7.1.1",
     "neostandard": "^0.13.0",
     "prettier": "^3.8.1",
     "react-refresh": "^0.18.0",

--- a/web/src/components/core/ConfigDialog.test.tsx
+++ b/web/src/components/core/ConfigDialog.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import ConfigDialog from "./ConfigDialog";
 import { plainRender } from "~/test-utils";
 
@@ -31,34 +31,11 @@ jest.mock("~/utils", () => ({
   isoTimestamp: () => mockIsoTimestamp(),
 }));
 
-// Monaco editor is too heavy to render in tests; replace with a lightweight stub
-// that exposes the props we care about.
-jest.mock("@patternfly/react-code-editor", () => ({
-  CodeEditor: ({
-    code,
-    downloadFileName,
-    emptyState,
-  }: {
-    code?: string;
-    downloadFileName: string;
-    emptyState?: React.ReactNode;
-  }) =>
-    code === undefined ? (
-      <>{emptyState}</>
-    ) : (
-      <div>
-        <pre aria-label="Configuration code">{code}</pre>
-        <div aria-label="Download filename">{downloadFileName}</div>
-      </div>
-    ),
-  Language: { json: "json" },
-}));
+// Monaco editor used in <ConfigEditor> is too heavy to render in tests
+jest.mock("~/components/core/ConfigEditor", () => () => <div>ConfigEditor Mock</div>);
 
-const mockConfig = { software: { product: "Agama" } };
 const mockOnClose = jest.fn();
-
 global.fetch = jest.fn();
-const fetchSpy = global.fetch as jest.Mock;
 
 const renderConfigDialog = () => {
   const { user } = plainRender(<ConfigDialog onClose={mockOnClose} />);
@@ -68,75 +45,22 @@ const renderConfigDialog = () => {
 describe("ConfigDialog", () => {
   beforeEach(() => {
     mockOnClose.mockReset();
-    mockIsoTimestamp.mockReturnValue("2026-06-03T10-30-00-000Z");
-    fetchSpy.mockReset();
   });
 
   it("renders the dialog with the correct title", async () => {
-    fetchSpy.mockResolvedValue({
-      text: () => Promise.resolve(JSON.stringify(mockConfig)),
-    } as Response);
-
-    renderConfigDialog();
+    await act(async () => {
+      renderConfigDialog();
+    });
 
     screen.getByRole("dialog", { name: "Installation settings in JSON format" });
   });
 
-  it("shows a spinner while the config is loading", () => {
-    fetchSpy.mockReturnValue(new Promise(() => {}));
-    renderConfigDialog();
-
-    screen.getByRole("progressbar");
-  });
-
-  it("displays the config content once loaded", async () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      text: () => Promise.resolve(JSON.stringify(mockConfig)),
-    } as Response);
-
-    renderConfigDialog();
-
-    await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
-
-    expect(screen.getByLabelText("Configuration code").textContent).toBe(
-      JSON.stringify(mockConfig, null, 2),
-    );
-  });
-
-  // The extension is omitted here on purpose: CodeEditor appends it based on
-  // its language prop.
-  it("uses a timestamped filename without extension for the download", async () => {
-    fetchSpy.mockResolvedValue({
-      text: () => Promise.resolve(JSON.stringify(mockConfig)),
-    } as Response);
-
-    renderConfigDialog();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Download filename")).toHaveTextContent(
-        "agama-config-2026-06-03T10-30-00-000Z",
-      );
-    });
-  });
-
-  it("falls back to an empty config on fetch error", async () => {
-    fetchSpy.mockRejectedValue(new Error("network error"));
-
-    renderConfigDialog();
-
-    await waitFor(() => {
-      expect(screen.queryByRole("progressbar")).toBeNull();
-      expect(screen.getByLabelText("Configuration code")).toHaveTextContent("");
-    });
-  });
-
   it("calls onClose when the close button is clicked", async () => {
-    fetchSpy.mockResolvedValue({
-      text: () => Promise.resolve(JSON.stringify(mockConfig)),
-    } as Response);
+    const { user } = await act(async () => {
+      return renderConfigDialog();
+    });
 
-    const { user } = renderConfigDialog();
+    // const { user } = renderConfigDialog();
     const closeButtons = screen.getAllByRole("button", { name: "Close" });
     await user.click(closeButtons[1]);
 

--- a/web/src/components/core/ConfigDialog.tsx
+++ b/web/src/components/core/ConfigDialog.tsx
@@ -20,44 +20,35 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useEffect, useState } from "react";
-import { Content, Flex, Spinner } from "@patternfly/react-core";
-import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import React, { Suspense } from "react";
+import { Bullseye, Content, Flex, Spinner } from "@patternfly/react-core";
 import Popup from "~/components/core/Popup";
-import { useAppearance } from "~/context/appearance";
-import { ROOT } from "~/routes/paths";
-import { isoTimestamp } from "~/utils";
 import { _ } from "~/i18n";
 
 type ConfigDialogProps = {
   onClose: () => void;
 };
 
+// load the component and its dependencies dynamically when needed, do not
+// include it in the default index.js file, the Monaco editor is huge
+const ConfigEditor = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "config-editor" */
+      "~/components/core/ConfigEditor"
+    ),
+);
+
 /**
  * Dialog showing the current installation configuration in JSON format, with
  * options to copy or download the content.
  */
 export default function ConfigDialog({ onClose }: ConfigDialogProps) {
-  const { isDark } = useAppearance();
-  const [config, setConfig] = useState<string | undefined>(undefined);
-  // CodeEditor appends the extension based on the language, so it must be omitted here.
-  const [downloadFileName, setDownloadFileName] = useState("agama-config");
-
-  useEffect(() => {
-    const loadConfig = async () => {
-      try {
-        const response = await fetch(ROOT.config);
-        const text = await response.text();
-        setConfig(JSON.stringify(JSON.parse(text), null, 2));
-        setDownloadFileName(`agama-config-${isoTimestamp()}`);
-      } catch (error) {
-        console.error("Failed to load config:", error);
-        setConfig("");
-      }
-    };
-
-    loadConfig();
-  }, []);
+  const fallback = (
+    <Bullseye>
+      <Spinner />
+    </Bullseye>
+  );
 
   return (
     <Popup
@@ -73,38 +64,9 @@ export default function ConfigDialog({ onClose }: ConfigDialogProps) {
             "Use this to reproduce this installation later using the installer command-line interface or the unattended mode.",
           )}
         </Content>
-        <CodeEditor
-          isDarkTheme={isDark}
-          isReadOnly
-          isCopyEnabled
-          isDownloadEnabled
-          copyButtonAriaLabel={_("Copy to the clipboard")}
-          copyButtonToolTipText={_("Copy to the clipboard")}
-          copyButtonSuccessTooltipText={_("Configuration added to clipboard")}
-          downloadButtonAriaLabel={_("Download configuration")}
-          downloadButtonToolTipText={_("Download configuration")}
-          downloadFileName={downloadFileName}
-          code={config}
-          emptyState={<Spinner />}
-          language={Language.json}
-          height="360px"
-          // PatternFly merges this into its own monaco options, so settings it
-          // derives from props (like readOnly from isReadOnly) are preserved.
-          // Based on https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#example-customizing-the-appearence-scrollbars
-          options={{
-            contextmenu: false,
-            scrollBeyondLastLine: false,
-            hideCursorInOverviewRuler: true,
-            // TRANSLATORS: error message displayed in the JSON editor when trying to change the read-only text
-            readOnlyMessage: { value: _("The configuration is read-only.") },
-          }}
-          // Runs in addition to PatternFly's own mount logic (e.g. Shift+Tab
-          // focus handling). Disables the command palette, based on
-          // https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#example-interacting-with-the-editor-listening-to-key-events
-          onEditorDidMount={(editor, monaco) => {
-            editor.addCommand(monaco.KeyCode.F1, () => null);
-          }}
-        />
+        <Suspense fallback={fallback}>
+          <ConfigEditor />
+        </Suspense>
       </Flex>
 
       <Popup.Actions>

--- a/web/src/components/core/ConfigEditor.test.tsx
+++ b/web/src/components/core/ConfigEditor.test.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import ConfigEditor from "./ConfigEditor";
+import { plainRender } from "~/test-utils";
+
+const mockIsoTimestamp = jest.fn();
+jest.mock("~/utils", () => ({
+  ...jest.requireActual("~/utils"),
+  isoTimestamp: () => mockIsoTimestamp(),
+}));
+
+// Monaco editor is too heavy to render in tests; replace with a lightweight stub
+// that exposes the props we care about.
+jest.mock("@patternfly/react-code-editor", () => ({
+  CodeEditor: ({
+    code,
+    downloadFileName,
+    emptyState,
+  }: {
+    code?: string;
+    downloadFileName: string;
+    emptyState?: React.ReactNode;
+  }) =>
+    code === undefined ? (
+      <>{emptyState}</>
+    ) : (
+      <div>
+        <pre aria-label="Configuration code">{code}</pre>
+        <div aria-label="Download filename">{downloadFileName}</div>
+      </div>
+    ),
+  Language: { json: "json" },
+}));
+
+jest.mock("@monaco-editor/react", () => ({
+  loader: {
+    config: jest.fn(),
+  },
+}));
+
+jest.mock("monaco-editor/esm/vs/editor/editor.api.js", () => ({}));
+
+const mockConfig = { software: { product: "Agama" } };
+
+global.fetch = jest.fn();
+const fetchSpy = global.fetch as jest.Mock;
+
+const renderConfigEditorDialog = () => {
+  const { user } = plainRender(<ConfigEditor />);
+  return { user };
+};
+
+describe("ConfigEditor", () => {
+  beforeEach(() => {
+    mockIsoTimestamp.mockReturnValue("2026-06-03T10-30-00-000Z");
+    fetchSpy.mockReset();
+  });
+
+  it("shows a spinner while the config is loading", () => {
+    fetchSpy.mockReturnValue(new Promise(() => {}));
+    renderConfigEditorDialog();
+
+    screen.getByRole("progressbar");
+  });
+
+  it("displays the config content once loaded", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockConfig)),
+    } as Response);
+
+    renderConfigEditorDialog();
+
+    await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
+
+    expect(screen.getByLabelText("Configuration code").textContent).toBe(
+      JSON.stringify(mockConfig, null, 2),
+    );
+  });
+
+  // The extension is omitted here on purpose: CodeEditor appends it based on
+  // its language prop.
+  it("uses a timestamped filename without extension for the download", async () => {
+    fetchSpy.mockResolvedValue({
+      text: () => Promise.resolve(JSON.stringify(mockConfig)),
+    } as Response);
+
+    renderConfigEditorDialog();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Download filename")).toHaveTextContent(
+        "agama-config-2026-06-03T10-30-00-000Z",
+      );
+    });
+  });
+
+  it("falls back to an empty config on fetch error", async () => {
+    fetchSpy.mockRejectedValue(new Error("network error"));
+    // mock console.error, the error is expected, do not print it on the terminal
+    jest.spyOn(global.console, "error").mockImplementation(() => {});
+
+    renderConfigEditorDialog();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("progressbar")).toBeNull();
+      expect(screen.getByLabelText("Configuration code")).toHaveTextContent("");
+    });
+
+    // remove the console mock
+    jest.spyOn(global.console, "error").mockRestore();
+  });
+});

--- a/web/src/components/core/ConfigEditor.tsx
+++ b/web/src/components/core/ConfigEditor.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useEffect, useState } from "react";
+import { Spinner } from "@patternfly/react-core";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+// import only the base editor to save some space
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+import { loader } from "@monaco-editor/react";
+import { useAppearance } from "~/context/appearance";
+import { ROOT } from "~/routes/paths";
+import { isoTimestamp } from "~/utils";
+import { _ } from "~/i18n";
+
+/**
+ * Component showing the current installation configuration in JSON format, with
+ * options to copy or download the content.
+ */
+export default function Editor() {
+  const { isDark } = useAppearance();
+  const [config, setConfig] = useState<string | undefined>(undefined);
+  // CodeEditor appends the extension based on the language, so it must be omitted here.
+  const [downloadFileName, setDownloadFileName] = useState("agama-config");
+
+  // avoid downloading the monaco editor parts from the CDN, load the locally bundled files
+  loader.config({ monaco });
+
+  useEffect(() => {
+    const loadConfig = async () => {
+      try {
+        const response = await fetch(ROOT.config);
+        const text = await response.text();
+        setConfig(JSON.stringify(JSON.parse(text), null, 2));
+        setDownloadFileName(`agama-config-${isoTimestamp()}`);
+      } catch (error) {
+        console.error("Failed to load config:", error);
+        setConfig("");
+      }
+    };
+
+    loadConfig();
+  }, []);
+
+  return (
+    <CodeEditor
+      isDarkTheme={isDark}
+      isReadOnly
+      isCopyEnabled
+      isDownloadEnabled
+      copyButtonAriaLabel={_("Copy to the clipboard")}
+      copyButtonToolTipText={_("Copy to the clipboard")}
+      copyButtonSuccessTooltipText={_("Configuration added to clipboard")}
+      downloadButtonAriaLabel={_("Download configuration")}
+      downloadButtonToolTipText={_("Download configuration")}
+      downloadFileName={downloadFileName}
+      code={config}
+      emptyState={<Spinner />}
+      language={Language.json}
+      height="360px"
+      // PatternFly merges this into its own monaco options, so settings it
+      // derives from props (like readOnly from isReadOnly) are preserved.
+      // Based on https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#example-customizing-the-appearence-scrollbars
+      options={{
+        contextmenu: false,
+        scrollBeyondLastLine: false,
+        hideCursorInOverviewRuler: true,
+        // TRANSLATORS: error message displayed in the JSON editor when trying to change the read-only text
+        readOnlyMessage: { value: _("The configuration is read-only.") },
+      }}
+      // Runs in addition to PatternFly's own mount logic (e.g. Shift+Tab
+      // focus handling). Disables the command palette, based on
+      // https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#example-interacting-with-the-editor-listening-to-key-events
+      onEditorDidMount={(editor, monaco) => {
+        editor.addCommand(monaco.KeyCode.F1, () => null);
+      }}
+    />
+  );
+}

--- a/web/src/components/core/InstallerOptionsMenu.test.tsx
+++ b/web/src/components/core/InstallerOptionsMenu.test.tsx
@@ -29,6 +29,9 @@ jest.mock("~/components/core/ChangeProductOption", () => () => (
   <a role="menuitem">Change product</a>
 ));
 
+// Monaco editor used in <ConfigEditor> is too heavy to render in tests
+jest.mock("~/components/core/ConfigEditor", () => () => <div>ConfigEditor Mock</div>);
+
 describe("InstallerOptionsMenu", () => {
   describe("toggle button", () => {
     it("renders a toggle with 'More options' aria-label", () => {

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -13,6 +13,7 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const ReactRefreshTypeScript = require("react-refresh-typescript");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const webpack = require("webpack");
 
 /* A standard nodejs and webpack pattern */
@@ -60,6 +61,10 @@ const plugins = [
   // run the TypeScript type checks in a parallel process (report the problems to the dev server in
   // the development mode)
   new ForkTsCheckerWebpackPlugin({ devServer: development }),
+  new MonacoWebpackPlugin({
+    // include only support for the JSON format in the Monaco editor
+    languages: ["json"],
+  }),
 ].filter(Boolean);
 
 if (eslint) {
@@ -189,8 +194,8 @@ module.exports = {
               sourceMap: true,
               url: {
                 // Only follow the Agama fonts links to be processed by the next rule and place
-                // them in dist/fonts
-                filter: (url) => url.includes("./fonts/"),
+                // them in dist/fonts, the codicon font is added by the Monaco editor
+                filter: (url) => url.includes("./fonts/") || url.includes("codicon.ttf"),
               },
             },
           },


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1268433
- When opening the Monaco editor using the "Show configuration" menu option it downloads some JavaScript files dynamically from a 3rd party CDN server

Screenshot from the browser devtools:
<img width="1280" height="800" alt="agama-monaco-cdn" src="https://github.com/user-attachments/assets/3f665208-07e3-497f-a6aa-d4bd8ea03eac" />


## Solution

- Bundle the editor locally

## Notes

- I have moved the configuration editor to a separate component so it can be lazily loaded. The Monaco editor is loaded only when the current configuration is displayed for the first time. Then it is kept in memory.

## Testing

- Tested manually

## TODO

- [x] There is 404 error for the `codicon.ttf` file, that is located in `node_modules/monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.ttf`, we need to copy this file.
- [x] The `index.js` file size in production build increased from ~1.7MB to ~5.5MB, that's a huge increase, try loading the `<CodeEditor>` component dynamically only when the editor is needed. The `index.css` size increased only slightly from 1.6MB to 1.7MB, that is OK.
- [x] Fix the failing unit tests :scream: 

## Screenshots

When opening the editor everything is loaded from the Agama server, the CDN is not used anymore:

<img width="1280" height="800" alt="agama-monaco-local3" src="https://github.com/user-attachments/assets/56f8783a-583d-4b76-8c2c-f4702df43d23" />

### Slow network

When the network is slow a spinner is displayed while the Monaco editor is being loaded. This was simulated in the Chrome browser using the "Fast 4G" network throttling option in the devtools:

[agama-editor-2026-06-18_16.04.05.webm](https://github.com/user-attachments/assets/53050da0-2924-4916-bc60-ca5ac5ccf11b)

