### PR TITLE
fix(web): improve accessibility of the software patterns selection

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 25 11:41:21 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Expose the software pattern categories as accessible groups,
+  so a pattern can be identified by its category
+  (gh#agama-project/agama#3667).
+
+-------------------------------------------------------------------
 Tue Jun 23 11:49:50 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Unify the localization settings into a single form: replace the

--- a/web/src/components/software/patterns-form/Form.test.tsx
+++ b/web/src/components/software/patterns-form/Form.test.tsx
@@ -84,6 +84,16 @@ describe("SoftwarePatternsSelection", () => {
     expect(headings).toHaveLength(3);
   });
 
+  it("exposes each category as a group labelled by its heading", async () => {
+    installerRender(<SoftwarePatternsSelection />);
+    const groups = await screen.findAllByRole("group");
+    expect(groups).toHaveLength(3);
+    // Each category checkbox set is reachable as a group labelled by its name.
+    screen.getByRole("group", { name: /Graphical Environments/ });
+    screen.getByRole("group", { name: /Base Technologies/ });
+    screen.getByRole("group", { name: /Desktop Functions/ });
+  });
+
   it("renders each category containing its patterns in order", async () => {
     installerRender(<SoftwarePatternsSelection />);
 

--- a/web/src/components/software/patterns-form/Form.test.tsx
+++ b/web/src/components/software/patterns-form/Form.test.tsx
@@ -21,12 +21,26 @@
  */
 
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { patchConfig } from "~/api";
 import testingPatterns from "./patterns.test.json";
 import testingProposal from "./proposal.test.json";
 import SoftwarePatternsSelection from "./Form";
+
+/**
+ * Accessible labels of the checkboxes inside a container, in DOM order.
+ *
+ * Reads each checkbox's associated `<label>` text, so it is agnostic to the
+ * checkbox id scheme (ids are not the pattern name).
+ */
+const checkboxLabelsIn = (container: HTMLElement): string[] =>
+  within(container)
+    .getAllByRole("checkbox")
+    .map(
+      (checkbox) =>
+        container.querySelector(`label[for="${checkbox.id}"]`)?.textContent?.trim() ?? "",
+    );
 
 const patternsWithPreselected = [
   ...testingPatterns,
@@ -94,38 +108,123 @@ describe("SoftwarePatternsSelection", () => {
     screen.getByRole("group", { name: /Desktop Functions/ });
   });
 
+  it("lets the user pick the right pattern when two categories share a label", async () => {
+    // Two distinct patterns (different name) that look identical (same summary)
+    // but live in different categories. The category group is what tells them
+    // apart for a screen reader and for scoped queries.
+    const sharedSummary = "Shared Tooling";
+    const lookalikePatterns = [
+      {
+        name: "shared_in_base",
+        category: "Base Technologies",
+        icon: "./pattern-base",
+        description: "Shared tooling under base technologies",
+        summary: sharedSummary,
+        order: "1000",
+        preselected: false,
+        desktop: false,
+      },
+      {
+        name: "shared_in_desktop",
+        category: "Desktop Functions",
+        icon: "./pattern-desktop",
+        description: "Shared tooling under desktop functions",
+        summary: sharedSummary,
+        order: "1000",
+        preselected: false,
+        desktop: false,
+      },
+    ];
+    mockAvailablePatterns.mockReturnValue({
+      all: lookalikePatterns,
+      desktops: [],
+      other: lookalikePatterns,
+    });
+
+    const { user } = installerRender(<SoftwarePatternsSelection />);
+
+    const baseGroup = await screen.findByRole("group", { name: /Base Technologies/ });
+    const desktopGroup = screen.getByRole("group", { name: /Desktop Functions/ });
+
+    // Same accessible label in both groups, yet each is uniquely reachable.
+    const baseCheckbox = within(baseGroup).getByRole("checkbox", { name: sharedSummary });
+    const desktopCheckbox = within(desktopGroup).getByRole("checkbox", { name: sharedSummary });
+    expect(baseCheckbox).not.toBe(desktopCheckbox);
+
+    // Picking the one under Base Technologies leaves the other untouched.
+    await user.click(baseCheckbox);
+    expect(baseCheckbox).toBeChecked();
+    expect(desktopCheckbox).not.toBeChecked();
+  });
+
+  it("stays valid when the backend lists the same pattern under several categories", async () => {
+    // Defensive: listing the same pattern name under several categories is not an
+    // expected or supported scenario, but the UI must not break if it ever does.
+    //
+    // A single pattern (same name) reported under two categories. The backend
+    // selects patterns by name, so both entries represent the same selection;
+    // each must still render with a unique id and a correctly associated label
+    // (no clashing ids, no broken label targeting).
+    const duplicatedPattern = (category: string) => ({
+      name: "shared_pattern",
+      category,
+      icon: "./pattern-shared",
+      description: `Shared pattern listed under ${category}`,
+      summary: "Shared Pattern",
+      order: "1000",
+      preselected: false,
+      desktop: false,
+    });
+    const patterns = [
+      duplicatedPattern("Base Technologies"),
+      duplicatedPattern("Desktop Functions"),
+    ];
+    mockAvailablePatterns.mockReturnValue({ all: patterns, desktops: [], other: patterns });
+
+    const { user } = installerRender(<SoftwarePatternsSelection />);
+
+    const baseGroup = await screen.findByRole("group", { name: /Base Technologies/ });
+    const desktopGroup = screen.getByRole("group", { name: /Desktop Functions/ });
+    const baseCheckbox = within(baseGroup).getByRole("checkbox", { name: "Shared Pattern" });
+    const desktopCheckbox = within(desktopGroup).getByRole("checkbox", { name: "Shared Pattern" });
+
+    // Distinct DOM nodes with distinct ids despite the shared pattern name.
+    expect(baseCheckbox.id).not.toEqual(desktopCheckbox.id);
+
+    // They back the same pattern, so toggling one reflects in both.
+    await user.click(baseCheckbox);
+    expect(baseCheckbox).toBeChecked();
+    expect(desktopCheckbox).toBeChecked();
+  });
+
   it("renders each category containing its patterns in order", async () => {
     installerRender(<SoftwarePatternsSelection />);
 
-    await screen.findByRole("heading", { name: /Base Technologies/, level: 3 });
-    // Find the checkboxes that come after the Base Technologies heading
-    const allCheckboxes = screen.getAllByRole("checkbox");
-    const baseStartIndex = allCheckboxes.findIndex((c) => c.id === "yast2_basis");
-    const ids = allCheckboxes.slice(baseStartIndex, baseStartIndex + 4).map((c) => c.id);
+    const baseGroup = await screen.findByRole("group", { name: /Base Technologies/ });
     // Order is driven by the `order` field on each pattern.
-    expect(ids).toEqual(["yast2_basis", "yast2_desktop", "yast2_server", "preselected_pattern"]);
+    expect(checkboxLabelsIn(baseGroup)).toEqual([
+      "YaST Base Utilities",
+      "YaST Desktop Utilities",
+      "YaST Server Utilities",
+      "Preselected Pattern",
+    ]);
   });
 
   it("sorts patterns by their order field within each category", async () => {
     installerRender(<SoftwarePatternsSelection />);
 
-    await screen.findByRole("heading", { name: /Graphical Environments/, level: 3 });
-    const allCheckboxes = screen.getAllByRole("checkbox");
-
-    // Graphical Environments patterns should be ordered by their order field:
+    const graphicalGroup = await screen.findByRole("group", { name: /Graphical Environments/ });
     // gnome (1010), kde (1110), xfce (1310), basic_desktop (1802)
-    const graphicalStartIndex = allCheckboxes.findIndex((c) => c.id === "gnome");
-    const graphicalIds = allCheckboxes
-      .slice(graphicalStartIndex, graphicalStartIndex + 4)
-      .map((c) => c.id);
-    expect(graphicalIds).toEqual(["gnome", "kde", "xfce", "basic_desktop"]);
+    expect(checkboxLabelsIn(graphicalGroup)).toEqual([
+      "GNOME Desktop Environment (Wayland)",
+      "KDE Applications and Plasma 5 Desktop",
+      "XFCE Desktop Environment",
+      "A very basic desktop (previously part of x11 pattern)",
+    ]);
 
-    // Desktop Functions patterns should be ordered: multimedia (1580), office (1640)
-    const desktopFuncStartIndex = allCheckboxes.findIndex((c) => c.id === "multimedia");
-    const desktopFuncIds = allCheckboxes
-      .slice(desktopFuncStartIndex, desktopFuncStartIndex + 2)
-      .map((c) => c.id);
-    expect(desktopFuncIds).toEqual(["multimedia", "office"]);
+    const desktopGroup = screen.getByRole("group", { name: /Desktop Functions/ });
+    // multimedia (1580), office (1640)
+    expect(checkboxLabelsIn(desktopGroup)).toEqual(["Multimedia", "Office Software"]);
   });
 
   it("renders a search input with placeholder and accessible name", async () => {
@@ -246,9 +345,14 @@ describe("SoftwarePatternsSelection", () => {
 
       // Should match yast2_basis (1220), yast2_desktop (1222), yast2_server (1224)
       // in order by their order field
-      const visibleCheckboxes = screen.getAllByRole("checkbox");
-      const ids = visibleCheckboxes.map((c) => c.id);
-      expect(ids).toEqual(["yast2_basis", "yast2_desktop", "yast2_server"]);
+      const names = screen
+        .getAllByRole("checkbox")
+        .map((c) => document.querySelector(`label[for="${c.id}"]`)?.textContent?.trim() ?? "");
+      expect(names).toEqual([
+        "YaST Base Utilities",
+        "YaST Desktop Utilities",
+        "YaST Server Utilities",
+      ]);
     });
   });
 

--- a/web/src/components/software/patterns-form/Form.tsx
+++ b/web/src/components/software/patterns-form/Form.tsx
@@ -404,12 +404,21 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
             >
               {({ values: formValues, fieldMeta }) => (
                 <Stack hasGutter>
-                  {sortGroupNames(allGroups).map((groupName) => {
+                  {sortGroupNames(allGroups).map((groupName, index) => {
                     const groupAll = allGroups[groupName];
                     const groupVisible = visibleByCategory[groupName] || [];
+                    // Ties the category heading to its group of checkboxes so a
+                    // screen reader announces the category when entering them.
+                    const headingId = `software-category-${index}`;
 
                     return (
-                      <Stack key={groupName} hasGutter>
+                      <Stack
+                        key={groupName}
+                        hasGutter
+                        component="section"
+                        role="group"
+                        aria-labelledby={headingId}
+                      >
                         <div
                           className="agm-sticky-category-header"
                           style={{ top: `${filterHeight}px` }}
@@ -418,7 +427,9 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
                             spaceItems={{ default: "spaceItemsSm" }}
                             alignItems={{ default: "alignItemsBaseline" }}
                           >
-                            <Title headingLevel="h3">{groupName}</Title>
+                            <Title headingLevel="h3" id={headingId}>
+                              {groupName}
+                            </Title>
                             <CategoryCounter
                               patterns={groupAll}
                               matchCount={groupVisible.length}

--- a/web/src/components/software/patterns-form/Form.tsx
+++ b/web/src/components/software/patterns-form/Form.tsx
@@ -441,14 +441,20 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
                         {groupVisible.length > 0 && (
                           <NestedContent>
                             <Stack hasGutter>
-                              {groupVisible.map((pattern) => {
+                              {groupVisible.map((pattern, patternIndex) => {
                                 const isAutoSelected = selection[pattern.name] === SelectedBy.AUTO;
                                 const isDirty = fieldMeta[pattern.name]?.isDirty ?? false;
+                                // The DOM id and React key must stay unique even if the
+                                // backend lists the same pattern name under more than one
+                                // category. The form field stays keyed by the pattern name
+                                // (the backend identity), so such duplicates reflect the
+                                // same selection instead of producing clashing ids.
+                                const checkboxId = `${headingId}-pattern-${patternIndex}`;
 
                                 return (
                                   <PatternCheckbox
-                                    key={pattern.name}
-                                    id={pattern.name}
+                                    key={checkboxId}
+                                    id={checkboxId}
                                     label={pattern.summary}
                                     description={pattern.description}
                                     isChecked={!!formValues[pattern.name]}


### PR DESCRIPTION
**TL;DR:** The pattern categories are now exposed as real, accessible sections (groups) labelled by their heading, so the category a pattern belongs to is conveyed programmatically instead of only visually.

## The long story

This came out of QA testing the patterns selection page (`software/patterns/select`): some patterns showed up with the same display name under different categories (**most likely a patterns-definition issue**), and it was hard to tell which one was the right one to pick, the one the tester was actually after, because nothing indicated which category each entry belonged to. A real screen-reader user could face the same ambiguity.

Looking into it surfaced that the categories were rendered as visual headings only, not as real, navigable sections: a screen reader user got headings to jump between but no programmatic grouping tying a category to its checkboxes. Exposing each category as a labelled group makes the intended pattern identifiable by its category and closes the underlying accessibility gap. Along the way we also hardened the checkbox ids so that even patterns sharing the exact same name (not just the same display name) across categories cannot break the markup.

## Changes

### Semantic groups (a11y)

- Each category is wrapped in a `section` with `role="group"` and `aria-labelledby` pointing at its heading. This is the ARIA equivalent of a `fieldset`/`legend` for a set of related form controls, and it is announced when entering the category's checkboxes. `role="group"` (rather than a `region` landmark) keeps the landmark list clean while heading navigation still works.
- The `h3` headings are preserved.

### Unique checkbox ids

- The checkbox derived its DOM id, its label's `htmlFor` target, and its React key from the pattern name. If the backend lists the same pattern name under more than one category, those collide (duplicate ids make every label resolve
  to the first input; React keys clash).
- The DOM id and key are now derived from the category and position, while the **form field stays keyed by the pattern name** (the backend identity). The backend selects patterns by name, so duplicate entries represent the same selection and now stay consistent without breaking the markup. Distinct patterns that merely share a visible label remain independent and are told apart by their category group.

## Tests

* Updated existing tests (adding new examples for increase coverage)

## Screenshots

Not needed, visually all still the same despite these markup changes.

## Additional info: the collapsible sections experiment

While working on this, we prototyped making the categories **expandable/collapsible** (an accordion, all expanded by default). While it might look nice at first sight, on review we realized it carried enough trade-offs for not including it now:

- **ARIA semantics conflict / landmark proliferation.** PatternFly's `ExpandableSection` hardcodes `role="region"` (a landmark) on each panel. That duplicates the `role="group"` semantics from this PR and adds one landmark per  category, i.e. the landmark proliferation we deliberately avoided. Resolving it means giving up the cleaner grouping in favour of an accordion-region model.
- **Sticky header edge cases.** The category headers are sticky. Collapsing a category the user had scrolled past let its sticky header detach and jump out of view, requiring JS scroll compensation (`scrollIntoView` + `scroll-margin`). That logic depends on layout and the scroll container, is not unit-testable (jsdom has no layout), and is fragile across viewports.
- **Filtering interaction complexity.** Collapsing interacts awkwardly with the existing filter: matches can hide inside a collapsed category. Handling it well needs extra signaling (e.g. a highlighted per-category match indicator) and a
  decision on whether to force-expand on filter vs respect the user's choice, all of which add state and surface area for bugs.
- **Translation freeze leaves it incomplete.** A usable collapsible UX wants bulk controls near the filter ("Expand all" / "Collapse all", and "Expand categories matching filter"). Those are new strings, which the current translation freeze  blocks, so the feature would ship half-implemented (only a FIXME placeholder).
- **Extra state to maintain.** Per-category collapse state, default-expanded handling, and its coupling with filtering add ongoing complexity for a feature that is largely cosmetic given the existing filter already narrows the list.

Conclusion: collapsible categories read more like a low-priority nice-to-have for a next major version (if really useful only) than something to land during the RC phase. The filter we already have covers the core need of narrowing a long list. **This PR therefore ships only the semantic/accessibility fix, and the exploration is kept aside in case we revisit it later.**
