### PR TITLE
Validate config generate

### DIFF
--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -341,10 +341,14 @@ async fn generate(
         from_json_or_jsonnet(client, url_or_path, insecure).await?
     };
 
+    if let Err(e) = validate(client, CliInput::Full(profile_json.clone())).await {
+        println!("{profile_json}\n");
+        return Err(e);
+    }
+
     let config = api::Config::from_json(&profile_json, &context.source)?;
     let config_json = serde_json::to_string_pretty(&config)?;
 
-    validate(client, CliInput::Full(config_json.clone())).await?;
     println!("{}", &config_json);
 
     Ok(())

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jun 18 14:00:31 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Validate the profile before parsing it (bsc#1268432).
+
+-------------------------------------------------------------------
 Wed Jun 17 13:30:47 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the "agama config validate" command to work with the


### PR DESCRIPTION
## Problem

- [bsc#1268432](https://bugzilla.suse.com/show_bug.cgi?id=1268432)


## Solution

- Validate the profile before parsing it.
- It prints the resulting profile just in case it was generated with Jsonnet or AutoYaST, so the user can figure out where the problem comes from.