### PR TITLE
refactor(web): make progress-tracking query waits explicit per page

### DIFF
--- a/rust/agama-iscsi/src/monitor.rs
+++ b/rust/agama-iscsi/src/monitor.rs
@@ -18,9 +18,7 @@
 // To contact SUSE LLC about this file by physical or electronic mail, you may
 // find current contact information at www.suse.com.
 
-use crate::storage_client::proxies::{
-    ISCSIProxy, ProgressChanged, ProgressFinished, SystemChanged,
-};
+use crate::storage_client::proxies::{iscsi, ISCSIProxy};
 use agama_utils::{
     actor::Handler,
     api::{
@@ -32,7 +30,7 @@ use agama_utils::{
 use serde::Deserialize;
 use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
-use zbus::{message, Connection, MatchRule, MessageStream};
+use zbus::{fdo::PropertiesChanged, message, Connection, MatchRule, MessageStream};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -42,6 +40,8 @@ pub enum Error {
     Event(#[from] broadcast::error::SendError<Event>),
     #[error(transparent)]
     DBus(#[from] zbus::Error),
+    #[error(transparent)]
+    DBusConversion(#[from] zbus::zvariant::Error),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 }
@@ -91,20 +91,21 @@ impl Monitor {
             .msg_type(message::Type::Signal)
             .sender(proxy.inner().destination())?
             .path(proxy.inner().path())?
-            .interface(proxy.inner().interface())?
             .build();
         let mut stream = MessageStream::for_match_rule(rule, &self.connection, None).await?;
 
-        while let Some(Ok(message)) = stream.next().await {
-            if let Some(signal) = SystemChanged::from_message(message.clone()) {
-                self.handle_system_changed(signal)?;
+        while let Some(message) = stream.next().await {
+            let message = message?;
+
+            if let Some(signal) = PropertiesChanged::from_message(message.clone()) {
+                self.handle_properties_changed(signal)?;
                 continue;
             }
-            if let Some(signal) = ProgressChanged::from_message(message.clone()) {
+            if let Some(signal) = iscsi::ProgressChanged::from_message(message.clone()) {
                 self.handle_progress_changed(signal).await?;
                 continue;
             }
-            if let Some(signal) = ProgressFinished::from_message(message.clone()) {
+            if let Some(signal) = iscsi::ProgressFinished::from_message(message.clone()) {
                 self.handle_progress_finished(signal).await?;
                 continue;
             }
@@ -114,14 +115,17 @@ impl Monitor {
         Ok(())
     }
 
-    fn handle_system_changed(&self, _signal: SystemChanged) -> Result<(), Error> {
-        self.events.send(Event::SystemChanged {
-            scope: Scope::ISCSI,
-        })?;
+    fn handle_properties_changed(&self, signal: PropertiesChanged) -> Result<(), Error> {
+        let args = signal.args()?;
+        if args.changed_properties().get("System").is_some() {
+            self.events.send(Event::SystemChanged {
+                scope: Scope::ISCSI,
+            })?;
+        }
         Ok(())
     }
 
-    async fn handle_progress_changed(&self, signal: ProgressChanged) -> Result<(), Error> {
+    async fn handle_progress_changed(&self, signal: iscsi::ProgressChanged) -> Result<(), Error> {
         let args = signal.args()?;
         let progress_data = serde_json::from_str::<ProgressData>(args.serialized_progress)?;
         self.progress
@@ -130,7 +134,10 @@ impl Monitor {
         Ok(())
     }
 
-    async fn handle_progress_finished(&self, _signal: ProgressFinished) -> Result<(), Error> {
+    async fn handle_progress_finished(
+        &self,
+        _signal: iscsi::ProgressFinished,
+    ) -> Result<(), Error> {
         self.progress
             .call(progress::message::Finish::new(Scope::ISCSI))
             .await?;

--- a/rust/agama-s390/src/dasd/monitor.rs
+++ b/rust/agama-s390/src/dasd/monitor.rs
@@ -32,7 +32,7 @@ use serde::Deserialize;
 use serde_json;
 use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
-use zbus::{message, Connection, MatchRule, MessageStream};
+use zbus::{fdo::PropertiesChanged, message, Connection, MatchRule, MessageStream};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -42,6 +42,8 @@ pub enum Error {
     Event(#[from] broadcast::error::SendError<Event>),
     #[error(transparent)]
     DBus(#[from] zbus::Error),
+    #[error(transparent)]
+    DBusConversion(#[from] zbus::zvariant::Error),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 }
@@ -91,15 +93,14 @@ impl Monitor {
             .msg_type(message::Type::Signal)
             .sender(proxy.inner().destination())?
             .path(proxy.inner().path())?
-            .interface(proxy.inner().interface())?
             .build();
         let mut stream = MessageStream::for_match_rule(rule, &self.connection, None).await?;
 
         while let Some(message) = stream.next().await {
             let message = message?;
 
-            if let Some(signal) = dasd::SystemChanged::from_message(message.clone()) {
-                self.handle_system_changed(signal)?;
+            if let Some(signal) = PropertiesChanged::from_message(message.clone()) {
+                self.handle_properties_changed(signal)?;
                 continue;
             }
             if let Some(signal) = dasd::ProgressChanged::from_message(message.clone()) {
@@ -124,12 +125,6 @@ impl Monitor {
         Ok(())
     }
 
-    fn handle_system_changed(&self, _signal: dasd::SystemChanged) -> Result<(), Error> {
-        self.events
-            .send(Event::SystemChanged { scope: Scope::DASD })?;
-        Ok(())
-    }
-
     async fn handle_progress_changed(&self, signal: dasd::ProgressChanged) -> Result<(), Error> {
         let args = signal.args()?;
         let progress_data = serde_json::from_str::<ProgressData>(args.progress)?;
@@ -143,6 +138,15 @@ impl Monitor {
         self.progress
             .call(progress::message::Finish::new(Scope::DASD))
             .await?;
+        Ok(())
+    }
+
+    fn handle_properties_changed(&self, signal: PropertiesChanged) -> Result<(), Error> {
+        let args = signal.args()?;
+        if args.changed_properties().get("System").is_some() {
+            self.events
+                .send(Event::SystemChanged { scope: Scope::DASD })?;
+        }
         Ok(())
     }
 

--- a/rust/agama-storage-client/src/proxies.rs
+++ b/rust/agama-storage-client/src/proxies.rs
@@ -24,8 +24,8 @@ pub use storage1::Storage1Proxy;
 mod bootloader;
 pub use bootloader::BootloaderProxy;
 
-mod iscsi;
-pub use iscsi::{ISCSIProxy, ProgressChanged, ProgressFinished, SystemChanged};
+pub mod iscsi;
+pub use iscsi::ISCSIProxy;
 
 pub mod dasd;
 pub use dasd::DASDProxy;

--- a/rust/agama-storage-client/src/proxies/dasd.rs
+++ b/rust/agama-storage-client/src/proxies/dasd.rs
@@ -32,14 +32,13 @@ pub trait DASD {
     /// Probe method
     fn probe(&self) -> zbus::Result<()>;
 
+    /// System property
+    #[zbus(property)]
+    fn system(&self) -> zbus::Result<String>;
+
     /// Config property
     #[zbus(property)]
     fn config(&self) -> zbus::Result<String>;
-
-    /// System property
-    /// Temporary rename to avoid clashing with the system_changed signal.
-    #[zbus(property, name = "System")]
-    fn dasd_system(&self) -> zbus::Result<String>;
 
     /// SetConfig method
     fn set_config(&self, serialized_config: &str) -> zbus::Result<()>;
@@ -51,10 +50,6 @@ pub trait DASD {
     /// FormatFinished signal
     #[zbus(signal)]
     fn format_finished(&self, status: &str) -> zbus::Result<()>;
-
-    /// SystemChanged signal
-    #[zbus(signal)]
-    fn system_changed(&self, system: &str) -> zbus::Result<()>;
 
     /// ProgressChanged signal
     #[zbus(signal)]

--- a/rust/agama-storage-client/src/proxies/iscsi.rs
+++ b/rust/agama-storage-client/src/proxies/iscsi.rs
@@ -40,16 +40,11 @@ pub trait ISCSI {
     #[zbus(signal)]
     fn progress_finished(&self) -> zbus::Result<()>;
 
-    /// SystemChanged signal
-    #[zbus(signal)]
-    fn system_changed(&self, serialized_system: &str) -> zbus::Result<()>;
-
     /// Config property
     #[zbus(property)]
     fn config(&self) -> zbus::Result<String>;
 
     /// System property
-    /// Temporary rename to avoid clashing with the system_changed signal.
-    #[zbus(property, name = "System")]
-    fn iscsi_system(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn system(&self) -> zbus::Result<String>;
 }

--- a/rust/agama-storage-client/src/service.rs
+++ b/rust/agama-storage-client/src/service.rs
@@ -344,7 +344,7 @@ impl MessageHandler<message::iscsi::GetSystem> for Service {
         &mut self,
         _message: message::iscsi::GetSystem,
     ) -> Result<Option<serde_json::Value>, Error> {
-        let raw_json = self.iscsi_proxy.iscsi_system().await?;
+        let raw_json = self.iscsi_proxy.system().await?;
         Ok(try_from_string(&raw_json)?)
     }
 }

--- a/rust/agama-storage-client/src/service.rs
+++ b/rust/agama-storage-client/src/service.rs
@@ -397,7 +397,7 @@ impl MessageHandler<message::dasd::GetSystem> for Service {
         _message: message::dasd::GetSystem,
     ) -> Result<Option<serde_json::Value>, Error> {
         if let Some(proxy) = &self.dasd_proxy {
-            let raw_json = proxy.dasd_system().await?;
+            let raw_json = proxy.system().await?;
             Ok(try_from_string(&raw_json)?)
         } else {
             Ok(None)

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 30 14:43:50 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Adapt iSCSI, DASD and zFCP monitors to the changes in the D-Bus
+  API (needed for bsc#1269224).
+
+-------------------------------------------------------------------
 Fri Jun 26 10:21:40 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Remove the translations from the Product's SystemInfo

--- a/service/lib/agama/dbus/storage/dasd.rb
+++ b/service/lib/agama/dbus/storage/dasd.rb
@@ -54,7 +54,6 @@ module Agama
           dbus_method(:SetConfig, "in serialized_config:s") do |serialized_config|
             configure(serialized_config)
           end
-          dbus_signal(:SystemChanged, "serialized_system:s")
           dbus_signal(:ProgressChanged, "serialized_progress:s")
           dbus_signal(:ProgressFinished)
           dbus_signal(:FormatChanged, "serialized_summary:s")
@@ -88,6 +87,21 @@ module Agama
           start_progress(1, _("Configuring DASD"))
           manager.configure(config_json)
 
+          # The "return if unchanged" guard has been removed from the methods below to always
+          # emit the corresponding signal.
+          #
+          # Since signals do not carry payloads yet, the UI cannot update the query cache
+          # directly and must refetch after receiving the signal. Without emitting the signal,
+          # the related queries are never invalidated and never refetched, leaving the progress
+          # overlay blocked indefinitely.
+          #
+          # The overlay intentionally waits until fresh data arrives before unblocking, since
+          # data can take time to appear after progress completes. Dismissing it
+          # earlier would cause flickering and leave users able to interact with stale data.
+          #
+          # It can be reverted (and UI progress adapted accordingly) when signals carry payloads
+          # that allow the UI to update the cache directly, removing the need to wait for a
+          # refetch as part of progress completion.
           update_serialized_system
           update_serialized_config
 
@@ -113,17 +127,16 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          return if self.serialized_system == serialized_system
+          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
-          self.SystemChanged(serialized_system)
         end
 
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          return if self.serialized_config == serialized_config
+          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config

--- a/service/lib/agama/dbus/storage/dasd.rb
+++ b/service/lib/agama/dbus/storage/dasd.rb
@@ -127,7 +127,6 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
@@ -136,7 +135,6 @@ module Agama
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config

--- a/service/lib/agama/dbus/storage/iscsi.rb
+++ b/service/lib/agama/dbus/storage/iscsi.rb
@@ -56,7 +56,6 @@ module Agama
           dbus_method(:Discover, "in serialized_options:s, out result:u") do |serialized_options|
             discover(serialized_options)
           end
-          dbus_signal(:SystemChanged, "serialized_system:s")
           dbus_signal(:ProgressChanged, "serialized_progress:s")
           dbus_signal(:ProgressFinished)
         end
@@ -79,6 +78,22 @@ module Agama
 
           start_progress(1, _("Configuring iSCSI"))
           manager.configure(config_json)
+
+          # The "return if unchanged" guard has been removed from the methods below to always
+          # emit the corresponding signal.
+          #
+          # Since signals do not carry payloads yet, the UI cannot update the query cache
+          # directly and must refetch after receiving the signal. Without emitting the signal,
+          # the related queries are never invalidated and never refetched, leaving the progress
+          # overlay blocked indefinitely.
+          #
+          # The overlay intentionally waits until fresh data arrives before unblocking, since
+          # data can take time to appear after progress completes. Dismissing it
+          # earlier would cause flickering and leave users able to interact with stale data.
+          #
+          # It can be reverted (and UI progress adapted accordingly) when signals carry payloads
+          # that allow the UI to update the cache directly, removing the need to wait for a
+          # refetch as part of progress completion.
           update_serialized_system
           update_serialized_config
           finish_progress
@@ -123,17 +138,16 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          return if self.serialized_system == serialized_system
+          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
-          self.SystemChanged(serialized_system)
         end
 
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          return if self.serialized_config == serialized_config
+          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config

--- a/service/lib/agama/dbus/storage/iscsi.rb
+++ b/service/lib/agama/dbus/storage/iscsi.rb
@@ -138,7 +138,6 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
@@ -147,7 +146,6 @@ module Agama
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -334,7 +334,6 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
@@ -344,7 +343,6 @@ module Agama
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config
@@ -353,7 +351,6 @@ module Agama
         # Updates the config model info if needed.
         def update_serialized_config_model
           serialized_config_model = serialize_config_model
-          # return if self.serialized_config_model == serialized_config_model
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config_model = serialized_config_model
@@ -362,7 +359,6 @@ module Agama
         # Updates the proposal info if needed.
         def update_serialized_proposal
           serialized_proposal = serialize_proposal
-          # return if self.serialized_proposal == serialized_proposal
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_proposal = serialized_proposal
@@ -372,7 +368,6 @@ module Agama
         # Updates the issues info if needed.
         def update_serialized_issues
           serialized_issues = serialize_issues
-          # return if self.serialized_issues == serialized_issues
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_issues = serialized_issues
@@ -381,7 +376,6 @@ module Agama
         # Updates the resolvables info if needed.
         def update_serialized_resolvables
           serialized_resolvables = serialize_storage_resolvables
-          # return if self.serialized_resolvables == serialized_resolvables
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_resolvables = serialized_resolvables

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -89,8 +89,6 @@ module Agama
           dbus_method(
             :SolveConfigModel, "in serialized_model:s, out result:s"
           ) { |m| solve_config_model(m) }
-          dbus_signal(:SystemChanged, "serialized_system:s")
-          dbus_signal(:ProposalChanged, "serialized_proposal:s")
           dbus_signal(:ProgressChanged, "serialized_progress:s")
           dbus_signal(:ProgressFinished)
         end
@@ -337,7 +335,6 @@ module Agama
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
-          self.SystemChanged(serialized_system)
         end
 
         # Updates the config info if needed.
@@ -362,7 +359,6 @@ module Agama
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_proposal = serialized_proposal
-          self.ProposalChanged(serialized_proposal)
         end
 
         # Updates the issues info if needed.

--- a/service/lib/agama/dbus/storage/zfcp.rb
+++ b/service/lib/agama/dbus/storage/zfcp.rb
@@ -128,6 +128,22 @@ module Agama
         # @param config_json [Hash]
         def perform_configuration(config_json)
           manager.configure(config_json)
+
+          # The "return if unchanged" guard has been removed from the methods below to always
+          # emit the corresponding signal.
+          #
+          # Since signals do not carry payloads yet, the UI cannot update the query cache
+          # directly and must refetch after receiving the signal. Without emitting the signal,
+          # the related queries are never invalidated and never refetched, leaving the progress
+          # overlay blocked indefinitely.
+          #
+          # The overlay intentionally waits until fresh data arrives before unblocking, since
+          # data can take time to appear after progress completes. Dismissing it
+          # earlier would cause flickering and leave users able to interact with stale data.
+          #
+          # It can be reverted (and UI progress adapted accordingly) when signals carry payloads
+          # that allow the UI to update the cache directly, removing the need to wait for a
+          # refetch as part of progress completion.
           update_serialized_system
           update_serialized_config
           update_serialized_issues
@@ -143,7 +159,7 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          return if self.serialized_system == serialized_system
+          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
@@ -152,7 +168,7 @@ module Agama
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          return if self.serialized_config == serialized_config
+          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config
@@ -161,7 +177,7 @@ module Agama
         # Updates the issues info if needed.
         def update_serialized_issues
           serialized_issues = serialize_issues
-          return if self.serialized_issues == serialized_issues
+          # return if self.serialized_issues == serialized_issues
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_issues = serialized_issues

--- a/service/lib/agama/dbus/storage/zfcp.rb
+++ b/service/lib/agama/dbus/storage/zfcp.rb
@@ -159,7 +159,6 @@ module Agama
         # Updates the system info if needed.
         def update_serialized_system
           serialized_system = serialize_system
-          # return if self.serialized_system == serialized_system
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_system = serialized_system
@@ -168,7 +167,6 @@ module Agama
         # Updates the config info if needed.
         def update_serialized_config
           serialized_config = serialize_config
-          # return if self.serialized_config == serialized_config
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_config = serialized_config
@@ -177,7 +175,6 @@ module Agama
         # Updates the issues info if needed.
         def update_serialized_issues
           serialized_issues = serialize_issues
-          # return if self.serialized_issues == serialized_issues
 
           # This assignment emits a D-Bus PropertiesChanged.
           self.serialized_issues = serialized_issues

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 30 14:40:25 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Always emit signals for iSCSI, DASD and zFCP (needed for
+  bsc#1269224).
+- Remove unnecessary custom SystemChanged signal.
+
+-------------------------------------------------------------------
 Tue Jun 23 11:48:47 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Do not take zypp lock (bsc#1268344).

--- a/service/test/agama/dbus/storage/dasd_test.rb
+++ b/service/test/agama/dbus/storage/dasd_test.rb
@@ -35,7 +35,7 @@ RSpec.describe Agama::DBus::Storage::DASD do
     allow(manager).to receive(:on_format_finish)
     allow(manager).to receive(:probe)
     allow(manager).to receive(:devices).and_return([])
-    allow(manager).to receive(:config_json).and_return(nil.to_json)
+    allow(manager).to receive(:config_json).and_return(nil)
     allow(manager).to receive(:probed?).and_return(true)
   end
 
@@ -47,9 +47,8 @@ RSpec.describe Agama::DBus::Storage::DASD do
     end
 
     it "probes for devices" do
-      expect(subject).to receive(:ProgressChanged).ordered
+      expect(subject).to receive(:ProgressChanged).with(kind_of(String)).ordered
       expect(manager).to receive(:probe).ordered
-      expect(subject).to receive(:SystemChanged).ordered
       expect(subject).to receive(:ProgressFinished).ordered
       subject.probe
     end
@@ -161,10 +160,9 @@ RSpec.describe Agama::DBus::Storage::DASD do
       end
 
       it "performs the configuration" do
-        expect(subject).to receive(:SystemChanged)
-        expect(subject).to receive(:ProgressChanged)
-        expect(subject).to receive(:ProgressFinished)
+        expect(subject).to receive(:ProgressChanged).with(kind_of(String))
         expect(manager).to receive(:configure).with(config_json)
+        expect(subject).to receive(:ProgressFinished)
 
         subject.configure(serialized_config)
       end

--- a/service/test/agama/dbus/storage/iscsi_test.rb
+++ b/service/test/agama/dbus/storage/iscsi_test.rb
@@ -201,7 +201,6 @@ describe Agama::DBus::Storage::ISCSI do
 
   describe "#configure" do
     before do
-      allow(subject).to receive(:SystemChanged)
       allow(subject).to receive(:ProgressChanged)
       allow(subject).to receive(:ProgressFinished)
     end
@@ -225,7 +224,6 @@ describe Agama::DBus::Storage::ISCSI do
 
       it "does not configure iSCSI" do
         expect(manager).to_not receive(:configure)
-        expect(subject).to_not receive(:SystemChanged)
         expect(subject).to_not receive(:ProgressChanged)
         expect(subject).to_not receive(:ProgressFinished)
         subject.configure(serialized_config)
@@ -241,7 +239,6 @@ describe Agama::DBus::Storage::ISCSI do
 
       it "does not configure iSCSI" do
         expect(manager).to_not receive(:configure)
-        expect(subject).to_not receive(:SystemChanged)
         expect(subject).to_not receive(:ProgressChanged)
         expect(subject).to_not receive(:ProgressFinished)
         subject.configure(serialized_config)
@@ -255,48 +252,19 @@ describe Agama::DBus::Storage::ISCSI do
         allow(manager).to receive(:configured?).with(config_json).and_return(false)
       end
 
-      it "tries to configure iSCSI" do
+      it "configures iSCSI and emits progress signals" do
         expect(subject).to receive(:ProgressChanged).ordered
         expect(manager).to receive(:configure).with(config_json).ordered
         expect(subject).to receive(:ProgressFinished).ordered
         subject.configure(serialized_config)
-      end
-
-      context "and the system is modified" do
-        before do
-          expect(manager).to receive(:configure).with(config_json).and_return(true)
-          # Set serialized system to null in order to check if the signal is emitted when the system
-          # changes.
-          subject.serialized_system = nil.to_json
-        end
-
-        it "emits SystemChanged signal" do
-          expect(subject).to receive(:SystemChanged)
-          subject.configure(serialized_config)
-        end
-      end
-
-      context "and the system is not modified" do
-        before do
-          expect(manager).to receive(:configure).with(config_json).and_return(false)
-        end
-
-        it "does not emit SystemChanged signal" do
-          expect(subject).to_not receive(:SystemChanged)
-          subject.configure(serialized_config)
-        end
       end
     end
   end
 
   describe "#discover" do
     before do
-      allow(subject).to receive(:SystemChanged)
       allow(subject).to receive(:ProgressChanged)
       allow(subject).to receive(:ProgressFinished)
-      # Set serialized system to null in order to check if the signal is emitted when the system
-      # changes.
-      subject.serialized_system = nil.to_json
     end
 
     let(:options_json) do
@@ -310,8 +278,7 @@ describe Agama::DBus::Storage::ISCSI do
       }
     end
 
-    it "performs iSCSI discovery" do
-      expect(subject).to receive(:SystemChanged)
+    it "performs iSCSI discovery and emits progress signals" do
       expect(subject).to receive(:ProgressChanged)
       expect(subject).to receive(:ProgressFinished)
       expect(manager).to receive(:discover) do |address, port, credentials:|

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -479,8 +479,6 @@ describe Agama::DBus::Storage::Manager do
 
   describe "#configure" do
     before do
-      allow(subject).to receive(:ProposalChanged)
-      allow(subject).to receive(:SystemChanged)
       allow(subject).to receive(:ProgressChanged)
       allow(subject).to receive(:ProgressFinished)
 
@@ -505,34 +503,6 @@ describe Agama::DBus::Storage::Manager do
 
     let(:serialized_product) { config_data.to_json }
     let(:serialized_config) { config_json.to_json }
-
-    RSpec.shared_examples "emit SystemChanged" do
-      it "emits the signal SystemChanged" do
-        expect(subject).to receive(:SystemChanged)
-        subject.configure(serialized_product, serialized_config)
-      end
-    end
-
-    RSpec.shared_examples "do not emit SystemChanged" do
-      it "does not emit the signal SystemChanged" do
-        expect(subject).to_not receive(:SystemChanged)
-        subject.configure(serialized_product, serialized_config)
-      end
-    end
-
-    RSpec.shared_examples "emit ProposalChanged" do
-      it "emits the signal ProposalChanged" do
-        expect(subject).to receive(:ProposalChanged)
-        subject.configure(serialized_product, serialized_config)
-      end
-    end
-
-    RSpec.shared_examples "do not emit ProposalChanged" do
-      it "does not emit the signal ProposalChanged" do
-        expect(subject).to_not receive(:ProposalChanged)
-        subject.configure(serialized_product, serialized_config)
-      end
-    end
 
     RSpec.shared_examples "emit ProgressChanged and ProgressFinished" do
       it "emits signals ProgressChanged and ProgressFinished" do
@@ -597,7 +567,6 @@ describe Agama::DBus::Storage::Manager do
       end
 
       include_examples "emit ProgressChanged and ProgressFinished"
-      include_examples "emit ProposalChanged"
     end
 
     RSpec.shared_examples "do not calculate proposal" do
@@ -607,7 +576,6 @@ describe Agama::DBus::Storage::Manager do
       end
 
       include_examples "do not emit ProgressChanged and ProgressFinished"
-      include_examples "do not emit ProposalChanged"
     end
 
     context "if no storage configuration is given" do
@@ -639,7 +607,6 @@ describe Agama::DBus::Storage::Manager do
           context "and the storage configuration has not changed" do
             include_examples "do not activate or probe"
             include_examples "update product configuration", ["/", "swap"]
-            include_examples "emit SystemChanged"
             include_examples "calculate proposal"
           end
 
@@ -650,7 +617,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "do not activate or probe"
             include_examples "update product configuration", ["/", "swap"]
-            include_examples "emit SystemChanged"
             include_examples "calculate proposal"
           end
         end
@@ -659,7 +625,6 @@ describe Agama::DBus::Storage::Manager do
           context "and the storage configuration has not changed" do
             include_examples "do not activate or probe"
             include_examples "do not update product configuration"
-            include_examples "do not emit SystemChanged"
             include_examples "do not calculate proposal"
           end
 
@@ -670,7 +635,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "do not activate or probe"
             include_examples "do not update product configuration"
-            include_examples "emit SystemChanged"
             include_examples "calculate proposal"
           end
         end
@@ -696,7 +660,6 @@ describe Agama::DBus::Storage::Manager do
           context "and the storage configuration has not changed" do
             include_examples "activate and probe"
             include_examples "update product configuration", ["/", "swap"]
-            include_examples "emit SystemChanged"
             include_examples "calculate proposal"
           end
 
@@ -707,7 +670,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "activate and probe"
             include_examples "update product configuration", ["/", "swap"]
-            include_examples "emit SystemChanged"
             include_examples "calculate proposal"
           end
         end
@@ -716,7 +678,6 @@ describe Agama::DBus::Storage::Manager do
           context "and the storage configuration has not changed" do
             include_examples "do not activate or probe"
             include_examples "do not update product configuration"
-            include_examples "do not emit SystemChanged"
             include_examples "do not calculate proposal"
           end
 
@@ -727,7 +688,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "activate and probe"
             include_examples "do not update product configuration"
-            include_examples "emit SystemChanged"
             include_examples "calculate proposal"
           end
         end
@@ -778,7 +738,6 @@ describe Agama::DBus::Storage::Manager do
         end
 
         include_examples "emit ProgressChanged and ProgressFinished"
-        include_examples "emit ProposalChanged"
 
         context "if the serialized config contains legacy AutoYaST settings" do
           let(:config_hash) do
@@ -798,7 +757,6 @@ describe Agama::DBus::Storage::Manager do
           end
 
           include_examples "emit ProgressChanged and ProgressFinished"
-          include_examples "emit ProposalChanged"
         end
       end
 
@@ -823,7 +781,6 @@ describe Agama::DBus::Storage::Manager do
 
           include_examples "do not activate or probe"
           include_examples "update product configuration", ["/", "swap"]
-          include_examples "emit SystemChanged"
           include_examples "calculate new proposal"
         end
 
@@ -835,7 +792,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "do not activate or probe"
             include_examples "do not update product configuration"
-            include_examples "do not emit SystemChanged"
             include_examples "do not calculate proposal"
           end
 
@@ -846,7 +802,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "do not activate or probe"
             include_examples "do not update product configuration"
-            include_examples "emit SystemChanged"
             include_examples "calculate new proposal"
           end
         end
@@ -871,7 +826,6 @@ describe Agama::DBus::Storage::Manager do
 
           include_examples "activate and probe"
           include_examples "update product configuration", ["/", "swap"]
-          include_examples "emit SystemChanged"
           include_examples "calculate new proposal"
         end
 
@@ -883,7 +837,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "do not activate or probe"
             include_examples "do not update product configuration"
-            include_examples "do not emit SystemChanged"
             include_examples "do not calculate proposal"
           end
 
@@ -894,7 +847,6 @@ describe Agama::DBus::Storage::Manager do
 
             include_examples "activate and probe"
             include_examples "do not update product configuration"
-            include_examples "emit SystemChanged"
             include_examples "calculate new proposal"
           end
         end
@@ -1144,8 +1096,6 @@ describe Agama::DBus::Storage::Manager do
 
   describe "#probe" do
     before do
-      allow(subject).to receive(:SystemChanged)
-      allow(subject).to receive(:ProposalChanged)
       allow(subject).to receive(:ProgressChanged)
       allow(subject).to receive(:ProgressFinished)
 
@@ -1190,14 +1140,7 @@ describe Agama::DBus::Storage::Manager do
         subject.probe
       end
 
-      it "emits signals for ProposalChanged, SystemChanged, ProgressChanged and ProgressFinished" do
-        expect(subject).to receive(:SystemChanged) do |system_str|
-          system = parse(system_str)
-          device = system[:devices].first
-          expect(device[:name]).to eq "/dev/sda"
-          expect(system[:availableDrives]).to eq [device[:sid]]
-        end
-        expect(subject).to receive(:ProposalChanged)
+      it "emits signals for ProgressChanged and ProgressFinished" do
         expect(subject).to receive(:ProgressChanged).with(/storage configuration/i)
         expect(subject).to receive(:ProgressFinished)
         subject.probe
@@ -1208,7 +1151,6 @@ describe Agama::DBus::Storage::Manager do
       before do
         allow(proposal).to receive(:storage_json).and_return config_json
         allow(backend).to receive(:config_json).and_return config_json
-        allow(subject).to receive(:ProposalChanged)
       end
 
       let(:config_json) do
@@ -1236,18 +1178,7 @@ describe Agama::DBus::Storage::Manager do
         subject.probe
       end
 
-      it "emits signals for ProposalChanged, SystemChanged, ProgressChanged and ProgressFinished" do
-        expect(subject).to receive(:SystemChanged) do |system_str|
-          system = parse(system_str)
-          device = system[:devices].first
-          expect(device[:name]).to eq "/dev/sda"
-          expect(system[:availableDrives]).to eq [device[:sid]]
-        end
-        expect(subject).to receive(:ProposalChanged) do |proposal_str|
-          proposal = parse(proposal_str)
-          expect(proposal[:devices]).to be_a Array
-          expect(proposal[:actions]).to be_a Array
-        end
+      it "emits signals for ProgressChanged and ProgressFinished" do
         expect(subject).to receive(:ProgressChanged).with(/storage configuration/i)
         expect(subject).to receive(:ProgressFinished)
 

--- a/service/test/agama/dbus/storage/zfcp_test.rb
+++ b/service/test/agama/dbus/storage/zfcp_test.rb
@@ -166,7 +166,7 @@ RSpec.describe Agama::DBus::Storage::ZFCP do
   describe "#probe" do
     it "probes the manager and emits signals" do
       expect(subject).to receive(:ProgressChanged).ordered
-      expect(manager).to receive(:probe)
+      expect(manager).to receive(:probe).ordered
       expect(subject).to receive(:ProgressChanged).ordered
       expect(subject).to receive(:ProgressFinished).ordered
       subject.probe
@@ -174,6 +174,14 @@ RSpec.describe Agama::DBus::Storage::ZFCP do
 
     it "configures with the current config" do
       expect(manager).to receive(:configure).with(config_json)
+      subject.probe
+    end
+
+    it "always emits property changes after configuration" do
+      allow(manager).to receive(:configure)
+      expect(subject).to receive(:serialized_system=).at_least(:once).and_call_original
+      expect(subject).to receive(:serialized_config=).at_least(:once).and_call_original
+      expect(subject).to receive(:serialized_issues=).at_least(:once).and_call_original
       subject.probe
     end
 
@@ -208,6 +216,14 @@ RSpec.describe Agama::DBus::Storage::ZFCP do
       expect(subject).to receive(:ProgressChanged).ordered
       expect(manager).to receive(:configure).with(config_json).ordered
       expect(subject).to receive(:ProgressFinished).ordered
+      subject.configure(JSON.generate(config_json))
+    end
+
+    it "always emits property changes after configuration" do
+      allow(manager).to receive(:configure)
+      expect(subject).to receive(:serialized_system=).and_call_original
+      expect(subject).to receive(:serialized_config=).and_call_original
+      expect(subject).to receive(:serialized_issues=).and_call_original
       subject.configure(JSON.generate(config_json))
     end
 

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 30 14:37:09 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Make pages to wait for an explicit set of queries (needed for
+  bsc#1269224).
+
+-------------------------------------------------------------------
 Sun Jun 28 21:50:40 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Polish the keyboard focus ring and assorted UI rough edges (control

--- a/web/src/components/core/Page.tsx
+++ b/web/src/components/core/Page.tsx
@@ -456,7 +456,13 @@ const StandardLayout = ({
  * @example
  * Page with progress tracking
  * ```tsx
- * <Page title="Software" progress={{ scope: "software" }}>
+ * <Page
+ *   title="Software"
+ *   progress={{
+ *     scope: "software",
+ *     waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]
+ *   }}
+ * >
  *   <Page.Section>
  *     <PatternSelector />
  *   </Page.Section>

--- a/web/src/components/core/Page.tsx
+++ b/web/src/components/core/Page.tsx
@@ -460,7 +460,7 @@ const StandardLayout = ({
  *   title="Software"
  *   progress={{
  *     scope: "software",
- *     awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]
+ *     awaitQueriesRefetch: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]
  *   }}
  * >
  *   <Page.Section>

--- a/web/src/components/core/Page.tsx
+++ b/web/src/components/core/Page.tsx
@@ -460,7 +460,7 @@ const StandardLayout = ({
  *   title="Software"
  *   progress={{
  *     scope: "software",
- *     waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]
+ *     awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]
  *   }}
  * >
  *   <Page.Section>

--- a/web/src/components/core/ProgressBackdrop.test.tsx
+++ b/web/src/components/core/ProgressBackdrop.test.tsx
@@ -227,7 +227,7 @@ describe("ProgressBackdrop", () => {
   });
 
   describe("query keys refetch tracking", () => {
-    it("uses empty array when no waitFor provided", () => {
+    it("uses empty array when no awaitFreshQueries provided", () => {
       mockProgresses([
         {
           scope: "software",
@@ -243,7 +243,7 @@ describe("ProgressBackdrop", () => {
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith([], expect.any(Function));
     });
 
-    it("tracks specified query keys when waitFor is provided", () => {
+    it("tracks specified query keys when awaitFreshQueries is provided", () => {
       mockProgresses([
         {
           scope: "storage",
@@ -254,7 +254,9 @@ describe("ProgressBackdrop", () => {
         },
       ]);
 
-      installerRender(<ProgressBackdrop scope="storage" waitFor={["proposal", "storageModel"]} />);
+      installerRender(
+        <ProgressBackdrop scope="storage" awaitFreshQueries={["proposal", "storageModel"]} />,
+      );
 
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
         ["proposal", "storageModel"],
@@ -274,7 +276,10 @@ describe("ProgressBackdrop", () => {
       ]);
 
       installerRender(
-        <ProgressBackdrop scope="network" waitFor={["system", "config", "connections"]} />,
+        <ProgressBackdrop
+          scope="network"
+          awaitFreshQueries={["system", "config", "connections"]}
+        />,
       );
 
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
@@ -296,14 +301,14 @@ describe("ProgressBackdrop", () => {
       ]);
 
       const { rerender } = installerRender(
-        <ProgressBackdrop scope="storage" waitFor={["storageModel"]} />,
+        <ProgressBackdrop scope="storage" awaitFreshQueries={["storageModel"]} />,
       );
 
       // Progress finishes
       mockProgresses([]);
 
-      rerender(<ProgressBackdrop scope="storage" waitFor={["storageModel"]} />);
-      rerender(<ProgressBackdrop scope="storage" waitFor={["storageModel"]} />);
+      rerender(<ProgressBackdrop scope="storage" awaitFreshQueries={["storageModel"]} />);
+      rerender(<ProgressBackdrop scope="storage" awaitFreshQueries={["storageModel"]} />);
 
       // Should have called startTracking
       await waitFor(() => {

--- a/web/src/components/core/ProgressBackdrop.test.tsx
+++ b/web/src/components/core/ProgressBackdrop.test.tsx
@@ -227,7 +227,7 @@ describe("ProgressBackdrop", () => {
   });
 
   describe("query keys refetch tracking", () => {
-    it("uses empty array when no awaitFreshQueries provided", () => {
+    it("uses empty array when no awaitRefreshQueries provided", () => {
       mockProgresses([
         {
           scope: "software",
@@ -243,7 +243,7 @@ describe("ProgressBackdrop", () => {
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith([], expect.any(Function));
     });
 
-    it("tracks specified query keys when awaitFreshQueries is provided", () => {
+    it("tracks specified query keys when awaitRefreshQueries is provided", () => {
       mockProgresses([
         {
           scope: "storage",
@@ -255,7 +255,7 @@ describe("ProgressBackdrop", () => {
       ]);
 
       installerRender(
-        <ProgressBackdrop scope="storage" awaitFreshQueries={["proposal", "storageModel"]} />,
+        <ProgressBackdrop scope="storage" awaitQueriesRefetch={["proposal", "storageModel"]} />,
       );
 
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
@@ -278,7 +278,7 @@ describe("ProgressBackdrop", () => {
       installerRender(
         <ProgressBackdrop
           scope="network"
-          awaitFreshQueries={["system", "config", "connections"]}
+          awaitQueriesRefetch={["system", "config", "connections"]}
         />,
       );
 
@@ -301,14 +301,14 @@ describe("ProgressBackdrop", () => {
       ]);
 
       const { rerender } = installerRender(
-        <ProgressBackdrop scope="storage" awaitFreshQueries={["storageModel"]} />,
+        <ProgressBackdrop scope="storage" awaitQueriesRefetch={["storageModel"]} />,
       );
 
       // Progress finishes
       mockProgresses([]);
 
-      rerender(<ProgressBackdrop scope="storage" awaitFreshQueries={["storageModel"]} />);
-      rerender(<ProgressBackdrop scope="storage" awaitFreshQueries={["storageModel"]} />);
+      rerender(<ProgressBackdrop scope="storage" awaitQueriesRefetch={["storageModel"]} />);
+      rerender(<ProgressBackdrop scope="storage" awaitQueriesRefetch={["storageModel"]} />);
 
       // Should have called startTracking
       await waitFor(() => {

--- a/web/src/components/core/ProgressBackdrop.test.tsx
+++ b/web/src/components/core/ProgressBackdrop.test.tsx
@@ -24,7 +24,6 @@ import React from "react";
 import { act, screen, waitFor, within } from "@testing-library/react";
 import { installerRender, mockProgresses } from "~/test-utils";
 import useTrackQueriesRefetch from "~/hooks/use-track-queries-refetch";
-import { COMMON_PROPOSAL_KEYS } from "~/hooks/model/proposal";
 import ProgressBackdrop from "./ProgressBackdrop";
 
 const mockStartTracking: jest.Mock = jest.fn();
@@ -228,7 +227,7 @@ describe("ProgressBackdrop", () => {
   });
 
   describe("query keys refetch tracking", () => {
-    it("tracks common proposal keys by default", () => {
+    it("uses empty array when no waitFor provided", () => {
       mockProgresses([
         {
           scope: "software",
@@ -241,14 +240,13 @@ describe("ProgressBackdrop", () => {
 
       installerRender(<ProgressBackdrop scope="software" />);
 
-      // Should be called with COMMON_PROPOSAL_KEYS and undefined additionalKeys
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
-        expect.arrayContaining(COMMON_PROPOSAL_KEYS),
+        [],
         expect.any(Function),
       );
     });
 
-    it("tracks additional query key along with common ones", () => {
+    it("tracks specified query keys when waitFor is provided", () => {
       mockProgresses([
         {
           scope: "storage",
@@ -259,16 +257,15 @@ describe("ProgressBackdrop", () => {
         },
       ]);
 
-      installerRender(<ProgressBackdrop scope="storage" ensureRefetched="storageModel" />);
+      installerRender(<ProgressBackdrop scope="storage" waitFor={["proposal", "storageModel"]} />);
 
-      // Should be called with COMMON_PROPOSAL_KEYS + storageModel
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
-        expect.arrayContaining([...COMMON_PROPOSAL_KEYS, "storageModel"]),
+        ["proposal", "storageModel"],
         expect.any(Function),
       );
     });
 
-    it("tracks multiple additional query keys along with common ones", () => {
+    it("tracks multiple query keys", () => {
       mockProgresses([
         {
           scope: "network",
@@ -280,12 +277,11 @@ describe("ProgressBackdrop", () => {
       ]);
 
       installerRender(
-        <ProgressBackdrop scope="network" ensureRefetched={["networkConfig", "connections"]} />,
+        <ProgressBackdrop scope="network" waitFor={["system", "config", "connections"]} />,
       );
 
-      // Should be called with COMMON_PROPOSAL_KEYS + networkConfig + connections
       expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
-        expect.arrayContaining([...COMMON_PROPOSAL_KEYS, "networkConfig", "connections"]),
+        ["system", "config", "connections"],
         expect.any(Function),
       );
     });
@@ -303,14 +299,14 @@ describe("ProgressBackdrop", () => {
       ]);
 
       const { rerender } = installerRender(
-        <ProgressBackdrop scope="storage" ensureRefetched="storageModel" />,
+        <ProgressBackdrop scope="storage" waitFor={["storageModel"]} />,
       );
 
       // Progress finishes
       mockProgresses([]);
 
-      rerender(<ProgressBackdrop scope="storage" ensureRefetched="storageModel" />);
-      rerender(<ProgressBackdrop scope="storage" ensureRefetched="storageModel" />);
+      rerender(<ProgressBackdrop scope="storage" waitFor={["storageModel"]} />);
+      rerender(<ProgressBackdrop scope="storage" waitFor={["storageModel"]} />);
 
       // Should have called startTracking
       await waitFor(() => {

--- a/web/src/components/core/ProgressBackdrop.test.tsx
+++ b/web/src/components/core/ProgressBackdrop.test.tsx
@@ -240,10 +240,7 @@ describe("ProgressBackdrop", () => {
 
       installerRender(<ProgressBackdrop scope="software" />);
 
-      expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith(
-        [],
-        expect.any(Function),
-      );
+      expect(mockUseTrackQueriesRefetch).toHaveBeenCalledWith([], expect.any(Function));
     });
 
     it("tracks specified query keys when waitFor is provided", () => {

--- a/web/src/components/core/ProgressBackdrop.tsx
+++ b/web/src/components/core/ProgressBackdrop.tsx
@@ -125,7 +125,7 @@ export default function ProgressBackdrop({
   // after an operation has completed.
   waitingLabel = _("Refreshing data..."),
 }: ProgressBackdropProps): React.ReactNode {
-  const { loading: isBlocked, progress } = useProgressTracking(scope, awaitFreshQueries);
+  const { loading: isBlocked, progress } = useProgressTracking(scope, awaitFreshQueries ?? []);
 
   if (!isBlocked) return null;
 

--- a/web/src/components/core/ProgressBackdrop.tsx
+++ b/web/src/components/core/ProgressBackdrop.tsx
@@ -56,35 +56,27 @@ export type ProgressBackdropProps = {
   /**
    * Query keys to wait for after progress completes.
    *
-   * Explicitly specify all TanStack Query keys that the page depends on.
-   * The backdrop will not dismiss until all specified queries have refetched
-   * with fresh data after the operation completes.
+   * Specify the TanStack Query keys for data that the page displays. The
+   * backdrop will not dismiss until all specified queries have refetched with
+   * fresh data after the operation completes.
    *
    * If omitted or empty, the backdrop dismisses as soon as the backend
    * operation completes without waiting for query refetches.
    *
-   * Match this list to the data hooks used by your page:
-   * - Page uses useProposal() → include PROPOSAL_QUERY_KEY and EXTENDED_CONFIG_QUERY_KEY
-   * - Page uses useSystem() → include SYSTEM_QUERY_KEY
-   * - Page uses useConfig() → include CONFIG_QUERY_KEY
-   * - Page uses storage hooks → include STORAGE_MODEL_QUERY_KEY
+   * Include the `*_QUERY_KEY` constant exported by each data hook the page
+   * uses. For example, a page calling `useProposal()` might include
+   * `PROPOSAL_QUERY_KEY` and `EXTENDED_CONFIG_QUERY_KEY`.
    *
    * @example
-   * // Storage page waits for proposal and storage model queries
    * <ProgressBackdrop
    *   scope="storage"
    *   waitFor={[PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]}
    * />
    *
    * @example
-   * // iSCSI page only waits for system and config queries
-   * <ProgressBackdrop
-   *   scope="iscsi"
-   *   waitFor={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]}
-   * />
+   * <ProgressBackdrop scope="iscsi" waitFor={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]} />
    *
    * @example
-   * // Page that only tracks progress without waiting for queries
    * <ProgressBackdrop scope="custom" />
    */
   waitFor?: readonly string[];

--- a/web/src/components/core/ProgressBackdrop.tsx
+++ b/web/src/components/core/ProgressBackdrop.tsx
@@ -69,18 +69,18 @@ export type ProgressBackdropProps = {
    * @example
    * <ProgressBackdrop
    *   scope="storage"
-   *   waitFor={[PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]}
+   *   awaitFreshQueries={[PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]}
    * />
    *
    * @example
-   * <ProgressBackdrop scope="iscsi" waitFor={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]} />
+   * <ProgressBackdrop scope="iscsi" awaitFreshQueries={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]} />
    *
    * @example
-   * // Omitting waitFor dismisses the backdrop as soon as progress ends,
+   * // Omitting awaitFreshQueries dismisses the backdrop as soon as progress ends,
    * // without waiting for any query refetch.
    * <ProgressBackdrop scope="zfcp" />
    */
-  waitFor?: readonly string[];
+  awaitFreshQueries?: readonly string[];
   /**
    * Additional content to render below the progress information.
    *
@@ -88,7 +88,7 @@ export type ProgressBackdropProps = {
    * per-device progress details for long-running operations.
    *
    * @example
-   * <ProgressBackdrop scope="dasd" waitFor={[...]} extraContent={<DASDFormatProgress />} />
+   * <ProgressBackdrop scope="dasd" awaitFreshQueries={[...]} extraContent={<DASDFormatProgress />} />
    */
   extraContent?: React.ReactNode;
   /**
@@ -98,7 +98,7 @@ export type ProgressBackdropProps = {
    * Defaults to `"Refreshing data..."` if not provided.
    *
    * @example
-   * <ProgressBackdrop scope="storage" waitFor={[...]} waitingLabel={_("Applying changes...")} />
+   * <ProgressBackdrop scope="storage" awaitFreshQueries={[...]} waitingLabel={_("Applying changes...")} />
    */
   waitingLabel?: string;
 };
@@ -111,7 +111,7 @@ export type ProgressBackdropProps = {
  * @remarks
  * Visibility is controlled through two mechanisms:
  * - Monitors active tasks from `useStatus()` that match the provided scope.
- * - Tracks refetches for all queries specified in `waitFor`.
+ * - Tracks refetches for all queries specified in `awaitFreshQueries`.
  *
  * Once shown, the backdrop remains visible until all specified queries have been
  * refetched after the tracked progress has finished, ensuring the UI does not
@@ -119,13 +119,13 @@ export type ProgressBackdropProps = {
  */
 export default function ProgressBackdrop({
   scope,
-  waitFor,
+  awaitFreshQueries,
   extraContent,
   // TRANSLATORS: Message shown next to a spinner while the UI is being updated
   // after an operation has completed.
   waitingLabel = _("Refreshing data..."),
 }: ProgressBackdropProps): React.ReactNode {
-  const { loading: isBlocked, progress } = useProgressTracking(scope, waitFor);
+  const { loading: isBlocked, progress } = useProgressTracking(scope, awaitFreshQueries);
 
   if (!isBlocked) return null;
 

--- a/web/src/components/core/ProgressBackdrop.tsx
+++ b/web/src/components/core/ProgressBackdrop.tsx
@@ -69,18 +69,18 @@ export type ProgressBackdropProps = {
    * @example
    * <ProgressBackdrop
    *   scope="storage"
-   *   awaitFreshQueries={[PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]}
+   *   awaitQueriesRefetch={[PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]}
    * />
    *
    * @example
-   * <ProgressBackdrop scope="iscsi" awaitFreshQueries={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]} />
+   * <ProgressBackdrop scope="iscsi" awaitQueriesRefetch={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]} />
    *
    * @example
-   * // Omitting awaitFreshQueries dismisses the backdrop as soon as progress ends,
+   * // Omitting awaitQueriesRefetch dismisses the backdrop as soon as progress ends,
    * // without waiting for any query refetch.
    * <ProgressBackdrop scope="zfcp" />
    */
-  awaitFreshQueries?: readonly string[];
+  awaitQueriesRefetch?: readonly string[];
   /**
    * Additional content to render below the progress information.
    *
@@ -88,7 +88,7 @@ export type ProgressBackdropProps = {
    * per-device progress details for long-running operations.
    *
    * @example
-   * <ProgressBackdrop scope="dasd" awaitFreshQueries={[...]} extraContent={<DASDFormatProgress />} />
+   * <ProgressBackdrop scope="dasd" awaitQueriesRefetch={[...]} extraContent={<DASDFormatProgress />} />
    */
   extraContent?: React.ReactNode;
   /**
@@ -98,7 +98,7 @@ export type ProgressBackdropProps = {
    * Defaults to `"Refreshing data..."` if not provided.
    *
    * @example
-   * <ProgressBackdrop scope="storage" awaitFreshQueries={[...]} waitingLabel={_("Applying changes...")} />
+   * <ProgressBackdrop scope="storage" awaitQueriesRefetch={[...]} waitingLabel={_("Applying changes...")} />
    */
   waitingLabel?: string;
 };
@@ -111,7 +111,7 @@ export type ProgressBackdropProps = {
  * @remarks
  * Visibility is controlled through two mechanisms:
  * - Monitors active tasks from `useStatus()` that match the provided scope.
- * - Tracks refetches for all queries specified in `awaitFreshQueries`.
+ * - Tracks refetches for all queries specified in `awaitQueriesRefetch`.
  *
  * Once shown, the backdrop remains visible until all specified queries have been
  * refetched after the tracked progress has finished, ensuring the UI does not
@@ -119,13 +119,13 @@ export type ProgressBackdropProps = {
  */
 export default function ProgressBackdrop({
   scope,
-  awaitFreshQueries,
+  awaitQueriesRefetch,
   extraContent,
   // TRANSLATORS: Message shown next to a spinner while the UI is being updated
   // after an operation has completed.
   waitingLabel = _("Refreshing data..."),
 }: ProgressBackdropProps): React.ReactNode {
-  const { loading: isBlocked, progress } = useProgressTracking(scope, awaitFreshQueries ?? []);
+  const { loading: isBlocked, progress } = useProgressTracking(scope, awaitQueriesRefetch ?? []);
 
   if (!isBlocked) return null;
 

--- a/web/src/components/core/ProgressBackdrop.tsx
+++ b/web/src/components/core/ProgressBackdrop.tsx
@@ -49,8 +49,7 @@ import shadowStyles from "@patternfly/react-styles/css/utilities/BoxShadow/box-s
 export type ProgressBackdropProps = {
   /**
    * Scope identifier to filter which progresses trigger the backdrop
-   * overlay. If undefined or no matching tasks exist, the backdrop won't be
-   * displayed.
+   * overlay. If no matching tasks exist, the backdrop won't be displayed.
    */
   scope: Scope;
   /**
@@ -77,7 +76,9 @@ export type ProgressBackdropProps = {
    * <ProgressBackdrop scope="iscsi" waitFor={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]} />
    *
    * @example
-   * <ProgressBackdrop scope="custom" />
+   * // Omitting waitFor dismisses the backdrop as soon as progress ends,
+   * // without waiting for any query refetch.
+   * <ProgressBackdrop scope="zfcp" />
    */
   waitFor?: readonly string[];
   /**

--- a/web/src/components/core/ProgressBackdrop.tsx
+++ b/web/src/components/core/ProgressBackdrop.tsx
@@ -21,7 +21,6 @@
  */
 
 import React from "react";
-import { concat } from "radashi";
 import { sprintf } from "sprintf-js";
 import {
   Alert,
@@ -34,7 +33,6 @@ import {
   Spinner,
 } from "@patternfly/react-core";
 import NestedContent from "~/components/core/NestedContent";
-import { COMMON_PROPOSAL_KEYS } from "~/hooks/model/proposal";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { _ } from "~/i18n";
 
@@ -50,34 +48,46 @@ import shadowStyles from "@patternfly/react-styles/css/utilities/BoxShadow/box-s
  */
 export type ProgressBackdropProps = {
   /**
-   * Scope identifier to filter which progresses trigger the backgrop
+   * Scope identifier to filter which progresses trigger the backdrop
    * overlay. If undefined or no matching tasks exist, the backdrop won't be
    * displayed.
    */
   scope: Scope;
   /**
-   * Additional query keys to track during progress operations.
+   * Query keys to wait for after progress completes.
    *
-   * The progress backdrop automatically tracks common proposal-related queries.
-   * Use this prop to specify additional query keys that must complete
-   * refetching before the backdrop unblocks the UI.
+   * Explicitly specify all TanStack Query keys that the page depends on.
+   * The backdrop will not dismiss until all specified queries have refetched
+   * with fresh data after the operation completes.
    *
-   * This is useful when a page needs to wait for additional queries beyond the
-   * common proposal-related ones, either because the page depends on them or
-   * because operations on the page invalidate them.
+   * If omitted or empty, the backdrop dismisses as soon as the backend
+   * operation completes without waiting for query refetches.
+   *
+   * Match this list to the data hooks used by your page:
+   * - Page uses useProposal() → include PROPOSAL_QUERY_KEY and EXTENDED_CONFIG_QUERY_KEY
+   * - Page uses useSystem() → include SYSTEM_QUERY_KEY
+   * - Page uses useConfig() → include CONFIG_QUERY_KEY
+   * - Page uses storage hooks → include STORAGE_MODEL_QUERY_KEY
    *
    * @example
-   * // Track storage model updates in addition to common proposal queries
-   * <ProgressBackdrop track={{ scope: "storage", ensureRefecthed={STORAGE_MODEL_KEY}} />
-   *
-   * @example
-   * // Track multiple additional queries
+   * // Storage page waits for proposal and storage model queries
    * <ProgressBackdrop
-   *   track="network"
-   *   ensureRefecthed={[NETWORK_CONFIG_KEY, CONNECTIONS_KEY]}
-   * >
+   *   scope="storage"
+   *   waitFor={[PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]}
+   * />
+   *
+   * @example
+   * // iSCSI page only waits for system and config queries
+   * <ProgressBackdrop
+   *   scope="iscsi"
+   *   waitFor={[SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY]}
+   * />
+   *
+   * @example
+   * // Page that only tracks progress without waiting for queries
+   * <ProgressBackdrop scope="custom" />
    */
-  ensureRefetched?: string | string[];
+  waitFor?: readonly string[];
   /**
    * Additional content to render below the progress information.
    *
@@ -85,7 +95,7 @@ export type ProgressBackdropProps = {
    * per-device progress details for long-running operations.
    *
    * @example
-   * <ProgressBackdrop scope="dasd" extraContent={<DASDFormatProgress />} />
+   * <ProgressBackdrop scope="dasd" waitFor={[...]} extraContent={<DASDFormatProgress />} />
    */
   extraContent?: React.ReactNode;
   /**
@@ -95,7 +105,7 @@ export type ProgressBackdropProps = {
    * Defaults to `"Refreshing data..."` if not provided.
    *
    * @example
-   * <ProgressBackdrop scope="storage" waitingLabel={_("Applying changes...")} />
+   * <ProgressBackdrop scope="storage" waitFor={[...]} waitingLabel={_("Applying changes...")} />
    */
   waitingLabel?: string;
 };
@@ -108,25 +118,21 @@ export type ProgressBackdropProps = {
  * @remarks
  * Visibility is controlled through two mechanisms:
  * - Monitors active tasks from `useStatus()` that match the provided scope.
- * - Tracks refetches for common proposal queries as well as any queries
- *   specified via `ensureRefetched`.
+ * - Tracks refetches for all queries specified in `waitFor`.
  *
- * Once shown, the backdrop remains visible until all involved queries have been
+ * Once shown, the backdrop remains visible until all specified queries have been
  * refetched after the tracked progress has finished, ensuring the UI does not
- * unblock prematurely.
+ * unblock prematurely with stale data.
  */
 export default function ProgressBackdrop({
   scope,
-  ensureRefetched,
+  waitFor,
   extraContent,
   // TRANSLATORS: Message shown next to a spinner while the UI is being updated
   // after an operation has completed.
   waitingLabel = _("Refreshing data..."),
 }: ProgressBackdropProps): React.ReactNode {
-  const { loading: isBlocked, progress } = useProgressTracking(
-    scope,
-    concat(COMMON_PROPOSAL_KEYS, ensureRefetched),
-  );
+  const { loading: isBlocked, progress } = useProgressTracking(scope, waitFor);
 
   if (!isBlocked) return null;
 

--- a/web/src/components/network/ConnectionPage.tsx
+++ b/web/src/components/network/ConnectionPage.tsx
@@ -31,6 +31,7 @@ import {
 import { Link, Page } from "~/components/core";
 import { useConnections } from "~/hooks/model/proposal/network";
 import { _ } from "~/i18n";
+import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
 import { sprintf } from "sprintf-js";
 import ConnectionDetails from "~/components/network/ConnectionDetails";
 import { Icon } from "~/components/layout";
@@ -73,7 +74,7 @@ export default function ConnectionPage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Network"), path: NETWORK.root }, { label: connection?.id }]}
-      progress={{ scope: "network", ensureRefetched: "system" }}
+      progress={{ scope: "network", waitFor: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <NoPersistentConnectionsAlert />

--- a/web/src/components/network/ConnectionPage.tsx
+++ b/web/src/components/network/ConnectionPage.tsx
@@ -74,7 +74,7 @@ export default function ConnectionPage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Network"), path: NETWORK.root }, { label: connection?.id }]}
-      progress={{ scope: "network", waitFor: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "network", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <NoPersistentConnectionsAlert />

--- a/web/src/components/network/ConnectionPage.tsx
+++ b/web/src/components/network/ConnectionPage.tsx
@@ -74,7 +74,7 @@ export default function ConnectionPage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Network"), path: NETWORK.root }, { label: connection?.id }]}
-      progress={{ scope: "network", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "network", awaitQueriesRefetch: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <NoPersistentConnectionsAlert />

--- a/web/src/components/network/NetworkPage.tsx
+++ b/web/src/components/network/NetworkPage.tsx
@@ -42,7 +42,7 @@ export default function NetworkPage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Network") }]}
-      progress={{ scope: "network", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "network", awaitQueriesRefetch: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <NoPersistentConnectionsAlert />

--- a/web/src/components/network/NetworkPage.tsx
+++ b/web/src/components/network/NetworkPage.tsx
@@ -42,7 +42,7 @@ export default function NetworkPage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Network") }]}
-      progress={{ scope: "network", waitFor: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "network", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <NoPersistentConnectionsAlert />

--- a/web/src/components/network/NetworkPage.tsx
+++ b/web/src/components/network/NetworkPage.tsx
@@ -30,6 +30,7 @@ import ConnectionsTable from "~/components/network/ConnectionsTable";
 import { useNetworkChanges, useSystem } from "~/hooks/model/system/network";
 import { NETWORK } from "~/routes/paths";
 import { _ } from "~/i18n";
+import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
 
 /**
  * Page component holding Network settings
@@ -41,7 +42,7 @@ export default function NetworkPage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Network") }]}
-      progress={{ scope: "network", ensureRefetched: "system" }}
+      progress={{ scope: "network", waitFor: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <NoPersistentConnectionsAlert />

--- a/web/src/components/network/WifiConnectionForm.tsx
+++ b/web/src/components/network/WifiConnectionForm.tsx
@@ -199,7 +199,7 @@ export default function wifiConnectionForm() {
         { label: _("Network"), path: PATHS.root },
         { label: _("New Wi-Fi connection") },
       ]}
-      progress={{ scope: "network", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "network", awaitQueriesRefetch: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <WifiConnectionFormContent />

--- a/web/src/components/network/WifiConnectionForm.tsx
+++ b/web/src/components/network/WifiConnectionForm.tsx
@@ -41,6 +41,7 @@ import WifiNetworksSelector from "./WifiNetworksSelector";
 import { useNavigate } from "react-router";
 import { PATHS } from "~/routes/network";
 import { N_, _ } from "~/i18n";
+import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
 
 const securityOptions = [
   // TRANSLATORS: WiFi authentication mode
@@ -198,7 +199,7 @@ export default function wifiConnectionForm() {
         { label: _("Network"), path: PATHS.root },
         { label: _("New Wi-Fi connection") },
       ]}
-      progress={{ scope: "network", ensureRefetched: "system" }}
+      progress={{ scope: "network", waitFor: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <WifiConnectionFormContent />

--- a/web/src/components/network/WifiConnectionForm.tsx
+++ b/web/src/components/network/WifiConnectionForm.tsx
@@ -199,7 +199,7 @@ export default function wifiConnectionForm() {
         { label: _("Network"), path: PATHS.root },
         { label: _("New Wi-Fi connection") },
       ]}
-      progress={{ scope: "network", waitFor: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "network", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <WifiConnectionFormContent />

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -28,6 +28,7 @@ import { sprintf } from "sprintf-js";
 import Summary from "~/components/core/Summary";
 import Link from "~/components/core/Link";
 import Text from "~/components/core/Text";
+import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
@@ -147,7 +148,7 @@ const Description = () => {
  * A software installation summary.
  */
 export default function SoftwareSummary() {
-  const { loading } = useProgressTracking("software");
+  const { loading } = useProgressTracking("software", [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]);
   const issues = useIssues("software");
   const hasIssues = !isEmpty(issues);
 

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -148,7 +148,10 @@ const Description = () => {
  * A software installation summary.
  */
 export default function SoftwareSummary() {
-  const { loading } = useProgressTracking("software", [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY]);
+  const { loading } = useProgressTracking("software", [
+    PROPOSAL_QUERY_KEY,
+    EXTENDED_CONFIG_QUERY_KEY,
+  ]);
   const issues = useIssues("software");
   const hasIssues = !isEmpty(issues);
 

--- a/web/src/components/overview/StorageSummary.tsx
+++ b/web/src/components/overview/StorageSummary.tsx
@@ -28,7 +28,8 @@ import Summary from "~/components/core/Summary";
 import Link from "~/components/core/Link";
 import Text from "~/components/core/Text";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
-import { useConfigModel } from "~/hooks/model/storage/config-model";
+import { useConfigModel, STORAGE_MODEL_QUERY_KEY } from "~/hooks/model/storage/config-model";
+import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
 import {
   useFlattenDevices as useSystemFlattenDevices,
   useAvailableDevices,
@@ -175,7 +176,11 @@ const Description = () => {
  *  - Hidden when configuration issues exist
  */
 export default function StorageSummary() {
-  const { loading } = useProgressTracking("storage");
+  const { loading } = useProgressTracking("storage", [
+    PROPOSAL_QUERY_KEY,
+    EXTENDED_CONFIG_QUERY_KEY,
+    STORAGE_MODEL_QUERY_KEY,
+  ]);
   const issues = useIssues("storage");
   const zfcpIssues = useIssues("zfcp");
 

--- a/web/src/components/overview/UsersSummary.tsx
+++ b/web/src/components/overview/UsersSummary.tsx
@@ -23,6 +23,7 @@
 import React from "react";
 import { isEmpty } from "radashi";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
+import { CONFIG_QUERY_KEY } from "~/hooks/model/config";
 import { useConfig } from "~/hooks/model/config";
 import { useIssues } from "~/hooks/model/issue";
 import Summary from "~/components/core/Summary";
@@ -143,7 +144,7 @@ const Description = () => {
 };
 
 export default function UsersSummary() {
-  const { loading } = useProgressTracking("users");
+  const { loading } = useProgressTracking("users", [CONFIG_QUERY_KEY]);
   const hasIssues = !!useIssues("users").length;
 
   return (

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -380,7 +380,7 @@ function SoftwarePage() {
       breadcrumbs={[{ label: _("Software") }]}
       progress={{
         scope: "software",
-        awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
+        awaitQueriesRefetch: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
       }}
     >
       <Page.Content>

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -53,6 +53,7 @@ import { useAvailablePatterns } from "~/hooks/model/system/software";
 import { isPatternSelected } from "~/utils/software";
 import { SOFTWARE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
+import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
 
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
@@ -375,7 +376,10 @@ function SoftwarePage() {
   );
 
   return (
-    <Page breadcrumbs={[{ label: _("Software") }]} progress={{ scope: "software" }}>
+    <Page
+      breadcrumbs={[{ label: _("Software") }]}
+      progress={{ scope: "software", waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY] }}
+    >
       <Page.Content>
         <IssuesAlert issues={issues} />
         <SoftwarePageContent />

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -378,7 +378,10 @@ function SoftwarePage() {
   return (
     <Page
       breadcrumbs={[{ label: _("Software") }]}
-      progress={{ scope: "software", waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY] }}
+      progress={{
+        scope: "software",
+        awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
+      }}
     >
       <Page.Content>
         <IssuesAlert issues={issues} />

--- a/web/src/components/software/patterns-form/Form.tsx
+++ b/web/src/components/software/patterns-form/Form.tsx
@@ -48,6 +48,7 @@ import { filterPatterns, groupPatterns, isPatternSelected, sortGroupNames } from
 import { SOFTWARE } from "~/routes/paths";
 import { N_, _, n_ } from "~/i18n";
 import { defaultOptions } from "./fields";
+import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
 
 import type { Pattern } from "~/model/system/software";
 
@@ -355,7 +356,7 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
           label: _(PAGE_TITLE[scope]),
         },
       ]}
-      progress={{ scope: "software" }}
+      progress={{ scope: "software", waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY] }}
     >
       <Page.Content>
         <form.AppForm>

--- a/web/src/components/software/patterns-form/Form.tsx
+++ b/web/src/components/software/patterns-form/Form.tsx
@@ -358,7 +358,7 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
       ]}
       progress={{
         scope: "software",
-        awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
+        awaitQueriesRefetch: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
       }}
     >
       <Page.Content>

--- a/web/src/components/software/patterns-form/Form.tsx
+++ b/web/src/components/software/patterns-form/Form.tsx
@@ -356,7 +356,10 @@ function SoftwarePatternsSelection({ scope = "all" }: { scope?: Scope }) {
           label: _(PAGE_TITLE[scope]),
         },
       ]}
-      progress={{ scope: "software", waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY] }}
+      progress={{
+        scope: "software",
+        awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
+      }}
     >
       <Page.Content>
         <form.AppForm>

--- a/web/src/components/storage/ISCSIPage.tsx
+++ b/web/src/components/storage/ISCSIPage.tsx
@@ -39,7 +39,7 @@ export default function ISCSIPage() {
         },
         { label: _("iSCSI") },
       ]}
-      progress={{ scope: "iscsi", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
+      progress={{ scope: "iscsi", awaitQueriesRefetch: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <Grid hasGutter>

--- a/web/src/components/storage/ISCSIPage.tsx
+++ b/web/src/components/storage/ISCSIPage.tsx
@@ -40,7 +40,7 @@ export default function ISCSIPage() {
         },
         { label: _("iSCSI") },
       ]}
-      progress={{ scope: "iscsi", waitFor: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
+      progress={{ scope: "iscsi", awaitFreshQueries: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
     >
       <Page.Content>
         <Grid hasGutter>

--- a/web/src/components/storage/ISCSIPage.tsx
+++ b/web/src/components/storage/ISCSIPage.tsx
@@ -28,7 +28,6 @@ import TargetsTable from "~/components/storage/iscsi/TargetsTable";
 import { STORAGE } from "~/routes/paths";
 import { _ } from "~/i18n";
 import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
-import { CONFIG_QUERY_KEY } from "~/hooks/model/config";
 
 export default function ISCSIPage() {
   return (
@@ -40,7 +39,7 @@ export default function ISCSIPage() {
         },
         { label: _("iSCSI") },
       ]}
-      progress={{ scope: "iscsi", awaitFreshQueries: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
+      progress={{ scope: "iscsi", awaitFreshQueries: [SYSTEM_QUERY_KEY] }}
     >
       <Page.Content>
         <Grid hasGutter>

--- a/web/src/components/storage/ISCSIPage.tsx
+++ b/web/src/components/storage/ISCSIPage.tsx
@@ -27,6 +27,8 @@ import Page from "~/components/core/Page";
 import TargetsTable from "~/components/storage/iscsi/TargetsTable";
 import { STORAGE } from "~/routes/paths";
 import { _ } from "~/i18n";
+import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
+import { CONFIG_QUERY_KEY } from "~/hooks/model/config";
 
 export default function ISCSIPage() {
   return (
@@ -38,7 +40,7 @@ export default function ISCSIPage() {
         },
         { label: _("iSCSI") },
       ]}
-      progress={{ scope: "iscsi" }}
+      progress={{ scope: "iscsi", waitFor: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
     >
       <Page.Content>
         <Grid hasGutter>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -325,7 +325,7 @@ export default function ProposalPage(): React.ReactNode {
       additionalContent={<ConnectedDevicesMenu />}
       progress={{
         scope: "storage",
-        waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY],
+        awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY],
       }}
     >
       <Page.Content>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -56,6 +56,7 @@ import { useIssues } from "~/hooks/model/issue";
 import { useReset } from "~/hooks/model/config/storage";
 import { useProposal } from "~/hooks/model/proposal/storage";
 import { STORAGE_MODEL_QUERY_KEY, useConfigModel } from "~/hooks/model/storage/config-model";
+import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 import { useLocation } from "react-router";
@@ -322,7 +323,10 @@ export default function ProposalPage(): React.ReactNode {
     <Page
       breadcrumbs={[{ label: _("Storage") }]}
       additionalContent={<ConnectedDevicesMenu />}
-      progress={{ scope: "storage", ensureRefetched: STORAGE_MODEL_QUERY_KEY }}
+      progress={{
+        scope: "storage",
+        waitFor: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY],
+      }}
     >
       <Page.Content>
         <IssuesAlert issues={zfcpIssues} />

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -325,7 +325,11 @@ export default function ProposalPage(): React.ReactNode {
       additionalContent={<ConnectedDevicesMenu />}
       progress={{
         scope: "storage",
-        awaitFreshQueries: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY],
+        awaitQueriesRefetch: [
+          PROPOSAL_QUERY_KEY,
+          EXTENDED_CONFIG_QUERY_KEY,
+          STORAGE_MODEL_QUERY_KEY,
+        ],
       }}
     >
       <Page.Content>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -55,7 +55,7 @@ import { useAvailableDevices } from "~/hooks/model/system/storage";
 import { useIssues } from "~/hooks/model/issue";
 import { useReset } from "~/hooks/model/config/storage";
 import { useProposal } from "~/hooks/model/proposal/storage";
-import { STORAGE_MODEL_KEY, useConfigModel } from "~/hooks/model/storage/config-model";
+import { STORAGE_MODEL_QUERY_KEY, useConfigModel } from "~/hooks/model/storage/config-model";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 import { useLocation } from "react-router";
@@ -322,7 +322,7 @@ export default function ProposalPage(): React.ReactNode {
     <Page
       breadcrumbs={[{ label: _("Storage") }]}
       additionalContent={<ConnectedDevicesMenu />}
-      progress={{ scope: "storage", ensureRefetched: STORAGE_MODEL_KEY }}
+      progress={{ scope: "storage", ensureRefetched: STORAGE_MODEL_QUERY_KEY }}
     >
       <Page.Content>
         <IssuesAlert issues={zfcpIssues} />

--- a/web/src/components/storage/dasd/DASDPage.tsx
+++ b/web/src/components/storage/dasd/DASDPage.tsx
@@ -72,7 +72,7 @@ export default function DASDPage() {
       breadcrumbs={[{ label: _("Storage"), path: STORAGE.root }, { label: _("DASD") }]}
       progress={{
         scope: "dasd",
-        waitFor: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY],
+        awaitFreshQueries: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY],
         extraContent: <DASDFormatProgress />,
       }}
     >

--- a/web/src/components/storage/dasd/DASDPage.tsx
+++ b/web/src/components/storage/dasd/DASDPage.tsx
@@ -29,6 +29,8 @@ import DASDFormatProgress from "~/components/storage/dasd/DASDFormatProgress";
 import { useSystem } from "~/hooks/model/system/dasd";
 import { STORAGE } from "~/routes/paths";
 import { _ } from "~/i18n";
+import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
+import { CONFIG_QUERY_KEY } from "~/hooks/model/config";
 
 /**
  * Renders a PatternFly `EmptyState` block used when no DASD devices are detected
@@ -70,6 +72,7 @@ export default function DASDPage() {
       breadcrumbs={[{ label: _("Storage"), path: STORAGE.root }, { label: _("DASD") }]}
       progress={{
         scope: "dasd",
+        waitFor: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY],
         extraContent: <DASDFormatProgress />,
       }}
     >

--- a/web/src/components/storage/dasd/DASDPage.tsx
+++ b/web/src/components/storage/dasd/DASDPage.tsx
@@ -72,7 +72,7 @@ export default function DASDPage() {
       breadcrumbs={[{ label: _("Storage"), path: STORAGE.root }, { label: _("DASD") }]}
       progress={{
         scope: "dasd",
-        awaitFreshQueries: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY],
+        awaitQueriesRefetch: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY],
         extraContent: <DASDFormatProgress />,
       }}
     >

--- a/web/src/components/storage/zfcp/ZFCPPage.tsx
+++ b/web/src/components/storage/zfcp/ZFCPPage.tsx
@@ -174,7 +174,7 @@ export default function ZFCPPage(): React.ReactNode {
   return (
     <Page
       breadcrumbs={[{ label: _("Storage"), path: STORAGE.root }, { label: _("zFCP") }]}
-      progress={{ scope: "zfcp", awaitFreshQueries: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
+      progress={{ scope: "zfcp", awaitQueriesRefetch: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
     >
       <Page.Content>
         <IssuesAlert issues={issues} />

--- a/web/src/components/storage/zfcp/ZFCPPage.tsx
+++ b/web/src/components/storage/zfcp/ZFCPPage.tsx
@@ -33,6 +33,8 @@ import {
   GridItem,
   Split,
 } from "@patternfly/react-core";
+import { SYSTEM_QUERY_KEY } from "~/hooks/model/system";
+import { CONFIG_QUERY_KEY } from "~/hooks/model/config";
 import Link from "~/components/core/Link";
 import Page from "~/components/core/Page";
 import Text from "~/components/core/Text";
@@ -172,7 +174,7 @@ export default function ZFCPPage(): React.ReactNode {
   return (
     <Page
       breadcrumbs={[{ label: _("Storage"), path: STORAGE.root }, { label: _("zFCP") }]}
-      progress={{ scope: "zfcp" }}
+      progress={{ scope: "zfcp", waitFor: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
     >
       <Page.Content>
         <IssuesAlert issues={issues} />

--- a/web/src/components/storage/zfcp/ZFCPPage.tsx
+++ b/web/src/components/storage/zfcp/ZFCPPage.tsx
@@ -174,7 +174,7 @@ export default function ZFCPPage(): React.ReactNode {
   return (
     <Page
       breadcrumbs={[{ label: _("Storage"), path: STORAGE.root }, { label: _("zFCP") }]}
-      progress={{ scope: "zfcp", waitFor: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
+      progress={{ scope: "zfcp", awaitFreshQueries: [SYSTEM_QUERY_KEY, CONFIG_QUERY_KEY] }}
     >
       <Page.Content>
         <IssuesAlert issues={issues} />

--- a/web/src/hooks/model/config.ts
+++ b/web/src/hooks/model/config.ts
@@ -26,11 +26,11 @@ import { getConfig, getExtendedConfig, putConfig } from "~/api";
 import type { Config } from "~/model/config";
 import type { AxiosResponse } from "axios";
 
-const CONFIG_KEY = "config";
-const EXTENDED_CONFIG_KEY = "extendedConfig";
+const CONFIG_QUERY_KEY = "config";
+const EXTENDED_CONFIG_QUERY_KEY = "extendedConfig";
 
 const configQuery = {
-  queryKey: [CONFIG_KEY],
+  queryKey: [CONFIG_QUERY_KEY],
   queryFn: getConfig,
 };
 
@@ -144,7 +144,7 @@ function useUpdateConfig(): UpdateConfigFn {
 }
 
 const extendedConfigQuery = {
-  queryKey: [EXTENDED_CONFIG_KEY],
+  queryKey: [EXTENDED_CONFIG_QUERY_KEY],
   queryFn: getExtendedConfig,
 };
 
@@ -153,8 +153,8 @@ function useExtendedConfig(): Config | null {
 }
 
 export {
-  CONFIG_KEY,
-  EXTENDED_CONFIG_KEY,
+  CONFIG_QUERY_KEY,
+  EXTENDED_CONFIG_QUERY_KEY,
   configQuery,
   extendedConfigQuery,
   useConfig,

--- a/web/src/hooks/model/proposal.test.ts
+++ b/web/src/hooks/model/proposal.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { QueryClient } from "@tanstack/react-query";
+import { installerRenderHook, createCallbackMock } from "~/test-utils";
+
+const [mockOnEvent, eventCallbacks] = createCallbackMock();
+
+jest.mock("~/context/installer", () => ({
+  useInstallerClient: () => ({ onEvent: mockOnEvent }),
+}));
+
+import { useProposalChanges } from "~/hooks/model/proposal";
+
+const emitEvent = (event: { type: string }) => eventCallbacks.forEach((cb) => cb(event));
+
+describe("useProposalChanges", () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  // Returns the first segment of every query key passed to invalidateQueries.
+  const invalidatedKeys = () => invalidateSpy.mock.calls.map(([filters]) => filters.queryKey[0]);
+
+  beforeEach(() => {
+    eventCallbacks.length = 0;
+    invalidateSpy = jest
+      .spyOn(QueryClient.prototype, "invalidateQueries")
+      .mockImplementation(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("invalidates the proposal-related queries on a ProposalChanged event", () => {
+    installerRenderHook(() => useProposalChanges());
+
+    emitEvent({ type: "ProposalChanged" });
+
+    // A proposal change must invalidate these four queries so they refetch.
+    expect(invalidatedKeys()).toEqual(
+      expect.arrayContaining(["proposal", "extendedConfig", "config", "storageModel"]),
+    );
+    // Every key must be a real string. The bug this test guards against left one
+    // key as undefined, so the loop invalidated nothing.
+    expect(invalidatedKeys()).not.toContain(undefined);
+  });
+
+  it("ignores events other than ProposalChanged", () => {
+    installerRenderHook(() => useProposalChanges());
+
+    emitEvent({ type: "SomethingElse" });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("stops listening when unmounted", () => {
+    const { unmount } = installerRenderHook(() => useProposalChanges());
+    expect(eventCallbacks).toHaveLength(1);
+
+    unmount();
+
+    expect(eventCallbacks).toHaveLength(0);
+  });
+});

--- a/web/src/hooks/model/proposal.ts
+++ b/web/src/hooks/model/proposal.ts
@@ -29,7 +29,6 @@ import { CONFIG_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/confi
 import { STORAGE_MODEL_QUERY_KEY } from "~/hooks/model/storage/config-model";
 
 const PROPOSAL_QUERY_KEY = "proposal" as const;
-const COMMON_PROPOSAL_KEYS = [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY] as const;
 
 const proposalQuery = {
   queryKey: [PROPOSAL_QUERY_KEY],
@@ -50,7 +49,18 @@ function useProposalChanges() {
     // TODO: replace the scope instead of invalidating the query.
     return client.onEvent((event) => {
       if (event.type === "ProposalChanged") {
-        [...COMMON_PROPOSAL_KEYS, CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY].forEach((queryKey) => {
+        // Build this list inside the handler, not at module load. The keys
+        // imported from other modules (EXTENDED_CONFIG_QUERY_KEY,
+        // CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY) can still be undefined
+        // while this module loads, because their source modules finish loading
+        // after this one. Once an event arrives, all of them hold their real
+        // values.
+        [
+          PROPOSAL_QUERY_KEY,
+          EXTENDED_CONFIG_QUERY_KEY,
+          CONFIG_QUERY_KEY,
+          STORAGE_MODEL_QUERY_KEY,
+        ].forEach((queryKey) => {
           queryClient.invalidateQueries({ queryKey: [queryKey] });
         });
       }
@@ -61,7 +71,6 @@ function useProposalChanges() {
 export {
   PROPOSAL_QUERY_KEY,
   EXTENDED_CONFIG_QUERY_KEY,
-  COMMON_PROPOSAL_KEYS,
   proposalQuery,
   useProposal,
   useProposalChanges,

--- a/web/src/hooks/model/proposal.ts
+++ b/web/src/hooks/model/proposal.ts
@@ -58,7 +58,14 @@ function useProposalChanges() {
   }, [client, queryClient]);
 }
 
-export { PROPOSAL_QUERY_KEY, COMMON_PROPOSAL_KEYS, proposalQuery, useProposal, useProposalChanges };
+export {
+  PROPOSAL_QUERY_KEY,
+  EXTENDED_CONFIG_QUERY_KEY,
+  COMMON_PROPOSAL_KEYS,
+  proposalQuery,
+  useProposal,
+  useProposalChanges,
+};
 export * as l10n from "~/hooks/model/proposal/l10n";
 export * as network from "~/hooks/model/proposal/network";
 export * as storage from "~/hooks/model/proposal/storage";

--- a/web/src/hooks/model/proposal.ts
+++ b/web/src/hooks/model/proposal.ts
@@ -25,14 +25,14 @@ import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { getProposal } from "~/api";
 import { useInstallerClient } from "~/context/installer";
 import type { Proposal } from "~/model/proposal";
-import { CONFIG_KEY, EXTENDED_CONFIG_KEY } from "~/hooks/model/config";
-import { STORAGE_MODEL_KEY } from "~/hooks/model/storage/config-model";
+import { CONFIG_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/config";
+import { STORAGE_MODEL_QUERY_KEY } from "~/hooks/model/storage/config-model";
 
-const PROPOSAL_KEY = "proposal" as const;
-const COMMON_PROPOSAL_KEYS = [PROPOSAL_KEY, EXTENDED_CONFIG_KEY] as const;
+const PROPOSAL_QUERY_KEY = "proposal" as const;
+const COMMON_PROPOSAL_KEYS = [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY] as const;
 
 const proposalQuery = {
-  queryKey: [PROPOSAL_KEY],
+  queryKey: [PROPOSAL_QUERY_KEY],
   queryFn: getProposal,
 };
 
@@ -50,7 +50,7 @@ function useProposalChanges() {
     // TODO: replace the scope instead of invalidating the query.
     return client.onEvent((event) => {
       if (event.type === "ProposalChanged") {
-        [...COMMON_PROPOSAL_KEYS, CONFIG_KEY, STORAGE_MODEL_KEY].forEach((queryKey) => {
+        [...COMMON_PROPOSAL_KEYS, CONFIG_QUERY_KEY, STORAGE_MODEL_QUERY_KEY].forEach((queryKey) => {
           queryClient.invalidateQueries({ queryKey: [queryKey] });
         });
       }
@@ -58,7 +58,7 @@ function useProposalChanges() {
   }, [client, queryClient]);
 }
 
-export { COMMON_PROPOSAL_KEYS, proposalQuery, useProposal, useProposalChanges };
+export { PROPOSAL_QUERY_KEY, COMMON_PROPOSAL_KEYS, proposalQuery, useProposal, useProposalChanges };
 export * as l10n from "~/hooks/model/proposal/l10n";
 export * as network from "~/hooks/model/proposal/network";
 export * as storage from "~/hooks/model/proposal/storage";

--- a/web/src/hooks/model/storage/config-model.test.tsx
+++ b/web/src/hooks/model/storage/config-model.test.tsx
@@ -55,7 +55,7 @@ import {
   useSetSpacePolicy,
   useConvertPartitionableToVolumeGroup,
   useConvertDevice,
-  STORAGE_MODEL_KEY,
+  STORAGE_MODEL_QUERY_KEY,
 } from "./config-model";
 import type { ConfigModel } from "~/model/storage/config-model";
 import type { Storage, Bootloader } from "~/model/system";
@@ -118,7 +118,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useConfigModel(), { wrapper });
 
@@ -126,7 +126,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when no config is available", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useConfigModel(), { wrapper });
 
@@ -141,7 +141,7 @@ describe("config-model hooks", () => {
         encryption: { password: "secret", tpm: true },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -154,7 +154,7 @@ describe("config-model hooks", () => {
         encryption: { password: "secret", tpm: false },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -167,7 +167,7 @@ describe("config-model hooks", () => {
         encryption: { password: "secret", tpm: true },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -180,7 +180,7 @@ describe("config-model hooks", () => {
         encryption: { password: "secret", tpm: true },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -188,7 +188,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns false when config is null", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -200,7 +200,7 @@ describe("config-model hooks", () => {
         boot: { configure: true, bootloader: "grub2" },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -212,7 +212,7 @@ describe("config-model hooks", () => {
         encryption: { password: "secret", tpm: true },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsGrub2WithTpm(), { wrapper });
 
@@ -234,7 +234,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -254,7 +254,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -267,7 +267,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(null);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -280,7 +280,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(null);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -293,7 +293,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -310,7 +310,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -325,7 +325,7 @@ describe("config-model hooks", () => {
       const config: ConfigModel.Config = {};
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -345,7 +345,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -362,7 +362,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -382,7 +382,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseBootloaderSystem.mockReturnValue(bootloaderSystem);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useIsTpmAvailable(), { wrapper });
 
@@ -406,7 +406,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseSystem.mockReturnValue(system);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useMissingMountPaths(), { wrapper });
 
@@ -428,7 +428,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseSystem.mockReturnValue(system);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useMissingMountPaths(), { wrapper });
 
@@ -441,7 +441,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseSystem.mockReturnValue(system);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useMissingMountPaths(), { wrapper });
 
@@ -456,7 +456,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseSystem.mockReturnValue(system);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useMissingMountPaths(), { wrapper });
 
@@ -469,7 +469,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseSystem.mockReturnValue(null);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useMissingMountPaths(), { wrapper });
 
@@ -485,7 +485,7 @@ describe("config-model hooks", () => {
     };
 
     it("returns device from drives collection", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDevice("drives", 0), { wrapper });
 
@@ -493,7 +493,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns device from mdRaids collection", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDevice("mdRaids", 0), { wrapper });
 
@@ -501,7 +501,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns device from volumeGroups collection", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDevice("volumeGroups", 0), { wrapper });
 
@@ -509,7 +509,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when index is out of bounds", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDevice("drives", 10), { wrapper });
 
@@ -517,7 +517,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when config is null", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useDevice("drives", 0), { wrapper });
 
@@ -557,7 +557,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda", partitions: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => usePartitionable("drives", 0), { wrapper });
 
@@ -569,7 +569,7 @@ describe("config-model hooks", () => {
         mdRaids: [{ name: "/dev/md0", partitions: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => usePartitionable("mdRaids", 0), { wrapper });
 
@@ -577,7 +577,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when config is null", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => usePartitionable("drives", 0), { wrapper });
 
@@ -591,7 +591,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }, { name: "/dev/sdb" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDrive(1), { wrapper });
 
@@ -599,7 +599,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when config is null", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useDrive(0), { wrapper });
 
@@ -613,7 +613,7 @@ describe("config-model hooks", () => {
         mdRaids: [{ name: "/dev/md0" }, { name: "/dev/md1" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useMdRaid(1), { wrapper });
 
@@ -621,7 +621,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when config is null", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useMdRaid(0), { wrapper });
 
@@ -638,7 +638,7 @@ describe("config-model hooks", () => {
         ],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useVolumeGroup(1), { wrapper });
 
@@ -646,7 +646,7 @@ describe("config-model hooks", () => {
     });
 
     it("returns null when config is null", () => {
-      queryClient.setQueryData([STORAGE_MODEL_KEY], null);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], null);
 
       const { result } = renderHook(() => useVolumeGroup(0), { wrapper });
 
@@ -661,7 +661,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useSetBootDevice(), { wrapper });
 
@@ -677,7 +677,7 @@ describe("config-model hooks", () => {
         boot: { configure: true },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useSetDefaultBootDevice(), { wrapper });
 
@@ -693,7 +693,7 @@ describe("config-model hooks", () => {
         boot: { configure: true },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDisableBoot(), { wrapper });
 
@@ -709,7 +709,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useSetEncryption(), { wrapper });
 
@@ -724,7 +724,7 @@ describe("config-model hooks", () => {
         encryption: { password: "secret", tpm: false },
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useSetEncryption(), { wrapper });
 
@@ -740,7 +740,7 @@ describe("config-model hooks", () => {
         drives: [],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useAddDrive(), { wrapper });
 
@@ -756,7 +756,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }, { name: "/dev/sdb" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDeleteDrive(), { wrapper });
 
@@ -772,7 +772,7 @@ describe("config-model hooks", () => {
         mdRaids: [],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useAddMdRaid(), { wrapper });
 
@@ -788,7 +788,7 @@ describe("config-model hooks", () => {
         mdRaids: [{ name: "/dev/md0" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDeleteMdRaid(), { wrapper });
 
@@ -804,7 +804,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useConvertPartitionableToVolumeGroup(), { wrapper });
 
@@ -820,7 +820,7 @@ describe("config-model hooks", () => {
         volumeGroups: [],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useAddVolumeGroup(), { wrapper });
 
@@ -836,7 +836,7 @@ describe("config-model hooks", () => {
         volumeGroups: [{ name: "vg0", vgName: "vg0", targetDevices: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useEditVolumeGroup(), { wrapper });
 
@@ -852,7 +852,7 @@ describe("config-model hooks", () => {
         volumeGroups: [{ name: "vg0", vgName: "vg0", targetDevices: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDeleteVolumeGroup(), { wrapper });
 
@@ -868,7 +868,7 @@ describe("config-model hooks", () => {
         volumeGroups: [{ name: "vg0", vgName: "vg0", targetDevices: [], logicalVolumes: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useAddLogicalVolume(), { wrapper });
 
@@ -891,7 +891,7 @@ describe("config-model hooks", () => {
         ],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useEditLogicalVolume(), { wrapper });
 
@@ -914,7 +914,7 @@ describe("config-model hooks", () => {
         ],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDeleteLogicalVolume(), { wrapper });
 
@@ -930,7 +930,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda", partitions: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useAddPartition(), { wrapper });
 
@@ -946,7 +946,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda", partitions: [{ mountPath: "/" }] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useEditPartition(), { wrapper });
 
@@ -962,7 +962,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda", partitions: [{ mountPath: "/" }] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useDeletePartition(), { wrapper });
 
@@ -978,7 +978,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda", partitions: [] }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useSetFilesystem(), { wrapper });
 
@@ -994,7 +994,7 @@ describe("config-model hooks", () => {
         drives: [{ name: "/dev/sda" }],
       };
 
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useSetSpacePolicy(), { wrapper });
 
@@ -1018,7 +1018,7 @@ describe("config-model hooks", () => {
       };
 
       mockUseSystem.mockReturnValue(system);
-      queryClient.setQueryData([STORAGE_MODEL_KEY], config);
+      queryClient.setQueryData([STORAGE_MODEL_QUERY_KEY], config);
 
       const { result } = renderHook(() => useConvertDevice(), { wrapper });
 

--- a/web/src/hooks/model/storage/config-model.ts
+++ b/web/src/hooks/model/storage/config-model.ts
@@ -37,10 +37,10 @@ import type {
   DeviceCollection,
 } from "~/model/storage/config-model";
 
-const STORAGE_MODEL_KEY = "storageModel" as const;
+const STORAGE_MODEL_QUERY_KEY = "storageModel" as const;
 
 const configModelQuery = {
-  queryKey: [STORAGE_MODEL_KEY],
+  queryKey: [STORAGE_MODEL_QUERY_KEY],
   queryFn: getStorageModel,
 };
 
@@ -372,7 +372,7 @@ function useIsTpmAvailable(): boolean {
 }
 
 export {
-  STORAGE_MODEL_KEY,
+  STORAGE_MODEL_QUERY_KEY,
   useConfigModel,
   useSolvedConfigModel,
   useMissingMountPaths,

--- a/web/src/hooks/model/system.ts
+++ b/web/src/hooks/model/system.ts
@@ -26,8 +26,10 @@ import { getSystem } from "~/api";
 import { useInstallerClient } from "~/context/installer";
 import type { System } from "~/model/system";
 
+const SYSTEM_QUERY_KEY = "system" as const;
+
 const systemQuery = {
-  queryKey: ["system"],
+  queryKey: [SYSTEM_QUERY_KEY],
   queryFn: getSystem,
 };
 
@@ -45,7 +47,7 @@ function useSystemChanges() {
     // TODO: replace the scope instead of invalidating the query.
     return client.onEvent((event) => {
       if (event.type === "SystemChanged") {
-        queryClient.invalidateQueries({ queryKey: ["system"] });
+        queryClient.invalidateQueries({ queryKey: [SYSTEM_QUERY_KEY] });
         if (event.scope === "storage")
           queryClient.invalidateQueries({ queryKey: ["solvedStorageModel"] });
       }
@@ -53,7 +55,7 @@ function useSystemChanges() {
   }, [client, queryClient]);
 }
 
-export { systemQuery, useSystem, useSystemChanges };
+export { SYSTEM_QUERY_KEY, systemQuery, useSystem, useSystemChanges };
 export * as l10n from "~/hooks/model/system/l10n";
 export * as software from "~/hooks/model/system/software";
 export * as storage from "~/hooks/model/system/storage";

--- a/web/src/hooks/use-progress-tracking.test.ts
+++ b/web/src/hooks/use-progress-tracking.test.ts
@@ -130,7 +130,7 @@ describe("useProgressTracking", () => {
       rerender();
 
       // Complete progress
-      jest.setSystemTime(1000);
+      jest.advanceTimersByTime(1000);
       mockProgresses([]);
       rerender();
 
@@ -141,7 +141,7 @@ describe("useProgressTracking", () => {
       expect(result.current.loading).toBe(true);
 
       // Queries refetch after progress finished
-      jest.setSystemTime(2000);
+      jest.advanceTimersByTime(1000);
 
       await waitFor(() => {
         mockRefetchCallback();
@@ -174,7 +174,7 @@ describe("useProgressTracking", () => {
       rerender();
 
       // Complete progress
-      jest.setSystemTime(1000);
+      jest.advanceTimersByTime(1000);
       mockProgresses([]);
       rerender();
 
@@ -185,7 +185,7 @@ describe("useProgressTracking", () => {
       expect(result.current.loading).toBe(true);
 
       // Queries refetch after progress finished
-      jest.setSystemTime(2000);
+      jest.advanceTimersByTime(1000);
 
       await waitFor(() => {
         mockRefetchCallback();
@@ -234,7 +234,7 @@ describe("useProgressTracking", () => {
       expect(result.current.loading).toBe(true);
 
       // Complete tasks
-      jest.setSystemTime(1000);
+      jest.advanceTimersByTime(1000);
       mockTasks([]);
       rerender();
 
@@ -245,7 +245,7 @@ describe("useProgressTracking", () => {
       expect(result.current.loading).toBe(true);
 
       // Queries refetch after tasks finished
-      jest.setSystemTime(2000);
+      jest.advanceTimersByTime(1000);
 
       await waitFor(() => {
         mockRefetchCallback();
@@ -273,7 +273,7 @@ describe("useProgressTracking", () => {
       expect(result.current.loading).toBe(true);
 
       // Progress completes but task still running
-      jest.setSystemTime(1000);
+      jest.advanceTimersByTime(1000);
       mockProgresses([]);
       mockTasks([fakeSoftwareTask]);
       rerender();
@@ -282,7 +282,7 @@ describe("useProgressTracking", () => {
       expect(mockStartTracking).not.toHaveBeenCalled();
 
       // Task also completes
-      jest.setSystemTime(2000);
+      jest.advanceTimersByTime(1000);
       mockTasks([]);
       rerender();
 
@@ -293,7 +293,7 @@ describe("useProgressTracking", () => {
       expect(result.current.loading).toBe(true);
 
       // Queries refetch
-      jest.setSystemTime(3000);
+      jest.advanceTimersByTime(1000);
 
       await waitFor(() => {
         mockRefetchCallback();
@@ -318,37 +318,36 @@ describe("useProgressTracking", () => {
       const { result, rerender } = renderHook(() => useProgressTracking("software"));
 
       // Start progress at T0
-      jest.setSystemTime(0);
       mockProgresses([fakeSoftwareProgress]);
       rerender();
 
       expect(result.current.loading).toBe(true);
 
-      // Query refetches during progress at T1000 (this would happen automatically
+      // Query refetches during progress at T+1000ms (this would happen automatically
       // in real app due to query invalidation or refetchInterval)
-      jest.setSystemTime(1000);
-      // In reality, TanStack Query would update the query's dataUpdatedAt to 1000
+      jest.advanceTimersByTime(1000);
+      // In reality, TanStack Query would update the query's dataUpdatedAt to T+1000
 
-      // Progress completes at T2000
-      jest.setSystemTime(2000);
+      // Progress completes at T+2000ms
+      jest.advanceTimersByTime(1000);
       mockProgresses([]);
       rerender();
 
-      // startTracking() is called now, capturing startedAt = 2000
+      // startTracking() is called now, capturing startedAt = T+2000
       await waitFor(() => {
         expect(mockStartTracking).toHaveBeenCalledTimes(1);
       });
 
-      // The query's dataUpdatedAt (1000) < startedAt (2000), so it won't be
+      // The query's dataUpdatedAt (T+1000) < startedAt (T+2000), so it won't be
       // detected as refetched by useTrackQueriesRefetch. The hook will wait
       // forever for a refetch that already happened.
       //
-      // Expected behavior: loading should become false when the refetch from T1000
+      // Expected behavior: loading should become false when the refetch from T+1000
       // is detected, but it stays true indefinitely
       expect(result.current.loading).toBe(true);
 
       // Even if time advances, loading stays true because no new refetch happens
-      jest.setSystemTime(5000);
+      jest.advanceTimersByTime(3000);
       rerender();
 
       expect(result.current.loading).toBe(true);

--- a/web/src/hooks/use-progress-tracking.test.ts
+++ b/web/src/hooks/use-progress-tracking.test.ts
@@ -344,5 +344,58 @@ describe("useProgressTracking", () => {
         expect(result.current.loading).toBe(false);
       });
     });
+
+    // FLAW: This test demonstrates that if a query is refetched BEFORE startTracking()
+    // is called (but after progress started), it will never be considered as refetched.
+    // The hook gets stuck in loading state because useTrackQueriesRefetch only detects
+    // queries with dataUpdatedAt > startedAt, where startedAt is captured when
+    // startTracking() is called, not when the progress originally started.
+    //
+    // This can happen in real scenarios where:
+    // 1. Progress starts at T0
+    // 2. Query automatically refetches at T1 (due to invalidation or auto-refetch)
+    // 3. Progress completes at T2
+    // 4. startTracking() is called at T2, capturing startedAt = T2
+    // 5. The query's dataUpdatedAt (T1) < startedAt (T2), so it's never considered refetched
+    // 6. Hook waits forever for a refetch that already happened
+    it("FLAW: gets stuck in loading state when query refetches before startTracking is called", async () => {
+      const { result, rerender } = renderHook(() => useProgressTracking("software"));
+
+      // Start progress at T0
+      jest.setSystemTime(0);
+      mockProgresses([fakeSoftwareProgress]);
+      rerender();
+
+      expect(result.current.loading).toBe(true);
+
+      // Query refetches during progress at T1000 (this would happen automatically
+      // in real app due to query invalidation or refetchInterval)
+      jest.setSystemTime(1000);
+      // In reality, TanStack Query would update the query's dataUpdatedAt to 1000
+
+      // Progress completes at T2000
+      jest.setSystemTime(2000);
+      mockProgresses([]);
+      rerender();
+
+      // startTracking() is called now, capturing startedAt = 2000
+      await waitFor(() => {
+        expect(mockStartTracking).toHaveBeenCalledTimes(1);
+      });
+
+      // The query's dataUpdatedAt (1000) < startedAt (2000), so it won't be
+      // detected as refetched by useTrackQueriesRefetch. The hook will wait
+      // forever for a refetch that already happened.
+      //
+      // Expected behavior: loading should become false when the refetch from T1000
+      // is detected, but it stays true indefinitely
+      expect(result.current.loading).toBe(true);
+
+      // Even if time advances, loading stays true because no new refetch happens
+      jest.setSystemTime(5000);
+      rerender();
+
+      expect(result.current.loading).toBe(true);
+    });
   });
 });

--- a/web/src/hooks/use-progress-tracking.test.ts
+++ b/web/src/hooks/use-progress-tracking.test.ts
@@ -20,7 +20,6 @@
  * find current contact information at www.suse.com.
  */
 
-import { act } from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { mockProgresses, mockTasks } from "~/test-utils";
 import useTrackQueriesRefetch from "~/hooks/use-track-queries-refetch";
@@ -144,11 +143,10 @@ describe("useProgressTracking", () => {
       // Queries refetch after progress finished
       jest.setSystemTime(2000);
 
-      act(() => {
+      await waitFor(() => {
         mockRefetchCallback(1000, 2000);
+        expect(result.current.loading).toBe(false);
       });
-
-      expect(result.current.loading).toBe(false);
     });
 
     it("ignores query refetches completed before progress finished", async () => {
@@ -168,9 +166,7 @@ describe("useProgressTracking", () => {
       });
 
       // Queries refetched before progress finished, must be ignored
-      act(() => {
-        mockRefetchCallback(500, 1000);
-      });
+      mockRefetchCallback(500, 1000);
 
       expect(result.current.loading).toBe(true);
     });
@@ -213,11 +209,10 @@ describe("useProgressTracking", () => {
       // Queries refetch after progress finished
       jest.setSystemTime(2000);
 
-      act(() => {
+      await waitFor(() => {
         mockRefetchCallback(1000, 2000);
+        expect(result.current.loading).toBe(false);
       });
-
-      expect(result.current.loading).toBe(false);
     });
 
     it("ignores query refetches completed before progress finished", async () => {
@@ -237,9 +232,7 @@ describe("useProgressTracking", () => {
       });
 
       // Queries refetched before progress finished, must be ignored
-      act(() => {
-        mockRefetchCallback(500, 1000);
-      });
+      mockRefetchCallback(500, 1000);
 
       expect(result.current.loading).toBe(true);
     });
@@ -298,11 +291,10 @@ describe("useProgressTracking", () => {
       // Queries refetch after tasks finished
       jest.setSystemTime(2000);
 
-      act(() => {
+      await waitFor(() => {
         mockRefetchCallback(1000, 2000);
+        expect(result.current.loading).toBe(false);
       });
-
-      expect(result.current.loading).toBe(false);
     });
 
     it("keeps loading true when both progress and tasks exist", () => {
@@ -346,11 +338,11 @@ describe("useProgressTracking", () => {
 
       // Queries refetch
       jest.setSystemTime(3000);
-      act(() => {
-        mockRefetchCallback(2000, 3000);
-      });
 
-      expect(result.current.loading).toBe(false);
+      await waitFor(() => {
+        mockRefetchCallback(2000, 3000);
+        expect(result.current.loading).toBe(false);
+      });
     });
   });
 });

--- a/web/src/hooks/use-progress-tracking.test.ts
+++ b/web/src/hooks/use-progress-tracking.test.ts
@@ -64,7 +64,7 @@ const fakeStorageTask: Task = {
 
 describe("useProgressTracking", () => {
   let mockStartTracking: jest.Mock;
-  let mockRefetchCallback: (startedAt: number, completedAt: number) => void;
+  let mockRefetchCallback: () => void;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -144,31 +144,9 @@ describe("useProgressTracking", () => {
       jest.setSystemTime(2000);
 
       await waitFor(() => {
-        mockRefetchCallback(1000, 2000);
+        mockRefetchCallback();
         expect(result.current.loading).toBe(false);
       });
-    });
-
-    it("ignores query refetches completed before progress finished", async () => {
-      const { result, rerender } = renderHook(() => useProgressTracking("software"));
-
-      // Start progress
-      mockProgresses([fakeSoftwareProgress]);
-      rerender();
-
-      // Complete progress
-      jest.setSystemTime(2000);
-      mockProgresses([]);
-      rerender();
-
-      await waitFor(() => {
-        expect(mockStartTracking).toHaveBeenCalled();
-      });
-
-      // Queries refetched before progress finished, must be ignored
-      mockRefetchCallback(500, 1000);
-
-      expect(result.current.loading).toBe(true);
     });
   });
   describe("without scope", () => {
@@ -210,31 +188,9 @@ describe("useProgressTracking", () => {
       jest.setSystemTime(2000);
 
       await waitFor(() => {
-        mockRefetchCallback(1000, 2000);
+        mockRefetchCallback();
         expect(result.current.loading).toBe(false);
       });
-    });
-
-    it("ignores query refetches completed before progress finished", async () => {
-      const { result, rerender } = renderHook(() => useProgressTracking());
-
-      // Start progress
-      mockProgresses([fakeSoftwareProgress]);
-      rerender();
-
-      // Complete progress
-      jest.setSystemTime(2000);
-      mockProgresses([]);
-      rerender();
-
-      await waitFor(() => {
-        expect(mockStartTracking).toHaveBeenCalled();
-      });
-
-      // Queries refetched before progress finished, must be ignored
-      mockRefetchCallback(500, 1000);
-
-      expect(result.current.loading).toBe(true);
     });
   });
 
@@ -292,7 +248,7 @@ describe("useProgressTracking", () => {
       jest.setSystemTime(2000);
 
       await waitFor(() => {
-        mockRefetchCallback(1000, 2000);
+        mockRefetchCallback();
         expect(result.current.loading).toBe(false);
       });
     });
@@ -340,7 +296,7 @@ describe("useProgressTracking", () => {
       jest.setSystemTime(3000);
 
       await waitFor(() => {
-        mockRefetchCallback(2000, 3000);
+        mockRefetchCallback();
         expect(result.current.loading).toBe(false);
       });
     });

--- a/web/src/hooks/use-progress-tracking.test.ts
+++ b/web/src/hooks/use-progress-tracking.test.ts
@@ -24,7 +24,6 @@ import { act } from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { mockProgresses, mockTasks } from "~/test-utils";
 import useTrackQueriesRefetch from "~/hooks/use-track-queries-refetch";
-import { COMMON_PROPOSAL_KEYS } from "~/hooks/model/proposal";
 import type { Progress, Task } from "~/model/status";
 import { useProgressTracking } from "./use-progress-tracking";
 
@@ -87,10 +86,17 @@ describe("useProgressTracking", () => {
     jest.useRealTimers();
   });
 
-  it("uses COMMON_PROPOSAL_KEYS by default", () => {
+  it("uses empty array by default when no query keys specified", () => {
     renderHook(() => useProgressTracking("software"));
 
-    expect(useTrackQueriesRefetch).toHaveBeenCalledWith(COMMON_PROPOSAL_KEYS, expect.any(Function));
+    expect(useTrackQueriesRefetch).toHaveBeenCalledWith([], expect.any(Function));
+  });
+
+  it("uses provided query keys when specified", () => {
+    const queryKeys = ["proposal", "config"];
+    renderHook(() => useProgressTracking("software", queryKeys));
+
+    expect(useTrackQueriesRefetch).toHaveBeenCalledWith(queryKeys, expect.any(Function));
   });
 
   describe("with a specific scope", () => {

--- a/web/src/hooks/use-progress-tracking.ts
+++ b/web/src/hooks/use-progress-tracking.ts
@@ -24,7 +24,6 @@ import { useEffect, useRef, useState } from "react";
 import { isEmpty } from "radashi";
 import useTrackQueriesRefetch from "~/hooks/use-track-queries-refetch";
 import { useProgress } from "~/hooks/model/progress";
-import { COMMON_PROPOSAL_KEYS } from "~/hooks/model/proposal";
 import { useStatus } from "~/hooks/model/status";
 import type { Scope } from "~/model/status";
 
@@ -38,7 +37,8 @@ import type { Scope } from "~/model/status";
  *
  * @param scope - The progress/task scope to monitor (e.g., "software", "storage")
  * @param queryKeys - Array of TanStack Query keys to track for refetches after
- *   progress completes. Defaults to COMMON_PROPOSAL_KEYS if not provided.
+ *   progress completes. Defaults to empty array (no query waiting). Explicitly
+ *   specify all query keys the page depends on to wait for them to refetch.
  *
  * @returns Object containing:
  *   - `loading`: Boolean indicating whether an operation is in progress, tasks
@@ -48,26 +48,30 @@ import type { Scope } from "~/model/status";
  *
  * @example
  * ```tsx
- * // Basic usage with default query keys
- * function SoftwareSummary() {
- *   const { loading } = useProgressTracking("software");
+ * // Storage page uses proposal and storage model data
+ * function StorageSummary() {
+ *   const { loading } = useProgressTracking("storage", [
+ *     PROPOSAL_QUERY_KEY,
+ *     EXTENDED_CONFIG_QUERY_KEY,
+ *     STORAGE_MODEL_QUERY_KEY
+ *   ]);
  *
  *   if (loading) return <Skeleton />;
- *   return <SoftwareSummary />;
+ *   return <StorageSummary />;
  * }
  * ```
  *
  * @example
  * ```tsx
- * // With custom query keys to ensure specific data is refetched
- * function ProgressBackdrop({ scope, ensureRefetched }) {
- *   const { loading: isBlocked, progress } = useProgressTracking(
- *     scope,
- *     [...COMMON_PROPOSAL_KEYS, ...ensureRefetched]
- *   );
+ * // iSCSI page only uses system and config data
+ * function ISCSIPage() {
+ *   const { loading } = useProgressTracking("iscsi", [
+ *     SYSTEM_QUERY_KEY,
+ *     CONFIG_QUERY_KEY
+ *   ]);
  *
- *   if (!isBlocked) return null;
- *   return <Backdrop message={progress.message} />;
+ *   if (loading) return <Skeleton />;
+ *   return <ISCSIContent />;
  * }
  * ```
  *
@@ -90,7 +94,7 @@ import type { Scope } from "~/model/status";
  */
 export function useProgressTracking(
   scope?: Scope,
-  queryKeys: readonly string[] = COMMON_PROPOSAL_KEYS,
+  queryKeys: readonly string[] = [],
 ) {
   const progress = useProgress(scope);
   const status = useStatus();

--- a/web/src/hooks/use-progress-tracking.ts
+++ b/web/src/hooks/use-progress-tracking.ts
@@ -37,8 +37,8 @@ import type { Scope } from "~/model/status";
  *
  * @param scope - The progress/task scope to monitor (e.g., "software", "storage")
  * @param queryKeys - Array of TanStack Query keys to track for refetches after
- *   progress completes. Defaults to empty array (no query waiting). Explicitly
- *   specify all query keys the page depends on to wait for them to refetch.
+ *   progress completes. Defaults to empty array (no query waiting). Typically
+ *   contains the `*_QUERY_KEY` constant exported by each data hook the page uses.
  *
  * @returns Object containing:
  *   - `loading`: Boolean indicating whether an operation is in progress, tasks
@@ -92,10 +92,7 @@ import type { Scope } from "~/model/status";
  * @see {@link useStatus} - For monitoring backend task status
  * @see {@link useTrackQueriesRefetch} - For tracking query refetch completion
  */
-export function useProgressTracking(
-  scope?: Scope,
-  queryKeys: readonly string[] = [],
-) {
+export function useProgressTracking(scope?: Scope, queryKeys: readonly string[] = []) {
   const progress = useProgress(scope);
   const status = useStatus();
   const [loading, setLoading] = useState(false);

--- a/web/src/hooks/use-progress-tracking.ts
+++ b/web/src/hooks/use-progress-tracking.ts
@@ -77,7 +77,7 @@ import type { Scope } from "~/model/status";
  *
  * @remarks
  *
- * In short, the hook works as follow
+ * In short, the hook works as follows
  *
  *   1. Backend operation starts or tasks are created → `loading` becomes `true`
  *   2. Backend operation finishes and tasks complete → hook waits for queries to refetch
@@ -85,8 +85,8 @@ import type { Scope } from "~/model/status";
  *      `loading` becomes `false`
  *
  *  The hook uses a ref to track when the operation finished, ensuring queries
- *  are only considered "fresh" if they refetched AFTER the operation completed
- *  to prevents showing stale data to users.
+ *  are only considered "fresh" if they refetched AFTER the operation completed,
+ *  to prevent showing stale data to users.
  *
  * @see {@link useProgress} - For monitoring backend progress status
  * @see {@link useStatus} - For monitoring backend task status
@@ -120,8 +120,10 @@ export function useProgressTracking(scope?: Scope, queryKeys: readonly string[] 
       progressFinishedAtRef.current = Date.now();
       startTracking();
     }
-  }, [allFinished, startTracking, loading, progressFinishedAtRef]);
+  }, [allFinished, startTracking, loading]);
 
+  // Enter the loading state as soon as an operation is detected. Setting state
+  // during render (instead of in an effect) avoids a flash of non-loading UI.
   if (!allFinished && !loading) {
     setLoading(true);
     progressFinishedAtRef.current = null;

--- a/web/src/hooks/use-progress-tracking.ts
+++ b/web/src/hooks/use-progress-tracking.ts
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { isEmpty } from "radashi";
 import useTrackQueriesRefetch from "~/hooks/use-track-queries-refetch";
 import { useProgress } from "~/hooks/model/progress";
@@ -96,13 +96,9 @@ export function useProgressTracking(scope?: Scope, queryKeys: readonly string[] 
   const progress = useProgress(scope);
   const status = useStatus();
   const [loading, setLoading] = useState(false);
-  const progressFinishedAtRef = useRef<number | null>(null);
 
-  const { startTracking } = useTrackQueriesRefetch(queryKeys, (_, completedAt) => {
-    if (progressFinishedAtRef.current && completedAt > progressFinishedAtRef.current) {
-      setLoading(false);
-      progressFinishedAtRef.current = null;
-    }
+  const { startTracking } = useTrackQueriesRefetch(queryKeys, () => {
+    setLoading(false);
   });
 
   // Filter tasks by scope
@@ -116,8 +112,7 @@ export function useProgressTracking(scope?: Scope, queryKeys: readonly string[] 
   const allFinished = progressesFinished && tasksFinished;
 
   useEffect(() => {
-    if (allFinished && loading && !progressFinishedAtRef.current) {
-      progressFinishedAtRef.current = Date.now();
+    if (allFinished && loading) {
       startTracking();
     }
   }, [allFinished, startTracking, loading]);
@@ -126,7 +121,6 @@ export function useProgressTracking(scope?: Scope, queryKeys: readonly string[] 
   // during render (instead of in an effect) avoids a flash of non-loading UI.
   if (!allFinished && !loading) {
     setLoading(true);
-    progressFinishedAtRef.current = null;
   }
 
   return { loading, progress };

--- a/web/src/hooks/use-track-queries-refetch.test.tsx
+++ b/web/src/hooks/use-track-queries-refetch.test.tsx
@@ -113,22 +113,21 @@ describe("useTrackQueriesRefetch", () => {
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
-  it("passes the start and completion timestamps to onSuccess", async () => {
+  it("calls onSuccess when tracked query refetches", async () => {
     const onSuccess = jest.fn();
 
     const { result } = renderTestHook(["q1"], onSuccess);
 
     result.current.queryClient.setQueryData(["q1"], "initial");
 
-    // startTracking records Date.now() (currently 0) as the start timestamp.
     result.current.startTracking();
 
-    advanceTime(5); // now = 5
+    advanceTime();
 
     result.current.queryClient.setQueryData(["q1"], "updated");
 
     await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalledWith(0, 5);
+      expect(onSuccess).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/web/src/hooks/use-track-queries-refetch.test.tsx
+++ b/web/src/hooks/use-track-queries-refetch.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import useTrackQueriesRefetch from "./use-track-queries-refetch";
 
@@ -30,7 +30,8 @@ describe("useTrackQueriesRefetch", () => {
   let now = 0;
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    // The hook reads Date.now() but schedules no timers, so a mocked clock
+    // counter is enough; no fake timers needed.
     now = 0;
     jest.spyOn(Date, "now").mockImplementation(() => now);
 
@@ -45,16 +46,12 @@ describe("useTrackQueriesRefetch", () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers();
     jest.restoreAllMocks();
     queryClient.clear();
   });
 
   const advanceTime = (ms = 1) => {
     now += ms;
-    act(() => {
-      jest.advanceTimersByTime(ms);
-    });
   };
 
   const renderTestHook = (queryKeys: string[], onSuccess: jest.Mock) => {
@@ -83,24 +80,85 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(["q1", "q2"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "initial");
-      result.current.queryClient.setQueryData(["q2"], "initial");
-    });
+    result.current.queryClient.setQueryData(["q1"], "initial");
+    result.current.queryClient.setQueryData(["q2"], "initial");
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "updated");
-      result.current.queryClient.setQueryData(["q2"], "updated");
-    });
+    result.current.queryClient.setQueryData(["q1"], "updated");
+    result.current.queryClient.setQueryData(["q2"], "updated");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not call onSuccess when only some queries refetch", () => {
+    const onSuccess = jest.fn();
+
+    const { result } = renderTestHook(["q1", "q2"], onSuccess);
+
+    result.current.queryClient.setQueryData(["q1"], "initial");
+    result.current.queryClient.setQueryData(["q2"], "initial");
+
+    result.current.startTracking();
+
+    advanceTime();
+
+    // Only one of the two tracked queries refetches.
+    result.current.queryClient.setQueryData(["q1"], "updated");
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("passes the start and completion timestamps to onSuccess", async () => {
+    const onSuccess = jest.fn();
+
+    const { result } = renderTestHook(["q1"], onSuccess);
+
+    result.current.queryClient.setQueryData(["q1"], "initial");
+
+    // startTracking records Date.now() (currently 0) as the start timestamp.
+    result.current.startTracking();
+
+    advanceTime(5); // now = 5
+
+    result.current.queryClient.setQueryData(["q1"], "updated");
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(0, 5);
+    });
+  });
+
+  it("can track a second cycle after the first one completes", async () => {
+    const onSuccess = jest.fn();
+
+    const { result } = renderTestHook(["q1"], onSuccess);
+
+    result.current.queryClient.setQueryData(["q1"], "initial");
+
+    // First cycle
+    result.current.startTracking();
+
+    advanceTime();
+
+    result.current.queryClient.setQueryData(["q1"], "first");
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    // Second cycle, reusing the same tracker instance
+    result.current.startTracking();
+
+    advanceTime();
+
+    result.current.queryClient.setQueryData(["q1"], "second");
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -109,9 +167,7 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook([], onSuccess);
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -123,23 +179,17 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(["q1", "q2"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "before");
-      result.current.queryClient.setQueryData(["q2"], "before");
-    });
+    result.current.queryClient.setQueryData(["q1"], "before");
+    result.current.queryClient.setQueryData(["q2"], "before");
 
     advanceTime(10);
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "after");
-      result.current.queryClient.setQueryData(["q2"], "after");
-    });
+    result.current.queryClient.setQueryData(["q1"], "after");
+    result.current.queryClient.setQueryData(["q2"], "after");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -151,31 +201,21 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(["q1", "q2"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "init");
-      result.current.queryClient.setQueryData(["q2"], "init");
-    });
+    result.current.queryClient.setQueryData(["q1"], "init");
+    result.current.queryClient.setQueryData(["q2"], "init");
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "cycle-1");
-    });
+    result.current.queryClient.setQueryData(["q1"], "cycle-1");
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "cycle-2");
-      result.current.queryClient.setQueryData(["q2"], "cycle-2");
-    });
+    result.current.queryClient.setQueryData(["q1"], "cycle-2");
+    result.current.queryClient.setQueryData(["q2"], "cycle-2");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -187,21 +227,15 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(["q1"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "init");
-    });
+    result.current.queryClient.setQueryData(["q1"], "init");
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "u1");
-      result.current.queryClient.setQueryData(["q1"], "u2");
-      result.current.queryClient.setQueryData(["q1"], "u3");
-    });
+    result.current.queryClient.setQueryData(["q1"], "u1");
+    result.current.queryClient.setQueryData(["q1"], "u2");
+    result.current.queryClient.setQueryData(["q1"], "u3");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -213,21 +247,15 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(["q1", "q2", "q1", "q2"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "init");
-      result.current.queryClient.setQueryData(["q2"], "init");
-    });
+    result.current.queryClient.setQueryData(["q1"], "init");
+    result.current.queryClient.setQueryData(["q2"], "init");
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "u1");
-      result.current.queryClient.setQueryData(["q2"], "u2");
-    });
+    result.current.queryClient.setQueryData(["q1"], "u1");
+    result.current.queryClient.setQueryData(["q2"], "u2");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -239,15 +267,11 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(["missing"], onSuccess);
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["missing"], "created-later");
-    });
+    result.current.queryClient.setQueryData(["missing"], "created-later");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -260,19 +284,13 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(keys, onSuccess);
 
-    act(() => {
-      keys.forEach((k) => result.current.queryClient.setQueryData([k], "init"));
-    });
+    keys.forEach((k) => result.current.queryClient.setQueryData([k], "init"));
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      keys.forEach((k) => result.current.queryClient.setQueryData([k], "update"));
-    });
+    keys.forEach((k) => result.current.queryClient.setQueryData([k], "update"));
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -284,23 +302,17 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result, rerender } = renderTestHook(["q1", "q2"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "init");
-      result.current.queryClient.setQueryData(["q2"], "init");
-    });
+    result.current.queryClient.setQueryData(["q1"], "init");
+    result.current.queryClient.setQueryData(["q2"], "init");
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     rerender({ keys: ["q1", "q2"] });
 
     advanceTime();
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "u1");
-      result.current.queryClient.setQueryData(["q2"], "u2");
-    });
+    result.current.queryClient.setQueryData(["q1"], "u1");
+    result.current.queryClient.setQueryData(["q2"], "u2");
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -313,19 +325,13 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result } = renderTestHook(keys, onSuccess);
 
-    act(() => {
-      keys.forEach((k) => result.current.queryClient.setQueryData([k], "init"));
-    });
+    keys.forEach((k) => result.current.queryClient.setQueryData([k], "init"));
 
-    act(() => {
-      result.current.startTracking();
-    });
+    result.current.startTracking();
 
     advanceTime();
 
-    act(() => {
-      keys.forEach((k) => result.current.queryClient.setQueryData([k], "update"));
-    });
+    keys.forEach((k) => result.current.queryClient.setQueryData([k], "update"));
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -337,17 +343,13 @@ describe("useTrackQueriesRefetch", () => {
 
     const { result, unmount } = renderTestHook(["q1"], onSuccess);
 
-    act(() => {
-      result.current.queryClient.setQueryData(["q1"], "init");
-      result.current.startTracking();
-    });
+    result.current.queryClient.setQueryData(["q1"], "init");
+    result.current.startTracking();
 
     unmount();
     advanceTime();
 
-    act(() => {
-      queryClient.setQueryData(["q1"], "after");
-    });
+    queryClient.setQueryData(["q1"], "after");
 
     expect(onSuccess).not.toHaveBeenCalled();
   });

--- a/web/src/hooks/use-track-queries-refetch.ts
+++ b/web/src/hooks/use-track-queries-refetch.ts
@@ -34,8 +34,7 @@ import { useQueryClient } from "@tanstack/react-query";
  *
  * @param queryKeys - Array of query key strings to track for refetches
  * @param onSuccess - Callback executed when considered all queries have
- *   refetched successfully. Receives the tracking start timestamp and completion
- *   timestamp.
+ *   refetched successfully.
  *
  * @returns Object containing the `startTracking` function to initiate tracking
  *
@@ -68,10 +67,7 @@ import { useQueryClient } from "@tanstack/react-query";
  *
  * @see {@link https://tanstack.com/query/latest/docs/reference/QueryCache#querycachesubscribe}
  */
-function useTrackQueriesRefetch(
-  queryKeys: readonly string[],
-  onSuccess: (startedAt: number, completedAt: number) => void,
-) {
+function useTrackQueriesRefetch(queryKeys: readonly string[], onSuccess: () => void) {
   const queryClient = useQueryClient();
 
   // Remove duplicates and create Set for faster lookups when matching query keys
@@ -110,7 +106,7 @@ function useTrackQueriesRefetch(
     if (completedRef.current || startedAtRef.current === null) return;
 
     completedRef.current = true;
-    onSuccess(startedAtRef.current, Date.now());
+    onSuccess();
     cleanup();
   }, [onSuccess, cleanup]);
 

--- a/web/src/hooks/use-track-queries-refetch.ts
+++ b/web/src/hooks/use-track-queries-refetch.ts
@@ -27,10 +27,10 @@ import { useQueryClient } from "@tanstack/react-query";
  * Custom hook that monitors multiple TanStack Query keys and triggers a
  * callback when all queries have been successfully refetched with fresh data.
  *
- * This hook subscribes to the specified queries and waits until each one
- * reports a `dataUpdatedAt` timestamp newer than when `startTracking()` was
- * called. Once all queries are updated, the `onSuccess` callback is
- * triggered and subscriptions are automatically cleaned up.
+ * This hook subscribes once to the query cache and waits until each tracked
+ * query reports a `dataUpdatedAt` timestamp newer than when `startTracking()`
+ * was called. Once all tracked queries are updated, the `onSuccess` callback is
+ * triggered and the subscription is automatically cleaned up.
  *
  * @param queryKeys - Array of query key strings to track for refetches
  * @param onSuccess - Callback executed when considered all queries have
@@ -66,7 +66,7 @@ import { useQueryClient } from "@tanstack/react-query";
  *   recalculates when the queryKeys reference changes. For optimal performance,
  *   memoize queryKeys in the parent component if it changes frequently.
  *
- * @see {@link https://tanstack.com/query/latest/docs/react/reference/QueryObserver}
+ * @see {@link https://tanstack.com/query/latest/docs/reference/QueryCache#querycachesubscribe}
  */
 function useTrackQueriesRefetch(
   queryKeys: readonly string[],
@@ -117,9 +117,10 @@ function useTrackQueriesRefetch(
   /**
    * Initiates tracking of query refetches.
    *
-   * Creates QueryObservers for each query key and monitors their status. When
-   * all queries are considered successfully refetched (their `dataUpdatedAt` is
-   * later than the startedAt value), the `onSuccess` callback is triggered.
+   * Subscribes once to the query cache and watches for updates to the tracked
+   * keys. When all of them are considered successfully refetched (their
+   * `dataUpdatedAt` is later than the startedAt value), the `onSuccess` callback
+   * is triggered.
    *
    * Calling this function multiple times will cancel previous tracking cycles.
    */

--- a/web/src/hooks/use-track-queries-refetch.ts
+++ b/web/src/hooks/use-track-queries-refetch.ts
@@ -42,8 +42,8 @@ import { useQueryClient } from "@tanstack/react-query";
  * ```tsx
  *   const { startTracking } = useTrackQueriesRefetch(
  *     ['users', 'posts', 'comments'],
- *     (startedAt, completedAt) => {
- *       console.log(`All queries refetched in ${completedAt - startedAt}ms`);
+ *     () => {
+ *       console.log("All queries refetched");
  *     })
  *   );
  *

--- a/web/src/hooks/use-track-queries-refetch.ts
+++ b/web/src/hooks/use-track-queries-refetch.ts
@@ -119,6 +119,22 @@ function useTrackQueriesRefetch(queryKeys: readonly string[], onSuccess: () => v
    * is triggered.
    *
    * Calling this function multiple times will cancel previous tracking cycles.
+   *
+   * KNOWN FLAW: If a query refetches BEFORE this function is called (but after
+   * the operation that triggered the need for tracking started), it will never
+   * be detected as refetched. This happens because `startedAt` is captured when
+   * this function is called, not when the original operation started. As a result,
+   * queries with `dataUpdatedAt < startedAt` are ignored, even if they refetched
+   * fresh data after the operation began. This can cause the hook to get stuck
+   * in a waiting state indefinitely.
+   *
+   * Example scenario:
+   * 1. Backend operation starts at T0
+   * 2. Query auto-refetches at T1 (due to invalidation or refetchInterval)
+   * 3. Backend operation completes at T2
+   * 4. startTracking() is called at T2, capturing startedAt = T2
+   * 5. Query's dataUpdatedAt (T1) < startedAt (T2), so it's never detected
+   * 6. Hook waits forever for a refetch that already happened
    */
   const startTracking = useCallback(() => {
     // Reset any previous tracking cycle

--- a/web/src/test-conventions.md
+++ b/web/src/test-conventions.md
@@ -254,6 +254,28 @@ transitions through `waitFor` keeps tests free of explicit `act`. Reach for a
 bare `jest.advanceTimersByTime` only when no state update results (such as
 advancing an already-cancelled timer).
 
+The same idea extends beyond timers. Two cases come up when testing hooks with
+`renderHook`:
+
+- **The action triggers no state update.** A hook built only on refs,
+  subscriptions, or callbacks does not re-render, so emitting an event or writing
+  to the query cache fires its callbacks synchronously with nothing to wrap.
+  Check what the hook actually does rather than assuming; if no `setState` runs,
+  no `act` is needed.
+- **The test itself triggers a state update** by invoking a callback it captured
+  from a mock (e.g. the `onSuccess` passed to a mocked hook). Call it from inside
+  `waitFor` so the update runs within `act`; the body may run more than once, so
+  keep that call idempotent.
+
+```tsx
+// mockRefetchCallback is captured from a mocked hook and calls setState.
+// Invoking it inside waitFor runs that update within act.
+await waitFor(() => {
+  mockRefetchCallback(startedAt, completedAt);
+  expect(result.current.loading).toBe(false);
+});
+```
+
 ---
 
 ## Quick checklist

--- a/web/src/test-conventions.md
+++ b/web/src/test-conventions.md
@@ -271,7 +271,7 @@ The same idea extends beyond timers. Two cases come up when testing hooks with
 // mockRefetchCallback is captured from a mocked hook and calls setState.
 // Invoking it inside waitFor runs that update within act.
 await waitFor(() => {
-  mockRefetchCallback(startedAt, completedAt);
+  mockRefetchCallback();
   expect(result.current.loading).toBe(false);
 });
 ```


### PR DESCRIPTION
## Problem

The current progress tracking implementation has a design flaw where all pages automatically wait for the "common proposal keys" (i.e., `proposal` and `extendedConfig`) to refetch, even when those keys are not relevant to the operation being tracked.

This causes a bug with iSCSI discovery in which the progress backdrop displays "Refreshing data..." indefinitely because:

1. The discovery operation completes and signals the `iscsi` scope.
2. The progress tracking automatically waits for `COMMON_PROPOSAL_KEYS` to refetch.
3. But discovery doesn't trigger a proposal change, so those queries never refetch.
4. The backdrop never dismisses, blocking user interaction.

See https://bugzilla.suse.com/show_bug.cgi?id=1269224.

As proposals come and go, the assumption that every operation affects the proposal becomes increasingly incorrect. Moreover, the upcoming architectural changes where some proposals might disappear make this assumption even more problematic, see check https://trello.com/c/jTgiokbJ.

## Solution

The solution is to make query-key subscriptions fully explicit, so each page declares exactly the queries it depends on. In other words, remove COMMON_PROPOSAL_KEYS and replace the `ensureRefetched` prop (which adds to the default common keys) with an `awaitQueriesRefetch` prop (which specifies all keys explicitly, with no defaults).

While the proposed change introduces additional verbosity by requiring each consumer to explicitly specify the query keys it depends on, it also makes those dependencies explicit, resulting in a more robust and future-proof design.

Note: some flaws were detected in the progress tracking, but it is out of the scope of this PR, see https://trello.com/c/3WLwI010/2400-improve-progress-tracking.

---

Assisted by Claude Sonnet 4.5