### PR TITLE
Add support for `alts` to the DUD mechanism

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/99agama-dud/agama-dud-apply.sh
@@ -163,7 +163,7 @@ unpack_rpm() {
   mkdir -p "$dest"
   pushd "$dest" || exit 1
   "$NEWROOT/usr/bin/chroot" "$NEWROOT" /usr/bin/rpm2cpio "${source##"$NEWROOT"}" |
-    cpio --extract --make-directories --preserve-modification-time
+    cpio --extract --make-directories --preserve-modification-time --unconditional
   popd || exit 1
 }
 
@@ -184,6 +184,8 @@ install_update() {
 }
 
 # Sets the alternative links
+#
+# It identifies whether it should use alts or update-alternatives.
 set_alternative() {
   dud_instsys=$1
   name=$2
@@ -191,12 +193,20 @@ set_alternative() {
   priority=150000
 
   executables=("$dud_instsys/usr/bin/${name}.ruby"*-*)
-  executable=${executables[0]}
+  executable="${executables[0]##"$dud_instsys"}"
+
   if [ -n "$executable" ]; then
-    "$NEWROOT/usr/bin/chroot" "$NEWROOT" /usr/sbin/update-alternatives \
-      --install "/usr/bin/$name" "$name" "${executable##"$dud_instsys"}" "$priority"
-    "$NEWROOT/usr/bin/chroot" "$NEWROOT" /usr/sbin/update-alternatives \
-      --set "$name" "${executable##"$dud_instsys"}"
+    alts=$("$NEWROOT/usr/bin/chroot" "$NEWROOT" /usr/bin/alts -l "$executable")
+    if [ -n "$alts" ]; then
+      echo "Setting alternative ${executable} using alts"
+      "$NEWROOT/usr/bin/chroot" "$NEWROOT" "/usr/bin/alts" -n "$name" "$executable"
+    else
+      "$NEWROOT/usr/bin/chroot" "$NEWROOT" /usr/sbin/update-alternatives \
+        --install "/usr/bin/$name" "$name" "$executable" "$priority"
+      "$NEWROOT/usr/bin/chroot" "$NEWROOT" /usr/sbin/update-alternatives \
+        --set "$name" "$executable"
+    fi
+
   fi
 }
 

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 18 08:16:25 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for alts as update-alternatives replacement
+  (gh#agama-project/agama#3645).
+
+-------------------------------------------------------------------
 Mon Jun 15 15:45:32 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 22
@@ -104,14 +110,14 @@ Wed Apr 22 06:43:48 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - bsc#1262229
   - Dropped mediacheck from the kiwi file as it caused build errors
-    after kiwi upgraded to new version 
+    after kiwi upgraded to new version
 
 -------------------------------------------------------------------
 Fri Apr 17 10:26:35 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - bsc#1261932
   - Explicitly allow virtual terminal switching for the gnome kiosk
-    session 
+    session
 
 -------------------------------------------------------------------
 Tue Apr 14 17:36:59 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>


### PR DESCRIPTION
## Problem

alts is replacing update-alternatives. This change affects the way in which our Driver Update Disk support. The reason is that, when it updates any of the rubygem-agama-yast
executables, it needs to update the alternatives.

## Solution

- Detect when using `alts`.
- Keep using `update-alternatives` otherwise.

## Testing

- *Added a new unit test*
- *Tested manually*