### PR TITLE
Rename network match settings field to "match" in JSON API

### DIFF
--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -586,6 +586,32 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
+    fn test_connection_match_settings_conversion() {
+        let match_settings = MatchSettings {
+            driver: vec!["e1000e".to_string()],
+            interface: vec!["eth0".to_string()],
+            path: vec!["pci-0000:00:1f.6".to_string()],
+            kernel: vec!["eth*".to_string()],
+        };
+        let net_conn = NetworkConnection {
+            id: "eth0".to_string(),
+            match_settings: Some(match_settings),
+            ..Default::default()
+        };
+
+        // NetworkConnection -> Connection
+        let conn = Connection::try_from(net_conn.clone()).unwrap();
+        assert_eq!(conn.match_config.driver, vec!["e1000e"]);
+        assert_eq!(conn.match_config.interface, vec!["eth0"]);
+        assert_eq!(conn.match_config.path, vec!["pci-0000:00:1f.6"]);
+        assert_eq!(conn.match_config.kernel, vec!["eth*"]);
+
+        // Connection -> NetworkConnection
+        let net_conn2 = NetworkConnection::try_from(conn).unwrap();
+        assert_eq!(net_conn.match_settings, net_conn2.match_settings);
+    }
+
+    #[test]
     fn test_add_connection() {
         let mut state = NetworkState::default();
         let uuid = Uuid::new_v4();
@@ -1196,6 +1222,15 @@ impl TryFrom<NetworkConnection> for Connection {
         connection.interface = conn.interface;
         connection.mtu = conn.mtu;
 
+        if let Some(match_settings) = conn.match_settings {
+            connection.match_config = MatchConfig {
+                driver: match_settings.driver,
+                interface: match_settings.interface,
+                path: match_settings.path,
+                kernel: match_settings.kernel,
+            };
+        }
+
         Ok(connection)
     }
 }
