### PR TITLE
Fix "unexpected error" drive is undefined for VROC RAID

### DIFF
--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/drive.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/drive.rb
@@ -38,7 +38,7 @@ module Agama
           # @param storage_device [Y2Storage::Device]
           # @return [Boolean]
           def self.apply?(storage_device)
-            storage_device.is?(:disk, :dm_raid, :multipath, :dasd) &&
+            (storage_device.is?(:disk, :dm_raid, :multipath, :dasd) || storage_device.is?(:md)) &&
               storage_device.is?(:disk_device)
           end
 

--- a/service/test/agama/storage/devicegraph_conversions/to_json_test.rb
+++ b/service/test/agama/storage/devicegraph_conversions/to_json_test.rb
@@ -31,6 +31,7 @@ describe Agama::Storage::DevicegraphConversions::ToJSON do
   before do
     mock_storage(devicegraph: scenario)
     allow_any_instance_of(Y2Storage::Partition).to receive(:resize_info).and_return(resize_info)
+    allow_any_instance_of(Y2Storage::LvmLv).to receive(:resize_info).and_return(resize_info)
   end
 
   subject { described_class.new(devicegraph) }
@@ -171,6 +172,18 @@ describe Agama::Storage::DevicegraphConversions::ToJSON do
         json = subject.convert
         wires = json.first[:multipath][:wireNames]
         expect(wires).to contain_exactly("/dev/sda", "/dev/sdb")
+      end
+    end
+
+    describe "for a devicegraph with BIOS RAID (such as VROC)" do
+      let(:scenario) { "lvm-over-hardware-raid.xml" }
+
+      it "exports BIOS RAID volumes with drive class and drive section" do
+        json = subject.convert
+        vols = json.select { |d| ["/dev/md/a", "/dev/md/b"].include?(d[:name]) }
+        expect(vols).to_not be_empty
+        expect(vols.map { |v| v[:class] }).to all(eq "drive")
+        expect(vols.map { |v| v.key?(:drive) }).to all(be true)
       end
     end
   end

--- a/web/src/components/storage/utils/device.tsx
+++ b/web/src/components/storage/utils/device.tsx
@@ -28,21 +28,21 @@ import { isEmpty } from "radashi";
 import { baseName } from "~/components/storage/utils";
 
 const driveTypeDescription = (device: System.Device): string => {
-  if (device.drive.type === "multipath") {
+  if (device.drive?.type === "multipath") {
     // TRANSLATORS: multipath device type
     return _("Multipath");
   }
 
-  if (device.drive.type === "dasd") {
+  if (device.drive?.type === "dasd") {
     // TRANSLATORS: %s is replaced by the device bus ID
     return sprintf(_("DASD %s"), device.drive.busId);
   }
 
-  if (device.drive.info.sdCard) {
+  if (device.drive?.info?.sdCard) {
     return _("SD Card");
   }
 
-  const technology = device.drive.transport || device.drive.bus;
+  const technology = device.drive?.transport || device.drive?.bus;
   return technology
     ? // TRANSLATORS: %s is substituted by the type of disk like "iSCSI" or "SATA"
       sprintf(_("%s disk"), technology)


### PR DESCRIPTION
## Problem

"Unexpected error" during SLES 16.1 installation when manually selecting the secondary VROC RAID 1 disk

- https://bugzilla.suse.com/show_bug.cgi?id=1271120

## Solution

Allow MD devices that are partitionable disk devices to export the "drive" section.

## Testing

- Added a new unit test

## Screenshots

No

## Documentation

_TODO: .changes_

*Remember to look at it from the user's perspective. Yes you have made the compiler happy.*
*But will the **humans** even know about your contribution? Sometimes they cannot miss it,*
*other times they need advertisement and explanation.*

*Look for relevant sections and adjust:*
- The `*.changes` files. For ALL affected packages.
- The description parts of the [JSON schema][profile.schema.json]
- Is the CLI affected? See [cli.md][] for a complete overview,
  change the `///` comments (rust doc)
  and update the .md with `cargo xtask markdown`
- <https://agama-project.github.io/> ([source][gh.io])
- Run: `git ls-files '*.md'`

[cli.md]: https://github.com/agama-project/agama-project.github.io/blob/main/docs/user/reference/cli.md
[profile.schema.json]: https://github.com/agama-project/agama/blob/master/rust/agama-lib/share/profile.schema.json
[gh.io]: https://github.com/agama-project/agama-project.github.io/
