### PR TITLE
Fix match settings for SLE-16

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "pin-project",
  "semver",
  "serde",
+ "serde_json",
  "serde_with",
  "strum",
  "thiserror 2.0.12",

--- a/rust/agama-network/Cargo.toml
+++ b/rust/agama-network/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 rust-version.workspace = true
 edition.workspace = true
 
+[dev-dependencies]
+serde_json = "1.0.140"
+
 [dependencies]
 agama-utils = { path = "../agama-utils" }
 anyhow = "1.0.98"

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -24,8 +24,8 @@
 //!   agnostic from the real network service (e.g., NetworkManager).
 use crate::error::NetworkStateError;
 use crate::settings::{
-    BondSettings, BridgeSettings, IEEE8021XSettings, MatchSettings, NetworkConnection, VlanSettings,
-    WirelessSettings,
+    BondSettings, BridgeSettings, IEEE8021XSettings, MatchSettings, NetworkConnection,
+    VlanSettings, WirelessSettings,
 };
 use crate::types::{BondMode, ConnectionState, DeviceState, DeviceType, Status, SSID};
 use agama_utils::openapi::schemas;

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -24,7 +24,7 @@
 //!   agnostic from the real network service (e.g., NetworkManager).
 use crate::error::NetworkStateError;
 use crate::settings::{
-    BondSettings, BridgeSettings, IEEE8021XSettings, NetworkConnection, VlanSettings,
+    BondSettings, BridgeSettings, IEEE8021XSettings, MatchSettings, NetworkConnection, VlanSettings,
     WirelessSettings,
 };
 use crate::types::{BondMode, ConnectionState, DeviceState, DeviceType, Status, SSID};
@@ -259,6 +259,32 @@ mod tests {
     use super::*;
     use crate::error::NetworkStateError;
     use uuid::Uuid;
+
+    #[test]
+    fn test_connection_match_settings_conversion() {
+        let match_settings = MatchSettings {
+            driver: vec!["e1000e".to_string()],
+            interface: vec!["eth0".to_string()],
+            path: vec!["pci-0000:00:1f.6".to_string()],
+            kernel: vec!["eth*".to_string()],
+        };
+        let net_conn = NetworkConnection {
+            id: "eth0".to_string(),
+            match_settings: Some(match_settings),
+            ..Default::default()
+        };
+
+        // NetworkConnection -> Connection
+        let conn = Connection::try_from(net_conn.clone()).unwrap();
+        assert_eq!(conn.match_config.driver, vec!["e1000e"]);
+        assert_eq!(conn.match_config.interface, vec!["eth0"]);
+        assert_eq!(conn.match_config.path, vec!["pci-0000:00:1f.6"]);
+        assert_eq!(conn.match_config.kernel, vec!["eth*"]);
+
+        // Connection -> NetworkConnection
+        let net_conn2 = NetworkConnection::try_from(conn).unwrap();
+        assert_eq!(net_conn.match_settings, net_conn2.match_settings);
+    }
 
     #[test]
     fn test_macaddress() {
@@ -687,6 +713,15 @@ impl TryFrom<NetworkConnection> for Connection {
         connection.interface = conn.interface;
         connection.mtu = conn.mtu;
 
+        if let Some(match_settings) = conn.match_settings {
+            connection.match_config = MatchConfig {
+                driver: match_settings.driver,
+                interface: match_settings.interface,
+                path: match_settings.path,
+                kernel: match_settings.kernel,
+            };
+        }
+
         Ok(connection)
     }
 }
@@ -716,6 +751,13 @@ impl TryFrom<Connection> for NetworkConnection {
         let autoconnect = Some(conn.autoconnect);
         let persistent = Some(conn.persistent);
 
+        let match_settings = (!conn.match_config.is_empty()).then(|| MatchSettings {
+            driver: conn.match_config.driver.clone(),
+            interface: conn.match_config.interface.clone(),
+            path: conn.match_config.path.clone(),
+            kernel: conn.match_config.kernel.clone(),
+        });
+
         let mut connection = NetworkConnection {
             id,
             status,
@@ -734,6 +776,7 @@ impl TryFrom<Connection> for NetworkConnection {
             ieee_8021x,
             autoconnect,
             persistent,
+            match_settings,
             ..Default::default()
         };
 
@@ -1085,6 +1128,15 @@ pub struct MatchConfig {
     pub path: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub kernel: Vec<String>,
+}
+
+impl MatchConfig {
+    pub fn is_empty(&self) -> bool {
+        self.driver.is_empty()
+            && self.interface.is_empty()
+            && self.path.is_empty()
+            && self.kernel.is_empty()
+    }
 }
 
 #[derive(Debug, Error)]

--- a/rust/agama-network/src/settings.rs
+++ b/rust/agama-network/src/settings.rs
@@ -35,7 +35,7 @@ pub struct NetworkSettings {
     pub connections: Vec<NetworkConnection>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct MatchSettings {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub driver: Vec<String>,
@@ -247,7 +247,7 @@ pub struct NetworkConnection {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interface: Option<String>,
     /// Match settings for the network connection
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "match", skip_serializing_if = "Option::is_none")]
     pub match_settings: Option<MatchSettings>,
     /// Identifier for the parent connection, if this connection is part of a bond
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -300,5 +300,46 @@ impl NetworkConnection {
         } else {
             DeviceType::Ethernet
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_network_connection_match_settings_round_trip() {
+        // Test round-trip: deserialize and serialize match settings
+        let json = r#"{
+            "id": "eth0",
+            "ignoreAutoDns": false,
+            "status": "up",
+            "match": {
+                "interface": ["eth0"],
+                "driver": ["e1000e"],
+                "path": ["pci-0000:00:1f.6"],
+                "kernel": ["eth*"]
+            },
+            "autoconnect": true,
+            "persistent": false
+        }"#;
+
+        // 1. Verify deserialization with the "match" key and all fields
+        let conn: NetworkConnection = serde_json::from_str(json).unwrap();
+        assert!(conn.match_settings.is_some());
+        let match_settings = conn.match_settings.as_ref().unwrap();
+        assert_eq!(match_settings.interface, vec!["eth0"]);
+        assert_eq!(match_settings.driver, vec!["e1000e"]);
+        assert_eq!(match_settings.path, vec!["pci-0000:00:1f.6"]);
+        assert_eq!(match_settings.kernel, vec!["eth*"]);
+
+        // 2. Verify serialization back uses "match" and does not contain "matchSettings"
+        let serialized = serde_json::to_string(&conn).unwrap();
+        assert!(serialized.contains("\"match\":"));
+        assert!(!serialized.contains("\"matchSettings\""));
+
+        // 3. Verify second-pass deserialization preserves identical settings
+        let conn2: NetworkConnection = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(conn.match_settings, conn2.match_settings);
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 10 13:12:36 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Rename the network device match settings attribute to "match"
+  (gh#agama-project/agama#3711, bsc#1271235).
+
+-------------------------------------------------------------------
 Thu Jul  9 10:38:18 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update openssl dependency (bsc#1270992, bsc#1270891, bsc#1270850,


### PR DESCRIPTION
## Problem

It is a backport of https://github.com/agama-project/agama/pull/3708 but for SLE-16.

- https://bugzilla.suse.com/show_bug.cgi?id=1271235


## Solution

The same as in the referenced PR:

- Rename the match_settings attribute to "match".
- Convert the MatchSettings to MatchConfig as currently it is not done.


## Testing

- *Added a new unit test*
