### PR TITLE
fix(web): apply UI language and keymap changes without a page reload

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 22 11:08:29 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Apply UI language and keymap changes right away, without needing
+  a page reload (gh#agama-project/agama#3657).
+
+-------------------------------------------------------------------
 Fri Jun 19 12:52:28 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Fine-tune and extend the Agama appearance system: improve font

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -52,6 +52,7 @@ const tumbleweed: Product = {
 
 const mockChangeUIKeymap = jest.fn();
 const mockChangeUILanguage = jest.fn();
+const mockChangeUIL10n = jest.fn();
 const mockPatchConfigFn = jest.fn();
 const mockConfigureL10nActionFn = jest.fn();
 const mockStateFn: jest.Mock<Stage> = jest.fn();
@@ -90,6 +91,7 @@ describe("InstallerL10nOptions", () => {
       language: "de-DE",
       changeKeymap: mockChangeUIKeymap,
       changeLanguage: mockChangeUILanguage,
+      changeL10n: mockChangeUIL10n,
     });
   });
 
@@ -172,8 +174,7 @@ describe("InstallerL10nOptions", () => {
       await user.selectOptions(keymapSelector, "English (UK)");
 
       await user.click(acceptButton);
-      expect(mockChangeUIKeymap).toHaveBeenCalledWith("gb");
-      expect(mockChangeUILanguage).toHaveBeenCalledWith("es-ES");
+      expect(mockChangeUIL10n).toHaveBeenCalledWith({ language: "es-ES", keymap: "gb" });
     });
 
     it("allows reusing settings for the selected product", async () => {
@@ -270,7 +271,7 @@ describe("InstallerL10nOptions", () => {
         await user.selectOptions(languageSelector, "Español");
         const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
         await user.click(acceptButton);
-        expect(mockChangeUIKeymap).not.toHaveBeenCalled();
+        expect(mockChangeUIL10n).toHaveBeenCalledWith({ language: "es-ES" });
       });
     });
   });