@@ -1225,6 +1260,13 @@ impl TryFrom<Connection> for NetworkConnection {
         let autoconnect = Some(conn.autoconnect);
         let persistent = Some(conn.persistent);
 
+        let match_settings = (!conn.match_config.is_empty()).then(|| MatchSettings {
+            driver: conn.match_config.driver.clone(),
+            interface: conn.match_config.interface.clone(),
+            path: conn.match_config.path.clone(),
+            kernel: conn.match_config.kernel.clone(),
+        });
+
         let mut connection = NetworkConnection {
             id,
             status,
@@ -1243,6 +1285,7 @@ impl TryFrom<Connection> for NetworkConnection {
             ieee_8021x,
             autoconnect,
             persistent,
+            match_settings,
             ..Default::default()
         };
 
@@ -1326,6 +1369,15 @@ pub struct MatchConfig {
     pub path: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub kernel: Vec<String>,
+}
+
+impl MatchConfig {
+    pub fn is_empty(&self) -> bool {
+        self.driver.is_empty()
+            && self.interface.is_empty()
+            && self.path.is_empty()
+            && self.kernel.is_empty()
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Deserialize, Serialize, JsonSchema)]

--- a/rust/agama-utils/src/api/network/settings.rs
+++ b/rust/agama-utils/src/api/network/settings.rs
@@ -423,43 +423,8 @@ mod tests {
     }
 
     #[test]
-    fn test_network_connection_match_settings_with_match_key() {
-        // Test that "match" key is accepted (not just "matchSettings")
-        let json = r#"{
-            "id": "eth0",
-            "match": {
-                "interface": ["eth0"]
-            },
-            "status": "up",
-            "autoconnect": true,
-            "persistent": false
-        }"#;
-        let conn: NetworkConnection = serde_json::from_str(json).unwrap();
-        assert!(conn.match_settings.is_some());
-        let match_settings = conn.match_settings.unwrap();
-        assert_eq!(match_settings.interface, vec!["eth0"]);
-    }
-
-    #[test]
-    fn test_network_connection_match_settings_serialization() {
-        // Test that match settings serialize back as "match" (not "matchSettings")
-        let mut conn = NetworkConnection {
-            id: "eth0".to_string(),
-            ..Default::default()
-        };
-        conn.match_settings = Some(MatchSettings {
-            interface: vec!["eth0".to_string()],
-            ..Default::default()
-        });
-
-        let serialized = serde_json::to_string(&conn).unwrap();
-        assert!(serialized.contains("\"match\""));
-        assert!(!serialized.contains("\"matchSettings\""));
-    }
-
-    #[test]
     fn test_network_connection_match_settings_round_trip() {
-        // Test round-trip: deserialize and serialize
+        // Test round-trip: deserialize and serialize match settings
         let json = r#"{
             "id": "eth0",
             "ignoreAutoDns": false,
@@ -474,6 +439,7 @@ mod tests {
             "persistent": false
         }"#;
 
+        // 1. Verify deserialization with the "match" key and all fields
         let conn: NetworkConnection = serde_json::from_str(json).unwrap();
         assert!(conn.match_settings.is_some());
         let match_settings = conn.match_settings.as_ref().unwrap();
@@ -482,11 +448,12 @@ mod tests {
         assert_eq!(match_settings.path, vec!["pci-0000:00:1f.6"]);
         assert_eq!(match_settings.kernel, vec!["eth*"]);
 
-        // Serialize back and verify it contains "match" key
+        // 2. Verify serialization back uses "match" and does not contain "matchSettings"
         let serialized = serde_json::to_string(&conn).unwrap();
-        assert!(serialized.contains("\"match\""));
+        assert!(serialized.contains("\"match\":"));
+        assert!(!serialized.contains("\"matchSettings\""));
 
-        // Deserialize again to ensure round-trip works
+        // 3. Verify second-pass deserialization preserves identical settings
         let conn2: NetworkConnection = serde_json::from_str(&serialized).unwrap();
         assert_eq!(conn.match_settings, conn2.match_settings);
     }

--- a/rust/agama-utils/src/api/network/settings.rs
+++ b/rust/agama-utils/src/api/network/settings.rs
@@ -327,7 +327,7 @@ pub struct NetworkConnection {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interface: Option<String>,
     /// Match settings for the network connection
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "match", skip_serializing_if = "Option::is_none")]
     pub match_settings: Option<MatchSettings>,
     /// Identifier for the parent connection, if this connection is part of a bond
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -420,5 +420,74 @@ mod tests {
         }"#;
         let conn: NetworkConnection = serde_json::from_str(json).unwrap();
         assert_eq!(conn.dns_searchlist, vec!["example.org"]);
+    }
+
+    #[test]
+    fn test_network_connection_match_settings_with_match_key() {
+        // Test that "match" key is accepted (not just "matchSettings")
+        let json = r#"{
+            "id": "eth0",
+            "match": {
+                "interface": ["eth0"]
+            },
+            "status": "up",
+            "autoconnect": true,
+            "persistent": false
+        }"#;
+        let conn: NetworkConnection = serde_json::from_str(json).unwrap();
+        assert!(conn.match_settings.is_some());
+        let match_settings = conn.match_settings.unwrap();
+        assert_eq!(match_settings.interface, vec!["eth0"]);
+    }
+
+    #[test]
+    fn test_network_connection_match_settings_serialization() {
+        // Test that match settings serialize back as "match" (not "matchSettings")
+        let mut conn = NetworkConnection {
+            id: "eth0".to_string(),
+            ..Default::default()
+        };
+        conn.match_settings = Some(MatchSettings {
+            interface: vec!["eth0".to_string()],
+            ..Default::default()
+        });
+
+        let serialized = serde_json::to_string(&conn).unwrap();
+        assert!(serialized.contains("\"match\""));
+        assert!(!serialized.contains("\"matchSettings\""));
+    }
+
+    #[test]
+    fn test_network_connection_match_settings_round_trip() {
+        // Test round-trip: deserialize and serialize
+        let json = r#"{
+            "id": "eth0",
+            "ignoreAutoDns": false,
+            "status": "up",
+            "match": {
+                "interface": ["eth0"],
+                "driver": ["e1000e"],
+                "path": ["pci-0000:00:1f.6"],
+                "kernel": ["eth*"]
+            },
+            "autoconnect": true,
+            "persistent": false
+        }"#;
+
+        let conn: NetworkConnection = serde_json::from_str(json).unwrap();
+        assert!(conn.match_settings.is_some());
+        let match_settings = conn.match_settings.as_ref().unwrap();
+        assert_eq!(match_settings.interface, vec!["eth0"]);
+        assert_eq!(match_settings.driver, vec!["e1000e"]);
+        assert_eq!(match_settings.path, vec!["pci-0000:00:1f.6"]);
+        assert_eq!(match_settings.kernel, vec!["eth*"]);
+
+        // Serialize back and verify it contains "match" key
+        let serialized = serde_json::to_string(&conn).unwrap();
+        assert!(serialized.contains("\"match\""));
+
+        // Deserialize again to ensure round-trip works
+        let conn2: NetworkConnection = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(conn.match_settings, conn2.match_settings);
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 10 12:02:12 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Rename the network device match settings attribute to "match"
+  (gh#agama-project/agama#3708, bsc#1271236).
+
+-------------------------------------------------------------------
 Thu Jul  9 13:17:27 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Handle VLAN flags properly, using the kernel default value


### PR DESCRIPTION
## Problem

The network device match settings are not serialized / deserialized properly at least according to the json schema and the [documentation](https://agama-project.github.io/docs/user/reference/profile/network#device-matching).

This example is not working and it should:
```json
{
  "network": {
    "connections": [
      {
        "id": "Wired connection 1",
        "match": {
          "interface": ["eth0"]
        }
      }
    ]
  }
}
```

- https://bugzilla.suse.com/show_bug.cgi?id=1271236

## Solution

- Rename the match_settings attribute to "match".
- Convert the MatchSettings to MatchConfig as currently it is not done.

## Testing

- *Added a new unit test*
- *Tested manually*
```
user@localhost:~$ cat config.json
{
  "network": {
    "connections": [
      {
        "id": "ethernet",
        "ignoreAutoDns": false,
        "status": "up",
        "match": {
          "interface": ["eth*", "ens*"]
        },
        "autoconnect": true,
        "persistent": true
      }
    ]
  }
}

user@localhost:~$ agama config load config.json
...
user@localhost:/etc/NetworkManager/system-connections$ sudo cat ethernet.nmconnection 
[connection]
id=ethernet
uuid=295fd439-f9c8-4185-91c9-fe8afe0d55ed
type=ethernet
timestamp=1783685898

[ethernet]

[match]
interface-name=eth*;ens*;

[ipv4]
method=auto

[ipv6]
addr-gen-mode=default
method=auto

[proxy]

```