### PR TITLE
fix: avoid calls to YaST software modules

### DIFF
--- a/products.d/README.md
+++ b/products.d/README.md
@@ -2,6 +2,17 @@
 
 This directory contains product definitions for the Agama installer.
 
+## Notes
+
+### *os-prober* Package
+
+In SLE 16.1, if the *os-prober* package is added to the product configuration as either a mandatory
+or optional package, then *yast-bootloader* will configure it to detected other operating systems
+installed on the machine and add them to the boot menu.
+
+This solution has a drawback: the package *os-prober* might be installed even if not needed, for
+example for *grub2-bls*. A better solution will be implemented for SLE 16.2.
+
 ## Contribution
 
 For updating the translations use the [Agama Weblate

--- a/products.d/kalpa.yaml
+++ b/products.d/kalpa.yaml
@@ -106,7 +106,7 @@ software:
     - NetworkManager
     - openSUSE-repos-MicroOS
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
-  optional_packages: []
+  optional_packages: [os-prober]
   base_product: Kalpa
 
 storage:

--- a/products.d/leap_161.yaml
+++ b/products.d/leap_161.yaml
@@ -104,7 +104,7 @@ software:
     - NetworkManager
     - openSUSE-repos-Leap
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
-  optional_packages: []
+  optional_packages: [os-prober]
   base_product: Leap
 
 storage:

--- a/products.d/leap_micro_62.yaml
+++ b/products.d/leap_micro_62.yaml
@@ -56,7 +56,7 @@ software:
     - opensuse-migration-tool
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
 
-  optional_packages: []
+  optional_packages: [os-prober]
   base_product: Leap-Micro
 
 storage:

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -162,7 +162,7 @@ software:
     - NetworkManager
     - openSUSE-repos-MicroOS
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
-  optional_packages: []
+  optional_packages: [os-prober]
   base_product: MicroOS
 
 storage:

--- a/products.d/slowroll.yaml
+++ b/products.d/slowroll.yaml
@@ -116,7 +116,7 @@ software:
     - NetworkManager
     - openSUSE-repos-Slowroll
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
-  optional_packages: []
+  optional_packages: [os-prober]
   base_product: openSUSE
 
 boot:

--- a/products.d/tumbleweed.yaml
+++ b/products.d/tumbleweed.yaml
@@ -159,7 +159,7 @@ software:
     - NetworkManager
     - openSUSE-repos-Tumbleweed
     - sudo-policy-wheel-auth-self # explicit wheel group policy to conform new auth model
-  optional_packages: []
+  optional_packages: [os-prober]
   base_product: openSUSE
 
 boot:

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -323,7 +323,7 @@ impl<'a> SoftwareStateBuilder<'a> {
             state.resolvables.add_or_replace_resolvable(
                 &resolvable,
                 ResolvableSelection::AutoSelected {
-                    skip_if_missing: false,
+                    skip_if_missing: resolvable.optional,
                 },
             );
         }

--- a/rust/agama-utils/src/resolvable.rs
+++ b/rust/agama-utils/src/resolvable.rs
@@ -28,6 +28,8 @@ pub struct Resolvable {
     pub name: String,
     #[serde(rename = "type")]
     pub r#type: ResolvableType,
+    #[serde(default)]
+    pub optional: bool,
 }
 
 impl Resolvable {
@@ -35,6 +37,7 @@ impl Resolvable {
         Self {
             name: name.to_string(),
             r#type,
+            optional: false,
         }
     }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 23 11:53:44 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Allow adding optional resolvables (gh#agama-project/agama#3649).
+
+-------------------------------------------------------------------
 Mon Jun 22 14:22:52 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Unify cargo dependencies and move it to shared one in workspace

--- a/service/.rubocop.yml
+++ b/service/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_from:
 AllCops:
   Exclude:
     - vendor/**/*
-    - lib/agama/dbus/y2dir/**/*
+    - lib/agama/y2dir/**/*
     - agama-yast.gemspec
     - package/*.spec
 
@@ -29,10 +29,6 @@ Lint/UselessAssignment:
 Metrics/AbcSize:
   Max: 33
 
-Metrics/ParameterLists:
-  Max: 6
-  Exclude:
-    - lib/agama/software/repository.rb
-
 Metrics/ClassLength:
   Max: 300
+

--- a/service/bin/agama-autoyast
+++ b/service/bin/agama-autoyast
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-#
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -21,8 +20,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-# TEMPORARY overwrite of Y2DIR to use DBus for communication with dependent yast modules
 require "yast"
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 # Set the PATH to a known value

--- a/service/bin/agamactl
+++ b/service/bin/agamactl
@@ -22,6 +22,10 @@
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
+# Mock some YaST modules like Package.
+agama_y2dir = File.expand_path("../lib/agama/y2dir", __dir__)
+ENV["Y2DIR"] = [ENV.fetch("Y2DIR", nil), agama_y2dir].compact.join(":")
+
 # Set the PATH to a known value
 ENV["PATH"] = "/sbin:/usr/sbin:/usr/bin:/bin"
 
@@ -53,10 +57,6 @@ end
 # @param name [Symbol] Service name
 # @see ORDERED_SERVICES
 def start_service(name)
-  # Mock some YaST modules like Package.
-  agama_y2dir = File.expand_path("../lib/agama/y2dir", __dir__)
-  ENV["Y2DIR"] = [ENV.fetch("Y2DIR", nil), agama_y2dir].compact.join(":")
-
   logger = logger_for(name)
   service_runner = Agama::DBus::ServiceRunner.new(name, logger: logger)
   service_runner.run

--- a/service/bin/agamactl
+++ b/service/bin/agamactl
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-#
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -54,6 +53,10 @@ end
 # @param name [Symbol] Service name
 # @see ORDERED_SERVICES
 def start_service(name)
+  # Mock some YaST modules like Package.
+  agama_y2dir = File.expand_path("../lib/agama/y2dir", __dir__)
+  ENV["Y2DIR"] = [ENV.fetch("Y2DIR", nil), agama_y2dir].compact.join(":")
+
   logger = logger_for(name)
   service_runner = Agama::DBus::ServiceRunner.new(name, logger: logger)
   service_runner.run

--- a/service/lib/agama/config.rb
+++ b/service/lib/agama/config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022-2023] SUSE LLC
+# Copyright (c) [2022-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -66,6 +66,20 @@ module Agama
     # @return [Boolean]
     def lvm?
       data.dig("storage", "lvm") || false
+    end
+
+    # Mandatory packages required by the product.
+    #
+    # @return [Array<String>]
+    def mandatory_packages
+      data.dig("software", "mandatory_packages") || []
+    end
+
+    # Optional packages required by the product.
+    #
+    # @return [Array<String>]
+    def optional_packages
+      data.dig("software", "optional_packages") || []
     end
 
   private

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -475,7 +475,7 @@ module Agama
         #
         # @return [String]
         def serialize_storage_resolvables
-          serialize_resolvables(packages: manager.packages)
+          serialize_resolvables(manager.packages)
         end
 
         # Generates the serialized JSON of the bootloader system.
@@ -501,7 +501,7 @@ module Agama
         #
         # @return [String]
         def serialize_bootloader_resolvables
-          serialize_resolvables(packages: manager.bootloader_packages)
+          serialize_resolvables(manager.bootloader_packages)
         end
 
         # Representation of the null JSON.

--- a/service/lib/agama/dbus/storage_service.rb
+++ b/service/lib/agama/dbus/storage_service.rb
@@ -28,6 +28,8 @@ require "agama/storage/iscsi/adapter"
 require "yast"
 require "y2storage/inhibitors"
 
+Yast.import "Package"
+
 module Agama
   module DBus
     # D-Bus service (org.opensuse.Agama.Storage1)
@@ -52,6 +54,7 @@ module Agama
 
       # Starts storage service.
       def start
+        configure_yast_modules
         # Inhibits various storage subsystem (udisk, systemd mounts, raid auto-assembly) that
         # interfere with the operation of yast-storage-ng and libstorage-ng.
         Y2Storage::Inhibitors.new.inhibit
@@ -84,6 +87,13 @@ module Agama
 
       MULTIPATH_CONFIG = "/etc/multipath.conf"
       private_constant :MULTIPATH_CONFIG
+
+      # Configures mocked YaST modules, see agama/y2dir/modules.
+      def configure_yast_modules
+        # Sets the manager to allow checking the package requirements of the product, see
+        # agama/y2dir/modules/Package.rb.
+        Yast::Package.storage = manager
+      end
 
       # Checks if all requirement for multipath probing is correct and if not then log it.
       def check_multipath

--- a/service/lib/agama/dbus/with_resolvables.rb
+++ b/service/lib/agama/dbus/with_resolvables.rb
@@ -27,26 +27,24 @@ module Agama
     module WithResolvables
       # Generates the serialized JSON of the given resolvables.
       #
-      # @param patterns [Array<String>]
-      # @param packages [Array<String>]
+      # @param packages [Array<Y2Storage::Feature::Package>]
       #
       # @return [String]
-      def serialize_resolvables(patterns: [], packages: [])
-        patterns_json = patterns.map { |p| resolvable_json(p, type: "pattern") }
-        packages_json = packages.map { |p| resolvable_json(p, type: "package") }
-        JSON.pretty_generate(patterns_json + packages_json)
+      def serialize_resolvables(packages)
+        packages_json = packages.map { |p| package_json(p) }
+        JSON.pretty_generate(packages_json)
       end
 
-      # JSON representation of the given resolvable.
+      # JSON representation of the given package.
       #
-      # @param name [String]
-      # @param type ["pattern", "package"]
+      # @param package [Y2Storage::Feature::Package]
       #
       # @return [Hash]
-      def resolvable_json(name, type: "package")
+      def package_json(package)
         {
-          name: name,
-          type: type
+          name:     package.name,
+          type:     "package",
+          optional: package.optional?
         }
       end
     end

--- a/service/lib/agama/storage/bootloader_manager.rb
+++ b/service/lib/agama/storage/bootloader_manager.rb
@@ -23,7 +23,6 @@ require "agama/storage/bootloader_config"
 require "agama/storage/bootloader_config_solver"
 require "agama/storage/bootloader_prober"
 require "bootloader/bootloader_factory"
-require "bootloader/os_prober"
 require "yast"
 
 Yast.import "BootStorage"
@@ -64,8 +63,6 @@ module Agama
       #
       # @param product_config [Agama::Config]
       def configure(product_config)
-        # TODO: get value from product ( probably for TW and maybe Leap?)
-        ::Bootloader::OsProber.package_available = false
         # reset disk to always read the recent storage configuration
         ::Yast::BootStorage.reset_disks
         # reset bootloader factory cache as we want here to reapply config from scratch

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -33,6 +33,7 @@ require "agama/storage/proposal"
 require "agama/with_locale"
 require "yast/i18n"
 require "y2storage/clients/inst_prepdisk"
+require "y2storage/feature"
 require "y2storage/luks"
 require "y2storage/storage_manager"
 
@@ -183,12 +184,12 @@ module Agama
 
       # Required packages for the used features.
       #
-      # @return [Array<String>]
+      # @return [Array<Y2Storage::Feature::Package>]
       def packages
         return [] unless proposal.success?
 
-        packages = devicegraph.used_features.pkg_list
-        packages += ISCSI::Manager::PACKAGES if need_iscsi?
+        packages = devicegraph.used_features.packages
+        packages += iscsi_packages if need_iscsi?
         packages
       end
 
@@ -255,9 +256,9 @@ module Agama
 
       # Required packages for bootloader.
       #
-      # @return [Array<String>]
+      # @return [Array<Y2Storage::Feature::Package>]
       def bootloader_packages
-        bootloader.packages
+        bootloader.packages.map { |n| Y2Storage::Feature::Package.new(n) }
       end
 
     private
@@ -267,6 +268,13 @@ module Agama
 
       # @return [Logger]
       attr_reader :logger
+
+      # Packages required by iSCSI.
+      #
+      # @return [Array<<2Storage::Feature::Package>]
+      def iscsi_packages
+        ISCSI::Manager::PACKAGES.map { |n| Y2Storage::Feature::Package.new(n) }
+      end
 
       # Whether iSCSI is needed in the target system.
       #

--- a/service/lib/agama/y2dir/README.md
+++ b/service/lib/agama/y2dir/README.md
@@ -1,0 +1,12 @@
+This directory contains some redefinitions of YaST modules in order to avoid executing the actual code of some YaST modules.
+
+# Why is this needed?
+
+Agama relies on YaST code but some parts of YaST have been replaced by rust code. We need to prevent calling to the YaST code that has been replaced. Otherwise, Agama will not work as expected.
+
+# How to replace a YaST module
+
+The code replacement of the YaST modules is done by means of the *Y2DIR* mechanism of YaST. When a
+service is started (check *agamactl* script), the YaST modules redefined by the service (under
+*lib/agama/y2dir/*) are added to the *Y2DIR* environment variable. YaST takes precedence of the
+paths at *Y2DIR*, so these files will be loaded instead of the files originally delivered by YaST.

--- a/service/lib/agama/y2dir/modules/Package.rb
+++ b/service/lib/agama/y2dir/modules/Package.rb
@@ -25,8 +25,10 @@ require "yast"
 module Yast
   # Replacement for the Yast::Package module.
   class PackageClass < Module
+    include Yast::Logger
+
     def main
-      puts "Loading mocked module #{__FILE__}"
+      log.info "Loading mocked module #{__FILE__}"
     end
 
     # Whether a package is available.
@@ -57,6 +59,8 @@ module Yast
     # @param name [String]
     # @return [Boolean]
     def Available(name)
+      log.info "Calling mocked module #{__FILE__}"
+
       # For os-prober, let's consider the package as available only if the product requires it.
       return require_os_prober? if name == OS_PROBER
 

--- a/service/lib/agama/y2dir/modules/Package.rb
+++ b/service/lib/agama/y2dir/modules/Package.rb
@@ -1,0 +1,37 @@
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Yast
+  # Replacement for the Yast::Package module.
+  class PackageClass < Module
+    def main
+      puts "Loading mocked module #{__FILE__}"
+    end
+
+    def Available(_name)
+      true
+    end
+  end
+
+  Package = PackageClass.new
+  Package.main
+end

--- a/service/lib/agama/y2dir/modules/Package.rb
+++ b/service/lib/agama/y2dir/modules/Package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
@@ -27,8 +29,61 @@ module Yast
       puts "Loading mocked module #{__FILE__}"
     end
 
-    def Available(_name)
+    # Whether a package is available.
+    #
+    # Agama changes the strategy for adding optional packages to the software proposal:
+    #
+    # * The traditional YaST strategy consists on checking for the availability of the package and
+    #   request it only if the package is available.
+    # * In Agama, a package is going to be always considered as available, but it will be requested
+    #   as optional package if the package is optional. The software proposal does not install an
+    #   optional package if it is not found.
+    #
+    # With this new approach, the YaST software modules are not called and Agama does not take the
+    # libzypp lock (bsc#1268344).
+    #
+    # @note The package os-prober requires a particular treatment. The logic of yast-bootloader
+    # depends on the availability of os-prober. As temporary solution, Agama is going to assume that
+    # os-prober is available if the product is configured to add os-prober package (as optional or
+    # mandatory).
+    #
+    # @todo This solution for os-prober is not perfect. Note that adding os-prober to the list of
+    # optional packages implies that the package will be always installed if it is available in the
+    # repositories, even if yast-bootloader does not need it (e.g., the selected bootloader is
+    # grub2-bls). This is the less agressive solution for the SLE 16.1 RC phase. A more robust
+    # solution will be implemented for 16.2, for example, with a dedicate option in the product
+    # config.
+    #
+    # @param name [String]
+    # @return [Boolean]
+    def Available(name)
+      # For os-prober, let's consider the package as available only if the product requires it.
+      return require_os_prober? if name == OS_PROBER
+
+      # For any other package, assume the package is available.
       true
+    end
+
+    # Sets the storage manager.
+    #
+    # @param storage [Agama::Storage::Manager]
+    def storage=(storage)
+      @storage = storage
+    end
+
+  private
+
+    OS_PROBER = "os-prober"
+    private_constant :OS_PROBER
+
+    # Whether the product requires "os-prober" package.
+    #
+    # @return [Boolean]
+    def require_os_prober?
+      mandatory_packages = @storage&.product_config&.mandatory_packages || []
+      optional_packages = @storage&.product_config&.optional_packages || []
+      packages = mandatory_packages + optional_packages
+      packages.include?(OS_PROBER)
     end
   end
 

--- a/service/lib/agama/y2dir/modules/PackagesProposal.rb
+++ b/service/lib/agama/y2dir/modules/PackagesProposal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.

--- a/service/lib/agama/y2dir/modules/PackagesProposal.rb
+++ b/service/lib/agama/y2dir/modules/PackagesProposal.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+# :nodoc:
+module Yast
+  # Replacement for the Yast::PackagesProposal module
+  class PackagesProposalClass < Module
+    def main
+      puts "Loading mocked module #{__FILE__}"
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L118
+    def AddResolvables(unique_id, type, resolvables, optional: false)
+      true
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L145
+    def SetResolvables(unique_id, type, resolvables, optional: false)
+      true
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L285
+    def GetResolvables(unique_id, type, optional: false)
+      []
+    end
+
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L177
+    def RemoveResolvables(unique_id, type, resolvables, optional: false)
+      true
+    end
+  end
+
+  PackagesProposal = PackagesProposalClass.new
+  PackagesProposal.main
+end

--- a/service/lib/agama/y2dir/modules/PackagesProposal.rb
+++ b/service/lib/agama/y2dir/modules/PackagesProposal.rb
@@ -25,27 +25,33 @@ require "yast"
 module Yast
   # Replacement for the Yast::PackagesProposal module
   class PackagesProposalClass < Module
+    include Yast::Logger
+
     def main
-      puts "Loading mocked module #{__FILE__}"
+      log.info "Loading mocked module #{__FILE__}"
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L118
     def AddResolvables(unique_id, type, resolvables, optional: false)
+      log.info "Calling mocked module #{__FILE__}"
       true
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L145
     def SetResolvables(unique_id, type, resolvables, optional: false)
+      log.info "Calling mocked module #{__FILE__}"
       true
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L285
     def GetResolvables(unique_id, type, optional: false)
+      log.info "Calling mocked module #{__FILE__}"
       []
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L177
     def RemoveResolvables(unique_id, type, resolvables, optional: false)
+      log.info "Calling mocked module #{__FILE__}"
       true
     end
   end

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -22,7 +22,7 @@
     Requires:       yast2-iscsi-client >= 5.0.11
     Requires:       yast2-network
     Requires:       yast2-proxy
-    Requires:       yast2-storage-ng >= 5.0.48
+    Requires:       yast2-storage-ng >= 5.0.49
     %ifarch s390 s390x
     Requires:       yast2-s390 >= 4.6.4
     Requires:       yast2-reipl

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 23 11:48:47 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Do not take zypp lock (bsc#1268344).
+- Avoid calling to YaST software and configure products to include
+  os-prober as optional package.
+
+-------------------------------------------------------------------
 Mon Jun 15 15:45:27 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 22

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -1334,7 +1334,12 @@ describe Agama::DBus::Storage::Manager do
     end
 
     context "if there are packages" do
-      let(:packages) { ["package1", "package2"] }
+      let(:packages) do
+        [
+          Y2Storage::Feature::Package.new("package1"),
+          Y2Storage::Feature::Package.new("package2")
+        ]
+      end
 
       it "returns the list of packages" do
         result = parse(subject.serialized_resolvables)
@@ -1342,12 +1347,14 @@ describe Agama::DBus::Storage::Manager do
         expect(result).to eq(
           [
             {
-              name: "package1",
-              type: "package"
+              name:     "package1",
+              type:     "package",
+              optional: false
             },
             {
-              name: "package2",
-              type: "package"
+              name:     "package2",
+              type:     "package",
+              optional: false
             }
           ]
         )
@@ -1369,7 +1376,12 @@ describe Agama::DBus::Storage::Manager do
     end
 
     context "if there are bootloader packages" do
-      let(:packages) { ["grub2", "shim"] }
+      let(:packages) do
+        [
+          Y2Storage::Feature::Package.new("grub2"),
+          Y2Storage::Feature::Package.new("shim")
+        ]
+      end
 
       it "returns the list of bootloader packages" do
         result = parse(subject.serialized_bootloader_resolvables)
@@ -1377,12 +1389,14 @@ describe Agama::DBus::Storage::Manager do
         expect(result).to eq(
           [
             {
-              name: "grub2",
-              type: "package"
+              name:     "grub2",
+              type:     "package",
+              optional: false
             },
             {
-              name: "shim",
-              type: "package"
+              name:     "shim",
+              type:     "package",
+              optional: false
             }
           ]
         )

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -324,7 +324,8 @@ describe Agama::Storage::Manager do
     let(:used_features) do
       instance_double(
         Y2Storage::StorageFeaturesList,
-        pkg_list: ["btrfsprogs", "snapper"],
+        packages: [Y2Storage::Feature::Package.new("btrfsprogs"),
+                   Y2Storage::Feature::Package.new("snapper")],
         any?:     false
       )
     end
@@ -332,7 +333,7 @@ describe Agama::Storage::Manager do
     let(:proposal_success) { true }
 
     it "returns packages for storage features" do
-      expect(storage.packages).to include("btrfsprogs", "snapper")
+      expect(storage.packages.map(&:name)).to include("btrfsprogs", "snapper")
     end
 
     context "if iSCSI was used" do
@@ -341,7 +342,7 @@ describe Agama::Storage::Manager do
       end
 
       it "includes the iSCSI packages" do
-        expect(storage.packages).to include("open-iscsi", "iscsiuio")
+        expect(storage.packages.map(&:name)).to include("open-iscsi", "iscsiuio")
       end
     end
 
@@ -364,7 +365,7 @@ describe Agama::Storage::Manager do
     end
 
     it "returns packages required by the bootloader" do
-      expect(storage.bootloader_packages).to eq(bootloader_packages)
+      expect(storage.bootloader_packages.map(&:name)).to eq(bootloader_packages)
     end
   end
 

--- a/service/test/agama/y2dir/modules/package_test.rb
+++ b/service/test/agama/y2dir/modules/package_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "agama/y2dir/modules/Package"
+require "agama/config"
+require "agama/storage/manager"
+
+describe Yast::PackageClass do
+  subject(:package) { Yast::Package }
+
+  describe "#Available" do
+    context "when checking for os-prober package" do
+      let(:storage) { instance_double(Agama::Storage::Manager, product_config: product_config) }
+      let(:product_config) do
+        instance_double(
+          Agama::Config,
+          mandatory_packages: mandatory_packages,
+          optional_packages:  optional_packages
+        )
+      end
+      let(:mandatory_packages) { [] }
+      let(:optional_packages) { [] }
+
+      before do
+        package.storage = storage
+      end
+
+      context "when the product requires os-prober in mandatory packages" do
+        let(:mandatory_packages) { ["os-prober", "other-package"] }
+
+        it "returns true" do
+          expect(package.Available("os-prober")).to be(true)
+        end
+      end
+
+      context "when the product requires os-prober in optional packages" do
+        let(:optional_packages) { ["os-prober", "other-package"] }
+
+        it "returns true" do
+          expect(package.Available("os-prober")).to be(true)
+        end
+      end
+
+      context "when the product requires os-prober in both mandatory and optional packages" do
+        let(:mandatory_packages) { ["os-prober"] }
+        let(:optional_packages) { ["os-prober"] }
+
+        it "returns true" do
+          expect(package.Available("os-prober")).to be(true)
+        end
+      end
+
+      context "when the product does not require os-prober" do
+        let(:mandatory_packages) { ["other-package"] }
+        let(:optional_packages) { ["another-package"] }
+
+        it "returns false" do
+          expect(package.Available("os-prober")).to be(false)
+        end
+      end
+
+      context "when storage is not set" do
+        before do
+          package.storage = nil
+        end
+
+        it "returns false" do
+          expect(package.Available("os-prober")).to be(false)
+        end
+      end
+
+      context "when storage does not have product_config" do
+        let(:storage) { instance_double(Agama::Storage::Manager, product_config: nil) }
+
+        it "returns false" do
+          expect(package.Available("os-prober")).to be(false)
+        end
+      end
+
+      context "when product_config does not have mandatory_packages" do
+        let(:product_config) do
+          instance_double(
+            Agama::Config,
+            mandatory_packages: nil,
+            optional_packages:  []
+          )
+        end
+
+        it "returns false" do
+          expect(package.Available("os-prober")).to be(false)
+        end
+      end
+
+      context "when product_config does not have optional_packages" do
+        let(:product_config) do
+          instance_double(
+            Agama::Config,
+            mandatory_packages: [],
+            optional_packages:  nil
+          )
+        end
+
+        it "returns false" do
+          expect(package.Available("os-prober")).to be(false)
+        end
+      end
+    end
+
+    context "when checking for any other package" do
+      it "returns true for random package names" do
+        expect(package.Available("vim")).to be(true)
+        expect(package.Available("emacs")).to be(true)
+        expect(package.Available("some-random-package")).to be(true)
+      end
+    end
+  end
+end

--- a/service/test/test_helper.rb
+++ b/service/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2022] SUSE LLC
+# Copyright (c) [2022-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,6 +18,10 @@
 #
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
+
+# Mock some YaST modules like Package.
+agama_y2dir = File.expand_path("../lib/agama/y2dir", __dir__)
+ENV["Y2DIR"] = [ENV.fetch("Y2DIR", nil), agama_y2dir].compact.join(":")
 
 require "yast"
 require "yast/rspec"


### PR DESCRIPTION
After the changes introduced by https://github.com/agama-project/agama/commit/908d17fe566c4879f6aed154e07b85893eb9f350, the Agama D-Bus service is using again the *YaST software modules* (e.g., `Yast::Package`) to check whether a package is available in the repositories.  But software is now configured by *agama-software* (rust service) instead of YaST, so calling YaST to check for the availability of the packages would report wrong results. Moreover,  calling to YaST software takes the libzypp lock, so it prevents the usage of *zypper* in the live image, see https://bugzilla.suse.com/show_bug.cgi?id=1268344.

Furthermore, the D-Bus service currently checks the availability of optional packages beforehand, so an optional package is requested to be installed only if it is available. But this approach has some drawbacks:

* The availability of a package cannot be checked until a product is selected or registered.
* The availability of a package might not be realliable if there was any network issue while reading the repositories.

This PR solves these problems by avoiding to check the availability of the packages. Now, all the packages are supposed to be available, but a package can be requested as optional. As result, *agama-software* will install the optional package only if it is available, achieving the same result as before without the need of checking for the availability of packages in advance.

There is a especial treatement for the *os-prober* package, as it is documented in the code.

Requires https://github.com/yast/yast-storage-ng/pull/1430