### PR TITLE
doc: improve ISO readme for Leap

### DIFF
--- a/live/src/README.md
+++ b/live/src/README.md
@@ -13,11 +13,12 @@ repository](https://github.com/openSUSE/agama/tree/master/live) repository.
 To build the ISO locally run the
 
 ```shell
-osc build -M <build_flavor> images
+osc build -M $BUILD_FLAVOR $REPO
 ```
 
-command. See the [_multibuild](_multibuild) file for the list of configured
-build flavors. To build for example the openSUSE flavor run this command:
+command. See the [`_multibuild`](_multibuild) file for the list of configured
+build flavors. See `osc repos` for the correct repo names.
+To build for example the openSUSE flavor run this command:
 
 ```shell
 osc build -M openSUSE images


### PR DESCRIPTION


## Problem

I try building agama-installer-Leap locally, to reproduce an OBS problem.
I get errors about unresolvable packages.
It turns out I run the `obs build` command wrong.

## Solution

Improve the docs.

## Testing

Tested manually: 

```sh
cd systemsmanagement:Agama:Devel/agama-installer-Leap
osc build -M Leap_16.1 images_Leap_16.1
```

now knows all packages
## Screenshots

No

## Documentation

This _is_ the documentation