### PR TITLE
Break a systemd service dependency cycle

### DIFF
--- a/live/README.md
+++ b/live/README.md
@@ -108,7 +108,7 @@ make build OBS_PROJECT=home:<USER>:branches:systemsmanagement:Agama:Devel
 To build a SLE image using the internal OBS instance run
 
 ```shell
-make build OBS_API=https://api.suse.de OBS_PROJECT=Devel:YaST:Agama:Head OBS_PACKAGE=agama-installer FLAVOR=SUSE_SLE_16.1
+make build OBS_API=https://api.suse.de OBS_PROJECT=Devel:YaST:Agama:Head OBS_PACKAGE=agama-installer FLAVOR=SUSE_SLE_16.1 OBS_TARGET=images_SLES-16.1
 ```
 
 #### Using locally built RPM packages

--- a/live/live-root/etc/systemd/system/initrd-nmtui.service
+++ b/live/live-root/etc/systemd/system/initrd-nmtui.service
@@ -10,8 +10,8 @@ After=network-online.target
 # after the console is initialized
 After=systemd-vconsole-setup.service
 # before running the pre-pivot dracut hooks (before the driver update),
-# before the self-update and before displaying the Plymouth splash screen
-Before=dracut-pre-pivot.service live-self-update.service plymouth-start.service
+# before the self-update
+Before=dracut-pre-pivot.service live-self-update.service
 
 ConditionKernelCommandLine=live.net_config_tui=1
 
@@ -22,6 +22,12 @@ Type=oneshot
 ExecStartPre=dmesg --console-off
 # disable the systemd status messages on the console
 ExecStartPre=kill -SIGRTMIN+21 1
+# hide the plymouth splash screen
+# NOTE: It should be enough to hide the splash with "plymouth hide-splash" and
+# then show it back with "plymouth show-splash". But unfortunately the nmtui
+# tool then for some reason does not work properly and does not react on
+# pressing the [Enter] key. As a workaround stop the plymouth splash completely.
+ExecStartPre=-plymouth quit
 
 ExecStart=initrd-network-setup.sh
 

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Jun 24 15:19:28 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
-- Break a systemd dependency cycle (systemd deletes some services
+- Break a initrd-nmtui systemd dependency cycle (systemd deletes some services
   to break the cycle, that services are then missing and it might
   trigger the emergency shell) (bsc#1268901)
 

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 24 15:19:28 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Break a systemd dependency cycle (systemd deletes some services
+  to break the cycle, that services are then missing and it might
+  trigger the emergency shell) (bsc#1268901)
+
+-------------------------------------------------------------------
 Thu Jun 18 08:16:25 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for alts as update-alternatives replacement


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1268901
- When systemd detects a cycle in the service dependencies then it deletes some services to break the cycle. But that services are missing in the boot sequence and that can have nasty side effects.

```
Jun 24 15:03:54 localhost systemd[1]: NetworkManager-initrd.service: Found ordering cycle: ignition-enable-network.service/start after ignition-fetch-offline.service/start after basic.target/start after sysinit.target/start after cryptsetup.target/start after systemd-ask-password-console.path/start after plymouth-start.service/start after initrd-nmtui.service/start after network-online.target/start after network.target/start after NetworkManager-initrd.service/start - after ignition-enable-network.service
Jun 24 15:03:54 localhost systemd[1]: NetworkManager-initrd.service: Job cryptsetup.target/start deleted to break ordering cycle starting with NetworkManager-initrd.service/start
```

## Solution

- Remove the `Before=plymouth-start.service` dependency which was used to start the interactive TUI tool before the splashscreen (otherwise it would not be visible).
- Instead of ordering the services quit plymouth before starting the TUI tool.

## Notes

- As written in the comment, it should be enough to use the `plymouth hide-splash` and `plymouth show-splash` pair in the pre/post scripts but unfortunately then the `nmtui` ignores pressing the `Enter` key and cannot be used. It is strange as the `dialog` tool used before running `nmtui` works fine.
- As a workaround quit the splash screen completely. As this boot option will be used rarely it is an acceptable solution.

## Testing

- Tested manually, no dependency cycle is reported and the `nmtui` tool works fine.
