### PR TITLE
refactor: unify Rust deps and upgrade React Router

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4213,7 +4213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,3 +33,51 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.88"
 edition = "2021"
+
+[workspace.dependencies]
+agama-access = { path = "agama-access" }
+agama-l10n = { path = "agama-l10n" }
+agama-lib = { path = "agama-lib" }
+agama-locale-data = { path = "agama-locale-data" }
+agama-network = { path = "agama-network" }
+agama-security = { path = "agama-security" }
+agama-software = { path = "agama-software" }
+agama-storage-client = { path = "agama-storage-client" }
+agama-transfer = { path = "agama-transfer" }
+agama-utils = { path = "agama-utils" }
+anyhow = { version = "1.0.100" }
+async-trait = { version = "0.1.89" }
+bindgen = { version = "0.72.1", features = ["runtime"] }
+camino = { version = "1.2.1" }
+chrono = { version = "0.4.38", features = ["alloc", "clock", "now", "std"] }
+cidr = { version = "0.3.1", features = ["serde"] }
+clap = { version = "4.5.19", features = ["derive", "wrap_help"] }
+fluent-uri = { version = "0.4.1", features = ["serde"] }
+futures-util = { version = "0.3.30", features = ["alloc"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
+glob = { version = "0.3.1" }
+home = { version = "0.5.11" }
+i18n-format = { version = "0.4.0" }
+macaddr = { version = "1.0.1", features = ["serde_std"] }
+merge = { version = "0.2.0", features = ["std"] }
+openssl = { version = "0.10.75" }
+pin-project = { version = "1.1.10" }
+regex = { version = "1.12.2" }
+schemars = { version = "1.2.1", features = ["url2", "uuid1"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1.0.145", features = ["raw_value"] }
+serde_with = { version = "3.16.1" }
+serde_yaml = { version = "0.9.34" }
+strum = { version = "0.27.2", features = ["derive"] }
+tempfile = { version = "3.27.0" }
+test-context = { version = "0.4.1" }
+thiserror = { version = "2.0.18" }
+tokio = { version = "1.52.1", features = ["full", "macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { version = "0.1.17" }
+tokio-test = { version = "0.4.4" }
+tracing = { version = "0.1.44" }
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+url = { version = "2.5.7", features = ["serde"] }
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
+zbus = { version = "5.12.0", features = ["tokio"] }
+zypp-agama = { path = "zypp-agama" }

--- a/rust/agama-access/Cargo.toml
+++ b/rust/agama-access/Cargo.toml
@@ -7,12 +7,12 @@ edition.workspace = true
 [dependencies]
 agama-utils = { path = "../agama-utils" }
 async-trait = "0.1.89"
-gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 openssl = "0.10.75"
-thiserror = "2.0.17"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
 tracing = "0.1.44"
 
 [dev-dependencies]
 test-context = "0.4.1"
-tempfile = "3.10.1"
+tempfile = "3.27.0"

--- a/rust/agama-access/Cargo.toml
+++ b/rust/agama-access/Cargo.toml
@@ -5,14 +5,14 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-async-trait = "0.1.89"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-openssl = "0.10.75"
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.44"
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+openssl = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tempfile = "3.27.0"
+tempfile = { workspace = true }
+test-context = { workspace = true }

--- a/rust/agama-autoinstall/Cargo.toml
+++ b/rust/agama-autoinstall/Cargo.toml
@@ -5,14 +5,14 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-l10n = { path = "../agama-l10n" }
-agama-lib = { path = "../agama-lib" }
-agama-utils = { path = "../agama-utils" }
-agama-transfer = { path = "../agama-transfer" }
-anyhow = { version = "1.0.100" }
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-i18n-format = "0.4.0"
-tempfile = "3.27.0"
-tokio = "1.52.1"
-tracing = "0.1.44"
-url = "2.5.7"
+agama-l10n = { workspace = true }
+agama-lib = { workspace = true }
+agama-transfer = { workspace = true }
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+gettext-rs = { workspace = true }
+i18n-format = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }

--- a/rust/agama-autoinstall/Cargo.toml
+++ b/rust/agama-autoinstall/Cargo.toml
@@ -9,10 +9,10 @@ agama-l10n = { path = "../agama-l10n" }
 agama-lib = { path = "../agama-lib" }
 agama-utils = { path = "../agama-utils" }
 agama-transfer = { path = "../agama-transfer" }
-anyhow = { version = "1.0.98" }
-gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
+anyhow = { version = "1.0.100" }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 i18n-format = "0.4.0"
-tempfile = "3.20.0"
-tokio = "1.46.0"
+tempfile = "3.27.0"
+tokio = "1.52.1"
 tracing = "0.1.44"
-url = "2.5.4"
+url = "2.5.7"

--- a/rust/agama-bootloader/Cargo.toml
+++ b/rust/agama-bootloader/Cargo.toml
@@ -8,13 +8,13 @@ edition.workspace = true
 agama-utils = { path = "../agama-utils" }
 agama-storage-client = { path = "../agama-storage-client" }
 async-trait = "0.1.89"
-gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.128", features = ["raw_value"] }
-thiserror = "2.0.16"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.41"
-zbus = "5.11.0"
+serde_json = { version = "1.0.145", features = ["raw_value"] }
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+tracing = "0.1.44"
+zbus = "5.12.0"
 
 [dev-dependencies]
 test-context = "0.4.1"

--- a/rust/agama-bootloader/Cargo.toml
+++ b/rust/agama-bootloader/Cargo.toml
@@ -5,17 +5,17 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-agama-storage-client = { path = "../agama-storage-client" }
-async-trait = "0.1.89"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.145", features = ["raw_value"] }
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.44"
-zbus = "5.12.0"
+agama-storage-client = { workspace = true }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -6,32 +6,29 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.19", features = ["derive", "wrap_help"] }
-agama-l10n = { path = "../agama-l10n" }
-agama-lib = { path = "../agama-lib" }
-agama-utils = { path = "../agama-utils" }
-agama-transfer = { path = "../agama-transfer" }
-serde_json = "1.0.145"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-thiserror = "2.0.18"
+agama-l10n = { workspace = true }
+agama-lib = { workspace = true }
+agama-transfer = { workspace = true }
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
 console = "0.15.8"
-anyhow = "1.0.100"
-tempfile = "3.27.0"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
-url = "2.5.7"
-inquire = { version = "0.9.4", default-features = false, features = [
-    "crossterm",
-    "one-liners",
-] }
-chrono = "0.4.38"
-regex = "1.12.2"
-home = "0.5.11"
-fluent-uri = "0.4.1"
-serde = { version = "1.0.228", features = ["derive"] }
-ratatui = "0.30"
 crossterm = { version = "0.29", features = ["event-stream"] }
-futures-util = "0.3"
-i18n-format = "0.4.0"
+fluent-uri = { workspace = true }
+futures-util = { workspace = true }
+gettext-rs = { workspace = true }
+home = { workspace = true }
+i18n-format = { workspace = true }
+inquire = { version = "0.9.4", default-features = false, features = ["crossterm", "one-liners",] }
+ratatui = "0.30"
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [[bin]]
 name = "agama"

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -11,20 +11,20 @@ agama-l10n = { path = "../agama-l10n" }
 agama-lib = { path = "../agama-lib" }
 agama-utils = { path = "../agama-utils" }
 agama-transfer = { path = "../agama-transfer" }
-serde_json = "1.0.128"
+serde_json = "1.0.145"
 gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-thiserror = "2.0.12"
+thiserror = "2.0.18"
 console = "0.15.8"
-anyhow = "1.0.89"
-tempfile = "3.13.0"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
-url = "2.5.2"
+anyhow = "1.0.100"
+tempfile = "3.27.0"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
+url = "2.5.7"
 inquire = { version = "0.9.4", default-features = false, features = [
     "crossterm",
     "one-liners",
 ] }
 chrono = "0.4.38"
-regex = "1.11.1"
+regex = "1.12.2"
 home = "0.5.11"
 fluent-uri = "0.4.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/rust/agama-files/Cargo.toml
+++ b/rust/agama-files/Cargo.toml
@@ -9,10 +9,10 @@ agama-utils = { path = "../agama-utils" }
 async-trait = "0.1.89"
 gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 strum = "0.27.2"
-tempfile = "3.23.0"
-thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["sync"] }
-tracing = "0.1.41"
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["sync"] }
+tracing = "0.1.44"
 
 [dev-dependencies]
 agama-l10n = { path = "../agama-l10n" }

--- a/rust/agama-files/Cargo.toml
+++ b/rust/agama-files/Cargo.toml
@@ -5,17 +5,17 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-async-trait = "0.1.89"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-strum = "0.27.2"
-tempfile = "3.27.0"
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["sync"] }
-tracing = "0.1.44"
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+strum = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-agama-l10n = { path = "../agama-l10n" }
-tokio-test = "0.4.4"
-test-context = "0.4.1"
-serde_json = "1.0.145"
+agama-l10n = { workspace = true }
+serde_json = { workspace = true }
+test-context = { workspace = true }
+tokio-test = { workspace = true }

--- a/rust/agama-hostname/Cargo.toml
+++ b/rust/agama-hostname/Cargo.toml
@@ -8,13 +8,13 @@ edition.workspace = true
 agama-utils = { version = "0.1.0", path = "../agama-utils" }
 anyhow = "1.0.100"
 async-trait = "0.1.89"
-tempfile = "3.23.0"
-thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "sync"] }
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1.17"
-tracing = "0.1.43"
+tracing = "0.1.44"
 zbus = "5.12.0"
 
 [dev-dependencies]
