### PR TITLE
agama-network: fix handling of flags for VLAN interfaces (#3701)

### DIFF
--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -1444,6 +1444,7 @@ fn vlan_config_to_dbus(cfg: &VlanConfig) -> NestedHash<'_> {
         ("id", cfg.id.into()),
         ("parent", cfg.parent.clone().into()),
         ("protocol", cfg.protocol.to_string().into()),
+        ("flags", 1u32.into()), // VLAN_FLAG_REORDER_HDR - kernel default
     ]);
 
     NestedHash::from([("vlan", vlan)])


### PR DESCRIPTION
vlan_config_to_dbus leaves the flags field unspecified which _should_ be fine, but is unfortunately not.  The NetworkManager developers have made a conscious decision to treat an absent flags field as the old default value of 0, and that value is written into the nmconnection file.

The problem is that the kernel defaults to a value to 1/VLAN_FLAG_REORDER_HDR.

Without this flag, software using AF_PACKET doesn't work, including tcpdump filters and dhcpd.

This fix adds the flags field with the kernel default value of 1.
