### PR TITLE
Move binding information to Settings and remove the dedicated edit link

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul  1 15:09:51 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Move binding information to Settings section and remove obsolete
+  dedicated "Binding" card and edit link in connection details
+  (gh#agama-project/agama#3686).
+
+-------------------------------------------------------------------
 Tue Jun 30 10:16:43 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Fix duplicate "Mode" labels in System page accessibility tree

--- a/web/src/components/network/ConnectionDetails.test.tsx
+++ b/web/src/components/network/ConnectionDetails.test.tsx
@@ -153,10 +153,10 @@ describe("ConnectionDetails", () => {
     });
   });
 
-  describe("Binding settings section", () => {
+  describe("Binding information in Settings", () => {
     it("renders information about the binding mode (all)", () => {
       installerRender(<ConnectionDetails connection={new Connection("Network #1")} />);
-      const section = screen.getByRole("region", { name: "Binding" });
+      const section = screen.getByRole("region", { name: "Settings" });
       within(section).getByText("Connection is available to all devices.");
     });
 
@@ -166,7 +166,7 @@ describe("ConnectionDetails", () => {
           connection={new Connection("Network #1", { macAddress: "AA:11:22:33:44:FF" })}
         />,
       );
-      const section = screen.getByRole("region", { name: "Binding" });
+      const section = screen.getByRole("region", { name: "Settings" });
       within(section).getByText("Connection is bound to MAC address AA:11:22:33:44:FF.");
     });
 
@@ -174,15 +174,8 @@ describe("ConnectionDetails", () => {
       installerRender(
         <ConnectionDetails connection={new Connection("Network #1", { iface: "enp1s0" })} />,
       );
-      const section = screen.getByRole("region", { name: "Binding" });
+      const section = screen.getByRole("region", { name: "Settings" });
       within(section).getByText("Connection is bound to device enp1s0.");
-    });
-
-    it("renders a link to for editing binding settings", () => {
-      installerRender(<ConnectionDetails connection={mockConnection} />);
-      const section = screen.getByRole("region", { name: "Binding" });
-      const editLink = within(section).getByRole("link", { name: "Edit binding settings" });
-      expect(editLink).toHaveAttribute("href", "/network/connections/Network%20%231/binding/edit");
     });
   });
 

--- a/web/src/components/network/ConnectionDetails.tsx
+++ b/web/src/components/network/ConnectionDetails.tsx
@@ -22,7 +22,6 @@
 
 import React, { useState } from "react";
 import {
-  Content,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -65,26 +64,6 @@ const bindingModeFor = (connection: Connection) => {
       // TRANSLATORS: %s will be replaced by MAC addrss, like 7C:D7:11:28:F5:40
       return sprintf(_("Connection is bound to MAC address %s."), connection.macAddress);
   }
-};
-
-const BindingSettings = ({ connection }: { connection: Connection }) => {
-  return (
-    <Page.Section
-      title={_("Binding")}
-      pfCardProps={{ isPlain: false, isFullHeight: false }}
-      actions={
-        <Link
-          to={generatePath(NETWORK.connection.editBinding, {
-            id: connection.id,
-          })}
-        >
-          {_("Edit binding settings")}
-        </Link>
-      }
-    >
-      <Content>{bindingModeFor(connection)}</Content>
-    </Page.Section>
-  );
 };
 
 const NetworkDetails = ({ connection }: { connection: Connection }) => {
@@ -376,6 +355,10 @@ const SettingsCard = ({ connection }: { connection: Connection }) => {
       <Stack hasGutter>
         <DescriptionList isHorizontal>
           <DescriptionListGroup>
+            <DescriptionListTerm>{_("Binding")}</DescriptionListTerm>
+            <DescriptionListDescription>{bindingModeFor(connection)}</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
             <DescriptionListTerm>{_("Mode")}</DescriptionListTerm>
             <DescriptionListDescription>
               <Flex direction={{ default: "column" }}>
@@ -453,17 +436,10 @@ export default function ConnectionDetails({ connection }: { connection: Connecti
       </GridItem>
       <GridItem md={6} order={{ default: "1", md: "2" }}>
         <Stack hasGutter>
-          {connection.wireless ? (
-            <NetworkDetails connection={connection} />
-          ) : connection.bond ? (
-            <BondDetails connection={connection} />
-          ) : connection.bridge ? (
-            <BridgeDetails connection={connection} />
-          ) : connection.vlan ? (
-            <VlanDetails connection={connection} />
-          ) : (
-            <BindingSettings connection={connection} />
-          )}
+          {connection.wireless && <NetworkDetails connection={connection} />}
+          {connection.bond && <BondDetails connection={connection} />}
+          {connection.bridge && <BridgeDetails connection={connection} />}
+          {connection.vlan && <VlanDetails connection={connection} />}
           <DevicesDetails connection={connection} />
         </Stack>
       </GridItem>


### PR DESCRIPTION
## Problem
 
Recently, the option to configure connection device binding was integrated directly into the main connection form, replacing the separate form that previously handled it. While the separate form and its link in the connections table were successfully removed, the dedicated "Binding" card section and the "Edit binding settings" link were mistakenly left in the connection details view, resulting in a dead link.

- https://trello.com/c/J7KxozJ8/5864-1268594-dead-link-in-network-connection-details
  
## Solution
 
This PR cleans up the connection details view and updates the layout:
  - **Relocates the read-only binding information** (e.g., "Connection is available to all devices") into the general **Settings** card.
  - **Removes the dedicated "Binding" section** and the dead "Edit binding settings" link.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1414" height="824" alt="image" src="https://github.com/user-attachments/assets/32d71213-7e8a-43d4-bb6a-f0a8727dc2d9" /> | <img width="1413" height="796" alt="image" src="https://github.com/user-attachments/assets/b97ae29f-837b-4ef3-96b8-ba7b16b85d70" /> |