-tempfile = "3.23.0"
+tempfile = "3.27.0"
 test-context = "0.4.1"

--- a/rust/agama-hostname/Cargo.toml
+++ b/rust/agama-hostname/Cargo.toml
@@ -5,16 +5,16 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { version = "0.1.0", path = "../agama-utils" }
-anyhow = "1.0.100"
-async-trait = "0.1.89"
-tempfile = "3.27.0"
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.17"
-tracing = "0.1.44"
-zbus = "5.12.0"
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.27.0"
-test-context = "0.4.1"
+tempfile = { workspace = true }
+test-context = { workspace = true }

--- a/rust/agama-iscsi/Cargo.toml
+++ b/rust/agama-iscsi/Cargo.toml
@@ -7,14 +7,14 @@ edition.workspace = true
 [dependencies]
 agama-utils = { path = "../agama-utils" }
 agama-storage-client = { path = "../agama-storage-client" }
-thiserror = "2.0.16"
+thiserror = "2.0.18"
 async-trait = "0.1.89"
-zbus = "5.7.1"
-tracing = "0.1.41"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.16"
+zbus = "5.12.0"
+tracing = "0.1.44"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = "0.1.17"
 serde = { version = "1.0.228" }
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 
 [dev-dependencies]
 test-context = "0.4.1"

--- a/rust/agama-iscsi/Cargo.toml
+++ b/rust/agama-iscsi/Cargo.toml
@@ -5,17 +5,17 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-agama-storage-client = { path = "../agama-storage-client" }
-thiserror = "2.0.18"
-async-trait = "0.1.89"
-zbus = "5.12.0"
-tracing = "0.1.44"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.17"
-serde = { version = "1.0.228" }
-serde_json = "1.0.145"
+agama-storage-client = { workspace = true }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }

