### PR TITLE
Provide early feedback when Agama start takes too long time

### DIFF
--- a/live/live-root/root/.local/bin/gnome-kiosk-script
+++ b/live/live-root/root/.local/bin/gnome-kiosk-script
@@ -10,7 +10,7 @@ PREFS=$HOME/.mozilla/firefox/profile/user.js
 LANG_FILE=/sys/firmware/efi/efivars/PlatformLang-8be4df61-93ca-11d2-aa0d-00e098032b8c
 
 # file exists and is not empty
-if [ -s  "$LANG_FILE" ]; then
+if [ -s "$LANG_FILE" ]; then
   # skip the first 4 bytes (the EFI attributes), keep only the characters allowed in a language code,
   # especially remove the trailing null byte
   EFI_LANG=$(cat "$LANG_FILE" | tail -c +5 | tr -cd "[_a-zA-Z-]")
@@ -22,10 +22,30 @@ if [ -s  "$LANG_FILE" ]; then
 fi
 
 # Waiting until Agama web server is listening.
+ATTEMPT=0
+# delay between the connection attempts
+DELAY=2
+LOADING_PID=""
+LOADING_PAGE="file:///usr/share/agama/web_ui/loading.html"
+# at which attempt to display the loading page
+LOADING_PAGE_ATTEMPT=3
 until [ "$(curl --silent --output /dev/null --write-out "%{http_code}" --head http://localhost/)" == "200" ]; do
   echo "Waiting for agama-web-server"
-  sleep 2
+  ATTEMPT=$((ATTEMPT + 1))
+  if [ "$ATTEMPT" -eq "$LOADING_PAGE_ATTEMPT" ]; then
+    # use the loading page as the temporary home page
+    sed -e "s@__HOMEPAGE__@$LOADING_PAGE@" $PREFS.template > $PREFS
+    firefox --profile $HOME/.mozilla/firefox/profile &
+    LOADING_PID=$!
+  fi
+  sleep "$DELAY"
 done
+
+# kill the loading page placeholder
+if [ -n "$LOADING_PID" ]; then
+  kill "$LOADING_PID" 2> /dev/null
+  wait "$LOADING_PID" 2> /dev/null
+fi
 
 TOKEN=$(cat $TOKEN_FILE)
 sed -e "s/__HOMEPAGE__/http:\/\/localhost\/login?token=$TOKEN$LANG_QUERY/" $PREFS.template > $PREFS

--- a/live/live-root/root/.mozilla/firefox/profile/user.js.template
+++ b/live/live-root/root/.mozilla/firefox/profile/user.js.template
@@ -74,6 +74,10 @@ user_pref("devtools.webconsole.timestampMessages", true);
 // disable "Link Preview" feature
 user_pref("browser.ml.linkPreview.enabled", false);
 
+// disable strict CORS policy for the file:// URLs, this allows displaying
+// a static "loading" HTML page before the Agama web server actually starts
+user_pref("security.fileuri.strict_origin_policy", false);
+
 // start always in the custom homepage
 user_pref("browser.startup.page", 1);
 // custom homepage: the value is expected to be replaced with the login URL by the startup script

--- a/rust/share/agama-web-server.service
+++ b/rust/share/agama-web-server.service
@@ -9,6 +9,8 @@ BindsTo=agama.service
 EnvironmentFile=-/run/agama/environment.conf
 Environment="AGAMA_LOG=debug,zbus=info"
 Type=notify
+# FIXME: this is just to simulate a long startup time, remove this!!
+ExecStartPre=-sleep 30
 # listen only on the loopback interface if the inst.remote=0 boot option is set
 ExecStart=/usr/bin/bash -c "grep -q '\\binst.remote=0\\b' /run/agama/cmdline.d/agama.conf && exec /usr/bin/agama-web-server serve --address ::1:80,127.0.0.1:80 --address ::1:443,127.0.0.1:443 || exec /usr/bin/agama-web-server serve --address :::80,0.0.0.0:80 --address :::443,0.0.0.0:443"
 PIDFile=/run/agama/web.pid

--- a/web/src/loading.html
+++ b/web/src/loading.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="stylesheet" href="loading.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agama</title>
+  </head>
+  <body>
+    <div id="root" style="height: 100vh;"></div>
+    <script type="module" src="./loading.js"></script>
+  </body>
+</html>

--- a/web/src/loading.tsx
+++ b/web/src/loading.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) [2022-2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+/**
+ * Import PF base styles before any JSX since components coming from PF may
+ * import styles dependent on variables and rules previously defined there.
+ */
+import "@patternfly/patternfly/dist/patternfly-base.scss";
+import "@patternfly/patternfly/dist/patternfly-addons.scss";
+
+/**
+ * As JSX components might import CSS stylesheets, our styles must be imported
+ * after them to preserve our overrides (e.g., PF overrides).
+ *
+ * Because mini-css-extract-plugin maintains the order of the imported CSS,
+ * adding the overrides here ensures the overrides will be placed appropriately
+ * at the end of our stylesheet when it extracts the CSS from dist/index.js
+ *
+ * See https://github.com/cockpit-project/starter-kit/blob/aeb81718e75b54e5d50ee450fe2abfbcfa58f5e6/src/index.js
+ */
+import "~/assets/styles/index.scss";
+import { Bullseye, Spinner } from "@patternfly/react-core";
+
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+root.render(
+  // TODO: display just a simple spinner for now, later we might add something more fancy
+  // or display some texts (after displaying the language switcher)
+  <Bullseye>
+    <Spinner size="xl" />
+  </Bullseye>,
+);

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -35,6 +35,7 @@ if (!agamaServer.startsWith("http")) {
 // Non-JS files which are copied verbatim to dist/
 const copy_files = [
   "./src/index.html",
+  "./src/loading.html",
   // TODO: consider using something more complete like https://github.com/jantimon/favicons-webpack-plugin
   "./src/assets/favicon.svg",
   "./src/languages.json",
@@ -111,6 +112,7 @@ module.exports = {
   },
   entry: {
     index: ["./src/index.tsx"],
+    loading: ["./src/loading.tsx"],
   },
   devServer: {
     hot: true,


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1270014
- No visual feedback when initializing the Agama server takes too long time
- There is just an empty grey screen
<img width="1280" height="800" alt="agama-init" src="https://github.com/user-attachments/assets/cede91e7-8555-4956-a1e0-7b34c5cd2766" />


## Solution

- Generate a separate HTML page which just shows a loading indicator (currently just a simple `<Spinner>` component but I guess @dgdavid can improve this :smiley: )
- Improve the  GNOME kiosk script so if Agama does not start in the limit the script starts the Firefox browser displaying the loading page.
- Use the `file://` protocol for the loading page so it does not need a running web server (Agama is not ready yet, starting yet another web server is an overkill).
- When Agama finally accepts connections the browser with the loading page is restarted with the standard Agama page.

[agama-early-feedback.webm](https://github.com/user-attachments/assets/b1064417-71cd-43dc-aee9-743c38fcc1e8)

## Testing

- Tested manually
- The testing ISO image is available at https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/early-feedback/images/iso/

## Notes

- This is just a proof of concept and needs some improvements.
- This is rather a quick workaround, we should find a proper solution for the long storage initialization in 16.2.

## TODO

- [ ] Remove the testing `sleep` before merging this change!