### PR TITLE
Firefox: Disable Link Preview feature

### DIFF
--- a/live/live-root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/live-root/root/.mozilla/firefox/profile/user.js.template
@@ -71,6 +71,9 @@ user_pref("devtools.toolbox.selectedTool", "console");
 // show time stamps in the console
 user_pref("devtools.webconsole.timestampMessages", true);
 
+// disable "Link Preview" feature
+user_pref("browser.ml.linkPreview.enabled", false);
+
 // start always in the custom homepage
 user_pref("browser.startup.page", 1);
 // custom homepage: the value is expected to be replaced with the login URL by the startup script

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 30 14:01:30 UTC 2026 - Santiago Zarate <santiago.zarate@suse.com>
+
+- Disable firefox's Link Preview feature gh#agama-project/agama#3687
+
+-------------------------------------------------------------------
 Wed Jun 24 15:19:28 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Break a initrd-nmtui systemd dependency cycle (systemd deletes some services


### PR DESCRIPTION
## Problem

Firefox's "Link Preview" feature can interfere with testing

Sometimes during openQA click-through tests there are [failures](https://openqa.opensuse.org/tests/6051781#step/agama/9) caused by the "Link Preview" feature stealing the focus away from the dropdown even though there is no link, causing the next needle not to match.

I could not reproduce the issue manually, on top of that to activate the feature one needs to click for ~2s on a link, but openQA clicks for 0.15 by default, which is even more confusing as to why it shows up.

<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/ad95fc66-08fe-486e-9669-7cdb250eafa7" />

- https://openqa.opensuse.org/tests/6051781#step/agama/9

## Solution

Disable the "Link Preview" feature
- https://bugzilla.mozilla.org/show_bug.cgi?id=1943389#c1

## Testing

- Built the ISO on a home project in [OBS](https://build.opensuse.org/package/show/home:szarate:branches:systemsmanagement:Agama:Devel/agama-installer)
- Verified manually that the setting is properly disabled
- Tested with [openQA](https://openqa.opensuse.org/tests/overview?result=passed&machine=uefi-3G&distri=opensuse&version=Tumbleweed&build=poo203262) using [agama-installer.x86_64-22.0.0-openSUSE-Build7.1.iso](https://download.opensuse.org/repositories/home:/szarate:/branches:/systemsmanagement:/Agama:/Devel/images/iso/agama-installer.x86_64-22.0.0-openSUSE-Build7.1.iso) from my home project