--- a/rust/agama-l10n/Cargo.toml
+++ b/rust/agama-l10n/Cargo.toml
@@ -5,21 +5,21 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.100"
-thiserror = "2.0.18"
-agama-locale-data = { path = "../agama-locale-data" }
-agama-utils = { path = "../agama-utils" }
-regex = "1.12.2"
-tracing = "0.1.44"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.17"
-zbus = "5.12.0"
-async-trait = "0.1.89"
+agama-locale-data = { workspace = true }
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+regex = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-l10n/Cargo.toml
+++ b/rust/agama-l10n/Cargo.toml
@@ -5,16 +5,16 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.99"
-thiserror = "2.0.16"
+anyhow = "1.0.100"
+thiserror = "2.0.18"
 agama-locale-data = { path = "../agama-locale-data" }
 agama-utils = { path = "../agama-utils" }
-regex = "1.11.2"
-tracing = "0.1.41"
-gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
+regex = "1.12.2"
+tracing = "0.1.44"
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1.17"
-zbus = "5.11.0"
+zbus = "5.12.0"
 async-trait = "0.1.89"
 
 [dev-dependencies]

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.100"
 agama-utils = { path = "../agama-utils" }
 agama-transfer = { path = "../agama-transfer" }
 jsonschema = { version = "0.30.0", default-features = false, features = [
@@ -14,16 +14,16 @@ jsonschema = { version = "0.30.0", default-features = false, features = [
 ] }
 log = "0.4"
 reqwest = { version = "0.12.8", default-features = false, features = ["json", "native-tls"] }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = { version = "1.0.128", features = ["raw_value"] }
-tempfile = "3.13.0"
-thiserror = "2.0.12"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1.16"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1.0.145", features = ["raw_value"] }
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
+tokio-stream = "0.1.17"
 tracing = "0.1.44"
-url = { version = "2.5.2", features = ["serde"] }
+url = { version = "2.5.7", features = ["serde"] }
 schemars = { version = "1.2.1", features = ["url2"] }
-zbus = { version = "5", default-features = false, features = ["tokio"] }
+zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
 jsonwebtoken = "9.3.0"
 chrono = { version = "0.4.38", default-features = false, features = [
     "now",
@@ -31,7 +31,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "alloc",
     "clock",
 ] }
-home = "0.5.9"
+home = "0.5.11"
 fs_extra = "1.3.0"
 fluent-uri = { version = "0.4.1", features = ["serde"] }
 tokio-tungstenite = { version = "0.29.0", features = ["native-tls"] }

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -6,41 +6,34 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.100"
-agama-utils = { path = "../agama-utils" }
-agama-transfer = { path = "../agama-transfer" }
-jsonschema = { version = "0.30.0", default-features = false, features = [
-    "resolve-file",
-] }
-log = "0.4"
-reqwest = { version = "0.12.8", default-features = false, features = ["json", "native-tls"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.145", features = ["raw_value"] }
-tempfile = "3.27.0"
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1.17"
-tracing = "0.1.44"
-url = { version = "2.5.7", features = ["serde"] }
-schemars = { version = "1.2.1", features = ["url2"] }
-zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
-jsonwebtoken = "9.3.0"
-chrono = { version = "0.4.38", default-features = false, features = [
-    "now",
-    "std",
-    "alloc",
-    "clock",
-] }
-home = "0.5.11"
+agama-transfer = { workspace = true }
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+fluent-uri = { workspace = true }
 fs_extra = "1.3.0"
-fluent-uri = { version = "0.4.1", features = ["serde"] }
-tokio-tungstenite = { version = "0.29.0", features = ["native-tls"] }
-tokio-native-tls = "0.3.1"
-socket2 = "0.6"
+home = { workspace = true }
+jsonschema = { version = "0.30.0", default-features = false, features = ["resolve-file",] }
+jsonwebtoken = "9.3.0"
+log = "0.4"
 percent-encoding = "2.3.1"
-uuid = { version = "1.17.0", features = ["serde", "v4"] }
-zypp-agama = { path = "../zypp-agama" }
+reqwest = { version = "0.12.8", default-features = false, features = ["json", "native-tls"] }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+socket2 = "0.6"
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-native-tls = "0.3.1"
+tokio-stream = { workspace = true }
+tokio-tungstenite = { version = "0.29.0", features = ["native-tls"] }
+tracing = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+zbus = { workspace = true }
+zypp-agama = { workspace = true }
 
 [dev-dependencies]
-httpmock = "0.8.3"
 env_logger = "0.11.5"
+httpmock = "0.8.3"

--- a/rust/agama-locale-data/Cargo.toml
+++ b/rust/agama-locale-data/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.210", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 quick-xml = { version = "0.37.5", features = ["serialize"] }
 flate2 = "1.0.34"
 chrono-tz = "0.10.3"
-regex = "1"
-thiserror = "2.0.12"
+regex = "1.12.2"
+thiserror = "2.0.18"
 schemars = "1.2.1"

--- a/rust/agama-locale-data/Cargo.toml
+++ b/rust/agama-locale-data/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-quick-xml = { version = "0.37.5", features = ["serialize"] }
-flate2 = "1.0.34"
 chrono-tz = "0.10.3"
-regex = "1.12.2"
-thiserror = "2.0.18"
-schemars = "1.2.1"
+flate2 = "1.0.34"
+quick-xml = { version = "0.37.5", features = ["serialize"] }
+regex = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/rust/agama-manager/Cargo.toml
+++ b/rust/agama-manager/Cargo.toml
@@ -5,36 +5,36 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
+agama-access = { workspace = true }
 agama-bootloader = { path = "../agama-bootloader" }
 agama-files = { path = "../agama-files" }
 agama-hostname = { path = "../agama-hostname" }
 agama-iscsi = { path = "../agama-iscsi" }
-agama-l10n = { path = "../agama-l10n" }
-agama-network = { path = "../agama-network" }
+agama-l10n = { workspace = true }
+agama-network = { workspace = true }
 agama-ntp = { path = "../agama-ntp" }
-agama-access = { path = "../agama-access" }
-agama-s390 = { path = "../agama-s390" }
-agama-security = { path = "../agama-security" }
-agama-software = { path = "../agama-software" }
-agama-storage = { path = "../agama-storage" }
-agama-utils = { path = "../agama-utils" }
-agama-users = { path = "../agama-users" }
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-async-trait = "0.1.89"
-zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
-serde_json = "1.0.145"
-tracing = "0.1.44"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_with = "3.16.1"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-merge = "0.2.0"
 agama-proxy = { version = "0.1.0", path = "../agama-proxy" }
-tempfile = "3.27.0"
+agama-s390 = { path = "../agama-s390" }
+agama-security = { workspace = true }
+agama-software = { workspace = true }
+agama-storage = { path = "../agama-storage" }
+agama-users = { path = "../agama-users" }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+merge = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-manager/Cargo.toml
+++ b/rust/agama-manager/Cargo.toml
@@ -19,12 +19,12 @@ agama-software = { path = "../agama-software" }
 agama-storage = { path = "../agama-storage" }
 agama-utils = { path = "../agama-utils" }
 agama-users = { path = "../agama-users" }
-thiserror = "2.0.12"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
-async-trait = "0.1.83"
-zbus = { version = "5", default-features = false, features = ["tokio"] }
-serde_json = "1.0.140"
-tracing = "0.1.41"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+async-trait = "0.1.89"
+zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
+serde_json = "1.0.145"
+tracing = "0.1.44"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_with = "3.16.1"
 gettext-rs = { version = "0.7.7", features = ["gettext-system"] }

--- a/rust/agama-network/Cargo.toml
+++ b/rust/agama-network/Cargo.toml
@@ -6,22 +6,22 @@ edition.workspace = true
 
 [dependencies]
 agama-utils = { path = "../agama-utils", default-features = false }
-anyhow = "1.0.98"
-async-trait = "0.1.88"
+anyhow = "1.0.100"
+async-trait = "0.1.89"
 cidr = { version = "0.3.1", features = ["serde"] }
 futures-util = { version = "0.3.30", default-features = false, features = [
     "alloc",
 ] }
 macaddr = { version = "1.0.1", features = ["serde_std"] }
 pin-project = "1.1.10"
-serde = { version = "1.0.219", features = ["derive"] }
-serde_with = "3.12.0"
-thiserror = "2.0.12"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "time"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_with = "3.16.1"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"
-tracing = "0.1.41"
+tracing = "0.1.44"
 schemars = { version = "1.2.1", features = ["uuid1"] }
-uuid = { version = "1.16.0", features = ["v4", "serde"] }
-zbus = { version = "5", default-features = false, features = ["tokio"] }
+uuid = { version = "1.17.0", features = ["v4", "serde"] }
+zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
 semver = "1.0.26"
 gettext-rs = "0.7.7"

--- a/rust/agama-network/Cargo.toml
+++ b/rust/agama-network/Cargo.toml
@@ -5,23 +5,21 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils", default-features = false }
-anyhow = "1.0.100"
-async-trait = "0.1.89"
-cidr = { version = "0.3.1", features = ["serde"] }
-futures-util = { version = "0.3.30", default-features = false, features = [
-    "alloc",
-] }
-macaddr = { version = "1.0.1", features = ["serde_std"] }
-pin-project = "1.1.10"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_with = "3.16.1"
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "time"] }
-tokio-stream = "0.1.17"
-tracing = "0.1.44"
-schemars = { version = "1.2.1", features = ["uuid1"] }
-uuid = { version = "1.17.0", features = ["v4", "serde"] }
-zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+cidr = { workspace = true }
+futures-util = { workspace = true }
+gettext-rs = { workspace = true }
+macaddr = { workspace = true }
+pin-project = { workspace = true }
+schemars = { workspace = true }
 semver = "1.0.26"
-gettext-rs = "0.7.7"
+serde = { workspace = true }
+serde_with = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+zbus = { workspace = true }

--- a/rust/agama-ntp/Cargo.toml
+++ b/rust/agama-ntp/Cargo.toml
@@ -5,14 +5,14 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { version = "0.1.0", path = "../agama-utils" }
-async-trait = "0.1.89"
-merge = { version = "0.2.0", default-features = false, features = ["std"] }
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.44"
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+merge = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-agama-l10n = { version = "0.1.0", path = "../agama-l10n" }
-test-context = "0.4.1"
-tempfile = "3.27.0"
+agama-l10n = { workspace = true }
+tempfile = { workspace = true }
+test-context = { workspace = true }

--- a/rust/agama-ntp/Cargo.toml
+++ b/rust/agama-ntp/Cargo.toml
@@ -9,10 +9,10 @@ agama-utils = { version = "0.1.0", path = "../agama-utils" }
 async-trait = "0.1.89"
 merge = { version = "0.2.0", default-features = false, features = ["std"] }
 thiserror = "2.0.18"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
 tracing = "0.1.44"
 
 [dev-dependencies]
 agama-l10n = { version = "0.1.0", path = "../agama-l10n" }
 test-context = "0.4.1"
-tempfile = "3.13.0"
+tempfile = "3.27.0"

--- a/rust/agama-proxy/Cargo.toml
+++ b/rust/agama-proxy/Cargo.toml
@@ -19,5 +19,5 @@ path = "src/main.rs"
 
 
 [dev-dependencies]
-tempfile = "3.13.0"
-tokio = { version = "1.49.0", features = ["full"] }
+tempfile = "3.27.0"
+tokio = { version = "1.52.1", features = ["full"] }

--- a/rust/agama-proxy/Cargo.toml
+++ b/rust/agama-proxy/Cargo.toml
@@ -5,13 +5,13 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { version = "0.1.0", path = "../agama-utils" }
-anyhow = "1.0.100"
-async-trait = "0.1.89"
-gettext-rs = "0.7.7"
-strum = "0.27.2"
-thiserror = "2.0.18"
-tracing = "0.1.44"
+agama-utils = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [[bin]]
 name = "agama-proxy-setup"
@@ -19,5 +19,5 @@ path = "src/main.rs"
 
 
 [dev-dependencies]
-tempfile = "3.27.0"
-tokio = { version = "1.52.1", features = ["full"] }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/rust/agama-s390/Cargo.toml
+++ b/rust/agama-s390/Cargo.toml
@@ -7,14 +7,14 @@ edition.workspace = true
 [dependencies]
 agama-utils = { path = "../agama-utils" }
 agama-storage-client = { path = "../agama-storage-client" }
-thiserror = "2.0.16"
+thiserror = "2.0.18"
 async-trait = "0.1.89"
-zbus = "5.7.1"
-tracing = "0.1.41"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.16"
+zbus = "5.12.0"
+tracing = "0.1.44"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = "0.1.17"
 serde = { version = "1.0.228" }
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 
 [dev-dependencies]
 test-context = "0.4.1"

--- a/rust/agama-s390/Cargo.toml
+++ b/rust/agama-s390/Cargo.toml
@@ -5,17 +5,17 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-agama-storage-client = { path = "../agama-storage-client" }
-thiserror = "2.0.18"
-async-trait = "0.1.89"
-zbus = "5.12.0"
-tracing = "0.1.44"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.17"
-serde = { version = "1.0.228" }
-serde_json = "1.0.145"
+agama-storage-client = { workspace = true }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }

