### PR TITLE
refactor(web): serve installation summary at root path

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 14 16:59:31 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Align paths and navigation with the Installation breadcrumb
+  instead of the internal overview concept
+  (gh#agama-project/agama#3722).
+
+-------------------------------------------------------------------
 Mon Jul 13 14:14:41 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed check for BIOS RAIDs (bsc#1271120).

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -113,7 +113,7 @@ function MainBreadcrumbs({
   if (product && breadcrumbs && !hideSummaryLink) {
     items.push({
       isEditorial: true,
-      path: ROOT.overview,
+      path: ROOT.root,
       // TRANSLATORS: First breadcrumb item, linking back to the main page
       // where the whole installation can be reviewed.
       label: _("Installation"),

--- a/web/src/components/users/authentication-form/Form.test.tsx
+++ b/web/src/components/users/authentication-form/Form.test.tsx
@@ -190,7 +190,7 @@ describe("AuthenticationForm", () => {
       expect(mockPutConfig).not.toHaveBeenCalled();
       screen.getByText("No changes to apply");
       const link = screen.getByRole("link", { name: "installation" });
-      expect(link).toHaveAttribute("href", "/overview");
+      expect(link).toHaveAttribute("href", "/");
     });
 
     it("creates first user when checkbox is checked", async () => {
@@ -405,7 +405,7 @@ describe("AuthenticationForm", () => {
 
       await screen.findByText("Changes successfully applied");
       const link = screen.getByRole("link", { name: "installation" });
-      expect(link).toHaveAttribute("href", "/overview");
+      expect(link).toHaveAttribute("href", "/");
     });
   });
 });

--- a/web/src/hooks/use-form-submit.tsx
+++ b/web/src/hooks/use-form-submit.tsx
@@ -325,7 +325,7 @@ export function useFormSubmit<TValues>({
                       }
                     >
                       {(linkText) => (
-                        <Link isInline variant="link" to={ROOT.overview}>
+                        <Link isInline variant="link" to={ROOT.root}>
                           {linkText}
                         </Link>
                       )}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -52,6 +52,10 @@ import { N_ } from "~/i18n";
 // bookmarked URLs and external links to naturally transition.
 const legacyRedirects = () => [
   {
+    path: "/overview",
+    element: <Navigate to={PATHS.root} replace />,
+  },
+  {
     path: "/hostname",
     element: <Navigate to={SYSTEM.root} replace />,
   },
@@ -70,10 +74,6 @@ const legacyRedirects = () => [
 ];
 
 const rootRoutes = () => [
-  {
-    path: "/overview",
-    element: <OverviewPage />,
-  },
   {
     path: SYSTEM.root,
     element: <SystemPage />,

--- a/web/src/routes/paths.ts
+++ b/web/src/routes/paths.ts
@@ -49,7 +49,6 @@ const REGISTRATION = {
 const ROOT = {
   root: "/",
   login: "/login",
-  overview: "/overview",
   installation: "/installation",
   installationProgress: "/installation/progress",
   installationFinished: "/installation/finished",


### PR DESCRIPTION
 Based on @ancorgs's [comment](https://github.com/agama-project/agama/pull/3697#pullrequestreview-4692312501) and a later meeting with him, this supersedes #3697, keeping only the route/path change from it.

The installation summary (`OverviewPage`) is now served only at the root path `/` instead of `/overview`. It was already rendered at the index route, so this just drops the redundant `/overview` route, repoints the breadcrumb and post-submit summary links to `/`, and adds a `/overview` to `/` redirection for bookmarked URLs.

The reasoning is that almost all other nested routes (software, authentication, storage, iSCSI, etc.) are not prefixed with either `/overview` or `/installation`. From that perspective, having the **Installation** breadcrumb always navigate to `/`, with the installation summary shown by default whenever no higher-priority page (such as product selection) takes precedence, provides a simpler and more consistent routing model.