### PR TITLE
Do not timeout when starting agama-web-server

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  9 10:21:27 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Set the service TimeoutStartSec to infinity in order to not
+  timeout when starting it (gh#agama-project/agama#3703).
+
+-------------------------------------------------------------------
 Wed Jul  8 07:58:08 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update openssl dependency (bsc#1270992, bsc#1270891, bsc#1270850,

--- a/rust/share/agama-web-server.service
+++ b/rust/share/agama-web-server.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/bash -c "grep -q '\\binst.remote=0\\b' /run/agama/cmdline.d/a
 PIDFile=/run/agama/web.pid
 User=root
 TimeoutStopSec=5
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

Starting **agama-web-server** service could timeout because the storage service is taking too long for starting.

## Solution

Set the service **StarTimeoutStartSec** to infinity in order to not timeout when starting it


## Testing

- *Tested manually*