--- a/rust/agama-security/Cargo.toml
+++ b/rust/agama-security/Cargo.toml
@@ -7,12 +7,12 @@ edition.workspace = true
 [dependencies]
 agama-utils = { path = "../agama-utils" }
 async-trait = "0.1.89"
-gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 openssl = "0.10.75"
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 tracing = "0.1.44"
 
 [dev-dependencies]
 test-context = "0.4.1"
-tempfile = "3.10.1"
-tokio = { version = "1.47.1", features = ["macros"] }
+tempfile = "3.27.0"
+tokio = { version = "1.52.1", features = ["macros"] }

--- a/rust/agama-security/Cargo.toml
+++ b/rust/agama-security/Cargo.toml
@@ -5,14 +5,14 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-async-trait = "0.1.89"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-openssl = "0.10.75"
-thiserror = "2.0.18"
-tracing = "0.1.44"
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+openssl = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tempfile = "3.27.0"
-tokio = { version = "1.52.1", features = ["macros"] }
+tempfile = { workspace = true }
+test-context = { workspace = true }
+tokio = { workspace = true }

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.100"
 agama-lib = { path = "../agama-lib" }
 agama-utils = { path = "../agama-utils" }
 agama-l10n = { path = "../agama-l10n" }
@@ -16,21 +16,21 @@ agama-manager = { path = "../agama-manager" }
 agama-network = { path = "../agama-network" }
 agama-software = { path = "../agama-software" }
 agama-transfer = { path = "../agama-transfer" }
