### PR TITLE
refactor(web): align connection form with current form conventions

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 25 13:56:41 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Improve the network connection form: show an alert and scroll to
+  the top when saving fails, and keep the form stable against
+  background data refreshes while editing
+  (gh#agama-project/agama#3670).
+
+-------------------------------------------------------------------
 Tue Jun 23 11:49:50 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Unify the localization settings into a single form: replace the

--- a/web/src/components/network/connection-form/Form.test.tsx
+++ b/web/src/components/network/connection-form/Form.test.tsx
@@ -33,6 +33,9 @@ import {
 import { CONNECTION_TYPE } from "~/utils/network";
 import ConnectionForm from "./Form";
 
+// Mock scrollTo which is not available in jsdom
+Element.prototype.scrollTo = jest.fn();
+
 const mockDevice1 = {
   name: "enp1s0",
   macAddress: "00:11:22:33:44:55",
@@ -749,6 +752,9 @@ describe("ConnectionForm", () => {
     });
   });
 
+  // These check the integration only: invalid input blocks the submit and shows
+  // the matching error in the UI. One representative case per connection type is
+  // kept here; the exhaustive per-rule coverage lives in validations.test.ts.
   describe("validation", () => {
     describe("IP Settings", () => {
       it("shows an error when IPv4 addresses are invalid", async () => {
@@ -764,19 +770,6 @@ describe("ConnectionForm", () => {
     });
 
     describe("Bond", () => {
-      it("shows an error when no device name is defined", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByText("Bond"));
-        await user.type(await screen.findByLabelText("Name"), "test-bond");
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await screen.findByText("Device name is required");
-        expect(mockMutateAsync).not.toHaveBeenCalled();
-      });
-
       it("shows an error when no bond ports are selected", async () => {
         const { user } = installerRender(<ConnectionForm />);
 
@@ -790,71 +783,9 @@ describe("ConnectionForm", () => {
         await screen.findByText("At least one bond port is required");
         expect(mockMutateAsync).not.toHaveBeenCalled();
       });
-
-      it("shows an error when 'primary' option is used with an invalid bond mode", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByText("Bond"));
-        await user.type(await screen.findByLabelText("Name"), "test-bond");
-        await user.type(await screen.findByLabelText("Device name"), "bond0");
-
-        // Default mode is balance-rr, which does not support 'primary'
-        await user.type(screen.getByLabelText("Bond options"), "primary=enp1s0{enter}");
-        await user.type(screen.getByRole("textbox", { name: "Bond ports" }), "enp1s0{enter}");
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await screen.findByText(
-          "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
-        );
-        expect(mockMutateAsync).not.toHaveBeenCalled();
-      });
-
-      it("allows 'primary' option with active-backup mode", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByText("Bond"));
-        await user.type(await screen.findByLabelText("Name"), "test-bond");
-        await user.type(await screen.findByLabelText("Device name"), "bond0");
-
-        await user.click(screen.getByLabelText("Bond mode"));
-        await user.click(screen.getByRole("option", { name: /active-backup/ }));
-
-        await user.type(screen.getByLabelText("Bond options"), "primary=enp1s0{enter}");
-        await user.type(screen.getByRole("textbox", { name: "Bond ports" }), "enp1s0{enter}");
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await waitFor(() => {
-          expect(
-            screen.queryByText(
-              "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
-            ),
-          ).not.toBeInTheDocument();
-          expect(mockMutateAsync).toHaveBeenCalled();
-        });
-      });
     });
 
     describe("Bridge", () => {
-      it("shows an error when no device name is defined", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByRole("option", { name: "Bridge" }));
-        await user.type(await screen.findByLabelText("Name"), "test-bridge");
-
-        const ifaceInput = await screen.findByLabelText("Device name");
-        await user.clear(ifaceInput);
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await screen.findByText("Device name is required");
-        expect(mockMutateAsync).not.toHaveBeenCalled();
-      });
-
       it("shows an error when no bridge ports are selected", async () => {
         const { user } = installerRender(<ConnectionForm />);
 
@@ -868,98 +799,9 @@ describe("ConnectionForm", () => {
         await screen.findByText("At least one bridge port is required");
         expect(mockMutateAsync).not.toHaveBeenCalled();
       });
-
-      it("shows errors when bridge STP settings are out of range", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByRole("option", { name: "Bridge" }));
-        await user.type(await screen.findByLabelText("Name"), "test-bridge");
-        await user.type(await screen.findByLabelText("Device name"), "br0");
-        await user.type(screen.getByLabelText("Bridge ports"), "enp1s0{enter}");
-
-        // Enable STP to see the fields
-        const stpSelector = screen.getByLabelText("Spanning Tree Protocol (STP)");
-        await user.click(stpSelector);
-        await user.click(screen.getByRole("option", { name: /^Custom/ }));
-
-        const priorityInput = screen.getByLabelText(/Priority/);
-        await user.clear(priorityInput);
-        await user.type(priorityInput, "70000");
-
-        const delayInput = screen.getByLabelText(/Forward delay/);
-        await user.clear(delayInput);
-        await user.type(delayInput, "2");
-
-        const helloInput = screen.getByLabelText(/Hello time/);
-        await user.clear(helloInput);
-        await user.type(helloInput, "11");
-
-        const maxAgeInput = screen.getByLabelText(/Max message age/);
-        await user.clear(maxAgeInput);
-        await user.type(maxAgeInput, "5");
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await screen.findByText("Priority must be between 0 and 61440");
-        await screen.findByText("Forward delay must be between 4 and 30 seconds");
-        await screen.findByText("Hello time must be between 1 and 10 seconds");
-        await screen.findByText("Max message age must be between 6 and 40 seconds");
-        expect(mockMutateAsync).not.toHaveBeenCalled();
-      });
-
-      it("allows empty STP settings when STP is enabled", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByRole("option", { name: "Bridge" }));
-        await user.type(await screen.findByLabelText("Name"), "test-bridge");
-        await user.type(await screen.findByLabelText("Device name"), "br0");
-        await user.type(screen.getByLabelText("Bridge ports"), "enp1s0{enter}");
-
-        // Enable STP
-        const stpSelector = screen.getByLabelText("Spanning Tree Protocol (STP)");
-        await user.click(stpSelector);
-        await user.click(screen.getByRole("option", { name: /^Custom/ }));
-
-        // Clear all STP fields
-        await user.clear(screen.getByLabelText(/Priority/));
-        await user.clear(screen.getByLabelText(/Forward delay/));
-        await user.clear(screen.getByLabelText(/Hello time/));
-        await user.clear(screen.getByLabelText(/Max message age/));
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await waitFor(() => {
-          expect(mockMutateAsync).toHaveBeenCalledWith(
-            expect.objectContaining({
-              bridge: expect.objectContaining({
-                stp: true,
-                priority: undefined,
-                forwardDelay: undefined,
-                helloTime: undefined,
-                maxAge: undefined,
-              }),
-            }),
-          );
-        });
-      });
     });
 
     describe("VLAN", () => {
-      it("shows an error when no device name is defined", async () => {
-        const { user } = installerRender(<ConnectionForm />);
-
-        await user.click(screen.getByLabelText("Type"));
-        await user.click(screen.getByText("VLAN"));
-        await user.type(await screen.findByLabelText("Name"), "test-vlan");
-
-        await user.click(screen.getByRole("button", { name: "Accept" }));
-
-        await screen.findByText("Device name is required");
-        expect(mockMutateAsync).not.toHaveBeenCalled();
-      });
-
       it("shows an error when no VLAN ID is defined", async () => {
         const { user } = installerRender(<ConnectionForm />);
 

--- a/web/src/components/network/connection-form/Form.tsx
+++ b/web/src/components/network/connection-form/Form.tsx
@@ -22,27 +22,19 @@
 
 import React from "react";
 import { generatePath, useNavigate, useParams } from "react-router";
-import { unique } from "radashi";
 import { Alert, ActionGroup, Flex, Form } from "@patternfly/react-core";
 import Page from "~/components/core/Page";
 import NestedContent from "~/components/core/NestedContent";
 import ResourceNotFound from "~/components/core/ResourceNotFound";
-import { useConnectionMutation, useConfig } from "~/hooks/model/config/network";
+import { withFrozenQuery } from "~/components/form/with-frozen-query";
+import { useConnectionMutation } from "~/hooks/model/config/network";
 import { useAppForm, mergeFormDefaults } from "~/hooks/form";
-import { useSystem, useDevices } from "~/hooks/model/system/network";
-import { extendCollection } from "~/utils";
+import { useFormSubmit } from "~/hooks/use-form-submit";
 import { NETWORK } from "~/routes/paths";
 import {
-  buildAddress,
-  connectionBindingMode,
-  connectionType,
-  CONNECTION_TYPE,
   connectionTypeLabel,
-  ensureIPPrefix,
-  formatIp,
+  CONNECTION_TYPE,
   generateConnectionName,
-  isVirtual,
-  isValidIPv4Address,
   isValidNameserver,
   isValidDNSSearchDomain,
 } from "~/utils/network";
@@ -53,248 +45,50 @@ import BridgeFields from "./BridgeFields";
 import VlanFields from "./VlanFields";
 import DeviceSelector from "./DeviceSelector";
 import IpFields from "./IpFields";
-import {
-  ADDRESS_REQUIRED_MODES,
-  BridgeStpMode,
-  FormIpMode,
-  VlanProtocolMode,
-  defaultOptions,
-  validate,
-} from "./fields";
+import { useConnectionFormContentQuery, useInitialConnection } from "./queries";
+import { buildPayload, toFormValues } from "./transformations";
+import { validate } from "./validations";
+import { defaultOptions, SUPPORTED_CONNECTION_TYPES } from "./fields";
 import { _ } from "~/i18n";
 
 import type { BreadcrumbProps } from "~/components/core/Breadcrumbs";
-import type {
-  FormIpMode as FormIpModeType,
-  BridgeStpMode as BridgeStpModeType,
-  VlanProtocolMode as VlanProtocolModeType,
-} from "./fields";
-import {
-  BondMode,
-  Bridge,
-  Connection,
-  ConnectionMethod,
-  ConnectionType,
-  VlanProtocol,
-} from "~/types/network";
-
-/**
- * Maps form mode values to their corresponding {@link ConnectionMethod}.
- *
- * Both AUTO and ADVANCED_AUTO map to ConnectionMethod.AUTO; they differ
- * only in UI behavior (whether address/gateway fields are shown).
- */
-const MODE_TO_METHOD: Record<FormIpModeType, ConnectionMethod> = {
-  [FormIpMode.AUTO]: ConnectionMethod.AUTO,
-  [FormIpMode.ADVANCED_AUTO]: ConnectionMethod.AUTO,
-  [FormIpMode.MANUAL]: ConnectionMethod.MANUAL,
-};
+import type { ConnectionFormContentQuery } from "./queries";
+import { ConnectionType } from "~/types/network";
 
 type FormValues = typeof defaultOptions.defaultValues;
 
 /**
- * Connection types supported by this form.
- */
-const SUPPORTED_CONNECTION_TYPES = [
-  CONNECTION_TYPE.ETHERNET,
-  CONNECTION_TYPE.BOND,
-  CONNECTION_TYPE.BRIDGE,
-  CONNECTION_TYPE.VLAN,
-] as const;
-
-/**
- * Infers the form IPvX mode from a stored {@link ConnectionMethod} and addresses.
+ * Inner form for creating or editing a network connection.
  *
- * The presence of addresses affects the interpretation:
- * - `MANUAL` method → MANUAL
- * - `AUTO` method with addresses → ADVANCED_AUTO
- * - `AUTO` method without addresses → AUTO
- * - `undefined` method with addresses → ADVANCED_AUTO (from system)
- * - `undefined` method without addresses → AUTO
- */
-function inferIpMode(method: ConnectionMethod | undefined, addresses: string[]): FormIpModeType {
-  if (method === ConnectionMethod.MANUAL) return FormIpMode.MANUAL;
-
-  return addresses.length > 0 ? FormIpMode.ADVANCED_AUTO : FormIpMode.AUTO;
-}
-
-/**
- * Infers the bridge STP mode from the stored {@link Bridge} configuration.
+ * Receives frozen query data as props via withFrozenQuery. The mutation hook
+ * and navigation are called internally and are intentionally not frozen: they
+ * must always reflect the current state.
  *
- * If `stp` is explicitly defined, that value is used.
- * If `stp` is absent but other STP-related options are present, it's
- * inferred as ENABLED. Otherwise, it defaults to DEFAULT (system default).
- */
-function inferBridgeStp(bridge: Bridge | undefined): BridgeStpModeType {
-  if (!bridge) return BridgeStpMode.DEFAULT;
-
-  if (bridge.stp !== undefined) {
-    return bridge.stp ? BridgeStpMode.ENABLED : BridgeStpMode.DISABLED;
-  }
-
-  const hasStpOptions =
-    bridge.priority !== undefined ||
-    bridge.forwardDelay !== undefined ||
-    bridge.helloTime !== undefined ||
-    bridge.maxAge !== undefined;
-
-  return hasStpOptions ? BridgeStpMode.ENABLED : BridgeStpMode.DEFAULT;
-}
-
-/**
- * Maps an existing {@link Connection} to initial form values for editing.
- */
-function connectionToFormValues(connection: Connection): Partial<FormValues> {
-  // Deduplicate addresses (config + system merge can create duplicates)
-  const uniqueAddresses = unique(connection.addresses, (addr) => `${addr.address}/${addr.prefix}`);
-
-  // Partition and format addresses in a single pass using proper IP validation
-  const addresses4: string[] = [];
-  const addresses6: string[] = [];
-
-  for (const addr of uniqueAddresses) {
-    const formatted = ensureIPPrefix(formatIp(addr));
-    if (isValidIPv4Address(addr.address)) {
-      addresses4.push(formatted);
-    } else {
-      addresses6.push(formatted);
-    }
-  }
-
-  return {
-    name: connection.id,
-    type: connectionType(connection),
-    iface: connection.iface ?? "",
-    ifaceMac: connection.macAddress ?? "",
-    bindingMode: connectionBindingMode(connection),
-    ipv4Mode: inferIpMode(connection.method4, addresses4),
-    addresses4,
-    gateway4: connection.gateway4 ?? "",
-    ipv6Mode: inferIpMode(connection.method6, addresses6),
-    addresses6,
-    gateway6: connection.gateway6 ?? "",
-    nameservers: unique(connection.nameservers),
-    dnsSearchList: unique(connection.dnsSearchList),
-    customDns: connection.nameservers.length > 0,
-    customDnsSearch: connection.dnsSearchList.length > 0,
-    bondIface: connection.iface,
-    bondMode: connection.bond?.mode ?? BondMode.BALANCE_ROUND_ROBIN,
-    bondOptions: connection.bond?.options ? connection.bond.options.split(" ") : [],
-    bondPorts: connection.bond?.ports ?? [],
-    bridgeIface: connection.iface,
-    bridgeStp: inferBridgeStp(connection.bridge),
-    bridgePriority: connection.bridge?.priority,
-    bridgeForwardDelay: connection.bridge?.forwardDelay,
-    bridgeHelloTime: connection.bridge?.helloTime,
-    bridgeMaxAge: connection.bridge?.maxAge,
-    bridgePorts: connection.bridge?.ports ?? [],
-    vlanIface: connection.iface,
-    vlanId: connection.vlan?.id,
-    vlanParent: connection.vlan?.parent ?? "",
-    vlanProtocol: (connection.vlan?.protocol ?? VlanProtocolMode.DEFAULT) as VlanProtocolModeType,
-  };
-}
-
-/**
- * Builds a {@link Connection} from the validated form values.
+ * ## Patterns Used
  *
- * Addresses in formValues already have prefixes (added by ArrayField's
- * normalize or when loading from backend), so no prefix addition is needed.
- */
-function buildConnection(formValues: FormValues): Connection {
-  const ipv4Addresses = ADDRESS_REQUIRED_MODES.includes(formValues.ipv4Mode)
-    ? formValues.addresses4.map(buildAddress)
-    : [];
-  const ipv6Addresses = ADDRESS_REQUIRED_MODES.includes(formValues.ipv6Mode)
-    ? formValues.addresses6.map(buildAddress)
-    : [];
-
-  let iface = "";
-  if (isVirtual(formValues.type)) {
-    iface = formValues[`${formValues.type}Iface`];
-  } else if (formValues.bindingMode === "iface") {
-    iface = formValues.iface;
-  }
-  return new Connection(formValues.name, {
-    iface,
-    macAddress: formValues.bindingMode === "mac" ? formValues.ifaceMac : "",
-    method4: MODE_TO_METHOD[formValues.ipv4Mode],
-    gateway4: ipv4Addresses.length > 0 ? formValues.gateway4 : "",
-    method6: MODE_TO_METHOD[formValues.ipv6Mode],
-    gateway6: ipv6Addresses.length > 0 ? formValues.gateway6 : "",
-    addresses: [...ipv4Addresses, ...ipv6Addresses],
-    nameservers: formValues.customDns ? formValues.nameservers : [],
-    dnsSearchList: formValues.customDnsSearch ? formValues.dnsSearchList : [],
-    bond:
-      formValues.type === CONNECTION_TYPE.BOND
-        ? {
-            mode: formValues.bondMode,
-            options: formValues.bondOptions.join(" "),
-            ports: formValues.bondPorts,
-          }
-        : undefined,
-    bridge:
-      formValues.type === CONNECTION_TYPE.BRIDGE
-        ? {
-            stp: (() => {
-              if (formValues.bridgeStp === BridgeStpMode.DEFAULT) return undefined;
-              return formValues.bridgeStp === BridgeStpMode.ENABLED;
-            })(),
-            priority:
-              formValues.bridgeStp === BridgeStpMode.ENABLED
-                ? formValues.bridgePriority
-                : undefined,
-            forwardDelay:
-              formValues.bridgeStp === BridgeStpMode.ENABLED
-                ? formValues.bridgeForwardDelay
-                : undefined,
-            helloTime:
-              formValues.bridgeStp === BridgeStpMode.ENABLED
-                ? formValues.bridgeHelloTime
-                : undefined,
-            maxAge:
-              formValues.bridgeStp === BridgeStpMode.ENABLED ? formValues.bridgeMaxAge : undefined,
-            ports: formValues.bridgePorts,
-          }
-        : undefined,
-    vlan:
-      formValues.type === CONNECTION_TYPE.VLAN
-        ? {
-            id: formValues.vlanId!,
-            parent: formValues.vlanParent,
-            protocol:
-              formValues.vlanProtocol !== VlanProtocolMode.DEFAULT
-                ? (formValues.vlanProtocol as VlanProtocol)
-                : undefined,
-          }
-        : undefined,
-  });
-}
-
-/**
- * Form for creating a new network connection.
+ * ### withFrozenQuery (see with-frozen-query.tsx)
+ * Wraps this component so it receives frozen initial data as props. Query
+ * refetches never reach this component, preventing flickering and protecting
+ * user edits.
  *
- * @remarks
- * Server errors are surfaced via TanStack Form's `validators.onSubmitAsync`.
- * This is the recommended pattern for forms where the server acts as the
- * validator: the call lives in the async validator, which returns `{ form:
- * message }` on failure. TanStack then exposes the message via
- * `state.errorMap.onSubmit.form` without throwing, keeping the button
- * re-enabled for a retry.
+ * ### useFormSubmit (see use-form-submit.tsx)
+ * Encapsulates the submit lifecycle for forms that navigate away:
+ * - Validation error alerts via refs + Subscribe (no extra re-renders)
+ * - Server error handling
+ * - Clean error state management
  *
- * @see https://tanstack.com/form/latest/docs/framework/react/guides/validation
- * @see https://github.com/TanStack/form/discussions/623#discussioncomment-13026699
+ * ### Field validation
+ * Stays in useAppForm's validators.onSubmitAsync where TanStack Form expects
+ * it. useFormSubmit's onSubmit is only called after field validation passes.
  */
-type ConnectionFormContentProps = {
-  defaults?: Partial<FormValues>;
-  isEditing?: boolean;
-};
-
-function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormContentProps) {
+function ConnectionFormContent({
+  initialConnection,
+  devices,
+  systemConnections,
+}: ConnectionFormContentQuery) {
   const navigate = useNavigate();
-  const devices = useDevices();
-  const { connections: systemConns } = useSystem();
   const { mutateAsync: updateConnection } = useConnectionMutation();
+  const isEditing = initialConnection !== null;
 
   // Generates and writes the auto-computed name when the binding changes, as
   // long as the user has not manually edited it. `isDirty` is used instead of
@@ -308,58 +102,55 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
 
     if (formApi.getFieldMeta("name")?.isDirty) return;
 
-    const existingIds = new Set(systemConns?.map((c) => c.id));
+    const existingIds = new Set(systemConnections.map((c) => c.id));
     formApi.setFieldValue("name", generateConnectionName(type, existingIds), {
       dontUpdateMeta: true,
       dontRunListeners: true,
     });
   };
 
+  // useFormSubmit is initialized before useAppForm so we can pass onSubmitAsync
+  // directly into the validators option — no mutation, no two-phase wiring.
+  const { onSubmitAsync, AlertSubscribe, formSubmitHandler } = useFormSubmit<FormValues>({
+    scrollOnSuccess: false,
+    onSubmit: async (values) => {
+      try {
+        await updateConnection(buildPayload(values));
+        navigate(-1);
+        return { patched: true as const };
+      } catch (e) {
+        return { error: e.message };
+      }
+    },
+  });
+
   const form = useAppForm({
     ...mergeFormDefaults(defaultOptions, {
       iface: devices[0]?.name ?? "",
       ifaceMac: devices[0]?.macAddress ?? "",
-      ...defaults,
+      ...toFormValues(initialConnection),
     }),
     validators: {
-      onSubmitAsync: async ({ value: formValues }) => {
-        const fieldErrors = validate(formValues);
+      onSubmitAsync: async (ctx) => {
+        // Field validation runs first. If it fails, TanStack Form reports
+        // errors per field and onSubmitAsync (business logic) is not called.
+        const fieldErrors = validate(ctx.value);
         if (fieldErrors) return fieldErrors;
 
-        try {
-          await updateConnection(buildConnection(formValues));
-        } catch (e) {
-          return { form: e.message };
-        }
+        // Business logic: payload building + API call.
+        return onSubmitAsync(ctx, form);
       },
     },
-    onSubmit: () => navigate(-1),
     // On mount, auto-fill the name field (e.g., "Ethernet", "Bond 2") since
-    // defaultValues can't access systemConns for duplicates. Changing the type
-    // updates the name via the type field's onChange listener.
+    // defaultValues can't access systemConnections for duplicates. Changing the
+    // type updates the name via the type field's onChange listener.
     listeners: isEditing ? undefined : { onMount: ({ formApi }) => syncName(formApi) },
   });
 
   return (
     <form.AppForm>
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          // Validation is intentionally deferred to submission so users are
-          // not interrupted while filling the form. All rules live in
-          // onSubmitAsync rather than per-field onSubmit validators because
-          // several checks are cross-field (e.g., gateway validity depends on
-          // the addresses list). TanStack Form only clears field errors set
-          // by onSubmitAsync when a per-field onSubmit validator runs for
-          // the same cause — which never happens here — so canSubmit stays
-          // false after a failed attempt. setErrorMap resets every field's
-          // errorMap.onSubmit before each new attempt, restoring canSubmit
-          // so onSubmitAsync is called again.
-          // @see https://tanstack.com/form/latest/docs/reference/formApi#seterrormap
-          form.setErrorMap({ onSubmit: { fields: {} } });
-          form.handleSubmit();
-        }}
-      >
+      <Form onSubmit={formSubmitHandler(form)}>
+        {/* Server error alert */}
         <form.Subscribe selector={(s) => s.errorMap.onSubmit?.form}>
           {(serverError) =>
             serverError && (
@@ -378,13 +169,16 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
           }
         </form.Subscribe>
 
+        {/* Validation error alert — managed by useFormSubmit */}
+        <AlertSubscribe form={form} />
+
         {!isEditing && (
           <>
             <form.AppField name="type" listeners={{ onChange: () => syncName(form) }}>
               {(field) => (
                 <field.DropdownField
                   label={
-                    // TRANSLATORS: checkbox label for custom DNS server configuration.
+                    // TRANSLATORS: label for the network connection type field.
                     _("Type")
                   }
                   options={SUPPORTED_CONNECTION_TYPES.map((type) => ({
@@ -548,9 +342,17 @@ function ConnectionFormContent({ defaults, isEditing = false }: ConnectionFormCo
   );
 }
 
-function NewConnectionForm() {
-  return <ConnectionFormContent />;
-}
+/**
+ * Memoized, refetch-protected wrapper around {@link ConnectionFormContent}.
+ *
+ * Freezes the result of {@link useConnectionFormContentQuery} on mount and
+ * passes it as props. Query refetches update the outer wrapper but never reach
+ * the form, preventing flickering and protecting user edits.
+ */
+const FrozenConnectionFormContent = withFrozenQuery(
+  useConnectionFormContentQuery,
+  ConnectionFormContent,
+);
 
 function ConnectionNotFound() {
   return (
@@ -567,45 +369,16 @@ function ConnectionNotFound() {
   );
 }
 
-function EditConnectionForm() {
-  const { id } = useParams();
-
-  let { connections: configConns = [] } = useConfig();
-  let { connections: systemConns = [] } = useSystem();
-  // Filter out removed connections before merging to avoid carrying over
-  // stale entries that may still exist in persisted config or system state.
-  configConns = configConns.filter((c) => c.status !== "removed");
-  systemConns = systemConns.filter((c) => c.status !== "removed");
-
-  // Merge config and system connections so the form reflects the user's
-  // explicit settings (config) while filling gaps from the live system state.
-  // Config wins for single values: e.g. configConn.method4 === undefined
-  // (the user chose "Automatic", meaning "do not put method in the config")
-  // must override systemConn.method4 === "auto" that Agama backend or
-  // NetworkManager might report.
-  //
-  // Arrays (addresses, nameservers, etc.) are concatenated so users can see
-  // existing system values even when config has empty arrays.
-  const { all: connections } = extendCollection(configConns, {
-    with: systemConns,
-    mergeArrays: true,
-  });
-  const connection = connections.find((c) => c.id === id);
-
-  if (!connection) return <ConnectionNotFound />;
-
-  return <ConnectionFormContent defaults={connectionToFormValues(connection)} isEditing />;
-}
-
 /**
- * Form for creating or editing a network connection.
+ * Page shell for the connection create/edit flow.
  *
- * @remarks
- * Renders {@link NewConnectionForm} when no route `id` param is present, or
- * {@link EditConnectionForm} when editing an existing connection. Both delegate
- * to {@link ConnectionFormContent} for the shared form rendering.
+ * Owns the breadcrumbs and the not-found guard. Delegates the actual form to
+ * {@link FrozenConnectionFormContent}, which is protected from refetches.
  *
- * Server errors are surfaced via TanStack Form's `validators.onSubmitAsync`.
+ * Renders the new-connection form when no route `id` param is present, or the
+ * edit form when editing an existing connection.
+ *
+ * Server errors are reported via TanStack Form's `validators.onSubmitAsync`.
  * This is the recommended pattern for forms where the server acts as the
  * validator: the call lives in the async validator, which returns `{ form:
  * message }` on failure. TanStack then exposes the message via
@@ -617,6 +390,8 @@ function EditConnectionForm() {
  */
 export default function ConnectionForm() {
   const { id } = useParams();
+  const connection = useInitialConnection();
+
   const breadcrumbs: BreadcrumbProps[] = [
     // TRANSLATORS: breadcrumb label for the network configuration section.
     { label: _("Network"), path: NETWORK.root },
@@ -638,7 +413,9 @@ export default function ConnectionForm() {
 
   return (
     <Page breadcrumbs={breadcrumbs}>
-      <Page.Content>{id ? <EditConnectionForm /> : <NewConnectionForm />}</Page.Content>
+      <Page.Content>
+        {id && !connection ? <ConnectionNotFound /> : <FrozenConnectionFormContent />}
+      </Page.Content>
     </Page>
   );
 }

--- a/web/src/components/network/connection-form/fields.ts
+++ b/web/src/components/network/connection-form/fields.ts
@@ -21,11 +21,11 @@
  */
 
 /**
- * Field vocabulary for the connection form: types, constants, and defaults.
+ * Field definitions for the connection form: types, constants, and defaults.
  *
- * This is the single source of truth every other form-local module builds on.
- * Validation lives in validations.ts and value mapping in transformations.ts;
- * both import from here, never the reverse.
+ * validations.ts and transformations.ts build on these definitions, importing
+ * the types and constants they need. The imports go one way only: this module
+ * never imports from them, so every field stays defined in a single place.
  */
 
 import { formOptions } from "@tanstack/react-form";

--- a/web/src/components/network/connection-form/fields.ts
+++ b/web/src/components/network/connection-form/fields.ts
@@ -20,39 +20,22 @@
  * find current contact information at www.suse.com.
  */
 
+/**
+ * Field vocabulary for the connection form: types, constants, and defaults.
+ *
+ * This is the single source of truth every other form-local module builds on.
+ * Validation lives in validations.ts and value mapping in transformations.ts;
+ * both import from here, never the reverse.
+ */
+
 import { formOptions } from "@tanstack/react-form";
-import { shake } from "radashi";
-import { sprintf } from "sprintf-js";
 
 import { BondMode, ConnectionType, ConnectionBindingMode, VlanProtocol } from "~/types/network";
 import { CONNECTION_TYPE } from "~/utils/network";
-import {
-  isValidIPv4Address,
-  isValidIPv6Address,
-  isValidIPv4,
-  isValidIPv6,
-  isValidNameserver,
-  isValidDNSSearchDomain,
-} from "~/utils/network";
-import {
-  requiredString,
-  requiredIntRange,
-  optionalIntRange,
-  requiredValidList,
-  optionalValidList,
-  requiredValidString,
-  optionalValidString,
-} from "~/components/form/validation-helpers";
-import { _, formatList } from "~/i18n";
-
-import type {
-  ValidationResult,
-  FieldsValidationResult,
-} from "~/components/form/validation-helpers";
 
 /** Types */
 
-type CommonFormFields = {
+export type CommonFormFields = {
   name: string;
   type: ConnectionType;
   iface: string;
@@ -60,7 +43,7 @@ type CommonFormFields = {
   bindingMode: ConnectionBindingMode;
 };
 
-type IpFormFields = {
+export type IpFormFields = {
   ipv4Mode: FormIpMode;
   addresses4: string[];
   gateway4: string;
@@ -73,14 +56,14 @@ type IpFormFields = {
   customDnsSearch: boolean;
 };
 
-type BondFormFields = {
+export type BondFormFields = {
   bondIface: string;
   bondMode: BondMode;
   bondOptions: string[];
   bondPorts: string[];
 };
 
-type BridgeFormFields = {
+export type BridgeFormFields = {
   bridgeIface: string;
   bridgeStp: BridgeStpMode;
   bridgePriority: number | undefined;
@@ -90,7 +73,7 @@ type BridgeFormFields = {
   bridgePorts: string[];
 };
 
-type VlanFormFields = {
+export type VlanFormFields = {
   vlanIface: string;
   vlanId: number | undefined;
   vlanParent: string;
@@ -104,6 +87,16 @@ export type FormFields = CommonFormFields &
   VlanFormFields;
 
 /** Exported domain constants */
+
+/**
+ * Connection types supported by this form.
+ */
+export const SUPPORTED_CONNECTION_TYPES = [
+  CONNECTION_TYPE.ETHERNET,
+  CONNECTION_TYPE.BOND,
+  CONNECTION_TYPE.BRIDGE,
+  CONNECTION_TYPE.VLAN,
+] as const;
 
 /**
  * Form IP mode values.
@@ -151,63 +144,12 @@ export const VlanProtocolMode = {
 
 export type VlanProtocolMode = (typeof VlanProtocolMode)[keyof typeof VlanProtocolMode];
 
-/** Private constants */
-
-/**
- * Bond modes that support the "primary" bond option.
- */
-const PRIMARY_BOND_OPTION_MODES: readonly BondMode[] = [
-  BondMode.ACTIVE_BACKUP,
-  BondMode.BALANCE_TLB,
-  BondMode.BALANCE_ALB,
-];
-
-/** Private helpers */
-
-/**
- * Helper for mode-dependent address validation.
- *
- * In MANUAL and ADVANCED_AUTO modes, at least one address is required.
- * In AUTO mode, addresses are optional (system handles them).
- */
-const validateAddresses = (
-  mode: FormIpMode,
-  addresses: string[],
-  isValid: (s: string) => boolean,
-  emptyMessage: string,
-  invalidMessage: string,
-) =>
-  ADDRESS_REQUIRED_MODES.includes(mode)
-    ? requiredValidList(addresses, isValid, emptyMessage, invalidMessage)
-    : optionalValidList(addresses, isValid, invalidMessage);
-
-/**
- * Helper for mode-dependent gateway validation.
- *
- * In MANUAL mode, gateway is required.
- * In ADVANCED_AUTO mode, gateway is optional.
- * In AUTO mode, gateway is not validated (system handles it).
- */
-const validateGateway = (
-  mode: FormIpMode,
-  gateway: string,
-  isValid: (s: string) => boolean,
-  emptyMessage: string,
-  invalidMessage: string,
-) => {
-  if (mode === FormIpMode.MANUAL)
-    return requiredValidString(gateway, isValid, emptyMessage, invalidMessage);
-  if (mode === FormIpMode.ADVANCED_AUTO)
-    return optionalValidString(gateway, isValid, invalidMessage);
-  return undefined;
-};
-
 /** Default values */
 
 /**
  * Default values for all ConnectionForm fields.
  *
- * Composed from field groups: common, IP, bond, and bridge.
+ * Composed from field groups: common, IP, bond, bridge, and VLAN.
  */
 const defaultValues = {
   // Common fields
@@ -258,226 +200,3 @@ const defaultValues = {
 export const defaultOptions = formOptions({
   defaultValues,
 });
-
-/** Validation */
-
-/**
- * Validates common connection fields.
- *
- * Only the name field requires validation. The other common fields (type,
- * iface, ifaceMac, bindingMode) are either guaranteed valid by the UI
- * (type is a dropdown) or validated elsewhere (iface/ifaceMac are device
- * properties, bindingMode is a controlled enum).
- */
-const validateCommonFields = (
-  fields: CommonFormFields,
-): FieldsValidationResult<CommonFormFields> => ({
-  // TRANSLATORS: validation error for the connection name field.
-  name: requiredString(fields.name, _("Name is required")),
-});
-
-/**
- * Validates IP settings fields.
- *
- * All conditionality — address requirements, gateway optionality, DNS
- * activation — is resolved at call time based on the current form
- * state, not encoded as cross-field rules at validation time.
- */
-const validateIpFields = (fields: IpFormFields): FieldsValidationResult<IpFormFields> => ({
-  // TRANSLATORS: validation error for the IPv4 addresses field.
-  addresses4: validateAddresses(
-    fields.ipv4Mode,
-    fields.addresses4,
-    isValidIPv4Address,
-    _("At least one IPv4 address is required"),
-    _("Some IPv4 addresses are invalid"),
-  ),
-  // TRANSLATORS: validation error for the IPv4 gateway field.
-  gateway4: validateGateway(
-    fields.ipv4Mode,
-    fields.gateway4,
-    isValidIPv4,
-    _("IPv4 gateway is required"),
-    _("Invalid IPv4 gateway"),
-  ),
-  // TRANSLATORS: validation error for the IPv6 addresses field.
-  addresses6: validateAddresses(
-    fields.ipv6Mode,
-    fields.addresses6,
-    isValidIPv6Address,
-    _("At least one IPv6 address is required"),
-    _("Some IPv6 addresses are invalid"),
-  ),
-  // TRANSLATORS: validation error for the IPv6 gateway field.
-  gateway6: validateGateway(
-    fields.ipv6Mode,
-    fields.gateway6,
-    isValidIPv6,
-    _("IPv6 gateway is required"),
-    _("Invalid IPv6 gateway"),
-  ),
-  // DNS fields: only validated when the corresponding toggle is on.
-  nameservers: fields.customDns
-    ? // TRANSLATORS: validation error for the DNS servers field.
-      requiredValidList(
-        fields.nameservers,
-        isValidNameserver,
-        _("At least one DNS server is required"),
-        _("Some DNS server addresses are invalid"),
-      )
-    : undefined,
-  dnsSearchList: fields.customDnsSearch
-    ? // TRANSLATORS: validation error for the DNS search domains field.
-      requiredValidList(
-        fields.dnsSearchList,
-        isValidDNSSearchDomain,
-        _("At least one DNS search domain is required"),
-        _("Some DNS search domains are invalid"),
-      )
-    : undefined,
-});
-
-/**
- * Validates bond-specific fields.
- *
- * Includes cross-field validation for the "primary" bond option, which is
- * only valid in certain modes (ACTIVE_BACKUP, BALANCE_TLB, BALANCE_ALB).
- * This rule depends on both bondMode and bondOptions, so it's evaluated
- * at validation time and returned as a field error on bondOptions.
- */
-const validateBondFields = (fields: BondFormFields): FieldsValidationResult<BondFormFields> => {
-  const { bondMode, bondOptions, bondPorts, bondIface } = fields;
-
-  const hasPrimaryOption = bondOptions.some((o) => o.startsWith("primary="));
-
-  const bondOptionsError = (() => {
-    if (!hasPrimaryOption) return undefined;
-    if (PRIMARY_BOND_OPTION_MODES.includes(bondMode)) return undefined;
-
-    const modeNames = PRIMARY_BOND_OPTION_MODES.map((m) => `'${m}'`);
-    // TRANSLATORS: validation error for the bond options field when the 'primary' option is used in an invalid mode.
-    // %s is replaced with a list of valid mode names.
-    return sprintf(_("The 'primary' option is only valid for %s modes"), formatList(modeNames));
-  })();
-
-  return {
-    // TRANSLATORS: validation error for the bond device name field.
-    bondIface: requiredString(bondIface, _("Device name is required")),
-    // TRANSLATORS: validation error for the bond mode name field.
-    bondMode: requiredString(bondMode, _("Bond mode is required")),
-    // TRANSLATORS: validation error for the bond ports field.
-    bondPorts: bondPorts.length === 0 ? _("At least one bond port is required") : undefined,
-    bondOptions: bondOptionsError,
-  };
-};
-
-/**
- * Validates bridge-specific fields.
- *
- * STP fields are conditionally validated based on whether STP is enabled.
- * When STP is disabled, those fields are not validated at all.
- */
-const validateBridgeFields = (
-  fields: BridgeFormFields,
-): FieldsValidationResult<BridgeFormFields> => {
-  const stpEnabled = fields.bridgeStp === BridgeStpMode.ENABLED;
-
-  return {
-    // TRANSLATORS: validation error for the bridge device name field.
-    bridgeIface: requiredString(fields.bridgeIface, _("Device name is required")),
-    // TRANSLATORS: validation error for the bridge ports field.
-    bridgePorts:
-      fields.bridgePorts.length === 0 ? _("At least one bridge port is required") : undefined,
-    // STP fields only validated when STP is enabled.
-    ...(stpEnabled && {
-      // TRANSLATORS: validation error for the bridge priority field.
-      bridgePriority: optionalIntRange(
-        fields.bridgePriority,
-        0,
-        61440,
-        _("Priority must be between 0 and 61440"),
-      ),
-      // TRANSLATORS: validation error for the bridge forward delay field.
-      bridgeForwardDelay: optionalIntRange(
-        fields.bridgeForwardDelay,
-        4,
-        30,
-        _("Forward delay must be between 4 and 30 seconds"),
-      ),
-      // TRANSLATORS: validation error for the bridge hello time field.
-      bridgeHelloTime: optionalIntRange(
-        fields.bridgeHelloTime,
-        1,
-        10,
-        _("Hello time must be between 1 and 10 seconds"),
-      ),
-      // TRANSLATORS: validation error for the bridge max message age field.
-      bridgeMaxAge: optionalIntRange(
-        fields.bridgeMaxAge,
-        6,
-        40,
-        _("Max message age must be between 6 and 40 seconds"),
-      ),
-    }),
-  };
-};
-
-/**
- * Validates VLAN-specific fields.
- */
-const validateVlanFields = (fields: VlanFormFields): FieldsValidationResult<VlanFormFields> => {
-  return {
-    // TRANSLATORS: validation error for the VLAN device name field.
-    vlanIface: requiredString(fields.vlanIface, _("Device name is required")),
-    // TRANSLATORS: validation error for the VLAN ID field.
-    vlanId: requiredIntRange(
-      fields.vlanId,
-      0,
-      4094,
-      _("VLAN ID is required"),
-      _("VLAN ID must be between 0 and 4094"),
-    ),
-  };
-};
-
-/**
- * Dispatches to the appropriate type-specific validator based on connection type.
- * Returns an empty object for types with no extra validation (e.g. Ethernet).
- */
-const validateTypeFields = (fields: FormFields): FieldsValidationResult<FormFields> => {
-  switch (fields.type) {
-    case CONNECTION_TYPE.BOND:
-      return validateBondFields(fields);
-    case CONNECTION_TYPE.BRIDGE:
-      return validateBridgeFields(fields);
-    case CONNECTION_TYPE.VLAN:
-      return validateVlanFields(fields);
-    default:
-      return {};
-  }
-};
-
-/**
- * Validates the form values for the active connection type.
- *
- * Designed for TanStack Form's validators. Returns undefined when valid
- * (TanStack Form convention), or a field-error map on failure.
- *
- * Composition:
- * - Common and IP validators run for all connection types
- * - Bond/Bridge validators run only for their respective types
- * - Cross-field validation (e.g., bond primary option) is handled within
- *   the type-specific validators and returned as field errors
- *
- * Field errors are collected by merging all validator outputs and
- * stripping undefined values.
- */
-export const validate = (fields: FormFields): ValidationResult<FormFields> => {
-  const fieldErrors = shake({
-    ...validateCommonFields(fields),
-    ...validateIpFields(fields),
-    ...validateTypeFields(fields),
-  });
-
-  return Object.keys(fieldErrors).length > 0 ? { fields: fieldErrors } : undefined;
-};

--- a/web/src/components/network/connection-form/queries.ts
+++ b/web/src/components/network/connection-form/queries.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Query hooks for the connection form.
+ *
+ * These compose route params with the network config and system queries to
+ * derive the data the form needs. They feed both the form's default values and
+ * field options, so they live in one place to avoid duplication.
+ */
+
+import { useParams } from "react-router";
+import { useConfig } from "~/hooks/model/config/network";
+import { useSystem, useDevices } from "~/hooks/model/system/network";
+import { extendCollection } from "~/utils";
+
+import type { Connection, Device } from "~/types/network";
+
+/**
+ * System connections available to the form, excluding removed ones.
+ *
+ * Used to generate non-colliding names for new connections.
+ */
+export function useSystemConnections(): Connection[] {
+  const { connections = [] } = useSystem();
+  return connections.filter((c) => c.status !== "removed");
+}
+
+/**
+ * Returns the connection being edited, or null when creating a new one.
+ *
+ * The route `id` param holds the connection id. Config and system connections
+ * are merged so the form reflects the user's explicit settings (config) while
+ * filling gaps from the live system state.
+ *
+ * Config wins for single values: e.g. configConn.method4 === undefined (the
+ * user chose "Automatic", meaning "do not put method in the config") must
+ * override systemConn.method4 === "auto" that the Agama backend or
+ * NetworkManager might report.
+ *
+ * Arrays (addresses, nameservers, etc.) are concatenated so users can see
+ * existing system values even when config has empty arrays.
+ *
+ * Removed connections are filtered out before merging to avoid carrying over
+ * stale entries that may still exist in persisted config or system state.
+ */
+export function useInitialConnection(): Connection | null {
+  const { id } = useParams();
+  const { connections: configConns = [] } = useConfig();
+  const systemConns = useSystemConnections();
+
+  const { all: connections } = extendCollection(
+    configConns.filter((c) => c.status !== "removed"),
+    { with: systemConns, mergeArrays: true },
+  );
+
+  return connections.find((c) => c.id === id) ?? null;
+}
+
+/**
+ * Query data frozen on mount to protect the form from mid-interaction
+ * refetches.
+ *
+ * @see withFrozenQuery
+ */
+export type ConnectionFormContentQuery = {
+  initialConnection: Connection | null;
+  devices: Device[];
+  systemConnections: Connection[];
+};
+
+/**
+ * Aggregates the query hooks whose data feeds the form's defaultValues and
+ * field options. Called at the wrapper level by withFrozenQuery.
+ */
+export function useConnectionFormContentQuery(): ConnectionFormContentQuery {
+  return {
+    initialConnection: useInitialConnection(),
+    devices: useDevices(),
+    systemConnections: useSystemConnections(),
+  };
+}

--- a/web/src/components/network/connection-form/transformations.test.ts
+++ b/web/src/components/network/connection-form/transformations.test.ts
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import {
+  BondMode,
+  Connection,
+  ConnectionMethod,
+  ConnectionState,
+  ConnectionStatus,
+} from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
+import { defaultOptions, FormIpMode, BridgeStpMode, VlanProtocolMode } from "./fields";
+import { buildPayload, toFormValues } from "./transformations";
+import type { FormFields } from "./fields";
+
+const formValues = (overrides: Partial<FormFields> = {}): FormFields => ({
+  ...defaultOptions.defaultValues,
+  name: "My connection",
+  ...overrides,
+});
+
+/** Builds a Connection instance from minimal API data, with sensible defaults. */
+const apiConnection = (id: string, overrides = {}) =>
+  Connection.fromApi({
+    id,
+    status: ConnectionStatus.UP,
+    state: ConnectionState.ACTIVATED,
+    persistent: true,
+    addresses: [],
+    nameservers: [],
+    dnsSearchList: [],
+    ...overrides,
+  });
+
+describe("buildPayload", () => {
+  it("uses the name as the connection id", () => {
+    expect(buildPayload(formValues({ name: "Work WiFi" })).id).toBe("Work WiFi");
+  });
+
+  describe("IPv4 addressing", () => {
+    it("omits addresses and forces AUTO method in Automatic mode", () => {
+      const result = buildPayload(
+        formValues({ ipv4Mode: FormIpMode.AUTO, addresses4: ["192.168.1.10/24"] }),
+      );
+      expect(result.method4).toBe(ConnectionMethod.AUTO);
+      expect(result.addresses).toEqual([]);
+    });
+
+    it("includes addresses and gateway in Manual mode", () => {
+      const result = buildPayload(
+        formValues({
+          ipv4Mode: FormIpMode.MANUAL,
+          addresses4: ["192.168.1.10/24"],
+          gateway4: "192.168.1.1",
+        }),
+      );
+      expect(result.method4).toBe(ConnectionMethod.MANUAL);
+      expect(result.addresses).toEqual([{ address: "192.168.1.10", prefix: 24 }]);
+      expect(result.gateway4).toBe("192.168.1.1");
+    });
+
+    it("keeps AUTO method but includes addresses in Automatic + manual mode", () => {
+      const result = buildPayload(
+        formValues({ ipv4Mode: FormIpMode.ADVANCED_AUTO, addresses4: ["192.168.1.10/24"] }),
+      );
+      expect(result.method4).toBe(ConnectionMethod.AUTO);
+      expect(result.addresses).toEqual([{ address: "192.168.1.10", prefix: 24 }]);
+    });
+
+    it("drops the gateway when there are no addresses", () => {
+      const result = buildPayload(
+        formValues({ ipv4Mode: FormIpMode.MANUAL, addresses4: [], gateway4: "192.168.1.1" }),
+      );
+      expect(result.gateway4).toBe("");
+    });
+  });
+
+  describe("DNS", () => {
+    it("includes nameservers and search domains when custom DNS is enabled", () => {
+      const result = buildPayload(
+        formValues({
+          customDns: true,
+          nameservers: ["8.8.8.8"],
+          customDnsSearch: true,
+          dnsSearchList: ["example.com"],
+        }),
+      );
+      expect(result.nameservers).toEqual(["8.8.8.8"]);
+      expect(result.dnsSearchList).toEqual(["example.com"]);
+    });
+
+    it("omits nameservers and search domains when custom DNS is disabled", () => {
+      const result = buildPayload(
+        formValues({
+          customDns: false,
+          nameservers: ["8.8.8.8"],
+          customDnsSearch: false,
+          dnsSearchList: ["example.com"],
+        }),
+      );
+      expect(result.nameservers).toEqual([]);
+      expect(result.dnsSearchList).toEqual([]);
+    });
+  });
+
+  describe("device binding", () => {
+    it("sets the iface when binding by name", () => {
+      const result = buildPayload(formValues({ bindingMode: "iface", iface: "enp1s0" }));
+      expect(result.iface).toBe("enp1s0");
+      expect(result.macAddress).toBeFalsy();
+    });
+
+    it("sets the MAC address when binding by MAC", () => {
+      const result = buildPayload(
+        formValues({ bindingMode: "mac", ifaceMac: "00:11:22:33:44:55", iface: "enp1s0" }),
+      );
+      expect(result.macAddress).toBe("00:11:22:33:44:55");
+      expect(result.iface).toBeFalsy();
+    });
+  });
+
+  describe("Bond", () => {
+    it("builds the bond config from the bond fields", () => {
+      const result = buildPayload(
+        formValues({
+          type: CONNECTION_TYPE.BOND,
+          bondIface: "bond0",
+          bondMode: BondMode.ACTIVE_BACKUP,
+          bondOptions: ["primary=enp1s0", "miimon=100"],
+          bondPorts: ["enp1s0", "enp2s0"],
+        }),
+      );
+      expect(result.iface).toBe("bond0");
+      expect(result.bond).toEqual({
+        mode: BondMode.ACTIVE_BACKUP,
+        options: "primary=enp1s0 miimon=100",
+        ports: ["enp1s0", "enp2s0"],
+      });
+    });
+
+    it("does not build a bond config for non-bond types", () => {
+      expect(buildPayload(formValues()).bond).toBeUndefined();
+    });
+  });
+
+  describe("Bridge", () => {
+    it("leaves STP undefined in Default mode", () => {
+      const result = buildPayload(
+        formValues({
+          type: CONNECTION_TYPE.BRIDGE,
+          bridgeIface: "br0",
+          bridgeStp: BridgeStpMode.DEFAULT,
+          bridgePorts: ["enp1s0"],
+        }),
+      );
+      expect(result.bridge?.stp).toBeUndefined();
+      expect(result.bridge?.ports).toEqual(["enp1s0"]);
+    });
+
+    it("includes STP options when STP is enabled", () => {
+      const result = buildPayload(
+        formValues({
+          type: CONNECTION_TYPE.BRIDGE,
+          bridgeIface: "br0",
+          bridgeStp: BridgeStpMode.ENABLED,
+          bridgePriority: 16384,
+          bridgeForwardDelay: 10,
+          bridgePorts: ["enp1s0"],
+        }),
+      );
+      expect(result.bridge?.stp).toBe(true);
+      expect(result.bridge?.priority).toBe(16384);
+      expect(result.bridge?.forwardDelay).toBe(10);
+    });
+
+    it("drops STP options when STP is disabled", () => {
+      const result = buildPayload(
+        formValues({
+          type: CONNECTION_TYPE.BRIDGE,
+          bridgeIface: "br0",
+          bridgeStp: BridgeStpMode.DISABLED,
+          bridgePriority: 16384,
+          bridgePorts: ["enp1s0"],
+        }),
+      );
+      expect(result.bridge?.stp).toBe(false);
+      expect(result.bridge?.priority).toBeUndefined();
+    });
+  });
+
+  describe("VLAN", () => {
+    it("builds the VLAN config from the VLAN fields", () => {
+      const result = buildPayload(
+        formValues({
+          type: CONNECTION_TYPE.VLAN,
+          vlanIface: "eth0.100",
+          vlanId: 100,
+          vlanParent: "eth0",
+          vlanProtocol: VlanProtocolMode.DEFAULT,
+        }),
+      );
+      expect(result.iface).toBe("eth0.100");
+      expect(result.vlan).toEqual({ id: 100, parent: "eth0", protocol: undefined });
+    });
+  });
+});
+
+describe("toFormValues", () => {
+  it("returns an empty object for a new connection (null)", () => {
+    expect(toFormValues(null)).toEqual({});
+  });
+
+  it("maps the basic identity fields", () => {
+    const result = toFormValues(new Connection("eth0", { iface: "enp1s0" }));
+    expect(result).toMatchObject({
+      name: "eth0",
+      type: CONNECTION_TYPE.ETHERNET,
+      iface: "enp1s0",
+      bindingMode: "iface",
+    });
+  });
+
+  describe("IP mode inference", () => {
+    it("infers Manual when the method is manual", () => {
+      const result = toFormValues(
+        apiConnection("eth0", { method4: "manual", addresses: ["192.168.1.10/24"] }),
+      );
+      expect(result.ipv4Mode).toBe(FormIpMode.MANUAL);
+      expect(result.addresses4).toEqual(["192.168.1.10/24"]);
+    });
+
+    it("infers Automatic + manual when method is auto but addresses exist", () => {
+      const result = toFormValues(
+        apiConnection("eth0", { method4: "auto", addresses: ["192.168.1.10/24"] }),
+      );
+      expect(result.ipv4Mode).toBe(FormIpMode.ADVANCED_AUTO);
+    });
+
+    it("infers Automatic when there is no method and no addresses", () => {
+      const result = toFormValues(apiConnection("eth0"));
+      expect(result.ipv4Mode).toBe(FormIpMode.AUTO);
+      expect(result.addresses4).toEqual([]);
+    });
+
+    it("splits addresses by family", () => {
+      const result = toFormValues(
+        apiConnection("eth0", { addresses: ["192.168.1.10/24", "2001:db8::1/64"] }),
+      );
+      expect(result.addresses4).toEqual(["192.168.1.10/24"]);
+      expect(result.addresses6).toEqual(["2001:db8::1/64"]);
+    });
+  });
+
+  describe("DNS toggles", () => {
+    it("enables custom DNS when nameservers are present", () => {
+      const result = toFormValues(apiConnection("eth0", { nameservers: ["8.8.8.8"] }));
+      expect(result.customDns).toBe(true);
+      expect(result.nameservers).toEqual(["8.8.8.8"]);
+    });
+
+    it("enables custom DNS search when search domains are present", () => {
+      const result = toFormValues(apiConnection("eth0", { dnsSearchList: ["example.com"] }));
+      expect(result.customDnsSearch).toBe(true);
+    });
+
+    it("leaves custom DNS off when there are no nameservers", () => {
+      const result = toFormValues(apiConnection("eth0"));
+      expect(result.customDns).toBe(false);
+    });
+  });
+
+  describe("bridge STP inference", () => {
+    it("infers Enabled when stp is true", () => {
+      const result = toFormValues(
+        apiConnection("br0", { bridge: { ports: ["enp1s0"], stp: true } }),
+      );
+      expect(result.bridgeStp).toBe(BridgeStpMode.ENABLED);
+    });
+
+    it("infers Disabled when stp is false", () => {
+      const result = toFormValues(
+        apiConnection("br0", { bridge: { ports: ["enp1s0"], stp: false } }),
+      );
+      expect(result.bridgeStp).toBe(BridgeStpMode.DISABLED);
+    });
+
+    it("infers Enabled when stp is missing but other STP options are present", () => {
+      const result = toFormValues(
+        apiConnection("br0", { bridge: { ports: ["enp1s0"], priority: 32768 } }),
+      );
+      expect(result.bridgeStp).toBe(BridgeStpMode.ENABLED);
+    });
+
+    it("infers Default when no STP information is present", () => {
+      const result = toFormValues(apiConnection("br0", { bridge: { ports: ["enp1s0"] } }));
+      expect(result.bridgeStp).toBe(BridgeStpMode.DEFAULT);
+    });
+  });
+});

--- a/web/src/components/network/connection-form/transformations.ts
+++ b/web/src/components/network/connection-form/transformations.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Transformation functions for the connection form.
+ *
+ * This module handles conversion between {@link Connection} structures and form
+ * field values. It provides:
+ *
+ * - **buildPayload**: Converts form values to a Connection for API mutations
+ * - **toFormValues**: Converts a Connection to initial form values
+ *
+ * ## Data Flow
+ *
+ * ```
+ * Initial load:
+ *   Connection → toFormValues() → FormValues → TanStack Form state
+ *
+ * Form submission:
+ *   TanStack Form state → FormValues → buildPayload() → Connection → API
+ * ```
+ */
+
+import { unique } from "radashi";
+import {
+  buildAddress,
+  connectionBindingMode,
+  connectionType,
+  CONNECTION_TYPE,
+  ensureIPPrefix,
+  formatIp,
+  isVirtual,
+  isValidIPv4Address,
+} from "~/utils/network";
+import {
+  ADDRESS_REQUIRED_MODES,
+  BridgeStpMode,
+  FormIpMode,
+  VlanProtocolMode,
+  defaultOptions,
+} from "./fields";
+
+import type {
+  FormIpMode as FormIpModeType,
+  BridgeStpMode as BridgeStpModeType,
+  VlanProtocolMode as VlanProtocolModeType,
+} from "./fields";
+import { BondMode, Bridge, Connection, ConnectionMethod, VlanProtocol } from "~/types/network";
+
+type FormValues = typeof defaultOptions.defaultValues;
+
+/**
+ * Maps form mode values to their corresponding {@link ConnectionMethod}.
+ *
+ * Both AUTO and ADVANCED_AUTO map to ConnectionMethod.AUTO; they differ
+ * only in UI behavior (whether address/gateway fields are shown).
+ */
+const MODE_TO_METHOD: Record<FormIpModeType, ConnectionMethod> = {
+  [FormIpMode.AUTO]: ConnectionMethod.AUTO,
+  [FormIpMode.ADVANCED_AUTO]: ConnectionMethod.AUTO,
+  [FormIpMode.MANUAL]: ConnectionMethod.MANUAL,
+};
+
+/**
+ * Infers the form IPvX mode from a stored {@link ConnectionMethod} and addresses.
+ *
+ * The presence of addresses affects the interpretation:
+ * - `MANUAL` method → MANUAL
+ * - `AUTO` method with addresses → ADVANCED_AUTO
+ * - `AUTO` method without addresses → AUTO
+ * - `undefined` method with addresses → ADVANCED_AUTO (from system)
+ * - `undefined` method without addresses → AUTO
+ */
+function inferIpMode(method: ConnectionMethod | undefined, addresses: string[]): FormIpModeType {
+  if (method === ConnectionMethod.MANUAL) return FormIpMode.MANUAL;
+
+  return addresses.length > 0 ? FormIpMode.ADVANCED_AUTO : FormIpMode.AUTO;
+}
+
+/**
+ * Infers the bridge STP mode from the stored {@link Bridge} configuration.
+ *
+ * If `stp` is explicitly defined, that value is used.
+ * If `stp` is absent but other STP-related options are present, it's
+ * inferred as ENABLED. Otherwise, it defaults to DEFAULT (system default).
+ */
+function inferBridgeStp(bridge: Bridge | undefined): BridgeStpModeType {
+  if (!bridge) return BridgeStpMode.DEFAULT;
+
+  if (bridge.stp !== undefined) {
+    return bridge.stp ? BridgeStpMode.ENABLED : BridgeStpMode.DISABLED;
+  }
+
+  const hasStpOptions =
+    bridge.priority !== undefined ||
+    bridge.forwardDelay !== undefined ||
+    bridge.helloTime !== undefined ||
+    bridge.maxAge !== undefined;
+
+  return hasStpOptions ? BridgeStpMode.ENABLED : BridgeStpMode.DEFAULT;
+}
+
+/**
+ * Maps an existing {@link Connection} to initial form values for editing.
+ *
+ * Returns an empty object when creating a new connection (connection is null),
+ * which allows the form defaults to take precedence.
+ */
+export function toFormValues(connection: Connection | null): Partial<FormValues> {
+  if (!connection) return {};
+
+  // Deduplicate addresses (config + system merge can create duplicates)
+  const uniqueAddresses = unique(connection.addresses, (addr) => `${addr.address}/${addr.prefix}`);
+
+  // Partition and format addresses in a single pass using proper IP validation
+  const addresses4: string[] = [];
+  const addresses6: string[] = [];
+
+  for (const addr of uniqueAddresses) {
+    const formatted = ensureIPPrefix(formatIp(addr));
+    if (isValidIPv4Address(addr.address)) {
+      addresses4.push(formatted);
+    } else {
+      addresses6.push(formatted);
+    }
+  }
+
+  return {
+    name: connection.id,
+    type: connectionType(connection),
+    iface: connection.iface ?? "",
+    ifaceMac: connection.macAddress ?? "",
+    bindingMode: connectionBindingMode(connection),
+    ipv4Mode: inferIpMode(connection.method4, addresses4),
+    addresses4,
+    gateway4: connection.gateway4 ?? "",
+    ipv6Mode: inferIpMode(connection.method6, addresses6),
+    addresses6,
+    gateway6: connection.gateway6 ?? "",
+    nameservers: unique(connection.nameservers),
+    dnsSearchList: unique(connection.dnsSearchList),
+    customDns: connection.nameservers.length > 0,
+    customDnsSearch: connection.dnsSearchList.length > 0,
+    bondIface: connection.iface,
+    bondMode: connection.bond?.mode ?? BondMode.BALANCE_ROUND_ROBIN,
+    bondOptions: connection.bond?.options ? connection.bond.options.split(" ") : [],
+    bondPorts: connection.bond?.ports ?? [],
+    bridgeIface: connection.iface,
+    bridgeStp: inferBridgeStp(connection.bridge),
+    bridgePriority: connection.bridge?.priority,
+    bridgeForwardDelay: connection.bridge?.forwardDelay,
+    bridgeHelloTime: connection.bridge?.helloTime,
+    bridgeMaxAge: connection.bridge?.maxAge,
+    bridgePorts: connection.bridge?.ports ?? [],
+    vlanIface: connection.iface,
+    vlanId: connection.vlan?.id,
+    vlanParent: connection.vlan?.parent ?? "",
+    vlanProtocol: (connection.vlan?.protocol ?? VlanProtocolMode.DEFAULT) as VlanProtocolModeType,
+  };
+}
+
+/**
+ * Builds a {@link Connection} from the validated form values.
+ *
+ * Addresses in formValues already have prefixes (added by ArrayField's
+ * normalize or when loading from backend), so no prefix addition is needed.
+ */
+export function buildPayload(formValues: FormValues): Connection {
+  const ipv4Addresses = ADDRESS_REQUIRED_MODES.includes(formValues.ipv4Mode)
+    ? formValues.addresses4.map(buildAddress)
+    : [];
+  const ipv6Addresses = ADDRESS_REQUIRED_MODES.includes(formValues.ipv6Mode)
+    ? formValues.addresses6.map(buildAddress)
+    : [];
+
+  let iface = "";
+  if (isVirtual(formValues.type)) {
+    iface = formValues[`${formValues.type}Iface`];
+  } else if (formValues.bindingMode === "iface") {
+    iface = formValues.iface;
+  }
+  return new Connection(formValues.name, {
+    iface,
+    macAddress: formValues.bindingMode === "mac" ? formValues.ifaceMac : "",
+    method4: MODE_TO_METHOD[formValues.ipv4Mode],
+    gateway4: ipv4Addresses.length > 0 ? formValues.gateway4 : "",
+    method6: MODE_TO_METHOD[formValues.ipv6Mode],
+    gateway6: ipv6Addresses.length > 0 ? formValues.gateway6 : "",
+    addresses: [...ipv4Addresses, ...ipv6Addresses],
+    nameservers: formValues.customDns ? formValues.nameservers : [],
+    dnsSearchList: formValues.customDnsSearch ? formValues.dnsSearchList : [],
+    bond:
+      formValues.type === CONNECTION_TYPE.BOND
+        ? {
+            mode: formValues.bondMode,
+            options: formValues.bondOptions.join(" "),
+            ports: formValues.bondPorts,
+          }
+        : undefined,
+    bridge:
+      formValues.type === CONNECTION_TYPE.BRIDGE
+        ? {
+            stp: (() => {
+              if (formValues.bridgeStp === BridgeStpMode.DEFAULT) return undefined;
+              return formValues.bridgeStp === BridgeStpMode.ENABLED;
+            })(),
+            priority:
+              formValues.bridgeStp === BridgeStpMode.ENABLED
+                ? formValues.bridgePriority
+                : undefined,
+            forwardDelay:
+              formValues.bridgeStp === BridgeStpMode.ENABLED
+                ? formValues.bridgeForwardDelay
+                : undefined,
+            helloTime:
+              formValues.bridgeStp === BridgeStpMode.ENABLED
+                ? formValues.bridgeHelloTime
+                : undefined,
+            maxAge:
+              formValues.bridgeStp === BridgeStpMode.ENABLED ? formValues.bridgeMaxAge : undefined,
+            ports: formValues.bridgePorts,
+          }
+        : undefined,
+    vlan:
+      formValues.type === CONNECTION_TYPE.VLAN
+        ? {
+            id: formValues.vlanId!,
+            parent: formValues.vlanParent,
+            protocol:
+              formValues.vlanProtocol !== VlanProtocolMode.DEFAULT
+                ? (formValues.vlanProtocol as VlanProtocol)
+                : undefined,
+          }
+        : undefined,
+  });
+}

--- a/web/src/components/network/connection-form/validations.test.ts
+++ b/web/src/components/network/connection-form/validations.test.ts
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { BondMode } from "~/types/network";
+import { CONNECTION_TYPE } from "~/utils/network";
+import { defaultOptions, FormIpMode, BridgeStpMode, VlanProtocolMode } from "./fields";
+import { validate } from "./validations";
+import type { FormFields } from "./fields";
+
+/** A valid Ethernet connection, used as the starting point for most cases. */
+const ethernetFields = (overrides: Partial<FormFields> = {}): FormFields => ({
+  ...defaultOptions.defaultValues,
+  name: "My connection",
+  ...overrides,
+});
+
+const bondFields = (overrides: Partial<FormFields> = {}): FormFields =>
+  ethernetFields({
+    type: CONNECTION_TYPE.BOND,
+    bondIface: "bond0",
+    bondPorts: ["enp1s0"],
+    ...overrides,
+  });
+
+const bridgeFields = (overrides: Partial<FormFields> = {}): FormFields =>
+  ethernetFields({
+    type: CONNECTION_TYPE.BRIDGE,
+    bridgeIface: "br0",
+    bridgePorts: ["enp1s0"],
+    ...overrides,
+  });
+
+const vlanFields = (overrides: Partial<FormFields> = {}): FormFields =>
+  ethernetFields({
+    type: CONNECTION_TYPE.VLAN,
+    vlanIface: "eth0.100",
+    vlanId: 100,
+    vlanProtocol: VlanProtocolMode.DEFAULT,
+    ...overrides,
+  });
+
+describe("validate", () => {
+  it("returns undefined for a valid connection", () => {
+    expect(validate(ethernetFields())).toBeUndefined();
+  });
+
+  describe("common fields", () => {
+    it("returns an error when the name is empty", () => {
+      const result = validate(ethernetFields({ name: "" }));
+      expect(result?.fields?.name).toBe("Name is required");
+    });
+
+    it("accepts a non-empty name", () => {
+      const result = validate(ethernetFields({ name: "Work WiFi" }));
+      expect(result?.fields?.name).toBeUndefined();
+    });
+  });
+
+  describe("IPv4 fields", () => {
+    describe("Manual mode", () => {
+      it("requires at least one address", () => {
+        const result = validate(ethernetFields({ ipv4Mode: FormIpMode.MANUAL, addresses4: [] }));
+        expect(result?.fields?.addresses4).toBe("At least one IPv4 address is required");
+      });
+
+      it("rejects invalid addresses", () => {
+        const result = validate(
+          ethernetFields({ ipv4Mode: FormIpMode.MANUAL, addresses4: ["not-an-ip"] }),
+        );
+        expect(result?.fields?.addresses4).toBe("Some IPv4 addresses are invalid");
+      });
+
+      it("requires the gateway", () => {
+        const result = validate(
+          ethernetFields({
+            ipv4Mode: FormIpMode.MANUAL,
+            addresses4: ["192.168.1.10/24"],
+            gateway4: "",
+          }),
+        );
+        expect(result?.fields?.gateway4).toBe("IPv4 gateway is required");
+      });
+
+      it("rejects an invalid gateway", () => {
+        const result = validate(
+          ethernetFields({
+            ipv4Mode: FormIpMode.MANUAL,
+            addresses4: ["192.168.1.10/24"],
+            gateway4: "nope",
+          }),
+        );
+        expect(result?.fields?.gateway4).toBe("Invalid IPv4 gateway");
+      });
+
+      it("accepts valid addresses and gateway", () => {
+        const result = validate(
+          ethernetFields({
+            ipv4Mode: FormIpMode.MANUAL,
+            addresses4: ["192.168.1.10/24"],
+            gateway4: "192.168.1.1",
+          }),
+        );
+        expect(result?.fields?.addresses4).toBeUndefined();
+        expect(result?.fields?.gateway4).toBeUndefined();
+      });
+    });
+
+    describe("Automatic + manual mode", () => {
+      it("requires at least one address", () => {
+        const result = validate(
+          ethernetFields({ ipv4Mode: FormIpMode.ADVANCED_AUTO, addresses4: [] }),
+        );
+        expect(result?.fields?.addresses4).toBe("At least one IPv4 address is required");
+      });
+
+      it("treats the gateway as optional", () => {
+        const result = validate(
+          ethernetFields({
+            ipv4Mode: FormIpMode.ADVANCED_AUTO,
+            addresses4: ["192.168.1.10/24"],
+            gateway4: "",
+          }),
+        );
+        expect(result?.fields?.gateway4).toBeUndefined();
+      });
+    });
+
+    describe("Automatic mode", () => {
+      it("does not require addresses", () => {
+        const result = validate(ethernetFields({ ipv4Mode: FormIpMode.AUTO, addresses4: [] }));
+        expect(result?.fields?.addresses4).toBeUndefined();
+      });
+
+      it("still rejects invalid addresses when provided", () => {
+        const result = validate(ethernetFields({ ipv4Mode: FormIpMode.AUTO, addresses4: ["bad"] }));
+        expect(result?.fields?.addresses4).toBe("Some IPv4 addresses are invalid");
+      });
+
+      it("does not validate the gateway", () => {
+        const result = validate(ethernetFields({ ipv4Mode: FormIpMode.AUTO, gateway4: "nope" }));
+        expect(result?.fields?.gateway4).toBeUndefined();
+      });
+    });
+  });
+
+  describe("IPv6 fields", () => {
+    it("requires at least one address in Manual mode", () => {
+      const result = validate(ethernetFields({ ipv6Mode: FormIpMode.MANUAL, addresses6: [] }));
+      expect(result?.fields?.addresses6).toBe("At least one IPv6 address is required");
+    });
+
+    it("rejects an invalid gateway in Manual mode", () => {
+      const result = validate(
+        ethernetFields({
+          ipv6Mode: FormIpMode.MANUAL,
+          addresses6: ["2001:db8::1/64"],
+          gateway6: "nope",
+        }),
+      );
+      expect(result?.fields?.gateway6).toBe("Invalid IPv6 gateway");
+    });
+
+    it("accepts valid addresses and gateway", () => {
+      const result = validate(
+        ethernetFields({
+          ipv6Mode: FormIpMode.MANUAL,
+          addresses6: ["2001:db8::1/64"],
+          gateway6: "2001:db8::ffff",
+        }),
+      );
+      expect(result?.fields?.addresses6).toBeUndefined();
+      expect(result?.fields?.gateway6).toBeUndefined();
+    });
+  });
+
+  describe("DNS fields", () => {
+    it("requires a server when custom DNS is enabled", () => {
+      const result = validate(ethernetFields({ customDns: true, nameservers: [] }));
+      expect(result?.fields?.nameservers).toBe("At least one DNS server is required");
+    });
+
+    it("rejects invalid servers when custom DNS is enabled", () => {
+      const result = validate(ethernetFields({ customDns: true, nameservers: ["bad"] }));
+      expect(result?.fields?.nameservers).toBe("Some DNS server addresses are invalid");
+    });
+
+    it("does not validate servers when custom DNS is disabled", () => {
+      const result = validate(ethernetFields({ customDns: false, nameservers: ["bad"] }));
+      expect(result?.fields?.nameservers).toBeUndefined();
+    });
+
+    it("requires a domain when custom DNS search is enabled", () => {
+      const result = validate(ethernetFields({ customDnsSearch: true, dnsSearchList: [] }));
+      expect(result?.fields?.dnsSearchList).toBe("At least one DNS search domain is required");
+    });
+
+    it("does not validate domains when custom DNS search is disabled", () => {
+      const result = validate(
+        ethernetFields({ customDnsSearch: false, dnsSearchList: ["bad domain"] }),
+      );
+      expect(result?.fields?.dnsSearchList).toBeUndefined();
+    });
+  });
+
+  describe("Bond fields", () => {
+    it("returns undefined for a valid bond", () => {
+      expect(validate(bondFields())).toBeUndefined();
+    });
+
+    it("requires the device name", () => {
+      const result = validate(bondFields({ bondIface: "" }));
+      expect(result?.fields?.bondIface).toBe("Device name is required");
+    });
+
+    it("requires at least one port", () => {
+      const result = validate(bondFields({ bondPorts: [] }));
+      expect(result?.fields?.bondPorts).toBe("At least one bond port is required");
+    });
+
+    it("rejects the 'primary' option in a mode that does not support it", () => {
+      const result = validate(
+        bondFields({ bondMode: BondMode.BALANCE_ROUND_ROBIN, bondOptions: ["primary=enp1s0"] }),
+      );
+      expect(result?.fields?.bondOptions).toBe(
+        "The 'primary' option is only valid for 'active-backup', 'balance-tlb', and 'balance-alb' modes",
+      );
+    });
+
+    it("accepts the 'primary' option in a supported mode", () => {
+      const result = validate(
+        bondFields({ bondMode: BondMode.ACTIVE_BACKUP, bondOptions: ["primary=enp1s0"] }),
+      );
+      expect(result?.fields?.bondOptions).toBeUndefined();
+    });
+  });
+
+  describe("Bridge fields", () => {
+    it("returns undefined for a valid bridge", () => {
+      expect(validate(bridgeFields())).toBeUndefined();
+    });
+
+    it("requires the device name", () => {
+      const result = validate(bridgeFields({ bridgeIface: "" }));
+      expect(result?.fields?.bridgeIface).toBe("Device name is required");
+    });
+
+    it("requires at least one port", () => {
+      const result = validate(bridgeFields({ bridgePorts: [] }));
+      expect(result?.fields?.bridgePorts).toBe("At least one bridge port is required");
+    });
+
+    describe("STP settings", () => {
+      it("validates ranges only when STP is enabled", () => {
+        const result = validate(
+          bridgeFields({
+            bridgeStp: BridgeStpMode.ENABLED,
+            bridgePriority: 70000,
+            bridgeForwardDelay: 2,
+            bridgeHelloTime: 11,
+            bridgeMaxAge: 5,
+          }),
+        );
+        expect(result?.fields?.bridgePriority).toBe("Priority must be between 0 and 61440");
+        expect(result?.fields?.bridgeForwardDelay).toBe(
+          "Forward delay must be between 4 and 30 seconds",
+        );
+        expect(result?.fields?.bridgeHelloTime).toBe("Hello time must be between 1 and 10 seconds");
+        expect(result?.fields?.bridgeMaxAge).toBe(
+          "Max message age must be between 6 and 40 seconds",
+        );
+      });
+
+      it("ignores out-of-range values when STP is not enabled", () => {
+        const result = validate(
+          bridgeFields({ bridgeStp: BridgeStpMode.DEFAULT, bridgePriority: 70000 }),
+        );
+        expect(result?.fields?.bridgePriority).toBeUndefined();
+      });
+
+      it("accepts in-range values and empty (optional) values when STP is enabled", () => {
+        const result = validate(
+          bridgeFields({
+            bridgeStp: BridgeStpMode.ENABLED,
+            bridgePriority: 16384,
+            bridgeForwardDelay: undefined,
+            bridgeHelloTime: undefined,
+            bridgeMaxAge: undefined,
+          }),
+        );
+        expect(result?.fields?.bridgePriority).toBeUndefined();
+        expect(result?.fields?.bridgeForwardDelay).toBeUndefined();
+      });
+    });
+  });
+
+  describe("VLAN fields", () => {
+    it("returns undefined for a valid VLAN", () => {
+      expect(validate(vlanFields())).toBeUndefined();
+    });
+
+    it("requires the device name", () => {
+      const result = validate(vlanFields({ vlanIface: "" }));
+      expect(result?.fields?.vlanIface).toBe("Device name is required");
+    });
+
+    it("requires the VLAN ID", () => {
+      const result = validate(vlanFields({ vlanId: undefined }));
+      expect(result?.fields?.vlanId).toBe("VLAN ID is required");
+    });
+
+    it("rejects an out-of-range VLAN ID", () => {
+      const result = validate(vlanFields({ vlanId: 5000 }));
+      expect(result?.fields?.vlanId).toBe("VLAN ID must be between 0 and 4094");
+    });
+  });
+
+  describe("composition", () => {
+    it("does not run type-specific validators for the wrong type", () => {
+      // Empty bondIface must not appear as an error while the type is Ethernet.
+      const result = validate(ethernetFields({ bondIface: "" }));
+      expect(result?.fields?.bondIface).toBeUndefined();
+    });
+
+    it("collects errors from several field groups at once", () => {
+      const result = validate(bridgeFields({ name: "", bridgeIface: "", bridgePorts: [] }));
+      expect(result?.fields?.name).toBeDefined();
+      expect(result?.fields?.bridgeIface).toBeDefined();
+      expect(result?.fields?.bridgePorts).toBeDefined();
+    });
+  });
+});

--- a/web/src/components/network/connection-form/validations.ts
+++ b/web/src/components/network/connection-form/validations.ts
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Validation for the connection form.
+ *
+ * Builds on the field definitions from fields.ts and the reusable rules from
+ * form/validation-helpers.ts. The exported validate function is wired into the
+ * form's onSubmitAsync validator, following the submit-only validation
+ * convention.
+ */
+
+import { shake } from "radashi";
+import { sprintf } from "sprintf-js";
+
+import { BondMode } from "~/types/network";
+import {
+  CONNECTION_TYPE,
+  isValidIPv4Address,
+  isValidIPv6Address,
+  isValidIPv4,
+  isValidIPv6,
+  isValidNameserver,
+  isValidDNSSearchDomain,
+} from "~/utils/network";
+import {
+  requiredString,
+  requiredIntRange,
+  optionalIntRange,
+  requiredValidList,
+  optionalValidList,
+  requiredValidString,
+  optionalValidString,
+} from "~/components/form/validation-helpers";
+import { ADDRESS_REQUIRED_MODES, BridgeStpMode, FormIpMode } from "./fields";
+import { _, formatList } from "~/i18n";
+
+import type {
+  ValidationResult,
+  FieldsValidationResult,
+} from "~/components/form/validation-helpers";
+import type {
+  CommonFormFields,
+  IpFormFields,
+  BondFormFields,
+  BridgeFormFields,
+  VlanFormFields,
+  FormFields,
+  FormIpMode as FormIpModeType,
+} from "./fields";
+
+/**
+ * Bond modes that support the "primary" bond option.
+ */
+const PRIMARY_BOND_OPTION_MODES: readonly BondMode[] = [
+  BondMode.ACTIVE_BACKUP,
+  BondMode.BALANCE_TLB,
+  BondMode.BALANCE_ALB,
+];
+
+/**
+ * Helper for mode-dependent address validation.
+ *
+ * In MANUAL and ADVANCED_AUTO modes, at least one address is required.
+ * In AUTO mode, addresses are optional (system handles them).
+ */
+const validateAddresses = (
+  mode: FormIpModeType,
+  addresses: string[],
+  isValid: (s: string) => boolean,
+  emptyMessage: string,
+  invalidMessage: string,
+) =>
+  ADDRESS_REQUIRED_MODES.includes(mode)
+    ? requiredValidList(addresses, isValid, emptyMessage, invalidMessage)
+    : optionalValidList(addresses, isValid, invalidMessage);
+
+/**
+ * Helper for mode-dependent gateway validation.
+ *
+ * In MANUAL mode, gateway is required.
+ * In ADVANCED_AUTO mode, gateway is optional.
+ * In AUTO mode, gateway is not validated (system handles it).
+ */
+const validateGateway = (
+  mode: FormIpModeType,
+  gateway: string,
+  isValid: (s: string) => boolean,
+  emptyMessage: string,
+  invalidMessage: string,
+) => {
+  if (mode === FormIpMode.MANUAL)
+    return requiredValidString(gateway, isValid, emptyMessage, invalidMessage);
+  if (mode === FormIpMode.ADVANCED_AUTO)
+    return optionalValidString(gateway, isValid, invalidMessage);
+  return undefined;
+};
+
+/**
+ * Validates common connection fields.
+ *
+ * Only the name field requires validation. The other common fields (type,
+ * iface, ifaceMac, bindingMode) are either guaranteed valid by the UI
+ * (type is a dropdown) or validated elsewhere (iface/ifaceMac are device
+ * properties, bindingMode is a controlled enum).
+ */
+const validateCommonFields = (
+  fields: CommonFormFields,
+): FieldsValidationResult<CommonFormFields> => ({
+  // TRANSLATORS: validation error for the connection name field.
+  name: requiredString(fields.name, _("Name is required")),
+});
+
+/**
+ * Validates IP settings fields.
+ *
+ * All conditionality — address requirements, gateway optionality, DNS
+ * activation — is resolved at call time based on the current form
+ * state, not encoded as cross-field rules at validation time.
+ */
+const validateIpFields = (fields: IpFormFields): FieldsValidationResult<IpFormFields> => ({
+  // TRANSLATORS: validation error for the IPv4 addresses field.
+  addresses4: validateAddresses(
+    fields.ipv4Mode,
+    fields.addresses4,
+    isValidIPv4Address,
+    _("At least one IPv4 address is required"),
+    _("Some IPv4 addresses are invalid"),
+  ),
+  // TRANSLATORS: validation error for the IPv4 gateway field.
+  gateway4: validateGateway(
+    fields.ipv4Mode,
+    fields.gateway4,
+    isValidIPv4,
+    _("IPv4 gateway is required"),
+    _("Invalid IPv4 gateway"),
+  ),
+  // TRANSLATORS: validation error for the IPv6 addresses field.
+  addresses6: validateAddresses(
+    fields.ipv6Mode,
+    fields.addresses6,
+    isValidIPv6Address,
+    _("At least one IPv6 address is required"),
+    _("Some IPv6 addresses are invalid"),
+  ),
+  // TRANSLATORS: validation error for the IPv6 gateway field.
+  gateway6: validateGateway(
+    fields.ipv6Mode,
+    fields.gateway6,
+    isValidIPv6,
+    _("IPv6 gateway is required"),
+    _("Invalid IPv6 gateway"),
+  ),
+  // DNS fields: only validated when the corresponding toggle is on.
+  nameservers: fields.customDns
+    ? // TRANSLATORS: validation error for the DNS servers field.
+      requiredValidList(
+        fields.nameservers,
+        isValidNameserver,
+        _("At least one DNS server is required"),
+        _("Some DNS server addresses are invalid"),
+      )
+    : undefined,
+  dnsSearchList: fields.customDnsSearch
+    ? // TRANSLATORS: validation error for the DNS search domains field.
+      requiredValidList(
+        fields.dnsSearchList,
+        isValidDNSSearchDomain,
+        _("At least one DNS search domain is required"),
+        _("Some DNS search domains are invalid"),
+      )
+    : undefined,
+});
+
+/**
+ * Validates bond-specific fields.
+ *
+ * Includes cross-field validation for the "primary" bond option, which is
+ * only valid in certain modes (ACTIVE_BACKUP, BALANCE_TLB, BALANCE_ALB).
+ * This rule depends on both bondMode and bondOptions, so it's evaluated
+ * at validation time and returned as a field error on bondOptions.
+ */
+const validateBondFields = (fields: BondFormFields): FieldsValidationResult<BondFormFields> => {
+  const { bondMode, bondOptions, bondPorts, bondIface } = fields;
+
+  const hasPrimaryOption = bondOptions.some((o) => o.startsWith("primary="));
+
+  const bondOptionsError = (() => {
+    if (!hasPrimaryOption) return undefined;
+    if (PRIMARY_BOND_OPTION_MODES.includes(bondMode)) return undefined;
+
+    const modeNames = PRIMARY_BOND_OPTION_MODES.map((m) => `'${m}'`);
+    // TRANSLATORS: validation error for the bond options field when the 'primary' option is used in an invalid mode.
+    // %s is replaced with a list of valid mode names.
+    return sprintf(_("The 'primary' option is only valid for %s modes"), formatList(modeNames));
+  })();
+
+  return {
+    // TRANSLATORS: validation error for the bond device name field.
+    bondIface: requiredString(bondIface, _("Device name is required")),
+    // TRANSLATORS: validation error for the bond mode name field.
+    bondMode: requiredString(bondMode, _("Bond mode is required")),
+    // TRANSLATORS: validation error for the bond ports field.
+    bondPorts: bondPorts.length === 0 ? _("At least one bond port is required") : undefined,
+    bondOptions: bondOptionsError,
+  };
+};
+
+/**
+ * Validates bridge-specific fields.
+ *
+ * STP fields are conditionally validated based on whether STP is enabled.
+ * When STP is disabled, those fields are not validated at all.
+ */
+const validateBridgeFields = (
+  fields: BridgeFormFields,
+): FieldsValidationResult<BridgeFormFields> => {
+  const stpEnabled = fields.bridgeStp === BridgeStpMode.ENABLED;
+
+  return {
+    // TRANSLATORS: validation error for the bridge device name field.
+    bridgeIface: requiredString(fields.bridgeIface, _("Device name is required")),
+    // TRANSLATORS: validation error for the bridge ports field.
+    bridgePorts:
+      fields.bridgePorts.length === 0 ? _("At least one bridge port is required") : undefined,
+    // STP fields only validated when STP is enabled.
+    ...(stpEnabled && {
+      // TRANSLATORS: validation error for the bridge priority field.
+      bridgePriority: optionalIntRange(
+        fields.bridgePriority,
+        0,
+        61440,
+        _("Priority must be between 0 and 61440"),
+      ),
+      // TRANSLATORS: validation error for the bridge forward delay field.
+      bridgeForwardDelay: optionalIntRange(
+        fields.bridgeForwardDelay,
+        4,
+        30,
+        _("Forward delay must be between 4 and 30 seconds"),
+      ),
+      // TRANSLATORS: validation error for the bridge hello time field.
+      bridgeHelloTime: optionalIntRange(
+        fields.bridgeHelloTime,
+        1,
+        10,
+        _("Hello time must be between 1 and 10 seconds"),
+      ),
+      // TRANSLATORS: validation error for the bridge max message age field.
+      bridgeMaxAge: optionalIntRange(
+        fields.bridgeMaxAge,
+        6,
+        40,
+        _("Max message age must be between 6 and 40 seconds"),
+      ),
+    }),
+  };
+};
+
+/**
+ * Validates VLAN-specific fields.
+ */
+const validateVlanFields = (fields: VlanFormFields): FieldsValidationResult<VlanFormFields> => {
+  return {
+    // TRANSLATORS: validation error for the VLAN device name field.
+    vlanIface: requiredString(fields.vlanIface, _("Device name is required")),
+    // TRANSLATORS: validation error for the VLAN ID field.
+    vlanId: requiredIntRange(
+      fields.vlanId,
+      0,
+      4094,
+      _("VLAN ID is required"),
+      _("VLAN ID must be between 0 and 4094"),
+    ),
+  };
+};
+
+/**
+ * Dispatches to the appropriate type-specific validator based on connection type.
+ * Returns an empty object for types with no extra validation (e.g. Ethernet).
+ */
+const validateTypeFields = (fields: FormFields): FieldsValidationResult<FormFields> => {
+  switch (fields.type) {
+    case CONNECTION_TYPE.BOND:
+      return validateBondFields(fields);
+    case CONNECTION_TYPE.BRIDGE:
+      return validateBridgeFields(fields);
+    case CONNECTION_TYPE.VLAN:
+      return validateVlanFields(fields);
+    default:
+      return {};
+  }
+};
+
+/**
+ * Validates the form values for the active connection type.
+ *
+ * Designed for TanStack Form's validators. Returns undefined when valid
+ * (TanStack Form convention), or a field-error map on failure.
+ *
+ * Composition:
+ * - Common and IP validators run for all connection types
+ * - Bond/Bridge validators run only for their respective types
+ * - Cross-field validation (e.g., bond primary option) is handled within
+ *   the type-specific validators and returned as field errors
+ *
+ * Field errors are collected by merging all validator outputs and
+ * stripping undefined values.
+ */
+export const validate = (fields: FormFields): ValidationResult<FormFields> => {
+  const fieldErrors = shake({
+    ...validateCommonFields(fields),
+    ...validateIpFields(fields),
+    ...validateTypeFields(fields),
+  });
+
+  return Object.keys(fieldErrors).length > 0 ? { fields: fieldErrors } : undefined;
+};


### PR DESCRIPTION
Bring network/connection-form up to the structure used by the storage forms: split data mapping into transformations.ts (buildPayload, toFormValues), validation into validations.ts, and data hooks into queries.ts, leaving fields.ts as the fields definition.
    
Form.tsx now uses withFrozenQuery to freeze initial data and useFormSubmit for the submit lifecycle, unifying the new and edit paths into a single content component.
    
Add unit tests for the extracted transformations and validations modules.Form.test.tsx keeps one representative validation case per connection type and points to validations.test.ts for the exhaustive coverage.

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>