### PR TITLE
Improve initialization process

### DIFF
--- a/rust/agama-storage-client/src/service.rs
+++ b/rust/agama-storage-client/src/service.rs
@@ -63,17 +63,10 @@ impl Starter {
     /// from each proxy to cache the current values.
     pub async fn start(self) -> Result<Handler<Service>, Error> {
         let storage_proxy = proxies::Storage1Proxy::new(&self.dbus).await?;
-        storage_proxy.config().await?;
-
         let bootloader_proxy = proxies::BootloaderProxy::new(&self.dbus).await?;
-        bootloader_proxy.config().await?;
-
         let iscsi_proxy = proxies::ISCSIProxy::new(&self.dbus).await?;
-        iscsi_proxy.config().await?;
-
         let dasd_proxy = if Arch::is_s390() {
             let proxy = proxies::DASDProxy::new(&self.dbus).await?;
-            proxy.config().await?;
             Some(proxy)
         } else {
             None
@@ -81,7 +74,6 @@ impl Starter {
 
         let zfcp_proxy = if Arch::is_s390() {
             let proxy = proxies::ZFCPProxy::new(&self.dbus).await?;
-            proxy.config().await?;
             Some(proxy)
         } else {
             None
@@ -94,6 +86,7 @@ impl Starter {
             dasd_proxy,
             zfcp_proxy,
         };
+
         let handler = actor::spawn(service);
         Ok(handler)
     }
@@ -137,8 +130,32 @@ impl Service {
     }
 }
 
+#[async_trait]
 impl Actor for Service {
     type Error = Error;
+
+    // Calls the D-Bus proxies in order to initialize and cache their data.
+    async fn init(&mut self) {
+        if let Err(error) = self.storage_proxy.config().await {
+            tracing::error!("Failed to initialize storage D-Bus proxy: {error}");
+        }
+        if let Err(error) = self.bootloader_proxy.config().await {
+            tracing::error!("Failed to initialize bootloader D-Bus proxy: {error}");
+        }
+        if let Err(error) = self.iscsi_proxy.config().await {
+            tracing::error!("Failed to initialize iSCSI D-Bus proxy: {error}");
+        }
+        if let Some(zfcp_proxy) = &self.zfcp_proxy {
+            if let Err(error) = zfcp_proxy.config().await {
+                tracing::error!("Failed to initialize zFCP D-Bus proxy: {error}");
+            }
+        }
+        if let Some(dasd_proxy) = &self.dasd_proxy {
+            if let Err(error) = dasd_proxy.config().await {
+                tracing::error!("Failed to initialize DASD D-Bus proxy: {error}");
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/rust/agama-utils/src/actor.rs
+++ b/rust/agama-utils/src/actor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) [2025] SUSE LLC
+// Copyright (c) [2025-2026] SUSE LLC
 //
 // All Rights Reserved.
 //
@@ -119,6 +119,7 @@ pub enum Error {
 /// Marks its implementors as potential actors.
 ///
 /// It enables those structs to handle actors messages.
+#[async_trait]
 pub trait Actor: 'static + Send {
     /// Actor error type. It should implement the conversion from the
     /// [ActorError] type, which represents communication-level problems.
@@ -128,6 +129,9 @@ pub trait Actor: 'static + Send {
     fn name() -> &'static str {
         std::any::type_name::<Self>()
     }
+
+    /// Initializes the actor.
+    async fn init(&mut self) {}
 }
 
 /// Marker trait to indicate that a its implementor is a potential message.
@@ -263,6 +267,7 @@ pub fn spawn<A: Actor>(mut actor: A) -> Handler<A> {
     let handler = Handler::<A> { sender: tx };
 
     tokio::spawn(async move {
+        actor.init().await;
         while let Some(mut msg) = rx.recv().await {
             msg.handle(&mut actor).await;
         }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 13 15:20:51 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Start the storage D-Bus service asynchronously (bsc#1265451,
+  bsc#1270014).
+
+-------------------------------------------------------------------
 Fri Jul 10 12:02:12 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Rename the network device match settings attribute to "match"


### PR DESCRIPTION
### Problem

The Agama web UI only appears once the Agama web server is ready. And the web server does not start until the storage D-Bus service finishes its startup. Sometimes, the storage D-Bus service takes long startup time. As consequence, the UI might take long time to appear.

* https://bugzilla.suse.com/show_bug.cgi?id=1265451
* https://bugzilla.suse.com/show_bug.cgi?id=1270014

### Solution

Asynchronously initialize the storage D-Bus service, so the web server is able to respond even though the D-Bus data is not loaded yet. The UI shows a spinner meanwhile the data is not ready.