-zbus = { version = "5", default-features = false, features = ["tokio"] }
-thiserror = "2.0.12"
-serde = { version = "1.0.210", features = ["derive"] }
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.16"
-async-trait = "0.1.83"
+zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
+thiserror = "2.0.18"
+serde = { version = "1.0.228", features = ["derive"] }
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = "0.1.17"
+async-trait = "0.1.89"
 axum = { version = "0.8.9", features = ["ws", "macros"] }
-serde_json = "1.0.128"
+serde_json = "1.0.145"
 tower-http = { version = "0.6.2", features = [
     "compression-br",
     "fs",
     "trace",
     "set-header",
 ] }
-tracing = "0.1.40"
+tracing = "0.1.44"
 clap = { version = "4.5.19", features = ["derive", "wrap_help"] }
 tower = { version = "0.5.2", features = ["util"] }
 aide = { version = "0.16.0-alpha.4", features = ["axum", "axum-extra", "axum-json", "axum-query", "macros"] }
@@ -42,8 +42,8 @@ axum-extra = { version = "0.12.6", features = ["cookie", "typed-header"] }
 # pam 0.8.0 (2023-11) plus an unreleased commit from 2023-12
 # that switches from users to uzers, fixing CVE-2025-5791
 pam = { git = "https://github.com/1wilkens/pam.git", rev = "daf26ae" }
-pin-project = "1.1.5"
-openssl = "0.10.66"
+pin-project = "1.1.10"
+openssl = "0.10.75"
 sd-notify = "0.4.2"
 hyper = "1.4.1"
 hyper-util = "0.1.9"
@@ -53,8 +53,8 @@ futures-util = { version = "0.3.30", default-features = false, features = [
 ] }
 gethostname = "1.0.0"
 tokio-util = "0.7.12"
-url = "2.5.2"
-gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
+url = "2.5.7"
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 
 [[bin]]
 name = "agama-web-server"
@@ -68,6 +68,8 @@ tokio-test = "0.4.4"
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }
 
-# here we force runtime for bindgen otherwise pam-sys fails
+# here we force runtime for bindgen otherwise pam-sys fails.
+# Also it intentionally force old version of bindgen, which is
+# the exact one that is used for pam-sys ( it looks like unmaintained for some years )
 [build-dependencies]
-bindgen = { version = "0.69", features = ["runtime"] }
+bindgen = { version = "0.69.5", features = ["runtime"] }

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -7,54 +7,47 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.100"
-agama-lib = { path = "../agama-lib" }
-agama-utils = { path = "../agama-utils" }
-agama-l10n = { path = "../agama-l10n" }
-agama-locale-data = { path = "../agama-locale-data" }
+agama-l10n = { workspace = true }
+agama-lib = { workspace = true }
+agama-locale-data = { workspace = true }
 agama-manager = { path = "../agama-manager" }
