### PR TITLE
fix(web): polish keyboard focus ring and other UI rough edges

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Jun 28 21:50:40 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Polish the keyboard focus ring and assorted UI rough edges (control
+  sizes, disabled-button spinner, dark skip link, form-alert scroll)
+  (gh#agama-project/agama#3675).
+
+-------------------------------------------------------------------
 Fri Jun 26 10:03:36 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Improve disabled text and status color contrast to meet WCAG AA

--- a/web/src/assets/products/example-advanced.css
+++ b/web/src/assets/products/example-advanced.css
@@ -74,6 +74,7 @@
   --agm-t--link--color: #bd3314; /* also used by link-style buttons, e.g. headings */
   --agm-t--action--background--color--hover: #ffefe9; /* hover / selection */
   --agm-t--focus--color: #fe7c3f; /* keyboard focus ring */
+  --agm-t--focus--separator--color: #fff; /* hairline between the ring and a button fill (defaults to the surface) */
 
   --agm-t--disabled--background--color: #dcdbdc;
   --agm-t--tooltip--background--color: #1d1d1d;
@@ -105,6 +106,7 @@
   --agm-t--link--color: #ffb184;
   --agm-t--action--background--color--hover: #3a2a1e;
   --agm-t--focus--color: #fe7c3f;
+  --agm-t--focus--separator--color: #1d1d1d;
 
   --agm-t--disabled--background--color: #2b2b2b;
   --agm-t--tooltip--background--color: #0f0f0f;

--- a/web/src/assets/products/example.css
+++ b/web/src/assets/products/example.css
@@ -36,6 +36,7 @@
   --agm-t--link--color: #bd3314;
   --agm-t--action--background--color--hover: #ffefe9;
   --agm-t--focus--color: #fe7c3f;
+  --agm-t--focus--separator--color: #fff;
 
   --agm-t--status--info--color: #2453ff;
   --agm-t--status--caution--color: #9a6700;
@@ -60,6 +61,7 @@
   --agm-t--link--color: #a98bff;
   --agm-t--action--background--color--hover: #262640;
   --agm-t--focus--color: #a98bff;
+  --agm-t--focus--separator--color: #141420;
 
   --agm-t--status--info--color: #6aa6ff;
   --agm-t--status--caution--color: #f0b429;

--- a/web/src/assets/styles/base/_reset.scss
+++ b/web/src/assets/styles/base/_reset.scss
@@ -98,10 +98,44 @@ input[type="radio"] {
 
 // Custom style for :focus-visible appearance. The color is the --agm-t--focus--color
 // role (products can override it); it defaults to waterhole.
+//
+// Links, checkboxes and radios use an outset outline. They rarely sit in tight
+// containers, and an outline keeps a single, consistent focus color (otherwise
+// they fall back to the browser/PatternFly default color).
+//
+// TODO: re-evaluate. The radio ring is square because a native radio ignores
+// border-radius; a round ring would need a custom (appearance: none) radio.
 a:focus-visible,
-button:focus-visible {
+input[type="checkbox"]:focus-visible,
+input[type="radio"]:focus-visible {
   outline: 3px solid var(--agm-t--focus--color, var(--agm-t--color--waterhole--50));
   outline-offset: 2px;
+}
+
+// Buttons draw the focus ring inside their box (inset box-shadow) instead of
+// outside it. An outset ring is easily clipped by tight containers (e.g. form
+// action rows), which left it showing only a couple of edges. An inset ring is
+// painted within the button, so it is always fully visible and follows the
+// button shape on any background. The transparent outline is the forced-colors
+// / high contrast fallback, where box-shadow is dropped.
+//
+// A thin separator inside the focus color keeps the ring visible on any button
+// fill: a single color washes out over a colored fill (e.g. the primary button),
+// but the separator (the surface color by default, so it reads as a gap) always
+// gives a contrasting edge. Both colors are themeable roles.
+//
+// A few PatternFly components built on <button> bring their own focus styling
+// (menu items, toggle segments, inline links); they opt out in
+// _patternfly-overrides.
+button:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow:
+    inset 0 0 0 3px var(--agm-t--focus--color, var(--agm-t--color--waterhole--50)),
+    inset 0 0 0 4px
+      var(
+        --agm-t--focus--separator--color,
+        var(--pf-t--global--background--color--primary--default)
+      );
 }
 
 fieldset {

--- a/web/src/assets/styles/base/_reset.scss
+++ b/web/src/assets/styles/base/_reset.scss
@@ -88,9 +88,12 @@ pre {
   white-space: pre-line;
 }
 
-input[type="checkbox"] {
-  inline-size: var(--pf-t--global--font--size--md);
-  block-size: var(--pf-t--global--font--size--md);
+// Enlarge checkboxes and radios for a more comfortable tap target and a
+// consistent size across every form.
+input[type="checkbox"],
+input[type="radio"] {
+  inline-size: 1.2em;
+  block-size: 1.2em;
 }
 
 // Custom style for :focus-visible appearance. The color is the --agm-t--focus--color

--- a/web/src/assets/styles/components/_agama-custom.scss
+++ b/web/src/assets/styles/components/_agama-custom.scss
@@ -33,8 +33,6 @@
 #productSelectionForm {
   input[type="radio"] {
     align-self: center;
-    inline-size: 1.2em;
-    block-size: 1.2em;
   }
 
   .pf-v6-c-card {

--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -248,6 +248,16 @@ label.pf-m-disabled + .pf-v6-c-check__description {
   gap: inherit;
 }
 
+// A button that is busy is often disabled at the same time (to block a second
+// submit). By default the spinner keeps the button's icon color (light), which
+// is nearly invisible on the gray disabled background and out of step with the
+// muted disabled label. Match the spinner to the current text color so it reads
+// the same as the label in every theme. Plain buttons keep their own treatment.
+.pf-v6-c-button.pf-m-in-progress:disabled:not(.pf-m-plain),
+.pf-v6-c-button.pf-m-in-progress.pf-m-aria-disabled:not(.pf-m-plain) {
+  --pf-v6-c-button__progress--Color: currentcolor;
+}
+
 .pf-v6-c-skip-to-content {
   --pf-v6-c-skip-to-content--focus--InsetInlineStart: var(
     --pf-t--global--spacer--inset--page-chrome

--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -314,7 +314,11 @@ label.pf-m-disabled + .pf-v6-c-check__description {
   );
 
   a.pf-m-primary {
-    background: var(--agm-t--focus--color, var(--agm-t--color--waterhole--50));
+    // Use the brand blue directly (not the focus role, which goes lighter in
+    // dark theme for ring contrast) and pin a light text color, so the link
+    // keeps the same readable look on the blue background in every theme.
+    background: var(--agm-t--color--waterhole--50);
+    color: var(--agm-t--color--fog--50);
     font-size: var(--pf-t--global--font--size--md);
   }
 }

--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -258,6 +258,56 @@ label.pf-m-disabled + .pf-v6-c-check__description {
   --pf-v6-c-button__progress--Color: currentcolor;
 }
 
+// PatternFly draws each variant's border with a ::after pseudo-element, which
+// would otherwise sit outside the inset focus ring (see base/_reset) and make
+// bordered variants (e.g. secondary) look different. Hide it while focused so
+// the ring is identical on every button.
+.pf-v6-c-button:focus-visible::after {
+  border-color: transparent;
+}
+
+// Inline link buttons sit within a line of text, where the inset ring would
+// overlap the text. Give them an outset outline instead, like a plain link.
+.pf-v6-c-button.pf-m-inline:focus-visible {
+  box-shadow: none;
+  outline: 3px solid var(--agm-t--focus--color, var(--agm-t--color--waterhole--50));
+  outline-offset: 2px;
+}
+
+// Menu items are a mix of <button> and (when they have a `to`) <a>, so left to
+// the generic styles they focus inconsistently: a black default outline on the
+// buttons, the blue link outline on the anchors, the latter clipped oddly on the
+// rounded last item. Give them all the same inset ring, which follows each item's
+// uniform radius. The transparent outline is the forced-colors fallback.
+.pf-v6-c-menu__item:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: inset 0 0 0 3px var(--agm-t--focus--color, var(--agm-t--color--waterhole--50));
+}
+
+// Text inputs and other form controls show focus through the control's outline,
+// which PatternFly positions but leaves the default (black) color. Paint it with
+// the focus color so it matches the rest.
+.pf-v6-c-form-control > :is(input, select, textarea):focus-visible {
+  outline: 2px solid var(--agm-t--focus--color, var(--agm-t--color--waterhole--50));
+}
+
+// Toggle segments are connected, so an outline ring around one looks awkward
+// (a sliver when inset, an ugly box when outset). Opt out of the button ring and
+// indicate focus by drawing the segment's own border in the focus color and a
+// bit thicker, so it stays clear even on the selected segment, which already has
+// a colored border.
+.pf-v6-c-toggle-group__button:focus-visible {
+  box-shadow: none;
+  --pf-v6-c-toggle-group__button--before--BorderColor: var(
+    --agm-t--focus--color,
+    var(--agm-t--color--waterhole--50)
+  );
+  --pf-v6-c-toggle-group__button--before--BorderWidth: var(
+    --pf-t--global--border--width--box--clicked
+  );
+  z-index: 1;
+}
+
 .pf-v6-c-skip-to-content {
   --pf-v6-c-skip-to-content--focus--InsetInlineStart: var(
     --pf-t--global--spacer--inset--page-chrome

--- a/web/src/assets/styles/themes/_dark.scss
+++ b/web/src/assets/styles/themes/_dark.scss
@@ -120,6 +120,10 @@
   --agm-t--surface--color--floating: var(--agm-t--surface--color--raised);
   --agm-t--border--color: color-mix(in srgb, var(--agm-t--color--pine--50) 70%, white);
 
+  // Lighter focus ring so it stays visible on the dark surfaces; the default
+  // (waterhole-50) is too dark against them, e.g. on a selected toggle.
+  --agm-t--focus--color: var(--agm-t--color--waterhole--30);
+
   --pf-t--global--background--color--primary--default: var(--agm-t--surface--color);
   --pf-t--global--background--color--secondary--default: var(--agm-t--surface--color--raised);
   --pf-t--global--background--color--floating--default: var(--agm-t--surface--color--floating);

--- a/web/src/assets/styles/tokens/_semantic.scss
+++ b/web/src/assets/styles/tokens/_semantic.scss
@@ -28,6 +28,9 @@
 //   --agm-t--disabled--background--color          disabled control background
 //   --agm-t--tooltip--background--color (+ --color) tooltip background and text
 //   --agm-t--focus--color                         keyboard focus ring (see base/_reset)
+//   --agm-t--focus--separator--color              hairline between the ring and a
+//                                                 button fill (keeps the ring
+//                                                 visible on colored fills)
 //   --agm-t--status--{info,caution,danger,success,custom}--color
 //                                                 alert / status variants
 //                                                 (caution maps to PF "warning")

--- a/web/src/hooks/use-form-submit.tsx
+++ b/web/src/hooks/use-form-submit.tsx
@@ -20,9 +20,8 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { Alert } from "@patternfly/react-core";
-import Page from "~/components/core/Page";
 import Interpolate from "~/components/core/Interpolate";
 import Link from "~/components/core/Link";
 import { ROOT } from "~/routes/paths";
@@ -86,10 +85,11 @@ type Options<TValues> = {
   errorTitle?: string;
 
   /**
-   * Whether to scroll to top on successful submit.
+   * Whether to show the success/info alert when the form stays mounted.
    *
-   * Defaults to true (always scroll). Set to false for forms that navigate away
-   * on success — scrolling is unnecessary since the user won't see the page.
+   * Defaults to true. Set to false for forms that navigate away on success,
+   * where a success alert (and its scroll) is unnecessary since the user won't
+   * see the page. Validation error alerts are shown regardless.
    */
   scrollOnSuccess?: boolean;
 };
@@ -175,6 +175,29 @@ type Options<TValues> = {
  * - TanStack Form issue #1681: form.reset during onSubmit ignores new values
  * - TanStack Form issue #1798: reset + useStore subscription bug
  */
+/**
+ * Scrolls its content into view once, when it first appears.
+ *
+ * Wraps the post-submit alert so the page moves to the alert itself instead of
+ * jumping to the very top. On pages with content above the form (e.g. an intro),
+ * scrolling to the top can leave the alert below the fold on small viewports.
+ */
+function ScrollIntoView({ children }: React.PropsWithChildren) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Defer to the next tick so the alert is laid out before scrolling. The
+    // scroll is a progressive enhancement, so scrollIntoView is optional-chained
+    // to stay a safe no-op where it is unavailable.
+    const id = window.setTimeout(() => {
+      ref.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+}
+
 export function useFormSubmit<TValues>({
   onSubmit,
   successTitle = _("Changes successfully applied"),
@@ -248,7 +271,8 @@ export function useFormSubmit<TValues>({
    * Renders success, info, or validation error alerts after submit.
    *
    * Subscribes to isDirty, isSubmitting, and isValid. Uses refs (not state) to avoid
-   * extra re-renders and to work around TanStack Form's reset bugs.
+   * extra re-renders and to work around TanStack Form's reset bugs. The rendered
+   * alert scrolls itself into view when it appears (see ScrollIntoView).
    *
    * Success/info alert shown when form is clean (!isDirty), not submitting, and a
    * submit outcome ref is set.
@@ -274,7 +298,11 @@ export function useFormSubmit<TValues>({
 
           // Show validation error alert
           if (submitAttempted.current && !isValid) {
-            return <Alert isInline variant="danger" title={errorTitle} />;
+            return (
+              <ScrollIntoView>
+                <Alert isInline variant="danger" title={errorTitle} />
+              </ScrollIntoView>
+            );
           }
 
           // Show success/info alert (skip for forms that navigate away)
@@ -284,24 +312,26 @@ export function useFormSubmit<TValues>({
 
             if (showSuccessOrInfo) {
               return (
-                <Alert
-                  isInline
-                  variant={wasPatched.current ? "success" : "info"}
-                  title={wasPatched.current ? successTitle : noChangesTitle}
-                >
-                  <Interpolate
-                    sentence={
-                      /* TRANSLATORS: Link shown in the alert after submitting a form. Text in [brackets] becomes a link. Keep the brackets. */
-                      _("Go to [installation] summary.")
-                    }
+                <ScrollIntoView>
+                  <Alert
+                    isInline
+                    variant={wasPatched.current ? "success" : "info"}
+                    title={wasPatched.current ? successTitle : noChangesTitle}
                   >
-                    {(linkText) => (
-                      <Link isInline variant="link" to={ROOT.overview}>
-                        {linkText}
-                      </Link>
-                    )}
-                  </Interpolate>
-                </Alert>
+                    <Interpolate
+                      sentence={
+                        /* TRANSLATORS: Link shown in the alert after submitting a form. Text in [brackets] becomes a link. Keep the brackets. */
+                        _("Go to [installation] summary.")
+                      }
+                    >
+                      {(linkText) => (
+                        <Link isInline variant="link" to={ROOT.overview}>
+                          {linkText}
+                        </Link>
+                      )}
+                    </Interpolate>
+                  </Alert>
+                </ScrollIntoView>
               );
             }
           }
@@ -313,13 +343,11 @@ export function useFormSubmit<TValues>({
   /**
    * Returns an onSubmit handler for the <Form> element.
    *
-   * Clears previous server errors, sets validation error flag (checked by
-   * AlertSubscribe), triggers TanStack Form submission, and scrolls to top
-   * when errors occur.
+   * Clears previous server errors, sets the validation error flag (checked by
+   * AlertSubscribe), and triggers TanStack Form submission.
    *
-   * Scrolling behavior:
-   * - scrollOnSuccess=true (default): always scroll immediately
-   * - scrollOnSuccess=false: only scroll after submit if there are errors
+   * The resulting alert scrolls itself into view when it appears (see
+   * AlertSubscribe / ScrollIntoView), so no manual scrolling is needed here.
    *
    * Receives the form instance at call time since it's created after this hook.
    */
@@ -328,21 +356,7 @@ export function useFormSubmit<TValues>({
       e.preventDefault();
       form.setErrorMap({ onSubmit: { fields: {} } });
       submitAttempted.current = true;
-
-      if (scrollOnSuccess) {
-        // Scroll immediately for forms that stay mounted
-        Page.scrollToTop();
-        form.handleSubmit();
-      } else {
-        // Wait for submit to complete, then scroll only if errors occurred
-        await form.handleSubmit();
-        // Check if there were errors (no success/noChanges flags set)
-        setTimeout(() => {
-          if (!wasPatched.current && !hadNoChanges.current) {
-            Page.scrollToTop();
-          }
-        }, 0);
-      }
+      form.handleSubmit();
     };
   }
 


### PR DESCRIPTION
## Summary

Follow-up polish addressing rough edges spotted after the recent look-and-feel work. Each fix targets a specific accessibility or consistency issue that affects usability and interaction methods.

- Make checkboxes and radios consistently sized across all forms
- Fix invisible loading spinners on disabled buttons
- Redesign button focus indicators to be fully visible and not clipped
- Improve skip-to-content link contrast in dark theme
- Fix form submission to scroll to alerts instead of page top

## Motivation

While implementing the dark theme and visual updates, several usability issues emerged:

1. **Invisible feedback**: Loading spinners disappeared when buttons were disabled, leaving users without visual confirmation that an action was processing
2. **Inconsistent sizing**: Radio buttons appeared at different sizes depending on which form they were in
3. **Clipped focus rings**: The outline-based focus indicator was frequently cut off by container overflow, making keyboard navigation harder to follow
4. **Low contrast**: The skip-to-content link (a critical accessibility feature) was nearly unreadable in dark theme
5. **Hidden alerts**: Form validation messages appeared below the viewport on pages with intro content, so users didn't see them

## Screencasts

### Before


https://github.com/user-attachments/assets/1560a65c-53a8-46b1-9179-ed398051f559


https://github.com/user-attachments/assets/16705099-7f0d-47a1-bb4b-873bdfb64ac2


### After


https://github.com/user-attachments/assets/3a17421a-9718-416e-ad4c-9582c9b66676


https://github.com/user-attachments/assets/922d9ce5-30a2-4ef7-81d2-80f3d1a8a65f


## Related PRs

This builds on the look-and-feel work in:
- #3604 (dark theme foundation)
- #3607 (color tokens)
- #3613 (component updates)
- #3647 (PatternFly overrides)
- #3662 (theme refinements)


---

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