@@ -298,7 +299,7 @@ describe("InstallerL10nOptions", () => {
       await user.selectOptions(languageSelector, "Español");
 
       await user.click(acceptButton);
-      expect(mockChangeUILanguage).toHaveBeenCalledWith("es-ES");
+      expect(mockChangeUIL10n).toHaveBeenCalledWith({ language: "es-ES" });
     });
 
     it("allows reusing settings for the selected product", async () => {
@@ -386,8 +387,7 @@ describe("InstallerL10nOptions", () => {
       await user.selectOptions(keymapSelector, "English (UK)");
 
       await user.click(acceptButton);
-      expect(mockChangeUIKeymap).toHaveBeenCalledWith("gb");
-      expect(mockChangeUILanguage).not.toHaveBeenCalled();
+      expect(mockChangeUIL10n).toHaveBeenCalledWith({ keymap: "gb" });
     });
 
     it("allows reusing settings for the selected product", async () => {

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -582,7 +582,7 @@ export default function InstallerL10nOptions({
 }: InstallerL10nOptionsProps) {
   const location = useLocation();
   const locales = useSystem()?.l10n?.locales ?? [];
-  const { language, keymap, changeLanguage, changeKeymap } = useInstallerL10n();
+  const { language, keymap, changeL10n } = useInstallerL10n();
   const { stage } = useStatus();
   const selectedProduct = useProductInfo();
   const initialFormState = {
@@ -630,21 +630,18 @@ export default function InstallerL10nOptions({
     e.preventDefault();
     dispatchDialogAction({ type: "SET_BUSY" });
 
-    // TODO: send unique request for all; await no longer works here
-    // keep logical order, reuse first, the trigger second, to avoid the latest
-    // "eating" the first request.
-    // const request = {};
-    // ...
-    // if(something) request.someelse  = whatever
-
     try {
-      if (variant !== "language" && localConnection()) {
-        await changeKeymap(formState.keymap);
-      }
+      const l10nOptions: { language?: string; keymap?: string } = {};
 
       if (variant !== "keyboard") {
-        await changeLanguage(formState.language);
+        l10nOptions.language = formState.language;
       }
+
+      if (variant !== "language" && localConnection()) {
+        l10nOptions.keymap = formState.keymap;
+      }
+
+      await changeL10n(l10nOptions);
 
       formState.allowReusingSettings && formState.reuseSettings && reuseSettings();
     } catch (e) {

--- a/web/src/context/__mocks__/installerL10n.tsx
+++ b/web/src/context/__mocks__/installerL10n.tsx
@@ -39,6 +39,7 @@ export const InstallerL10nProvider = ({ children }) => {
     keymap: "us",
     changeLanguage: jest.fn(),
     changeKeymap: jest.fn(),
+    changeL10n: jest.fn(),
   };
 
   return <L10nContext.Provider value={value}>{children}</L10nContext.Provider>;

--- a/web/src/context/installerL10n.test.tsx
+++ b/web/src/context/installerL10n.test.tsx
@@ -21,13 +21,13 @@
  */
 
 import React, { Suspense } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { _ } from "~/i18n";
 import agama from "~/agama";
 import { InstallerL10nProvider, useInstallerL10n } from "~/context/installerL10n";
 import { InstallerClientProvider } from "./installer";
+import { plainRender } from "~/test-utils";
 
 jest.unmock("~/context/installerL10n");
 
@@ -96,7 +96,7 @@ const renderProvider = () => {
     },
   });
 
-  return render(
+  return plainRender(
     <QueryClientProvider client={queryClient}>
       <Suspense fallback="Loading...">
         <InstallerClientProvider client={client}>
@@ -128,8 +128,7 @@ describe("InstallerL10nProvider", () => {
   });
 
   it("applies the new translations when the language changes", async () => {
-    const user = userEvent.setup();
-    renderProvider();
+    const { user } = renderProvider();
 
     await screen.findByRole("heading", { name: "Cancel" });
 
@@ -139,8 +138,7 @@ describe("InstallerL10nProvider", () => {
   });
 
   it("keeps the translations in sync with the language on every render", async () => {
-    const user = userEvent.setup();
-    renderProvider();
+    const { user } = renderProvider();
 
     await screen.findByRole("heading", { name: "Cancel" });
 

--- a/web/src/context/installerL10n.test.tsx
+++ b/web/src/context/installerL10n.test.tsx
@@ -22,13 +22,18 @@
 
 import React, { Suspense } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
+import { _ } from "~/i18n";
+import agama from "~/agama";
 import { InstallerL10nProvider, useInstallerL10n } from "~/context/installerL10n";
 import { InstallerClientProvider } from "./installer";
 
 jest.unmock("~/context/installerL10n");
 
-const mockUseSystemFn = jest.fn();
+// Locale reported by the (mocked) system query. Updated by configureL10nAction
+// to emulate the backend persisting the change.
+let currentLocale = "en_US.UTF-8";
 const mockConfigureL10nFn = jest.fn();
 
 jest.mock("~/context/installer", () => ({
@@ -38,12 +43,13 @@ jest.mock("~/context/installer", () => ({
 
 jest.mock("~/api", () => ({
   ...jest.requireActual("~/api"),
+  getSystem: () => Promise.resolve({ l10n: { locale: currentLocale, locales: [], keymap: "us" } }),
   configureL10nAction: (config) => mockConfigureL10nFn(config),
 }));
 
-jest.mock("~/hooks/model/system", () => ({
-  ...jest.requireActual("~/hooks/model/system"),
-  useSystem: () => mockUseSystemFn(),
+jest.mock("~/languages.json", () => ({
+  "en-US": "English (US)",
+  "es-ES": "Español",
 }));
 
 const client = {
@@ -55,51 +61,97 @@ const client = {
   onEvent: jest.fn(),
 };
 
-jest.mock("~/languages.json", () => ({
-  "es-AR": "Español (Argentina)",
-  "cs-CZ": "čeština",
-  "en-US": "English (US)",
-  "es-ES": "Español",
-}));
+// "Cancel" is translated as "Cancelar" in the Spanish catalog, so its rendered
+// value reveals which catalog is currently applied to the global translations.
+const Heading = () => <h1>{_("Cancel")}</h1>;
 
-// Helper component that displays a translated message depending on the
-// agamaLang value.
-const TranslatedContent = () => {
-  const { language } = useInstallerL10n();
-  const text = {
-    "cs-CZ": "ahoj",
-    "en-US": "hello",
-    "es-ES": "hola",
-    "es-AR": "hola!",
+const Controls = () => {
+  const { changeL10n } = useInstallerL10n();
+  const queryClient = useQueryClient();
+
+  // Resets the global catalog to English without changing the selected language
+  // and then forces the provider to re-render (here, by refreshing the system
+  // query). This reproduces the conditions of the original bug, where some other
+  // code left the global catalog out of sync with the selected language.
+  const resetCatalogAndRefresh = () => {
+    agama.locale(null);
+    queryClient.invalidateQueries({ queryKey: ["system"] });
   };
 
-  return <>{text[language]}</>;
+  return (
+    <>
+      <button onClick={() => changeL10n({ language: "es-ES" })}>Switch to Spanish</button>
+      <button onClick={resetCatalogAndRefresh}>Reset catalog</button>
+    </>
+  );
+};
+
+const renderProvider = () => {
+  // Mirror the production client: cached queries are not refetched on mount and
+  // structural sharing is off (so a refetch returning identical data still
+  // triggers a re-render).
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnMount: false, structuralSharing: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Suspense fallback="Loading...">
+        <InstallerClientProvider client={client}>
+          <InstallerL10nProvider>
+            <Heading />
+            <Controls />
+          </InstallerL10nProvider>
+        </InstallerClientProvider>
+      </Suspense>
+    </QueryClientProvider>,
+  );
 };
 
 describe("InstallerL10nProvider", () => {
-  beforeAll(() => {
-    mockConfigureL10nFn.mockResolvedValue(true);
-    mockUseSystemFn.mockReturnValue({ l10n: { locale: "es_ES.UTF-8" } });
-    jest.spyOn(window.navigator, "languages", "get").mockReturnValue(["es-ES", "cs-CZ"]);
+  beforeEach(() => {
+    currentLocale = "en_US.UTF-8";
+    agama.locale(null);
+    mockConfigureL10nFn.mockImplementation((config) => {
+      if (config.locale) currentLocale = config.locale;
+      return Promise.resolve(true);
+    });
   });
 
-  it("sets the language from the backend", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+  it("applies the language reported by the backend", async () => {
+    currentLocale = "es_ES.UTF-8";
+    renderProvider();
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback="Loading...">
-          <InstallerClientProvider client={client}>
-            <InstallerL10nProvider>
-              <TranslatedContent />
-            </InstallerL10nProvider>
-          </InstallerClientProvider>
-        </Suspense>
-      </QueryClientProvider>,
-    );
+    await screen.findByRole("heading", { name: "Cancelar" });
+  });
 
-    await waitFor(() => screen.getByText("hola"));
+  it("applies the new translations when the language changes", async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await screen.findByRole("heading", { name: "Cancel" });
+
+    await user.click(screen.getByRole("button", { name: "Switch to Spanish" }));
+
+    await screen.findByRole("heading", { name: "Cancelar" });
+  });
+
+  it("keeps the translations in sync with the language on every render", async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await screen.findByRole("heading", { name: "Cancel" });
+
+    await user.click(screen.getByRole("button", { name: "Switch to Spanish" }));
+    await screen.findByRole("heading", { name: "Cancelar" });
+
+    // The global catalog is reset while the selected language stays the same,
+    // and then the provider re-renders. The Spanish texts must be reapplied
+    // instead of falling back to English.
+    await user.click(screen.getByRole("button", { name: "Reset catalog" }));
+
+    await waitFor(() => expect(screen.getByRole("heading")).toHaveTextContent("Cancelar"));
   });
 });

--- a/web/src/context/installerL10n.tsx
+++ b/web/src/context/installerL10n.tsx
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import agama from "~/agama";
 import supportedLanguages from "~/languages.json";
@@ -41,6 +41,7 @@ interface L10nContext {
   loadedLanguage: string;
   changeLanguage: (language: string) => Promise<void>;
   changeKeymap: (keymap: string) => Promise<void>;
+  changeL10n: (options: { language?: string; keymap?: string }) => Promise<void>;
 }
 
 function useInstallerL10n(): L10nContext {
@@ -110,22 +111,28 @@ function findSupportedLanguage(languages: Array<string>): string | undefined {
   }
 }
 
+// Translation catalog as exported by the po.<lang>.js files. A null catalog
+// means there are no translations and the original English texts must be used.
+type TranslationCatalog = object | null;
+
 /**
- * Load the web frontend translations from the server.
+ * Loads the web frontend translation catalog for the given locale.
+ *
+ * The catalog is returned as plain data so the caller decides when to apply it
+ * to the global translation singleton. A `null` result means the original
+ * (English) texts must be used.
  *
  * @param locale requested locale
- * @returns Promise with a dynamic import
+ * @returns Promise resolving to the translation catalog, or null when there are
+ *   no translations for the locale
  */
-async function loadTranslations(locale: string): Promise<string> {
+async function loadTranslations(locale: string): Promise<TranslationCatalog> {
   // load the translations dynamically, first try the language + territory
   return import(
     /* webpackChunkName: "[request]" */
     `../po/po.${locale}`
   )
-    .then((m) => {
-      agama.locale(m.default);
-      return agama.language.replace("-", "_");
-    })
+    .then((m) => m.default)
     .catch(async () => {
       // if it fails try the language only
       const po = locale.split("-")[0];
@@ -133,17 +140,13 @@ async function loadTranslations(locale: string): Promise<string> {
         /* webpackChunkName: "[request]" */
         `../po/po.${po}`
       )
-        .then((m) => {
-          agama.locale(m.default);
-          return agama.language.replace("-", "_");
-        })
+        .then((m) => m.default)
         .catch(() => {
           if (locale && locale !== "en-US") {
             console.error("Cannot load frontend translations for", locale);
           }
-          // reset the current translations (use the original English texts)
-          agama.locale(null);
-          return agama.language.replace("-", "_");
+          // no translations available, fall back to the original English texts
+          return null;
         });
     });
 }
@@ -178,30 +181,59 @@ function InstallerL10nProvider({
   const language = locale ? languageFromLocale(locale) : initialLanguage || "en-US";
   const keymap = l10n?.keymap;
 
-  const { data: loadedLanguage } = useSuspenseQuery({
+  // Load the translation catalog for the current language. Suspends until the
+  // catalog is ready, so the children below never render before it is available.
+  const { data: catalog } = useSuspenseQuery({
     queryKey: ["translations", language],
     queryFn: () => loadTranslations(language),
   });
 
-  const changeLanguage = useCallback(
-    async (lang: string) => {
-      const candidateLanguages = [
-        lang,
-        lang?.split("-")[0], // fallback to the language (e.g., "es" for "es-AR")
-        language,
-      ].filter((l) => l);
-      const newLanguage = findSupportedLanguage(candidateLanguages) || "en-US";
-      document.documentElement.lang = newLanguage.split("-")[0];
+  // Apply the catalog to the global translation singleton on every render,
+  // before the children read it. Doing it here (instead of as a side effect
+  // inside the query function) keeps the active translations in sync with the
+  // rendered language even when the query is served from cache, which makes
+  // switching languages reliable without reloading the page.
+  agama.locale(catalog);
+  const loadedLanguage = agama.language.replace("-", "_");
 
-      await configureL10nAction({ locale: languageToLocale(newLanguage) });
-      await queryClient.invalidateQueries({ queryKey: ["translations"] });
+  // Keep the <html lang> attribute in sync for assistive technologies, both on
+  // the initial load and after a language change.
+  useEffect(() => {
+    document.documentElement.lang = language.split("-")[0];
+  }, [language]);
+
+  // Resolves a requested language to the closest supported one, falling back to
+  // the current language and finally to English.
+  const resolveSupportedLanguage = useCallback(
+    (requested: string): string => {
+      const candidates = [requested, requested.split("-")[0], language].filter(Boolean);
+      return findSupportedLanguage(candidates) || "en-US";
     },
-    [language, queryClient],
+    [language],
   );
 
-  const changeKeymap = useCallback(async (id: string) => {
-    await configureL10nAction({ keymap: id });
-  }, []);
+  // Updates the language and/or the keymap in a single backend request.
+  // Refreshing the system query updates the locale, which makes the provider
+  // re-render with the new language and apply the matching translations.
+  const changeL10n = useCallback(
+    async ({ language: lang, keymap: km }: { language?: string; keymap?: string }) => {
+      const config: { locale?: string; keymap?: string } = {};
+
+      if (lang !== undefined) config.locale = languageToLocale(resolveSupportedLanguage(lang));
+      if (km !== undefined) config.keymap = km;
+
+      await configureL10nAction(config);
+      await queryClient.invalidateQueries({ queryKey: ["system"] });
+    },
+    [resolveSupportedLanguage, queryClient],
+  );
+
+  const changeLanguage = useCallback(
+    (lang: string) => changeL10n({ language: lang }),
+    [changeL10n],
+  );
+
+  const changeKeymap = useCallback((id: string) => changeL10n({ keymap: id }), [changeL10n]);
 
   const value = {
     loadedLanguage,
@@ -209,6 +241,7 @@ function InstallerL10nProvider({
     changeLanguage,
     keymap,
     changeKeymap,
+    changeL10n,
   };
 
   // Setting the key forces to reload the children when the language changes

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -282,6 +282,7 @@ const mockL10n = (l10n: {
   language?: string;
   changeKeymap?: jest.Mock;
   changeLanguage?: jest.Mock;
+  changeL10n?: jest.Mock;
 }) => {
   const current = mockUseInstallerL10n.getMockImplementation()?.() || mockUseInstallerL10n();
   mockUseInstallerL10n.mockReturnValue({ ...current, ...l10n });


### PR DESCRIPTION
## Summary

- Changing the installer UI language (and keymap) from the localization dialog now updates the interface right away, without needing a manual page reload.
- The translation catalog is loaded as plain query data and applied to the global translation singleton on every provider render, so the visible texts always match the selected language.
- Language and keymap are now updated through a single `changeL10n` request.
- Adds regression tests covering a language change and the catalog staying in sync across re-renders.

## Motivation

When changing the UI language from the localization dialog (for example English to French), the interface did not update reliably:

- It frequently kept the **previously selected** language (not necessarily English).
- The result was **intermittent**: sometimes it worked, sometimes it did not, depending on timing.
- A manual page reload always applied the correct language.

The product descriptions did update, because they come **already translated from the backend** in the `system` query payload. Only the frontend UI strings (loaded from the `po.<lang>.js` files) were affected.

## Root cause

UI strings are translated through a global singleton (`agama`, used by the `_()` helper), which is updated by calling `agama.locale(catalog)`. Previously that call happened **as a side effect inside the translations query function** (`loadTranslations`), and the query was cached per language.

That made applying the active catalog depend on cache state and on the order in which asynchronous queries resolved, which is fragile in two ways:

1. **A cached language did not re-apply its catalog.** The query function only runs when the query actually fetches. With the cached query served as-is, `agama.locale(...)` was not called again, so the global catalog could stay on a different language than the one being rendered.
2. **An out-of-order load could leave the wrong language active.** The change flow invalidated all translation queries, which could refetch the previously active language while the provider had not re-rendered into the new one yet. That refetch reapplied the old catalog, leaving the global singleton pointing at the wrong language.

A full page reload worked because it loads everything once, in order, with the correct language.

## Fix

Separate **loading** the catalog from **applying** it:

- `loadTranslations` now returns the catalog as data (or `null` when there are no translations), instead of mutating the global singleton.
- `InstallerL10nProvider` applies the catalog with `agama.locale(catalog)` on every render, before the children read it. Because applying no longer depends on the query function running, the visible texts stay in sync with the rendered language regardless of cache state or query timing.
- Language and keymap changes go through a single `changeL10n` request that refreshes the `["system"]` query. The locale update flows back through the provider, which re-renders with the new language and applies the matching catalog. The previous unfiltered translations invalidation is removed.
- `changeLanguage` and `changeKeymap` are kept as thin wrappers over `changeL10n` to avoid duplicating the language-resolution logic.
- The `<html lang>` attribute is now kept in sync on the initial load too (via an effect), not only after a change, which helps assistive technologies.

## Do we still cache the translations?

Yes. This change does **not** reload the translations on every render or on every switch:

- Each language's catalog is fetched **once** and cached by React Query (per `["translations", <language>]`). With refetch-on-mount disabled and no more translation-query invalidation, switching back to an already loaded language reuses the cached catalog instead of fetching again.
- Loading a catalog is a dynamic `import()` of the language chunk, which the browser also caches. So even when React Query drops an inactive language from its cache (after the default timeout), switching back to it does not hit the backend; it reuses the already downloaded chunk.
- Applying the catalog on render (`agama.locale(catalog)`) does no network or disk work. It only points the global translation singleton at the catalog already held in memory, which is cheap.

In short: fetching is still cached and happens at most once per language; the only thing that now runs on each render is the in-memory "make this catalog the active one" step, which is what guarantees the texts match the selected language.


## Known caveat

> [!NOTE]
> 
> **Switching the language causes a brief blink**: the whole interface is intentionally re-rendered so every text picks up the new catalog (the provider remounts its children when the language changes). The transition is fast, so usually nothing more than a quick flash is noticeable. This only happens at the moment of the change, not during normal usage, and it is a **reasonable trade-off compared to the previous behavior, where the interface was left showing stale translations (the previously selected language), sometimes even mixed, until a full page reload**.


## Tests

- [x] `npm run test -- src/context/installerL10n.test.tsx`
- [x] `npm run test -- src/components/core/InstallerL10nOptions.test.tsx`
- [x] `npm run check-types`
- [x] `npm run eslint`
- [x] Manual: change the UI language from the localization dialog and confirm the interface updates immediately, on both the product selection and the overview pages, without a page reload.

### Regression tests added

`src/context/installerL10n.test.tsx`:

- applies the language reported by the backend
- applies the new translations when the language changes
- keeps the translations in sync with the language on every render (this last one fails against the previous side-effect approach and passes with the fix)

---

Co-Authored-By: Knut Anderssen <kanderssen@suse.com>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

---

Related to https://trello.com/c/CpKVYDEp/ (protected link)
