### PR TITLE
Fix detection of hardware RAIDs in /api/system

### DIFF
--- a/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/drive.rb
+++ b/service/lib/agama/storage/devicegraph_conversions/to_json_conversions/drive.rb
@@ -38,7 +38,7 @@ module Agama
           # @param storage_device [Y2Storage::Device]
           # @return [Boolean]
           def self.apply?(storage_device)
-            storage_device.is?(:disk, :dm_raid, :multipath, :dasd) &&
+            storage_device.is?(:disk, :bios_raid, :multipath, :dasd) &&
               storage_device.is?(:disk_device)
           end
 
@@ -64,7 +64,7 @@ module Agama
           def drive_type
             if storage_device.is?(:disk)
               "disk"
-            elsif storage_device.is?(:dm_raid)
+            elsif storage_device.is?(:bios_raid)
               "raid"
             elsif storage_device.is?(:multipath)
               "multipath"

--- a/service/test/agama/storage/devicegraph_conversions/to_json_test.rb
+++ b/service/test/agama/storage/devicegraph_conversions/to_json_test.rb
@@ -31,6 +31,7 @@ describe Agama::Storage::DevicegraphConversions::ToJSON do
   before do
     mock_storage(devicegraph: scenario)
     allow_any_instance_of(Y2Storage::Partition).to receive(:resize_info).and_return(resize_info)
+    allow_any_instance_of(Y2Storage::LvmLv).to receive(:resize_info).and_return(resize_info)
   end
 
   subject { described_class.new(devicegraph) }
@@ -171,6 +172,30 @@ describe Agama::Storage::DevicegraphConversions::ToJSON do
         json = subject.convert
         wires = json.first[:multipath][:wireNames]
         expect(wires).to contain_exactly("/dev/sda", "/dev/sdb")
+      end
+    end
+
+    describe "for a devicegraph with BIOS RAIDs" do
+      let(:scenario) { "lvm-over-hardware-raid.xml" }
+
+      it "generates an entry for each usable disk, RAID and volume group" do
+        json = subject.convert
+        expect(json).to contain_exactly(
+          a_hash_including(name: "/dev/sda", class: "drive"),
+          a_hash_including(name: "/dev/md/a", class: "drive"),
+          a_hash_including(name: "/dev/md/b", class: "drive"),
+          a_hash_including(name: "/dev/system", class: "volumeGroup")
+        )
+      end
+
+      it "exports the level and members of the MD RAIDs" do
+        json = subject.convert
+        mda = json.find { |d| d[:name] == "/dev/md/a" }
+        expect(mda[:drive][:type]).to eq "raid"
+        expect(mda[:md][:level]).to eq "raid0"
+        members = mda[:md][:devices]
+        expect(members).to be_a Array
+        expect(members.size).to eq 2
       end
     end
   end

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jul 13 14:14:41 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed check for BIOS RAIDs (bsc#1271120).
+
+-------------------------------------------------------------------
 Tue Jul  7 10:55:04 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Introduced the "MarkedString" type and activated a new linter


### PR DESCRIPTION
## Problem

The list of existing storage devices (read from the libstorage-ng devicegraph) is exported as part of `/api/system`. In that representation, the BIOS-based RAIDs (a.k.a. hardware RAIDs) are represented as "drives" since they are fully equivalent to a disk.

But the logic to detect when a drive is a BIOS RAID was wrong. The code actually checked whether it was a DM RAID, which is a legacy kind of RAID not even supported in recent versions of SUSE and/or openSUSE.

As a consequence, the UI was failing is shown here.

<img width="1019" height="620" alt="hardware-raid-wrong" src="https://github.com/user-attachments/assets/355c7a93-b87c-43d9-854f-6c2e0717138a" />


## Solution

Use the correct method to check if the RAID is based on BIOS/hardware. That proper check returns `true` for the deprecated DM RAIDs but also for any other kind of BIOS RAID.

As a result, the UI works again and the RAID can be selected just as a regular disk.

<img width="1028" height="648" alt="hardware-raid" src="https://github.com/user-attachments/assets/79747c2c-a84d-4c35-9b45-f803071746ed" />


## Testing

- Added a new unit test
- Tested manually using a devicegraph from a bug report (as seen in the screenshots).
