### PR TITLE
Fix building the web UI in OBS

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.13.6",
         "fast-sort": "^3.4.1",
         "ipaddr.js": "^2.3.0",
+        "monaco-editor": "^0.55.1",
         "radashi": "^12.7.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5459,8 +5460,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/webpack-env": {
       "version": "1.18.8",
@@ -8556,7 +8556,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -13612,7 +13611,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -13870,7 +13868,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -104,6 +104,7 @@
     "axios": "^1.13.6",
     "fast-sort": "^3.4.1",
     "ipaddr.js": "^2.3.0",
+    "monaco-editor": "^0.55.1",
     "radashi": "^12.7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 23 09:14:41 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Explicitly require "monaco-editor" NPM package to fix a build
+  failure in OBS (related to bsc#1268433)
+
+-------------------------------------------------------------------
 Mon Jun 22 12:54:33 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Do not load the parts of the Monaco editor from an external 3rd


### PR DESCRIPTION
## Problem

- The Web UI does not build in OBS, it prints this error:

```
[   75s] + cd agama
[   75s] + NODE_ENV=production
[   75s] + npm run build
[   76s] 
[   76s] > build
[   76s] > webpack
[   76s] 
[   77s] [webpack-cli] Failed to load '/home/abuild/rpmbuild/BUILD/agama-web-ui-22+87.f741e1d07-build/agama/webpack.config.js' config
[   77s] [webpack-cli] Error: Cannot find module 'metadata.js'
```

## Solution

- Explicitly require the `monaco-editor` NPM package
- It works fine when building locally as that is installed as a peer NPM package, but during RPM build that fails.

## Testing

- Builds fine in a [testing OBS project](https://build.opensuse.org/package/live_build_log/systemsmanagement:Agama:branches:fix-web-build/agama-web-ui/openSUSE_Tumbleweed/x86_64)
