### PR TITLE
Fixed in the backend for handling VLAN flags

### DIFF
--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -712,6 +712,14 @@
                     "type": "string",
                     "default": "802.1Q",
                     "enum": ["802.1Q", "802.1ad"]
+                  },
+                  "flags": {
+                    "title": "VLAN flags",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": ["reorder-headers", "gvrp", "loose-binding", "mvrp"]
+                    }
                   }
                 }
               }

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -24,7 +24,7 @@
 //!   agnostic from the real network service (e.g., NetworkManager).
 use crate::error::NetworkStateError;
 use crate::settings::{
-    BondSettings, BridgeSettings, IEEE8021XSettings, MatchSettings, NetworkConnection,
+    BondSettings, BridgeSettings, IEEE8021XSettings, MatchSettings, NetworkConnection, VlanFlag,
     VlanSettings, WirelessSettings,
 };
 use crate::types::{BondMode, ConnectionState, DeviceState, DeviceType, Status, SSID};
@@ -1296,6 +1296,8 @@ pub struct VlanConfig {
     pub parent: String,
     pub id: u32,
     pub protocol: VlanProtocol,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flags: Option<Vec<VlanFlag>>,
 }
 
 #[serde_as]
@@ -1347,6 +1349,7 @@ impl TryFrom<VlanSettings> for VlanConfig {
         let mut config = VlanConfig {
             id,
             parent,
+            flags: settings.flags,
             ..Default::default()
         };
 
@@ -1367,6 +1370,7 @@ impl TryFrom<VlanConfig> for VlanSettings {
             id: vlan.id,
             parent: vlan.parent,
             protocol: Some(vlan.protocol.to_string()),
+            flags: vlan.flags,
         })
     }
 }

--- a/rust/agama-network/src/model.rs
+++ b/rust/agama-network/src/model.rs
@@ -287,6 +287,39 @@ mod tests {
     }
 
     #[test]
