### PR TITLE
Fix device selector text

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  6 05:10:24 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Use correct empty state text for LVM tab in the device selector
+  (gh#agama-project/agama#3690).
+
+-------------------------------------------------------------------
 Fri Jul  3 11:13:28 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Add missing translations (bsc#1269514).

--- a/web/src/components/storage/SearchedDeviceMenu.tsx
+++ b/web/src/components/storage/SearchedDeviceMenu.tsx
@@ -30,7 +30,7 @@ import { isDrive, isMd, isVolumeGroup } from "~/model/storage/device";
 import { useAvailableDevices } from "~/hooks/model/system/storage";
 import { useConfigModel, useConvertDevice } from "~/hooks/model/storage/config-model";
 import { deviceBaseName, formattedPath } from "~/components/storage/utils";
-import { _, n_, formatList } from "~/i18n";
+import { _, n_, formatList, TranslatedString } from "~/i18n";
 
 import type { MenuItemProps } from "@patternfly/react-core";
 import type { CustomToggleProps } from "~/components/core/MenuButton";
@@ -353,6 +353,10 @@ export default function SearchedDeviceMenu({
     convertDevice(selected.name, device.name);
   };
 
+  const vgEmptyStateTitle = (): TranslatedString | undefined => {
+    return modelDevice.filesystem ? _("Volume groups cannot be formatted") : undefined;
+  };
+
   return (
     <>
       <MenuButton
@@ -380,7 +384,7 @@ export default function SearchedDeviceMenu({
           mdRaids={mdRaids}
           volumeGroups={volumeGroups}
           sideEffects={{ volumeGroups: vgSelectionSideEffect }}
-          emptyStateTitles={{ volumeGroups: _("Volume groups cannot be formatted") }}
+          emptyStateTitles={{ volumeGroups: vgEmptyStateTitle() }}
           onConfirm={onDeviceChange}
           onCancel={() => setIsSelectorOpen(false)}
         />


### PR DESCRIPTION
## Problem

The LVM tab in the device selector was wrongly rendering the message "Volume groups cannot be formatted" even though the current device is not formatted but partitioned.

<img width="2048" height="1760" alt="localhost_8080_" src="https://github.com/user-attachments/assets/674dfc77-315e-4d57-8150-0d19ce53b891" />


## Solution

Use correct empty state message: 
* No formatted device: "No LVM volume groups found".
* Formatted device: "Volume groups cannot be formatted".

<img width="2048" height="1760" alt="localhost_8080_ (2)" src="https://github.com/user-attachments/assets/3b06eb59-2034-4923-983f-d98b9bfef527" />
