### PR TITLE
network: keep curl-sys out of agama-network's dependency tree

### DIFF
--- a/rust/agama-network/Cargo.toml
+++ b/rust/agama-network/Cargo.toml
@@ -5,7 +5,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-utils = { workspace = true }
+agama-utils = { path = "../agama-utils", default-features = false }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 cidr = { workspace = true }


### PR DESCRIPTION
## Problem

A previous refactor (7b723cc5a) switched `agama-network`'s dependency on `agama-utils` to `{ workspace = true }`, which silently dropped the `default-features = false` override needed to keep the `curl` feature (and `curl-sys`/openssl) out of `agama-network`'s dependency tree. This breaks `wicked2nm`, which depends on `agama-network` and needs to build without curl/openssl on targets where openssl doesn't build.

## Solution

Reverted `agama-network`'s dependency on `agama-utils` to a plain `path` dependency with `default-features = false`. Cargo doesn't currently support overriding `default-features` on a `workspace = true` dependency (tracked upstream in rust rfcs#3945, not yet implemented), so `workspace = true` isn't usable here yet.

## Testing

- Tested manually: `cargo tree -i curl-sys` on an isolated consumer of `agama-network` shows no match; `cargo check -p agama-network` builds cleanly in the workspace.