+    fn test_vlan_connection_conversion() {
+        let vlan_settings = VlanSettings {
+            id: 100,
+            parent: "eth0".to_string(),
+            protocol: Some("802.1Q".to_string()),
+            flags: Some(vec![VlanFlag::ReorderHeaders, VlanFlag::LooseBinding]),
+        };
+        let net_conn = NetworkConnection {
+            id: "eth0.100".to_string(),
+            vlan: Some(vlan_settings),
+            ..Default::default()
+        };
+
+        // NetworkConnection -> Connection
+        let conn = Connection::try_from(net_conn.clone()).unwrap();
+        if let ConnectionConfig::Vlan(config) = &conn.config {
+            assert_eq!(config.id, 100);
+            assert_eq!(config.parent, "eth0");
+            assert_eq!(config.protocol, VlanProtocol::IEEE802_1Q);
+            assert_eq!(
+                config.flags,
+                Some(vec![VlanFlag::ReorderHeaders, VlanFlag::LooseBinding])
+            );
+        } else {
+            panic!("Expected Vlan connection config");
+        }
+
+        // Connection -> NetworkConnection
+        let net_conn2 = NetworkConnection::try_from(conn).unwrap();
+        assert_eq!(net_conn.vlan, net_conn2.vlan);
+    }
+
+    #[test]
     fn test_macaddress() {
         let mut val: Option<String> = None;
         assert!(matches!(

--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -24,6 +24,7 @@
 //! with nested hash maps (see [NestedHash] and [OwnedNestedHash]).
 use super::{error::NmError, model::*};
 use crate::model::*;
+use crate::settings::VlanFlag;
 use crate::types::{BondMode, SSID};
 use agama_utils::dbus::{
     get_optional_property, get_property, to_owned_hash, NestedHash, OwnedNestedHash,
@@ -397,6 +398,16 @@ pub fn cleanup_dbus_connection(conn: &mut NestedHash) {
         ipv6.remove("dns");
         if ipv6.get("address-data").is_some_and(is_empty_value) {
             ipv6.remove("gateway");
+        }
+    }
+
+    if let Some(vlan) = conn.get_mut("vlan") {
+        if !vlan.contains_key("flags") {
+            // Default to VLAN_FLAG_REORDER_HDR if flags are not specified (bsc#1271079)
+            vlan.insert(
+                "flags",
+                VlanFlag::to_bitmask(&[VlanFlag::ReorderHeaders]).into(),
+            );
         }
     }
 }
@@ -1375,11 +1386,15 @@ fn bond_config_from_dbus(conn: &OwnedNestedHash) -> Result<Option<BondConfig>, N
 }
 
 fn vlan_config_to_dbus(cfg: &VlanConfig) -> NestedHash {
-    let vlan: HashMap<&str, zvariant::Value> = HashMap::from([
+    let mut vlan: HashMap<&str, zvariant::Value> = HashMap::from([
         ("id", cfg.id.into()),
         ("parent", cfg.parent.clone().into()),
         ("protocol", cfg.protocol.to_string().into()),
     ]);
+
+    if let Some(flags) = &cfg.flags {
+        vlan.insert("flags", VlanFlag::to_bitmask(flags).into());
+    }
 
     NestedHash::from([("vlan", vlan)])
 }
@@ -1394,10 +1409,15 @@ fn vlan_config_from_dbus(conn: &OwnedNestedHash) -> Result<Option<VlanConfig>, N
         _ => Default::default(),
     };
 
+    let flags = get_property::<u32>(vlan, "flags")
+        .ok()
+        .map(VlanFlag::from_bitmask);
+
     Ok(Some(VlanConfig {
         id: get_property(vlan, "id")?,
         parent: get_property(vlan, "parent")?,
         protocol,
+        flags,
     }))
 }
 
@@ -1570,15 +1590,15 @@ fn is_empty_value(value: &zvariant::Value) -> bool {
 #[cfg(test)]
 mod test {
     use super::{
-        connection_from_dbus, connection_to_dbus, merge_dbus_connections, NestedHash,
-        OwnedNestedHash,
+        connection_from_dbus, connection_to_dbus, merge_dbus_connections, vlan_config_to_dbus,
+        NestedHash, OwnedNestedHash,
     };
     use crate::types::{BondMode, SSID};
     use crate::{
         model::*,
         nm::{
             dbus::{
-                BOND_KEY, BRIDGE_KEY, ETHERNET_KEY, INFINIBAND_KEY, WIRELESS_KEY,
+                BOND_KEY, BRIDGE_KEY, ETHERNET_KEY, INFINIBAND_KEY, VLAN_KEY, WIRELESS_KEY,
                 WIRELESS_SECURITY_KEY,
             },
             error::NmError,
@@ -1838,6 +1858,104 @@ mod test {
         if let ConnectionConfig::Bond(config) = connection.config {
             assert_eq!(config.mode, BondMode::ActiveBackup);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_connection_from_dbus_vlan() -> anyhow::Result<()> {
+        let uuid = Uuid::new_v4().to_string();
+        let connection_section = HashMap::from([hi("id", "eth0.100")?, hi("uuid", uuid)?]);
+
+        // Scenario 1: DBus has flags
+        let vlan_section_with_flags = HashMap::from([
+            hi("id", 100_u32)?,
+            hi("parent", "eth0")?,
+            hi("protocol", "802.1Q")?,
+            hi(
+                "flags",
+                VlanFlag::to_bitmask(&[VlanFlag::ReorderHeaders, VlanFlag::LooseBinding]),
+            )?,
+        ]);
+        let dbus_conn = HashMap::from([
+            ("connection".to_string(), connection_section.clone()),
+            (VLAN_KEY.to_string(), vlan_section_with_flags),
+        ]);
+        let connection = connection_from_dbus(dbus_conn).unwrap();
+        if let ConnectionConfig::Vlan(config) = connection.config {
+            assert_eq!(config.id, 100_u32);
+            assert_eq!(config.parent, "eth0");
+            assert_eq!(config.protocol, VlanProtocol::IEEE802_1Q);
+            assert_eq!(
+                config.flags,
+                Some(vec![VlanFlag::ReorderHeaders, VlanFlag::LooseBinding])
+            );
+        } else {
+            panic!("Wrong connection type");
+        }
+
+        // Scenario 2: D-Bus does not have flags
+        let vlan_section_no_flags = HashMap::from([
+            hi("id", 100_u32)?,
+            hi("parent", "eth0")?,
+            hi("protocol", "802.1Q")?,
+        ]);
+        let dbus_conn_no_flags = HashMap::from([
+            ("connection".to_string(), connection_section),
+            (VLAN_KEY.to_string(), vlan_section_no_flags),
+        ]);
+        let connection_no_flags = connection_from_dbus(dbus_conn_no_flags).unwrap();
+        if let ConnectionConfig::Vlan(config) = connection_no_flags.config {
+            assert_eq!(config.flags, None);
+        } else {
+            panic!("Wrong connection type");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_dbus_from_vlan_connection() -> anyhow::Result<()> {
+        // Scenario 1: VlanConfig with flags specified -> should write flags to D-Bus
+        let vlan_config = VlanConfig {
+            id: 100,
+            parent: "eth0".to_string(),
+            protocol: VlanProtocol::IEEE802_1Q,
+            flags: Some(vec![VlanFlag::ReorderHeaders, VlanFlag::LooseBinding]),
+        };
+        let nested = vlan_config_to_dbus(&vlan_config);
+        let vlan_section = nested.get("vlan").unwrap();
+        assert_eq!(vlan_section.get("id"), Some(&Value::from(100_u32)));
+        assert_eq!(vlan_section.get("parent"), Some(&Value::from("eth0")));
+        assert_eq!(vlan_section.get("protocol"), Some(&Value::from("802.1Q")));
+        assert_eq!(
+            vlan_section.get("flags"),
+            Some(&Value::from(VlanFlag::to_bitmask(&[
+                VlanFlag::ReorderHeaders,
+                VlanFlag::LooseBinding
+            ])))
+        );
+
+        // Scenario 2: VlanConfig with no flags (flags: None) -> vlan_config_to_dbus should omit flags
+        let vlan_config_no_flags = VlanConfig {
+            id: 100,
+            parent: "eth0".to_string(),
+            protocol: VlanProtocol::IEEE802_1Q,
+            flags: None,
+        };
+        let mut nested_no_flags = vlan_config_to_dbus(&vlan_config_no_flags);
+        let vlan_section_no_flags = nested_no_flags.get("vlan").unwrap();
+        assert_eq!(vlan_section_no_flags.get("flags"), None);
+
+        // Scenario 3: cleanup_dbus_connection should default omitted flags to 1
+        super::cleanup_dbus_connection(&mut nested_no_flags);
+        let vlan_section_cleaned = nested_no_flags.get("vlan").unwrap();
+        assert_eq!(
+            vlan_section_cleaned.get("flags"),
+            Some(&Value::from(VlanFlag::to_bitmask(&[
+                VlanFlag::ReorderHeaders
+            ])))
+        );
 
         Ok(())
     }

--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -1591,7 +1591,7 @@ fn is_empty_value(value: &zvariant::Value) -> bool {
 mod test {
     use super::{
         connection_from_dbus, connection_to_dbus, merge_dbus_connections, vlan_config_to_dbus,
-        NestedHash, OwnedNestedHash,
+        NestedHash, OwnedNestedHash, VlanFlag,
     };
     use crate::types::{BondMode, SSID};
     use crate::{

--- a/rust/agama-network/src/settings.rs
+++ b/rust/agama-network/src/settings.rs
@@ -361,6 +361,8 @@ impl NetworkConnection {
             DeviceType::Bond
         } else if self.bridge.is_some() {
             DeviceType::Bridge
+        } else if self.vlan.is_some() {
+            DeviceType::Vlan
         } else {
             DeviceType::Ethernet
         }

--- a/rust/agama-network/src/settings.rs
+++ b/rust/agama-network/src/settings.rs
@@ -205,7 +205,7 @@ impl VlanFlag {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct VlanSettings {
     pub parent: String,
     pub id: u32,

--- a/rust/agama-network/src/settings.rs
+++ b/rust/agama-network/src/settings.rs
@@ -143,12 +143,76 @@ impl Default for BridgeSettings {
     }
 }
 
+/// VLAN flags controlling behavior
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, utoipa::ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum VlanFlag {
+    /// Reorder Ethernet headers to make packets look less like VLAN packets
+    ReorderHeaders,
+    /// GARP VLAN Registration Protocol - dynamically register/deregister VLANs
+    Gvrp,
+    /// Allow changing master device while connection is active
+    LooseBinding,
+    /// Multiple VLAN Registration Protocol - next generation of GVRP
+    Mvrp,
+}
+
+impl VlanFlag {
+    /// Valid bitmask for all known VLAN flags
+    const VALID_MASK: u32 = 0xF; // 0x1 | 0x2 | 0x4 | 0x8
+
+    /// Convert a slice of VlanFlags to a bitmask value for NetworkManager
+    pub fn to_bitmask(flags: &[VlanFlag]) -> u32 {
+        flags.iter().fold(0, |acc, flag| {
+            acc | match flag {
+                VlanFlag::ReorderHeaders => 0x1,
+                VlanFlag::Gvrp => 0x2,
+                VlanFlag::LooseBinding => 0x4,
+                VlanFlag::Mvrp => 0x8,
+            }
+        })
+    }
+
+    /// Convert a bitmask value from NetworkManager to a Vec of VlanFlags
+    ///
+    /// Unknown flag bits are silently ignored to maintain forward compatibility
+    /// with future NetworkManager versions.
+    pub fn from_bitmask(bitmask: u32) -> Vec<VlanFlag> {
+        let mut flags = Vec::new();
+        if bitmask & 0x1 != 0 {
+            flags.push(VlanFlag::ReorderHeaders);
+        }
+        if bitmask & 0x2 != 0 {
+            flags.push(VlanFlag::Gvrp);
+        }
+        if bitmask & 0x4 != 0 {
+            flags.push(VlanFlag::LooseBinding);
+        }
+        if bitmask & 0x8 != 0 {
+            flags.push(VlanFlag::Mvrp);
+        }
+
+        // Log warning if unknown bits are set
+        if bitmask & !Self::VALID_MASK != 0 {
+            tracing::warn!(
+                "Unknown VLAN flags in bitmask: {:#x} (unknown bits: {:#x})",
+                bitmask,
+                bitmask & !Self::VALID_MASK
+            );
+        }
+
+        flags
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct VlanSettings {
     pub parent: String,
     pub id: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flags: Option<Vec<VlanFlag>>,
 }
 
 /// IEEE 802.1x (EAP) settings

--- a/rust/agama-server/src/web/docs/network.rs
+++ b/rust/agama-server/src/web/docs/network.rs
@@ -58,6 +58,7 @@ impl ApiDocBuilder for NetworkApiDocBuilder {
             .schema_from::<agama_lib::network::settings::NetworkSettings>()
             .schema_from::<agama_lib::network::settings::NetworkSettings>()
             .schema_from::<agama_lib::network::settings::VlanSettings>()
+            .schema_from::<agama_lib::network::settings::VlanFlag>()
             .schema_from::<agama_lib::network::settings::WirelessSettings>()
             .schema_from::<agama_lib::network::types::BondMode>()
             .schema_from::<agama_lib::network::types::ConnectionState>()

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 13 12:40:10 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Support VLAN flags configuration, defaulting to REORDER_HDR if not
+  specified (gh#agama-project/agama#3718, bsc#1271079).
+
+-------------------------------------------------------------------
 Fri Jul 10 13:12:36 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Rename the network device match settings attribute to "match"

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Mon Jul 13 12:40:10 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
-- Support VLAN flags configuration, defaulting to REORDER_HDR if not
-  specified (gh#agama-project/agama#3718, bsc#1271079).
+- Handle VLAN flags properly, using the kernel default value
+  of VLAN_FLAG_REORDER_HDR when not specified
+  (gh#agama-project/agama#3718, bsc#1271079).
 
 -------------------------------------------------------------------
 Fri Jul 10 13:12:36 UTC 2026 - Knut Anderssen <kanderssen@suse.com>


### PR DESCRIPTION
It backports #3705 to SLE-16, the VLAN configuration is not supported in the UI therefore, only the backend is adapted.

- https://bugzilla.suse.com/show_bug.cgi?id=1271079