### PR TITLE
fix(web): resolve duplicate Mode labels in system page a11y tree

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 30 10:16:43 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Fix duplicate "Mode" labels in System page accessibility tree
+  (gh#agama-project/agama#3684).
+
+-------------------------------------------------------------------
 Sun Jun 28 21:50:40 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Polish the keyboard focus ring and assorted UI rough edges (control

--- a/web/src/components/form/DropdownField.tsx
+++ b/web/src/components/form/DropdownField.tsx
@@ -46,6 +46,17 @@ type DropdownFieldProps<T> = {
   helperText?: React.ReactNode;
   isDisabled?: boolean;
   /**
+   * Optional additional ID to include in the composite accessible name.
+   *
+   * When provided, this ID will be combined with the field's label ID to
+   * create a composite aria-labelledby value. Useful for referencing parent
+   * elements like fieldset legends to disambiguate fields with identical labels.
+   *
+   * Example: passing a legend ID "hostname-legend" when label is "Mode"
+   * creates accessible name "Hostname Mode".
+   */
+  additionalLabelId?: string;
+  /**
    * Render prop for content that depends on the current value, such as
    * nested fields that appear when a specific option is selected.
    */
@@ -96,6 +107,7 @@ export default function DropdownField<T extends string>({
   options,
   helperText,
   isDisabled = false,
+  additionalLabelId,
   children,
 }: DropdownFieldProps<T>) {
   const field = useFieldContext<T>();
@@ -105,8 +117,11 @@ export default function DropdownField<T extends string>({
     (opt) => !("divider" in opt) && opt.value === field.state.value,
   );
 
+  const labelId = `${field.name}-label`;
+  const ariaLabelledBy = additionalLabelId ? `${additionalLabelId} ${labelId}` : undefined;
+
   return (
-    <FormGroup fieldId={field.name} label={label}>
+    <FormGroup fieldId={field.name} label={<span id={labelId}>{label}</span>}>
       <Select
         ref={menuRef}
         isOpen={isOpen}
@@ -125,6 +140,7 @@ export default function DropdownField<T extends string>({
             onClick={() => setIsOpen(!isOpen)}
             isExpanded={isOpen}
             isDisabled={isDisabled}
+            aria-labelledby={ariaLabelledBy}
           >
             {selectedOption && "label" in selectedOption ? selectedOption.label : field.state.value}
           </MenuToggle>

--- a/web/src/components/form/DropdownField.tsx
+++ b/web/src/components/form/DropdownField.tsx
@@ -52,8 +52,13 @@ type DropdownFieldProps<T> = {
    * create a composite aria-labelledby value. Useful for referencing parent
    * elements like fieldset legends to disambiguate fields with identical labels.
    *
-   * Example: passing a legend ID "hostname-legend" when label is "Mode"
-   * creates accessible name "Hostname Mode".
+   * @example Creates accessible name "Hostname Mode"
+   * <legend id="hostname-legend">{_("Hostname")}</legend>
+   * <DropdownField
+   *   label={_("Mode")}
+   *   additionalLabelId="hostname-legend"
+   *   options={MODE_OPTIONS}
+   * />
    */
   additionalLabelId?: string;
   /**

--- a/web/src/components/form/Fieldset.tsx
+++ b/web/src/components/form/Fieldset.tsx
@@ -30,6 +30,14 @@ export interface FieldsetProps extends React.FieldsetHTMLAttributes<HTMLFieldSet
    */
   legend: string;
   /**
+   * Optional ID for the legend element.
+   *
+   * Useful for creating composite accessible names via aria-labelledby,
+   * allowing fields within the fieldset to reference the legend for context
+   * without changing visible labels.
+   */
+  legendId?: string;
+  /**
    * Optional descriptive text displayed below the legend
    */
   description?: React.ReactNode;
@@ -67,10 +75,10 @@ export interface FieldsetProps extends React.FieldsetHTMLAttributes<HTMLFieldSet
  * </Fieldset>
  * ```
  */
-export function Fieldset({ legend, description, children, ...props }: FieldsetProps) {
+export function Fieldset({ legend, legendId, description, children, ...props }: FieldsetProps) {
   return (
     <fieldset {...props}>
-      <legend>{legend}</legend>
+      <legend id={legendId}>{legend}</legend>
       <NestedContent margin="mxLg">
         {description && <Text textStyle={["fontSizeXs", "textColorSubtle"]}>{description}</Text>}
         {children}

--- a/web/src/components/system/system-form/Form.test.tsx
+++ b/web/src/components/system/system-form/Form.test.tsx
@@ -104,9 +104,11 @@ describe("SystemForm", () => {
     });
 
     it("only sends NTP config when NTP settings changed", async () => {
-      const { user} = installerRender(<SystemForm />);
+      const { user } = installerRender(<SystemForm />);
 
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -136,7 +138,9 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Switch to custom mode
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -173,7 +177,9 @@ describe("SystemForm", () => {
       await user.type(hostnameInput, "test-server");
 
       // Change NTP to custom
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -204,7 +210,9 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Make a change to trigger an update
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -224,7 +232,9 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Change something to trigger API call
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -264,7 +274,9 @@ describe("SystemForm", () => {
     it("shows error when custom NTP mode has no servers", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -280,7 +292,9 @@ describe("SystemForm", () => {
     it("shows error when NTP servers are invalid", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -302,7 +316,9 @@ describe("SystemForm", () => {
     it("accepts valid NTP server hostnames", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+      const ntpModeButton = screen.getByRole("button", {
+        name: "Time Synchronization Servers Mode",
+      });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });

--- a/web/src/components/system/system-form/Form.test.tsx
+++ b/web/src/components/system/system-form/Form.test.tsx
@@ -70,6 +70,12 @@ describe("SystemForm", () => {
     screen.getByRole("group", { name: "Time Synchronization Servers" });
   });
 
+  it("renders Mode dropdowns with unique accessible names", () => {
+    installerRender(<SystemForm />);
+    screen.getByRole("button", { name: "Hostname Mode" });
+    screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
+  });
+
   describe("form submission", () => {
     it("does not send config when nothing changed", async () => {
       const { user } = installerRender(<SystemForm />);
@@ -98,10 +104,9 @@ describe("SystemForm", () => {
     });
 
     it("only sends NTP config when NTP settings changed", async () => {
-      const { user } = installerRender(<SystemForm />);
+      const { user} = installerRender(<SystemForm />);
 
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -131,8 +136,7 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Switch to custom mode
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -158,8 +162,7 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Change hostname mode to static
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const hostnameModeButton = modeButtons[0];
+      const hostnameModeButton = screen.getByRole("button", { name: "Hostname Mode" });
       await user.click(hostnameModeButton);
 
       const staticOption = screen.getByRole("option", { name: /Static/ });
@@ -170,7 +173,7 @@ describe("SystemForm", () => {
       await user.type(hostnameInput, "test-server");
 
       // Change NTP to custom
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -201,8 +204,7 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Make a change to trigger an update
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -222,8 +224,7 @@ describe("SystemForm", () => {
       const { user } = installerRender(<SystemForm />);
 
       // Change something to trigger API call
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -244,8 +245,7 @@ describe("SystemForm", () => {
     it("shows error when static hostname is empty", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const hostnameModeButton = modeButtons[0];
+      const hostnameModeButton = screen.getByRole("button", { name: "Hostname Mode" });
       await user.click(hostnameModeButton);
 
       const staticOption = screen.getByRole("option", { name: /Static/ });
@@ -264,8 +264,7 @@ describe("SystemForm", () => {
     it("shows error when custom NTP mode has no servers", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -281,8 +280,7 @@ describe("SystemForm", () => {
     it("shows error when NTP servers are invalid", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });
@@ -304,8 +302,7 @@ describe("SystemForm", () => {
     it("accepts valid NTP server hostnames", async () => {
       const { user } = installerRender(<SystemForm />);
 
-      const modeButtons = screen.getAllByLabelText("Mode");
-      const ntpModeButton = modeButtons[1];
+      const ntpModeButton = screen.getByRole("button", { name: "Time Synchronization Servers Mode" });
       await user.click(ntpModeButton);
 
       const customOption = screen.getByRole("option", { name: /Custom/ });

--- a/web/src/components/system/system-form/HostnameFields.tsx
+++ b/web/src/components/system/system-form/HostnameFields.tsx
@@ -96,6 +96,7 @@ const HostnameFields = withForm({
 
     return (
       <Fieldset
+        legendId="hostname-legend"
         legend={
           // TRANSLATORS: fieldset legend for hostname configuration
           _("Hostname")
@@ -107,6 +108,7 @@ const HostnameFields = withForm({
               <field.DropdownField
                 // TRANSLATORS: label for hostname mode selector
                 label={_("Mode")}
+                additionalLabelId="hostname-legend"
                 options={[
                   {
                     value: HOSTNAME_MODE.TRANSIENT,

--- a/web/src/components/system/system-form/NtpFields.tsx
+++ b/web/src/components/system/system-form/NtpFields.tsx
@@ -39,6 +39,7 @@ const NtpFields = withForm({
   render: function Render({ form }) {
     return (
       <Fieldset
+        legendId="ntp-legend"
         legend={
           // TRANSLATORS: fieldset legend for NTP configuration
           _("Time Synchronization Servers")
@@ -55,6 +56,7 @@ const NtpFields = withForm({
             <field.DropdownField
               // TRANSLATORS: label for NTP mode selector
               label={_("Mode")}
+              additionalLabelId="ntp-legend"
               options={[
                 {
                   value: NTP_MODE.DEFAULT,


### PR DESCRIPTION
## Summary

- Fix duplicate "Mode" accessible names in SystemPage
- Use `aria-labelledby` to create composite accessible names without adding translations
- Result: "Mode" labels now have unique accessible names ("Hostname Mode" and "Time Synchronization Servers Mode")

## Context

@jknphy reported that Puppeteer automated tests were finding two elements when trying to select the "Mode" dropdown in SystemPage. The issue was that both the Hostname and NTP sections had dropdowns with the same accessible name "Mode", making them indistinguishable to:

- Screen reader navigation by form controls
- Voice control users ("click Mode" → ambiguous)
- Automated testing tools (Puppeteer)

Changing visible labels is not an option since they could sound redundant with the fieldset legend. Moreover, at this moment Agama is currently in string freeze phase.

## Solution

The fix leverages `aria-labelledby` to create composite accessible names by combining parent context (fieldset legends) with field labels:

**Changes to components:**

1. **Fieldset**: Added optional `legendId` prop
   - Allows fieldset legends to be referenced by descendant elements
   - When provided, adds `id` attribute to the `<legend>` element

2. **DropdownField**: Added optional `additionalLabelId` prop
   - Wraps label in `<span id="{fieldName}-label">` for referenceability
   - When `additionalLabelId` is provided, combines it with the label ID: `aria-labelledby="{additionalLabelId} {fieldName}-label"`
   - When not provided, works as before (no aria-labelledby)

3. **HostnameFields & NtpFields**: Wire up the legend and label IDs
   - Set `legendId` on Fieldset
   - Pass same ID as `additionalLabelId` to DropdownField

**Result:**
- Visible labels: "Mode" (unchanged - no new translations needed)
- Accessible names:
  - Hostname dropdown: "Hostname Mode"
  - NTP dropdown: "Time Synchronization Servers Mode"
- Both dropdowns are now uniquely identifiable by their accessible names

## Before

<img width="1458" height="650" alt="Screenshot_2026-06-30_11-05-08" src="https://github.com/user-attachments/assets/00cc4493-e642-416c-8c12-3a863daf3455" />


## After

<img width="1458" height="650" alt="Screenshot_2026-06-30_11-04-41" src="https://github.com/user-attachments/assets/0556427d-4c43-4a1c-bd9c-3adab8b5aff1" />



## Related

This approach can be reused for other cases where:
- Fields have identical labels within the same page/form
- String freeze prevents changing visible labels
- Parent context (fieldset, section) can disambiguate
