### PR TITLE
Missing translations

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jul  3 11:13:28 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Add missing translations (bsc#1269514).
+
+-------------------------------------------------------------------
 Thu Jul  2 12:01:52 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Allow form fields to build their accessible name from their own

--- a/web/src/components/storage/SpaceActionsTable.test.tsx
+++ b/web/src/components/storage/SpaceActionsTable.test.tsx
@@ -107,10 +107,10 @@ describe("SpaceActionsTable", () => {
     plainRender(<SpaceActionsTable {...props} />);
 
     screen.getByRole("row", {
-      name: "sda1 Swap partition 2 GiB Do not modify Allow shrink Delete",
+      name: "sda1 Swap partition 2 GiB Do not modify Allow shrinking Delete",
     });
     screen.getByRole("row", {
-      name: "sda2 EXT4 partition 6 GiB Do not modify Allow shrink Delete",
+      name: "sda2 EXT4 partition 6 GiB Do not modify Allow shrinking Delete",
     });
     screen.getByRole("row", { name: "Unused space 2 GiB" });
   });
@@ -120,12 +120,12 @@ describe("SpaceActionsTable", () => {
 
     const sda1Row = screen.getByRole("row", { name: /sda1/ });
     within(sda1Row).getByRole("button", { name: "Do not modify", pressed: true });
-    within(sda1Row).getByRole("button", { name: "Allow shrink", pressed: false });
+    within(sda1Row).getByRole("button", { name: "Allow shrinking", pressed: false });
     within(sda1Row).getByRole("button", { name: "Delete", pressed: false });
 
     const sda2Row = screen.getByRole("row", { name: /sda2/ });
     within(sda2Row).getByRole("button", { name: "Do not modify", pressed: false });
-    within(sda2Row).getByRole("button", { name: "Allow shrink", pressed: false });
+    within(sda2Row).getByRole("button", { name: "Allow shrinking", pressed: false });
     within(sda2Row).getByRole("button", { name: "Delete", pressed: true });
   });
 
@@ -133,11 +133,11 @@ describe("SpaceActionsTable", () => {
     plainRender(<SpaceActionsTable {...props} />);
 
     const sda1Row = screen.getByRole("row", { name: /sda1/ });
-    const sda1ShrinkButton = within(sda1Row).getByRole("button", { name: "Allow shrink" });
+    const sda1ShrinkButton = within(sda1Row).getByRole("button", { name: "Allow shrinking" });
     expect(sda1ShrinkButton).toBeDisabled();
 
     const sda2Row = screen.getByRole("row", { name: /sda2/ });
-    const sda2ShrinkButton = within(sda2Row).getByRole("button", { name: "Allow shrink" });
+    const sda2ShrinkButton = within(sda2Row).getByRole("button", { name: "Allow shrinking" });
     expect(sda2ShrinkButton).not.toBeDisabled();
   });
 
@@ -150,7 +150,7 @@ describe("SpaceActionsTable", () => {
       plainRender(<SpaceActionsTable {...props} />);
 
       const sda2Row = screen.getByRole("row", { name: /sda2/ });
-      const sda2ShrinkButton = within(sda2Row).getByRole("button", { name: "Allow shrink" });
+      const sda2ShrinkButton = within(sda2Row).getByRole("button", { name: "Allow shrinking" });
       const sda2DeleteButton = within(sda2Row).getByRole("button", { name: "Delete" });
       expect(sda2ShrinkButton).toBeDisabled();
       expect(sda2DeleteButton).toBeDisabled();

--- a/web/src/components/storage/SpaceActionsTable.tsx
+++ b/web/src/components/storage/SpaceActionsTable.tsx
@@ -149,20 +149,20 @@ const DeviceActionSelector = ({
       <FlexItem>
         <ToggleGroup isCompact>
           <ToggleGroupItem
-            text="Do not modify"
+            text={_("Do not modify")}
             buttonId="not-modify"
             isSelected={adjustedAction === "keep"}
             onChange={() => changeAction("keep")}
           />
           <ToggleGroupItem
-            text="Allow shrink"
+            text={_("Allow shrinking")}
             buttonId="resize"
             isDisabled={isResizeDisabled}
             isSelected={adjustedAction === "resizeIfNeeded"}
             onChange={() => changeAction("resizeIfNeeded")}
           />
           <ToggleGroupItem
-            text="Delete"
+            text={_("Delete")}
             buttonId="delete"
             isDisabled={isDeleteDisabled}
             isSelected={adjustedAction === "delete"}

--- a/web/src/components/storage/SpacePolicyMenu.tsx
+++ b/web/src/components/storage/SpacePolicyMenu.tsx
@@ -42,6 +42,7 @@ import {
 import { useDevice } from "~/hooks/model/system/storage";
 import type { ConfigModel } from "~/model/storage/config-model";
 import type { SpacePolicy } from "~/components/storage/utils";
+import { _ } from "~/i18n";
 
 type PolicyItemProps = {
   policy: SpacePolicy;
@@ -86,7 +87,8 @@ const PolicyItem = ({ policy, collection, index }: PolicyItemProps) => {
       description={description()}
       onClick={changePolicy}
     >
-      <Text isBold={isSelected}>{policy.label}</Text>
+      {/* eslint-disable-next-line agama-i18n/string-literals */}
+      <Text isBold={isSelected}>{_(policy.label)}</Text>
     </MenuButton.Item>
   );
 };

--- a/web/src/components/storage/SpacePolicyMenu.tsx
+++ b/web/src/components/storage/SpacePolicyMenu.tsx
@@ -27,8 +27,8 @@ import Text from "~/components/core/Text";
 import Icon from "~/components/layout/Icon";
 import { useNavigate } from "react-router";
 import {
-  PARTITIONABLE_SPACE_POLICIES,
-  VOLUME_GROUP_SPACE_POLICIES,
+  partitionableSpacePolicyLabel,
+  volumeGroupSpacePolicyLabel,
 } from "~/components/storage/utils";
 import { STORAGE as PATHS } from "~/routes/paths";
 import * as driveUtils from "~/components/storage/utils/drive";
@@ -41,25 +41,23 @@ import {
 } from "~/hooks/model/storage/config-model";
 import { useDevice } from "~/hooks/model/system/storage";
 import type { ConfigModel } from "~/model/storage/config-model";
-import type { SpacePolicy } from "~/components/storage/utils";
-import { _ } from "~/i18n";
 
 type PolicyItemProps = {
-  policy: SpacePolicy;
+  policyId: ConfigModel.SpacePolicy;
   collection: "drives" | "mdRaids" | "volumeGroups";
   index: number;
 };
 
-const PolicyItem = ({ policy, collection, index }: PolicyItemProps) => {
+const PolicyItem = ({ policyId, collection, index }: PolicyItemProps) => {
   const navigate = useNavigate();
   const setSpacePolicy = useSetSpacePolicy();
   const deviceConfig = useDeviceConfig(collection, index);
 
   const changePolicy = () => {
-    if (policy.id === "custom") {
+    if (policyId === "custom") {
       return navigate(generateEncodedPath(PATHS.editSpacePolicy, { collection, index }));
     } else {
-      setSpacePolicy(collection, index, { type: policy.id });
+      setSpacePolicy(collection, index, { type: policyId });
     }
   };
 
@@ -67,28 +65,37 @@ const PolicyItem = ({ policy, collection, index }: PolicyItemProps) => {
     switch (collection) {
       case "drives":
       case "mdRaids": {
-        return driveUtils.contentActionsDescription(deviceConfig as ConfigModel.Drive, policy.id);
+        return driveUtils.contentActionsDescription(deviceConfig as ConfigModel.Drive, policyId);
       }
       case "volumeGroups": {
         return volumeGroupUtils.contentActionsDescription(
           deviceConfig as ConfigModel.VolumeGroup,
-          policy.id,
+          policyId,
         );
       }
     }
   };
 
-  const isSelected = policy.id === deviceConfig.spacePolicy;
+  const label = (): string => {
+    switch (collection) {
+      case "drives":
+      case "mdRaids":
+        return partitionableSpacePolicyLabel(policyId);
+      case "volumeGroups":
+        return volumeGroupSpacePolicyLabel(policyId);
+    }
+  };
+
+  const isSelected = policyId === deviceConfig.spacePolicy;
 
   return (
     <MenuButton.Item
-      itemId={policy.id}
+      itemId={policyId}
       isSelected={isSelected}
       description={description()}
       onClick={changePolicy}
     >
-      {/* eslint-disable-next-line agama-i18n/string-literals */}
-      <Text isBold={isSelected}>{_(policy.label)}</Text>
+      <Text isBold={isSelected}>{label()}</Text>
     </MenuButton.Item>
   );
 };
@@ -149,16 +156,8 @@ export default function SpacePolicyMenu({ collection, index }: SpacePolicyMenuPr
 
   if (!hasVolumes) return;
 
-  const policies = (): SpacePolicy[] => {
-    switch (collection) {
-      case "drives":
-      case "mdRaids": {
-        return PARTITIONABLE_SPACE_POLICIES;
-      }
-      case "volumeGroups": {
-        return VOLUME_GROUP_SPACE_POLICIES;
-      }
-    }
+  const policies = (): ConfigModel.SpacePolicy[] => {
+    return ["delete", "resize", "keep", "custom"];
   };
 
   return (
@@ -166,8 +165,8 @@ export default function SpacePolicyMenu({ collection, index }: SpacePolicyMenuPr
       toggleProps={{
         variant: "plainText",
       }}
-      items={policies().map((policy) => (
-        <PolicyItem key={policy.id} policy={policy} collection={collection} index={index} />
+      items={policies().map((policyId) => (
+        <PolicyItem key={policyId} policyId={policyId} collection={collection} index={index} />
       ))}
       customToggle={<SpacePolicyMenuToggle collection={collection} index={index} />}
     />

--- a/web/src/components/storage/iscsi/TargetLoginPage.tsx
+++ b/web/src/components/storage/iscsi/TargetLoginPage.tsx
@@ -261,7 +261,7 @@ function TargetLoginForm({ target }): React.ReactNode {
                   onChange={onChange}
                 />
               </FormGroup>
-              <FormGroup fieldId="reversePassword" label="Initiator password">
+              <FormGroup fieldId="reversePassword" label={_("Initiator password")}>
                 <PasswordInput
                   id="reversePassword"
                   name="reversePassword"

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -29,9 +29,9 @@
 
 import xbytes from "xbytes";
 import { _ } from "~/i18n";
-import type { TranslatedString } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import configModel from "~/model/storage/config-model";
+import type { TranslatedString } from "~/i18n";
 import type { ConfigModel, Partitionable } from "~/model/storage/config-model";
 import type { Storage as System } from "~/model/system";
 import type { Storage as Proposal } from "~/model/proposal";

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -28,7 +28,8 @@
  */
 
 import xbytes from "xbytes";
-import { _, N_ } from "~/i18n";
+import { _ } from "~/i18n";
+import type { TranslatedString } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import configModel from "~/model/storage/config-model";
 import type { ConfigModel, Partitionable } from "~/model/storage/config-model";
@@ -43,11 +44,6 @@ export type SizeObject = {
   unit: string | undefined;
 };
 
-export type SpacePolicy = {
-  id: ConfigModel.SpacePolicy;
-  label: string;
-};
-
 export type SizeMethod = "auto" | "fixed" | "range";
 
 const SIZE_METHODS = Object.freeze({
@@ -56,75 +52,45 @@ const SIZE_METHODS = Object.freeze({
   RANGE: "range",
 });
 
-const SIZE_UNITS = Object.freeze({
-  K: N_("KiB"),
-  M: N_("MiB"),
-  G: N_("GiB"),
-  T: N_("TiB"),
-  P: N_("PiB"),
-});
-
-const FILESYSTEM_NAMES = Object.freeze({
-  bcachefs: N_("Bcachefs"),
-  bitlocke: N_("BitLocker"),
-  btrfs: N_("Btrfs"),
-  btrfsImmutable: N_("immutable Btrfs"),
-  btrfsSnapshots: N_("Btrfs with snapshots"),
-  exfat: N_("ExFAT"),
-  ext2: N_("Ext2"),
-  ext3: N_("Ext3"),
-  ext4: N_("Ext4"),
-  f2fs: N_("F2FS"),
-  jfs: N_("JFS"),
-  nfs: N_("NFS"),
-  nilfs2: N_("NILFS2"),
-  ntfs: N_("NTFS"),
-  reiserfs: N_("ReiserFS"),
-  swap: N_("Swap"),
-  tmpfs: N_("Tmpfs"),
-  vfat: N_("FAT"),
-  xfs: N_("XFS"),
-});
-
 const DEFAULT_SIZE_UNIT = "GiB";
 
-const PARTITIONABLE_SPACE_POLICIES: SpacePolicy[] = [
-  {
-    id: "delete",
-    label: N_("Delete current content"),
-  },
-  {
-    id: "resize",
-    label: N_("Shrink existing partitions"),
-  },
-  {
-    id: "keep",
-    label: N_("Use available space"),
-  },
-  {
-    id: "custom",
-    label: N_("Custom"),
-  },
-];
+/**
+ * Returns the translated label for a partitionable device space policy.
+ *
+ * @param policy - Space policy identifier
+ * @returns Translated policy label
+ */
+const partitionableSpacePolicyLabel = (policy: ConfigModel.SpacePolicy): TranslatedString => {
+  switch (policy) {
+    case "delete":
+      return _("Delete current content");
+    case "resize":
+      return _("Shrink existing partitions");
+    case "keep":
+      return _("Use available space");
+    case "custom":
+      return _("Custom");
+  }
+};
 
-const VOLUME_GROUP_SPACE_POLICIES: SpacePolicy[] = [
-  {
-    id: "delete",
-    label: N_("Delete current content"),
-  },
-  {
-    id: "resize",
-    label: N_("Shrink existing logical volumes"),
-  },
-  {
-    id: "keep",
-    label: N_("Use available space"),
-  },
-  {
-    id: "custom",
-    label: N_("Custom"),
-  },
-];
+/**
+ * Returns the translated label for a volume group space policy.
+ *
+ * @param policy - Space policy identifier
+ * @returns Translated policy label
+ */
+const volumeGroupSpacePolicyLabel = (policy: ConfigModel.SpacePolicy): TranslatedString => {
+  switch (policy) {
+    case "delete":
+      return _("Delete current content");
+    case "resize":
+      return _("Shrink existing logical volumes");
+    case "keep":
+      return _("Use available space");
+    case "custom":
+      return _("Custom");
+  }
+};
 
 /**
  * Returns the equivalent in bytes resulting from parsing given input
@@ -311,16 +277,56 @@ const volumeLabel = (volume: System.Volume): string =>
   volume.mountPath === "/" ? "root" : volume.mountPath;
 
 /**
+ * Generates a translated label for the given filesystem type.
+ *
+ * @param fstype - Filesystem type from ConfigModel
+ * @returns Translated filesystem label
  * @see filesystemType
  */
-const filesystemLabel = (fstype: string): string => {
-  const name = FILESYSTEM_NAMES[fstype];
-
-  // eslint-disable-next-line agama-i18n/string-literals
-  if (name) return _(name);
-
-  // Fallback for unknown filesystem types
-  return fstype.charAt(0).toUpperCase() + fstype.slice(1);
+const filesystemLabel = (fstype: ConfigModel.FilesystemType): TranslatedString => {
+  switch (fstype) {
+    case "bcachefs":
+      return _("Bcachefs");
+    case "btrfs":
+      return _("Btrfs");
+    case "btrfsImmutable":
+      return _("immutable Btrfs");
+    case "btrfsSnapshots":
+      return _("Btrfs with snapshots");
+    case "exfat":
+      return _("ExFAT");
+    case "ext2":
+      return _("Ext2");
+    case "ext3":
+      return _("Ext3");
+    case "ext4":
+      return _("Ext4");
+    case "f2fs":
+      return _("F2FS");
+    case "jfs":
+      return _("JFS");
+    case "nfs":
+      return _("NFS");
+    case "nilfs2":
+      return _("NILFS2");
+    case "ntfs":
+      return _("NTFS");
+    case "reiserfs":
+      return _("ReiserFS");
+    case "swap":
+      return _("Swap");
+    case "tmpfs":
+      return _("Tmpfs");
+    case "vfat":
+      return _("FAT");
+    case "xfs":
+      return _("XFS");
+    default: {
+      // Fallback for future filesystem types not yet handled
+      const fs = fstype as string;
+      return (fs.charAt(0).toUpperCase() + fs.slice(1)) as TranslatedString;
+    }
+  }
 };
 
 /**
@@ -392,9 +398,8 @@ function findPartitionableDevice(
 export {
   DEFAULT_SIZE_UNIT,
   SIZE_METHODS,
-  SIZE_UNITS,
-  PARTITIONABLE_SPACE_POLICIES,
-  VOLUME_GROUP_SPACE_POLICIES,
+  partitionableSpacePolicyLabel,
+  volumeGroupSpacePolicyLabel,
   baseName,
   deviceBaseName,
   deviceLabel,

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -36,6 +36,7 @@ import {
   SecurityProtocols,
 } from "~/types/network";
 import { _, N_ } from "~/i18n";
+import type { TranslatedString } from "~/i18n";
 
 /**
  * Connection type constants.
@@ -66,8 +67,9 @@ const CONNECTION_STATE_LABELS: Record<ConnectionState, string> = {
 /**
  * Returns the translated label for a connection state.
  */
-// eslint-disable-next-line agama-i18n/string-literals
-const connectionStateLabel = (state: ConnectionState): string => _(CONNECTION_STATE_LABELS[state]);
+const connectionStateLabel = (state: ConnectionState): TranslatedString =>
+  // eslint-disable-next-line agama-i18n/string-literals
+  _(CONNECTION_STATE_LABELS[state]);
 
 /**
  * Returns true if the given connection type is virtual.
@@ -81,19 +83,21 @@ const isVirtual = (type: ConnectionType): boolean =>
  * Labels for connection types.
  */
 const CONNECTION_TYPE_LABELS: Record<ConnectionType, string> = {
-  [CONNECTION_TYPE.ETHERNET]: "Ethernet",
-  [CONNECTION_TYPE.WIFI]: "Wi-Fi",
-  [CONNECTION_TYPE.LOOPBACK]: "Loopback",
-  [CONNECTION_TYPE.BOND]: "Bond",
-  [CONNECTION_TYPE.BRIDGE]: "Bridge",
-  [CONNECTION_TYPE.VLAN]: "VLAN",
-  [CONNECTION_TYPE.UNKNOWN]: "Unknown",
+  [CONNECTION_TYPE.ETHERNET]: N_("Ethernet"),
+  [CONNECTION_TYPE.WIFI]: N_("Wi-Fi"),
+  [CONNECTION_TYPE.LOOPBACK]: N_("Loopback"),
+  [CONNECTION_TYPE.BOND]: N_("Bond"),
+  [CONNECTION_TYPE.BRIDGE]: N_("Bridge"),
+  [CONNECTION_TYPE.VLAN]: N_("VLAN"),
+  [CONNECTION_TYPE.UNKNOWN]: N_("Unknown"),
 };
 
 /**
  * Returns the label for a connection type.
  */
-const connectionTypeLabel = (type: ConnectionType): string => CONNECTION_TYPE_LABELS[type];
+const connectionTypeLabel = (type: ConnectionType): TranslatedString =>
+  // eslint-disable-next-line agama-i18n/string-literals
+  _(CONNECTION_TYPE_LABELS[type]);
 
 /**
  * Returns the type for the given connection.


### PR DESCRIPTION
## Problem

Some strings are not translated. Missing translatated strings should be detected by the linter, but there are two edge cases:

* Literal string directly passed as prop to a PF component.
* Literal strings marked for translation with `N_` but then it is not translated with `_()`.

Examples:
~~~
<PFComponent foo="bar" />

const LABEL = N_("Disk");

<Text>{LABEL}</Text>
~~~

https://bugzilla.suse.com/show_bug.cgi?id=1269514

## Solution

Properly mark the literal strings for translations when they are used in a prop and fix missing translations in storage UI components by converting translation-marked constants to type-safe translation functions.

Changes

* Replaced static translation-marked constants (FILESYSTEM_NAMES, PARTITIONABLE_SPACE_POLICIES, VOLUME_GROUP_SPACE_POLICIES) with dedicated translation functions (filesystemLabel, partitionableSpacePolicyLabel, volumeGroupSpacePolicyLabel).
* Fixed untranslated space policy labels in SpacePolicyMenu and SpaceActionsTable.
* Removed unused SIZE_UNITS constant.

Moving translation logic into functions ensures translations are always applied and prevents future instances of forgotten translations.

In network, the connection type labels were not marked for translation. Fortunatelly, there are already translations for that strings.