-agama-network = { path = "../agama-network" }
-agama-software = { path = "../agama-software" }
-agama-transfer = { path = "../agama-transfer" }
-zbus = { version = "5.12.0", default-features = false, features = ["tokio"] }
-thiserror = "2.0.18"
-serde = { version = "1.0.228", features = ["derive"] }
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.17"
-async-trait = "0.1.89"
-axum = { version = "0.8.9", features = ["ws", "macros"] }
-serde_json = "1.0.145"
-tower-http = { version = "0.6.2", features = [
-    "compression-br",
-    "fs",
-    "trace",
-    "set-header",
-] }
-tracing = "0.1.44"
-clap = { version = "4.5.19", features = ["derive", "wrap_help"] }
-tower = { version = "0.5.2", features = ["util"] }
+agama-network = { workspace = true }
+agama-software = { workspace = true }
+agama-transfer = { workspace = true }
+agama-utils = { workspace = true }
 aide = { version = "0.16.0-alpha.4", features = ["axum", "axum-extra", "axum-json", "axum-query", "macros"] }
-indexmap = "2.7"
-schemars = { version = "1.2.1", features = ["uuid1", "url2"] }
-config = "0.15.11"
-rand = "0.9.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+axum = { version = "0.8.9", features = ["ws", "macros"] }
 axum-extra = { version = "0.12.6", features = ["cookie", "typed-header"] }
+clap = { workspace = true }
+config = "0.15.11"
+indexmap = "2.7"
+rand = "0.9.1"
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tower = { version = "0.5.2", features = ["util"] }
+tower-http = { version = "0.6.2", features = ["compression-br", "fs", "trace", "set-header",] }
+tracing = { workspace = true }
+zbus = { workspace = true }
 # pam 0.8.0 (2023-11) plus an unreleased commit from 2023-12
 # that switches from users to uzers, fixing CVE-2025-5791
-pam = { git = "https://github.com/1wilkens/pam.git", rev = "daf26ae" }
-pin-project = "1.1.10"
-openssl = "0.10.75"
-sd-notify = "0.4.2"
+futures-util = { workspace = true }
+gethostname = "1.0.0"
+gettext-rs = { workspace = true }
 hyper = "1.4.1"
 hyper-util = "0.1.9"
+openssl = { workspace = true }
+pam = { git = "https://github.com/1wilkens/pam.git", rev = "daf26ae" }
+pin-project = { workspace = true }
+sd-notify = "0.4.2"
 tokio-openssl = "0.6.5"
-futures-util = { version = "0.3.30", default-features = false, features = [
-    "alloc",
-] }
-gethostname = "1.0.0"
 tokio-util = "0.7.12"
-url = "2.5.7"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
+url = { workspace = true }
 
 [[bin]]
 name = "agama-web-server"
@@ -62,8 +55,8 @@ path = "src/agama-web-server.rs"
 
 [dev-dependencies]
 http-body-util = "0.1.2"
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-software/Cargo.toml
+++ b/rust/agama-software/Cargo.toml
@@ -5,27 +5,27 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-l10n = { path = "../agama-l10n" }
-agama-utils = { path = "../agama-utils" }
-agama-security = { path = "../agama-security" }
-async-trait = "0.1.89"
-camino = "1.2.1"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-glob = "0.3.1"
-i18n-format = "0.4.0"
-serde = { version = "1.0.228", features = ["derive"] }
-strum = { version = "0.27.2", features = ["derive"] }
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.44"
-url = "2.5.7"
-schemars = { version = "1.2.1", features = ["uuid1"] }
+agama-l10n = { workspace = true }
+agama-security = { workspace = true }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+camino = { workspace = true }
+gettext-rs = { workspace = true }
+glob = { workspace = true }
+i18n-format = { workspace = true }
+openssl = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
 suseconnect-agama = { path = "../suseconnect-agama" }
-zypp-agama = { path = "../zypp-agama" }
-openssl = "0.10.75"
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+zypp-agama = { workspace = true }
 
 [dev-dependencies]
-serde_yaml = "0.9.34"
-tempfile = "3.27.0"
-tracing-subscriber = "0.3.22"
-glob = "0.3.1"
+glob = { workspace = true }
+serde_yaml = { workspace = true }
+tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/rust/agama-software/Cargo.toml
+++ b/rust/agama-software/Cargo.toml
@@ -10,14 +10,14 @@ agama-utils = { path = "../agama-utils" }
 agama-security = { path = "../agama-security" }
 async-trait = "0.1.89"
 camino = "1.2.1"
-gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 glob = "0.3.1"
 i18n-format = "0.4.0"
-serde = { version = "1.0.210", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 strum = { version = "0.27.2", features = ["derive"] }
-thiserror = "2.0.12"
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
-tracing = "0.1.41"
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+tracing = "0.1.44"
 url = "2.5.7"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 suseconnect-agama = { path = "../suseconnect-agama" }
@@ -26,6 +26,6 @@ openssl = "0.10.75"
 
 [dev-dependencies]
 serde_yaml = "0.9.34"
-tempfile = "3.23.0"
-tracing-subscriber = "0.3.18"
+tempfile = "3.27.0"
+tracing-subscriber = "0.3.22"
 glob = "0.3.1"

--- a/rust/agama-storage-client/Cargo.toml
+++ b/rust/agama-storage-client/Cargo.toml
@@ -5,12 +5,12 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-thiserror = "2.0.18"
-async-trait = "0.1.89"
-zbus = "5.12.0"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-serde = { version = "1.0.228" }
-serde_json = "1.0.145"
-tracing = "0.1.44"
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 

--- a/rust/agama-storage-client/Cargo.toml
+++ b/rust/agama-storage-client/Cargo.toml
@@ -6,11 +6,11 @@ edition.workspace = true
 
 [dependencies]
 agama-utils = { path = "../agama-utils" }
-thiserror = "2.0.16"
+thiserror = "2.0.18"
 async-trait = "0.1.89"
-zbus = "5.7.1"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
+zbus = "5.12.0"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
 serde = { version = "1.0.228" }
-serde_json = "1.0.140"
-tracing = "0.1.41"
+serde_json = "1.0.145"
+tracing = "0.1.44"
 

--- a/rust/agama-storage/Cargo.toml
+++ b/rust/agama-storage/Cargo.toml
@@ -7,14 +7,14 @@ edition.workspace = true
 [dependencies]
 agama-utils = { path = "../agama-utils" }
 agama-storage-client = { path = "../agama-storage-client" }
-thiserror = "2.0.16"
+thiserror = "2.0.18"
 async-trait = "0.1.89"
-zbus = "5.7.1"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.16"
+zbus = "5.12.0"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = "0.1.17"
 serde = { version = "1.0.228" }
-serde_json = "1.0.140"
-tracing = "0.1.41"
+serde_json = "1.0.145"
+tracing = "0.1.44"
 
 [dev-dependencies]
 test-context = "0.4.1"

--- a/rust/agama-storage/Cargo.toml
+++ b/rust/agama-storage/Cargo.toml
@@ -5,17 +5,17 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { path = "../agama-utils" }
-agama-storage-client = { path = "../agama-storage-client" }
-thiserror = "2.0.18"
-async-trait = "0.1.89"
-zbus = "5.12.0"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-tokio-stream = "0.1.17"
-serde = { version = "1.0.228" }
-serde_json = "1.0.145"
-tracing = "0.1.44"
+agama-storage-client = { workspace = true }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }

