### PR TITLE
Agama22 full iso unattended fix

### DIFF
--- a/rust/agama-software/src/model.rs
+++ b/rust/agama-software/src/model.rs
@@ -89,6 +89,8 @@ pub trait ModelAdapter: Send + Sync + 'static {
         l10n: Handler<agama_l10n::Service>,
         progress: Handler<progress::Service>,
     ) -> Result<WriteIssues, service::Error>;
+
+    fn predefined_repositories(&self) -> Vec<Repository>;
 }
 
 /// [ModelAdapter] implementation for libzypp systems.
@@ -128,6 +130,10 @@ impl Model {
 impl ModelAdapter for Model {
     fn set_product(&mut self, product_spec: ProductSpec) {
         self.selected_product = Some(product_spec);
+    }
+
+    fn predefined_repositories(&self) -> Vec<Repository> {
+        self.predefined_repositories.clone()
     }
 
     async fn write(

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -26,9 +26,12 @@ use std::collections::HashMap;
 use std::fmt;
 
 use agama_utils::{
-    api::{self, software::{
-        Config, PatternsConfig, ProductConfig, RepositoryConfig, SoftwareConfig, SystemInfo,
-    }},
+    api::{
+        self,
+        software::{
+            Config, PatternsConfig, ProductConfig, RepositoryConfig, SoftwareConfig, SystemInfo,
+        },
+    },
     kernel_cmdline::KernelCmdline,
     products::{ProductSpec, UserPatternSpec},
 };
@@ -150,7 +153,6 @@ impl<'a> SoftwareStateBuilder<'a> {
         self.predefined_repositories = predefined_repositories;
         self
     }
-
 
     /// Builds the [SoftwareState] combining all the sources.
     pub fn build(self) -> SoftwareState {
@@ -1006,22 +1008,11 @@ mod tests {
             predefined: true,
         };
 
-        let another_repo = Repository {
-            alias: "another".to_string(),
-            name: "another".to_string(),
-            url: "https://example.lan/SLES/".to_string(),
-            enabled: false,
-            predefined: false,
-        };
-
-        let system = SystemInfo {
-            repositories: vec![base_repo, another_repo],
-            ..Default::default()
-        };
+        let repos = vec![base_repo];
 
         let state = SoftwareStateBuilder::for_product(&product)
             .with_config(&config)
-            .with_system(&system)
+            .with_predefined_repositories(repos)
             .build();
 
         let aliases: Vec<_> = state.repositories.iter().map(|r| r.alias.clone()).collect();

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -26,9 +26,9 @@ use std::collections::HashMap;
 use std::fmt;
 
 use agama_utils::{
-    api::software::{
+    api::{self, software::{
         Config, PatternsConfig, ProductConfig, RepositoryConfig, SoftwareConfig, SystemInfo,
-    },
+    }},
     kernel_cmdline::KernelCmdline,
     products::{ProductSpec, UserPatternSpec},
 };
@@ -96,6 +96,8 @@ pub struct SoftwareStateBuilder<'a> {
     selection: Option<&'a SoftwareSelection>,
     /// Kernel command-line options.
     kernel_cmdline: KernelCmdline,
+    /// List of predefined repositories.
+    predefined_repositories: Vec<api::software::Repository>,
 }
 
 impl<'a> SoftwareStateBuilder<'a> {
@@ -107,6 +109,7 @@ impl<'a> SoftwareStateBuilder<'a> {
             system: None,
             selection: None,
             kernel_cmdline: KernelCmdline::default(),
+            predefined_repositories: vec![],
         }
     }
 
@@ -140,6 +143,15 @@ impl<'a> SoftwareStateBuilder<'a> {
         self
     }
 
+    pub fn with_predefined_repositories(
+        mut self,
+        predefined_repositories: Vec<api::software::Repository>,
+    ) -> Self {
+        self.predefined_repositories = predefined_repositories;
+        self
+    }
+
+
     /// Builds the [SoftwareState] combining all the sources.
     pub fn build(self) -> SoftwareState {
         let mut state = self.to_software_state();
@@ -161,16 +173,8 @@ impl<'a> SoftwareStateBuilder<'a> {
 
     /// Adds the elements from the underlying system.
     ///
-    /// It searches for repositories in the underlying system. The idea is to
-    /// use the repositories for off-line installation or Driver Update Disks.
-    fn add_system_config(&self, state: &mut SoftwareState, system: &SystemInfo) {
-        let repositories = system
-            .repositories
-            .iter()
-            .filter(|r| r.predefined)
-            .map(Repository::from);
-        state.repositories.extend(repositories);
-
+    /// Predefined repositories are handled separatly.
+    fn add_system_config(&self, state: &mut SoftwareState, _system: &SystemInfo) {
         // hardcode here kernel as it is not in basic dependencies due to
         // containers, but for agama usage, it does not make sense to skip kernel
         // If needs arise, we can always add more smarter kernel selection later.
@@ -332,7 +336,7 @@ impl<'a> SoftwareStateBuilder<'a> {
     fn to_software_state(&self) -> SoftwareState {
         let software = &self.product.software;
         let kernel_repos = self.kernel_cmdline.get_last("inst.install_url");
-        let repositories = if let Some(kernel_repos) = kernel_repos {
+        let mut repositories: Vec<_> = if let Some(kernel_repos) = kernel_repos {
             kernel_repos
                 .split(",")
                 .enumerate()
@@ -364,6 +368,11 @@ impl<'a> SoftwareStateBuilder<'a> {
                 })
                 .collect()
         };
+
+        // add all predefined repositories here
+        for repo in self.predefined_repositories.iter() {
+            repositories.push(Repository::from(repo));
+        }
 
         let mut resolvables = ResolvablesState::default();
         for pattern in &software.mandatory_patterns {
@@ -440,12 +449,14 @@ impl SoftwareState {
         config: &Config,
         system: &SystemInfo,
         selection: &SoftwareSelection,
+        predefined_repositories: Vec<api::software::Repository>,
     ) -> Self {
         SoftwareStateBuilder::for_product(product)
             .with_config(config)
             .with_system(system)
             .with_selection(selection)
             .with_kernel_cmdline(KernelCmdline::parse().unwrap_or_default())
+            .with_predefined_repositories(predefined_repositories)
             .build()
     }
 }

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -233,10 +233,15 @@ impl Service {
 
         let product = product.read().await.clone();
 
+        let predefined_repositories = {
+            let model = self.model.lock().await;
+            model.predefined_repositories()
+        };
+
         let new_state = {
             let state = self.state.read().await;
-            tracing::info!("computing state from {product:?} and {:?}", state);
-            SoftwareState::build_from(&product, &state.config, &state.system, &self.selection)
+            tracing::info!("computing state from {:?} and {:?} with repos {:?}", product.id, state, &predefined_repositories);
+            SoftwareState::build_from(&product, &state.config, &state.system, &self.selection, predefined_repositories)
         };
 
         tracing::info!("Wanted software state: {new_state:?}");

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -184,7 +184,7 @@ pub struct Service {
     kernel_cmdline: KernelCmdline,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ServiceState {
     config: Config,
     system: SystemInfo,
@@ -235,6 +235,7 @@ impl Service {
 
         let new_state = {
             let state = self.state.read().await;
+            tracing::info!("computing state from {product:?} and {:?}", state);
             SoftwareState::build_from(&product, &state.config, &state.system, &self.selection)
         };
 

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -240,8 +240,19 @@ impl Service {
 
         let new_state = {
             let state = self.state.read().await;
-            tracing::info!("computing state from {:?} and {:?} with repos {:?}", product.id, state, &predefined_repositories);
-            SoftwareState::build_from(&product, &state.config, &state.system, &self.selection, predefined_repositories)
+            tracing::info!(
+                "computing state from {:?} and {:?} with repos {:?}",
+                product.id,
+                state,
+                &predefined_repositories
+            );
+            SoftwareState::build_from(
+                &product,
+                &state.config,
+                &state.system,
+                &self.selection,
+                predefined_repositories,
+            )
         };
 
         tracing::info!("Wanted software state: {new_state:?}");

--- a/rust/agama-software/src/test_utils.rs
+++ b/rust/agama-software/src/test_utils.rs
@@ -22,8 +22,7 @@ use agama_security::test_utils::start_service as start_security_service;
 use agama_utils::{
     actor::Handler,
     api::{
-        event,
-        software::{SoftwareProposal, SystemInfo},
+        self, event, software::{SoftwareProposal, SystemInfo}
     },
     issue,
     products::ProductSpec,
@@ -45,6 +44,10 @@ pub struct TestModel;
 impl ModelAdapter for TestModel {
     async fn system_info(&self) -> Result<SystemInfo, service::Error> {
         Ok(SystemInfo::default())
+    }
+
+    fn predefined_repositories(&self) -> Vec<api::software::Repository> {
+        Default::default()
     }
 
     async fn proposal(&self) -> Result<SoftwareProposal, service::Error> {

--- a/rust/agama-software/src/test_utils.rs
+++ b/rust/agama-software/src/test_utils.rs
@@ -22,7 +22,8 @@ use agama_security::test_utils::start_service as start_security_service;
 use agama_utils::{
     actor::Handler,
     api::{
-        self, event, software::{SoftwareProposal, SystemInfo}
+        self, event,
+        software::{SoftwareProposal, SystemInfo},
     },
     issue,
     products::ProductSpec,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun 24 13:18:37 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- fix unattended installation for full medium SLES iso
+  (bsc#1268635)
+- fix premature reboot or shutdown in unattended installation
+  when inst.finish kernel parameter is used (bsc##1268803)
+
+-------------------------------------------------------------------
 Thu Jun 18 14:00:31 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Validate the profile before parsing it (bsc#1268432).


### PR DESCRIPTION
## Problem

With full medium and unattended installation agama reports that product is missing. But it is caused that it does not add predefined repositories during initial run and report issue.

More detailed explanation is that previously software even in unattended mode compute proposal multiple times. At least twice as it compute its configuration and then storage ask for software. The first computation do not have available software info from /system as it was computed after initial configuration. But the second computation has it already, so predefined repositories are added to it during that second run and all works. The change that breaks it was https://github.com/agama-project/agama/pull/3585 which now cause only single run of proposal. The change itself is good, but reveal this limitation.


## Solution

Add more logging that was useful when debugging wanted state.
And separate computing system and setting predefined repositories. Now predefined repositories are available from start of software service and is added also during initial computation of proposal.
The patch goal is to be minimal for agama 22. For master follow up PR will be opened with more cleaning.

## Testing

- *Tested manually* - downloaded full iso from openqa they use for testing, then `cargo build --release` and with resulting binaries I modify that full iso - `sudo ~/prace/agama-devtools/live-iso/builder/agama-iso-builder --copy-root agama-web-server /usr/bin/agama-web-server --copy-root agama /usr/bin/agama SLES-16.1-Full-x86_64-Build48.1.install.iso`
- also TW build was manually tested just to be sure it is not completely broken now - https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/agama22-full-iso-unattended-fix/images/iso/