### PR TITLE
Agama 22 fix inst finish

### DIFF
--- a/rust/agama-manager/src/actions.rs
+++ b/rust/agama-manager/src/actions.rs
@@ -249,11 +249,11 @@ impl InstallAction {
                     .call(progress::message::SetStage::new(Stage::Finished))
                     .await
                     .map_err(TaskError::from_error)?;
-                // Here we use default Stop, so only explicit kernel parameter do something
-                // Its main use case is interactive installation as auto-installation call explicitly
+                // Here we use the default Stop, so only an explicit kernel parameter does something.
+                // Its main use case is interactive installation, as auto-installation calls the explicit
                 // finish action with its own default.
-                let method =
-                    api::FinishMethod::from_kernel_cmdline().unwrap_or(api::FinishMethod::Stop);
+                let method = agama_utils::api::FinishMethod::from_kernel_cmdline()
+                    .unwrap_or(agama_utils::api::FinishMethod::Stop);
                 let finish = FinishAction::new(method);
                 finish.run();
                 Ok(())

--- a/rust/agama-manager/src/actions.rs
+++ b/rust/agama-manager/src/actions.rs
@@ -249,6 +249,13 @@ impl InstallAction {
                     .call(progress::message::SetStage::new(Stage::Finished))
                     .await
                     .map_err(TaskError::from_error)?;
+                // Here we use default Stop, so only explicit kernel parameter do something
+                // Its main use case is interactive installation as auto-installation call explicitly
+                // finish action with its own default.
+                let method =
+                    api::FinishMethod::from_kernel_cmdline().unwrap_or(api::FinishMethod::Stop);
+                let finish = FinishAction::new(method);
+                finish.run();
                 Ok(())
             })
             .await;

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -894,9 +894,9 @@ impl MessageHandler<message::RunAction> for Service {
                 };
 
                 if let Err(error) = action.run().await {
+                    // FIXME: this won't work well as it catches only issues when installation tasks fail to spawn,
+                    // and not for real installation failures.
                     if let Err(e) = ipmi.failed() {
-                        // FIXME: this won't work well as it catch only issues when installation tasks failed to be spawn
-                        // not for real installation failure.
                         tracing::error!("IPMI failed: {}", e);
                     }
                     tracing::error!("Installation failed: {error}");

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -895,6 +895,8 @@ impl MessageHandler<message::RunAction> for Service {
 
                 if let Err(error) = action.run().await {
                     if let Err(e) = ipmi.failed() {
+                        // FIXME: this won't work well as it catch only issues when installation tasks failed to be spawn
+                        // not for real installation failure.
                         tracing::error!("IPMI failed: {}", e);
                     }
                     tracing::error!("Installation failed: {error}");
@@ -902,11 +904,6 @@ impl MessageHandler<message::RunAction> for Service {
                 }
 
                 tracing::info!("Installation tasks spawned");
-
-                let method =
-                    api::FinishMethod::from_kernel_cmdline().unwrap_or(api::FinishMethod::Stop);
-                let finish = FinishAction::new(method);
-                finish.run();
             }
             Action::Finish(method) => {
                 checks::check_stage(&self.progress, Stage::Finished).await?;


### PR DESCRIPTION
## Problem

When there is in `inst.finish` parameter used, then installation ends prematurly as it does not wait for finish of installation task.


## Solution

This is just minimal quick fix as issue is ship stopper that move processing and executing finish to the last task of install task.

Note: more complex fix by @imobachgs is at https://github.com/agama-project/agama/compare/agama-22...fix-inst-finish?expand=1


## Testing


- *Tested manually*