### PR TITLE
Ignition/combustion fixes related to bsc#1268779

### DIFF
--- a/live/live-root/usr/lib/dracut/modules.d/95initrd-firstboot/module-setup.sh
+++ b/live/live-root/usr/lib/dracut/modules.d/95initrd-firstboot/module-setup.sh
@@ -4,11 +4,11 @@
 
 check() {
   # always include this dracut module in the initramfs
-	return 0
+  return 0
 }
 
 depends() {
-	echo bash systemd
+  echo bash systemd
 }
 
 install() {
@@ -19,6 +19,9 @@ install() {
   # The problem is that the first boot detection fails because of the
   # complicated Live ISO setup which uses the device mapper for creating
   # writable overlay over the squashfs read-only image.
-	$SYSTEMCTL -q --root "$initdir" disable firstboot-detect.service
-	$SYSTEMCTL -q --root "$initdir" enable firstboot.target
+  $SYSTEMCTL -q --root "$initdir" disable firstboot-detect.service
+
+  # do not enable ignition/combustion by default, they can be explicitly
+  # enabled with the "rd.systemd.wants=firstboot.target" boot option
+  $SYSTEMCTL -q --root "$initdir" disable firstboot.target
 }

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul  8 13:19:39 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+Fixes related to bsc#1268779:
+- Removed "ignition" from the installer image
+- Do not start "combustion" by default, can be manually enabled
+  with the "rd.systemd.wants=firstboot.target" boot option
+
+-------------------------------------------------------------------
 Tue Jun 30 14:01:30 UTC 2026 - Santiago Zarate <santiago.zarate@suse.com>
 
 - Disable firefox's Link Preview feature gh#agama-project/agama#3687

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -64,7 +64,6 @@
         <package name="avahi"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
-        <package name="ignition"/>
         <package name="combustion"/>
         <package name="procps"/>
         <package name="iputils"/>


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1268779

## Solution

- Removed `ignition` from the installer image
- Do not start `combustion` by default, can be manually enabled with the `rd.systemd.wants=firstboot.target` boot option

## Testing

- Tested manually using a locally built ISO
- Ignition is not present anymore
- Combustion does not start by default but can explicitly started with the `rd.systemd.wants=firstboot.target` option
