### PR TITLE
fix(web): enable dropdown menu flip to prevent overflow

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  6 08:28:06 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Fix dropdown menus overflowing beyond viewport boundaries
+  (bsc#1262122).
+
+-------------------------------------------------------------------
 Mon Jul  6 05:10:24 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Use correct empty state text for LVM tab in the device selector

--- a/web/src/components/core/MenuButton.tsx
+++ b/web/src/components/core/MenuButton.tsx
@@ -221,7 +221,12 @@ export default function MenuButton({
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       toggleRef={pfToggleRef}
-      popperProps={{ direction: "down", enableFlip: false, ...menuProps.popperProps }}
+      popperProps={{
+        direction: "down",
+        enableFlip: true,
+        flipBehavior: ["bottom-start"],
+        ...menuProps.popperProps,
+      }}
       toggle={
         React.isValidElement(customToggle) ? (
           React.cloneElement(customToggle as React.ReactElement, baseToggleProps)


### PR DESCRIPTION
## Problem

In the Storage page, when selecting "Create LVM volume group" from the installation device dropdown and then opening the volume group actions menu, the dropdown would extend beyond the visible screen area. This happened because MenuButton had flip behavior disabled.

Related to https://bugzilla.suse.com/show_bug.cgi?id=1262122 (protected link)

## Solution

Modified `MenuButton` component to enable PatternFly's flip behavior:

- Changed `enableFlip` from `false` to `true`
- Added `flipBehavior: ["bottom-start"]` to prefer bottom positioning but allow automatic repositioning when viewport boundaries are reached

This ensures all dropdown menus in the application built with MenuButton component stay fully visible regardless of their position on screen.

## Screenshots

**Before**: Menu extends beyond visible area

<img width="2048" height="1836" alt="localhost_8080_ (3)" src="https://github.com/user-attachments/assets/69bc5c6f-93b5-427f-8798-0fee029ea21b" />


**After**: Menu properly repositioned within viewport

<img width="2048" height="1836" alt="localhost_8080_ (2)" src="https://github.com/user-attachments/assets/78ba4687-2144-473b-a5f7-e023fac35ef7" />