--- a/rust/agama-transfer/Cargo.toml
+++ b/rust/agama-transfer/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 
 [dependencies]
 curl = { version = "0.4.49", features = ["protocol-ftp"] }
-regex = "1.12.2"
-thiserror = "2.0.18"
-url = { version = "2.5.7", features = ["serde"] }
+regex = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }

--- a/rust/agama-transfer/Cargo.toml
+++ b/rust/agama-transfer/Cargo.toml
@@ -7,5 +7,5 @@ edition.workspace = true
 [dependencies]
 curl = { version = "0.4.49", features = ["protocol-ftp"] }
 regex = "1.12.2"
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 url = { version = "2.5.7", features = ["serde"] }

--- a/rust/agama-users/Cargo.toml
+++ b/rust/agama-users/Cargo.toml
@@ -5,19 +5,19 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-thiserror = "2.0.18"
-agama-utils = { path = "../agama-utils" }
-agama-access = { path = "../agama-access" }
-tracing = "0.1.44"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
-async-trait = "0.1.89"
-serde = { version = "1.0.228", features = ["derive"] }
-schemars = "1.2.1"
+agama-access = { workspace = true }
+agama-utils = { workspace = true }
+async-trait = { workspace = true }
+gettext-rs = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-users/Cargo.toml
+++ b/rust/agama-users/Cargo.toml
@@ -5,12 +5,12 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-thiserror = "2.0.16"
+thiserror = "2.0.18"
 agama-utils = { path = "../agama-utils" }
 agama-access = { path = "../agama-access" }
-tracing = "0.1.41"
-gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync"] }
+tracing = "0.1.44"
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync"] }
 async-trait = "0.1.89"
 serde = { version = "1.0.228", features = ["derive"] }
 schemars = "1.2.1"

--- a/rust/agama-utils/Cargo.toml
+++ b/rust/agama-utils/Cargo.toml
@@ -9,36 +9,36 @@ default = ["curl"]
 curl = ["dep:agama-transfer"]
 
 [dependencies]
-agama-locale-data = { path = "../agama-locale-data" }
-agama-transfer = { path = "../agama-transfer", optional = true }
-anyhow = { version = "1.0.100" }
-async-trait = "0.1.89"
-camino = "1.2.1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-serde_with = "3.16.1"
-strum = { version = "0.27.2", features = ["derive"] }
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "process", "sync", "time"] }
-schemars = { version = "1.2.1", features = ["url2"] }
-zbus = "5.12.0"
-zvariant = "5.5.2"
-gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
-regex = "1.12.2"
-libsystemd = "0.7.2"
-tracing = "0.1.44"
-tracing-journald = "0.3.2"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-serde_yaml = "0.9.34"
-uuid = { version = "1.17.0", features = ["v4"] }
-cidr = { version = "0.3.1", features = ["serde"] }
-macaddr = { version = "1.0.1", features = ["serde_std"] }
+agama-locale-data = { workspace = true }
+agama-transfer = { workspace = true, optional = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+camino = { workspace = true }
+cidr = { workspace = true }
+fluent-uri = { workspace = true }
 fs-err = "3.2.0"
-fluent-uri = { version = "0.4.1", features = ["serde"] }
-tempfile = "3.27.0"
-merge = "0.2.0"
-url = { version = "2.5.7", features = ["serde"] }
+gettext-rs = { workspace = true }
+libsystemd = "0.7.2"
+macaddr = { workspace = true }
+merge = { workspace = true }
+regex = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+serde_yaml = { workspace = true }
+strum = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-journald = "0.3.2"
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+zbus = { workspace = true }
+zvariant = "5.5.2"
 
 [dev-dependencies]
-test-context = "0.4.1"
-tokio-test = "0.4.4"
+test-context = { workspace = true }
+tokio-test = { workspace = true }

--- a/rust/agama-utils/Cargo.toml
+++ b/rust/agama-utils/Cargo.toml
@@ -11,31 +11,31 @@ curl = ["dep:agama-transfer"]
 [dependencies]
 agama-locale-data = { path = "../agama-locale-data" }
 agama-transfer = { path = "../agama-transfer", optional = true }
-anyhow = { version = "1.0.98" }
+anyhow = { version = "1.0.100" }
 async-trait = "0.1.89"
 camino = "1.2.1"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.140"
-serde_with = "3.14.0"
+serde_json = "1.0.145"
+serde_with = "3.16.1"
 strum = { version = "0.27.2", features = ["derive"] }
-thiserror = "2.0.16"
-tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "process", "sync", "time"] }
+thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "process", "sync", "time"] }
 schemars = { version = "1.2.1", features = ["url2"] }
