### PR TITLE
properly set selinux parameters bsc#1269581

### DIFF
--- a/rust/agama-bootloader/src/client.rs
+++ b/rust/agama-bootloader/src/client.rs
@@ -50,12 +50,16 @@ pub trait BootloaderClient {
     /// Retrieves the bootloader resolvables.
     async fn get_resolvables(&self) -> ClientResult<Vec<Resolvable>>;
     /// Sets the bootloader configuration.
-    async fn set_config(&self, config: &Config) -> ClientResult<BoxFuture<Result<(), Error>>>;
+    async fn set_config(&mut self, config: &Config) -> ClientResult<BoxFuture<Result<(), Error>>>;
     /// Sets the extra kernel args for given scope.
     ///
     /// * `id`: identifier of the kernel argument so it can be later changed.
     /// * `value`: plaintext value that will be appended to kernel commandline.
-    async fn set_kernel_arg(&mut self, id: String, value: String);
+    async fn set_kernel_arg(
+        &mut self,
+        id: String,
+        value: String,
+    ) -> ClientResult<BoxFuture<Result<(), Error>>>;
 }
 
 // full config used on dbus which beside public config passes
@@ -74,15 +78,29 @@ pub type ClientResult<T> = Result<T, Error>;
 #[derive(Clone)]
 pub struct Client {
     storage_client: Handler<storage_client::Service>,
-    kernel_args: HashMap<String, String>,
+    // full config, so we can replace only modified part
+    full_config: FullConfig,
 }
 
 impl Client {
     pub async fn new(storage_client: Handler<storage_client::Service>) -> ClientResult<Client> {
         Ok(Self {
             storage_client,
-            kernel_args: HashMap::new(),
+            full_config: FullConfig::default(),
         })
+    }
+
+    async fn send_config(&self) -> ClientResult<BoxFuture<Result<(), Error>>> {
+        let full_config = self.full_config.clone();
+        tracing::info!("sending bootloader config {:?}", full_config);
+        // ignore return value as currently it does not fail and who knows what future brings
+        // but it should not be part of result and instead transformed to Issue
+        let value = serde_json::to_value(&full_config)?;
+        let rx = self
+            .storage_client
+            .call(message::bootloader::SetConfig::new(value))
+            .await?;
+        Ok(Box::pin(async move { rx.await.map_err(Error::from) }))
     }
 }
 
@@ -109,23 +127,17 @@ impl BootloaderClient for Client {
             .await?)
     }
 
-    async fn set_config(&self, config: &Config) -> ClientResult<BoxFuture<Result<(), Error>>> {
-        let full_config = FullConfig {
-            config: config.clone(),
-            kernel_args: self.kernel_args.clone(),
-        };
-        tracing::info!("sending bootloader config {:?}", full_config);
-        // ignore return value as currently it does not fail and who knows what future brings
-        // but it should not be part of result and instead transformed to Issue
-        let value = serde_json::to_value(&full_config)?;
-        let rx = self
-            .storage_client
-            .call(message::bootloader::SetConfig::new(value))
-            .await?;
-        Ok(Box::pin(async move { rx.await.map_err(Error::from) }))
+    async fn set_config(&mut self, config: &Config) -> ClientResult<BoxFuture<Result<(), Error>>> {
+        self.full_config.config = config.clone();
+        self.send_config().await
     }
 
-    async fn set_kernel_arg(&mut self, id: String, value: String) {
-        self.kernel_args.insert(id, value);
+    async fn set_kernel_arg(
+        &mut self,
+        id: String,
+        value: String,
+    ) -> ClientResult<BoxFuture<Result<(), Error>>> {
+        self.full_config.kernel_args.insert(id, value);
+        self.send_config().await
     }
 }

--- a/rust/agama-bootloader/src/service.rs
+++ b/rust/agama-bootloader/src/service.rs
@@ -132,7 +132,9 @@ impl MessageHandler<message::SetConfig<Config>> for Service {
 #[async_trait]
 impl MessageHandler<message::SetKernelArg> for Service {
     async fn handle(&mut self, message: message::SetKernelArg) -> Result<(), Error> {
-        self.client.set_kernel_arg(message.id, message.value).await;
+        if let Err(err) = self.client.set_kernel_arg(message.id, message.value).await {
+            tracing::error!("Failed to set kernel args {:?}", err);
+        }
         Ok(())
     }
 }

--- a/rust/agama-bootloader/src/test_utils.rs
+++ b/rust/agama-bootloader/src/test_utils.rs
@@ -91,13 +91,19 @@ impl BootloaderClient for TestClient {
         Ok(vec![])
     }
 
-    async fn set_config(&self, config: &Config) -> Result<BoxFuture<Result<(), Error>>, Error> {
+    async fn set_config(&mut self, config: &Config) -> Result<BoxFuture<Result<(), Error>>, Error> {
         let mut state = self.state.lock().await;
         state.config = config.clone();
         Ok(Box::pin(async { Ok(()) }))
     }
 
-    async fn set_kernel_arg(&mut self, _id: String, _value: String) {}
+    async fn set_kernel_arg(
+        &mut self,
+        _id: String,
+        _value: String,
+    ) -> Result<BoxFuture<Result<(), Error>>, Error> {
+        Ok(Box::pin(async { Ok(()) }))
+    }
 }
 
 /// Starts a testing storage service.

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul 15 09:16:44 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix setting security kernel parameter (bsc#1269581)
+
+-------------------------------------------------------------------
 Mon Jul 13 16:17:18 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Do not start config tasks until pre-scripts have finished


### PR DESCRIPTION
## Problem

Selinux kernel parameters are no longer set up as in unattended installation config is set just once and set_kernel_param is called afterwards.


## Solution

Send data to dbus for both methods.


## Testing

- *Tested manually* using https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:selinux_fix

