### PR TITLE
fix(rust): use correct profile schema path

### DIFF
--- a/rust/agama-cli/src/config.rs
+++ b/rust/agama-cli/src/config.rs
@@ -143,7 +143,7 @@ fn build_config_generate_cmd() -> Command {
         // TRANSLATORS: CLI help for: agama config generate
         gettext("Generate and print a native Agama JSON configuration from any kind and location");
     // TRANSLATORS: CLI help for: agama config generate (details)
-    let long_about = make_long(&about, &gettext("\
+    let long_about = make_long(&about,&gettext("\
         Kinds:\n\
         - JSON\n\
         - Jsonnet, injecting the hardware information\n\

--- a/rust/agama-lib/src/profile.rs
+++ b/rust/agama-lib/src/profile.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2024] SUSE LLC
+// Copyright (c) [2024-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -129,7 +129,8 @@ pub struct ProfileValidator {
 impl ProfileValidator {
     pub fn default_schema() -> Result<Self, ProfileError> {
         // profile.schema.json moved to from /rust/agama-lib/share to /rust/share/
-        let relative_path = PathBuf::from("../share/profile.schema.json");
+        let source_file_dir = Path::new(file!()).parent().unwrap_or(Path::new(""));
+        let relative_path = source_file_dir.join("../../share/profile.schema.json");
         let path = if relative_path.exists() {
             relative_path
         } else {

--- a/rust/agama-server/tests/server_service.rs
+++ b/rust/agama-server/tests/server_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -45,7 +45,7 @@ impl AsyncTestContext for Context {
     async fn setup() -> Context {
         let share_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test/share");
         std::env::set_var("AGAMA_SHARE_DIR", share_dir.display().to_string());
-        let schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../agama-lib/share");
+        let schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../share");
         std::env::set_var("AGAMA_SCHEMA_DIR", schema_dir.display().to_string());
 
         let (events_tx, events_rx) = channel(100);

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 25 12:03:06 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Use correct path for the source profile schema
+  (gh#agama-project/agama#3668).
+
+-------------------------------------------------------------------
 Wed Jun 24 13:18:37 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - fix unattended installation for full medium SLES iso


### PR DESCRIPTION
## Problem

The relative path for the profile schema is wrong, so the installation path (*/usr/share/agama/schema*) is always used. This is not good when running Agama from sources.

## Solution

Calculate the profile schema path based on the source file path.