-zbus = "5.7.1"
+zbus = "5.12.0"
 zvariant = "5.5.2"
-gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 regex = "1.12.2"
 libsystemd = "0.7.2"
 tracing = "0.1.44"
 tracing-journald = "0.3.2"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 serde_yaml = "0.9.34"
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["v4"] }
 cidr = { version = "0.3.1", features = ["serde"] }
 macaddr = { version = "1.0.1", features = ["serde_std"] }
 fs-err = "3.2.0"
 fluent-uri = { version = "0.4.1", features = ["serde"] }
-tempfile = "3.23.0"
+tempfile = "3.27.0"
 merge = "0.2.0"
 url = { version = "2.5.7", features = ["serde"] }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 22 14:22:52 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- Unify cargo dependencies and move it to shared one in workspace
+  for easier future updates (gh#agama-project/agama#3652)
+
+-------------------------------------------------------------------
 Thu Jun 18 15:43:40 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Validate the profile before parsing it (bsc#1268432).

--- a/rust/suseconnect-agama/Cargo.toml
+++ b/rust/suseconnect-agama/Cargo.toml
@@ -9,13 +9,13 @@ name = "suseconnect_agama"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde = { workspace = true }
+serde_json = { workspace = true }
 suseconnect-agama-sys = { path="./suseconnect-agama-sys" }
-thiserror = "2.0.18"
-tracing = "0.1.44"
-url = { version = "2.5.7", features = ["serde"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.27.0"
-tracing-subscriber = "0.3.22"
+tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/rust/suseconnect-agama/Cargo.toml
+++ b/rust/suseconnect-agama/Cargo.toml
@@ -10,12 +10,12 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 suseconnect-agama-sys = { path="./suseconnect-agama-sys" }
-thiserror = "2.0.16"
-tracing = "0.1.41"
-url = { version = "2.5.4", features = ["serde"] }
+thiserror = "2.0.18"
+tracing = "0.1.44"
+url = { version = "2.5.7", features = ["serde"] }
 
 [dev-dependencies]
-tempfile = "3.20.0"
-tracing-subscriber = "0.3.20"
+tempfile = "3.27.0"
+tracing-subscriber = "0.3.22"

--- a/rust/suseconnect-agama/suseconnect-agama-sys/Cargo.toml
+++ b/rust/suseconnect-agama/suseconnect-agama-sys/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition.workspace = true
 
 [build-dependencies]
-bindgen = { version= "0.72.1", features = ["runtime"] }
+bindgen = { workspace = true }

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -7,11 +7,11 @@ edition.workspace = true
 [dependencies]
 agama-cli = { path = "../agama-cli" }
 agama-server = { path = "../agama-server" }
-agama-utils = { path = "../agama-utils" }
-clap = { version = "4.5.19", default-features = false }
+agama-utils = { workspace = true }
+clap = { workspace = true }
 clap-markdown = "0.1.4"
 clap_complete = "4.5.32"
 clap_mangen = "0.2.23"
-serde_json = "1.0.145"
-serde_yaml = "0.9.34"
-tokio = "1.52.1"
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -12,6 +12,6 @@ clap = { version = "4.5.19", default-features = false }
 clap-markdown = "0.1.4"
 clap_complete = "4.5.32"
 clap_mangen = "0.2.23"
-serde_json = "1.0"
-serde_yaml = "0.9"
+serde_json = "1.0.145"
+serde_yaml = "0.9.34"
 tokio = "1.52.1"

--- a/rust/zypp-agama/Cargo.toml
+++ b/rust/zypp-agama/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 zypp-agama-sys = { path="./zypp-agama-sys" }
-tracing = "0.1.41"
+tracing = "0.1.44"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/rust/zypp-agama/Cargo.toml
+++ b/rust/zypp-agama/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+tracing = { workspace = true }
 zypp-agama-sys = { path="./zypp-agama-sys" }
-tracing = "0.1.44"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-glob = "0.3.1"
+glob = { workspace = true }
 
 [[bench]]
 name = "list_patterns"

--- a/rust/zypp-agama/zypp-agama-sys/Cargo.toml
+++ b/rust/zypp-agama/zypp-agama-sys/Cargo.toml
@@ -6,4 +6,4 @@ edition.workspace = true
 [dependencies]
 
 [build-dependencies]
-bindgen = { version= "0.72.1", features = ["runtime"] }
+bindgen = { workspace = true }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "radashi": "^12.7.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router": "7.13.1",
+        "react-router": "7.14.0",
         "sprintf-js": "^1.1.3",
         "stacktracey": "^2.1.8",
         "xbytes": "^1.9.1"
@@ -3997,9 +3997,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4021,9 +4018,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4045,9 +4039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4069,9 +4060,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4093,9 +4081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4117,9 +4102,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5872,9 +5854,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5889,9 +5868,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5906,9 +5882,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5923,9 +5896,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5940,9 +5910,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5957,9 +5924,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5974,9 +5938,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5991,9 +5952,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6008,9 +5966,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6025,9 +5980,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15794,9 +15746,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -106,7 +106,7 @@
     "radashi": "^12.7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "7.13.1",
+    "react-router": "7.14.0",
     "sprintf-js": "^1.1.3",
     "stacktracey": "^2.1.8",
     "xbytes": "^1.9.1"

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 19 22:09:14 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- Update react router to fix CVE-2026-34077
+  (bsc#1267500)
+
+-------------------------------------------------------------------
 Fri Jun 19 12:52:28 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Fine-tune and extend the Agama appearance system: improve font


### PR DESCRIPTION
## Problem

React router in version agama uses has security vulnerability.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1267500


## Solution

Update react router.
When touching dependencies also one long term deficite in rust dependencies is addressed. Our rust dependencies was not unified, caused need to compile and download multiple versions of one crate. This is now unified, so it is easier to build and maintain them.


## Testing

- *Tested manually*