### PR TITLE
Update OpenSSL dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3377,15 +3377,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3415,9 +3414,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4213,7 +4212,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,7 +60,7 @@ home = { version = "0.5.11" }
 i18n-format = { version = "0.4.0" }
 macaddr = { version = "1.0.1", features = ["serde_std"] }
 merge = { version = "0.2.0", features = ["std"] }
-openssl = { version = "0.10.75" }
+openssl = { version = "0.10.81" }
 pin-project = { version = "1.1.10" }
 regex = { version = "1.12.2" }
 schemars = { version = "1.2.1", features = ["url2", "uuid1"] }

--- a/rust/agama-security/src/certificate.rs
+++ b/rust/agama-security/src/certificate.rs
@@ -121,8 +121,7 @@ impl Certificate {
     /// * `nid`: entry identifier.
     fn extract_entry(name: &X509NameRef, nid: Nid) -> Option<String> {
         let entry = name.entries_by_nid(nid).next()?;
-
-        entry.data().as_utf8().map(|l| l.to_string()).ok()
+        entry.data().to_string().map(|l| l.to_string()).ok()
     }
 }
 

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul  8 07:58:08 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Update openssl dependency (bsc#1270992, bsc#1270891, bsc#1270850,
+  bsc#1270784, bsc#1270678, bsc#1270526, bsc#1270602, CVE-2026-45784,
+  CVE-2026-44662, CVE-2026-41898, CVE-2026-41681, CVE-2026-41678,
+  CVE-2026-42327, CVE-2026-41677).
+
+-------------------------------------------------------------------
 Tue Jun 30 14:43:50 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Adapt iSCSI, DASD and zFCP monitors to the changes in the D-Bus


### PR DESCRIPTION
## Problem

The current version of the `openssl` crate is affected by a set of potential security problems.

- [bsc#1270992](https://bugzilla.suse.com/show_bug.cgi?id=1270992), [bsc#1270891](https://bugzilla.suse.com/show_bug.cgi?id=1270891), [bsc#1270850](https://bugzilla.suse.com/show_bug.cgi?id=1270850), [bsc#1270784](https://bugzilla.suse.com/show_bug.cgi?id=1270784), [bsc#1270678](https://bugzilla.suse.com/show_bug.cgi?id=1270678), [bsc#1270526](https://bugzilla.suse.com/show_bug.cgi?id=1270526), [bsc#1270602](https://bugzilla.suse.com/show_bug.cgi?id=1270602).

## Solution

* Update to the latest `openssl` crate version, which fixes the previous issues.
* Replace `as_utf8` with `to_string` as suggested by Clippy (*error: use of deprecated method `openssl::asn1::Asn1StringRef::as_utf8`: truncates at the first interior NUL byte; use `to_string` instead*).