### PR TITLE
Tune Tokio runtimes per binary

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6057,7 +6057,6 @@ version = "0.1.0"
 dependencies = [
  "agama-cli",
  "agama-server",
- "agama-utils",
  "clap",
  "clap-markdown",
  "clap_complete",

--- a/rust/agama-autoinstall/src/main.rs
+++ b/rust/agama-autoinstall/src/main.rs
@@ -26,7 +26,6 @@ use agama_utils::{
     api::{status::Stage, FinishMethod},
     kernel_cmdline::KernelCmdline,
     logging::init_logging,
-    runtime::run_async,
 };
 use anyhow::anyhow;
 use anyhow::Context;
@@ -114,6 +113,7 @@ async fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn main() -> anyhow::Result<()> {
-    run_async(run())
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    run().await
 }

--- a/rust/agama-cli/src/main.rs
+++ b/rust/agama-cli/src/main.rs
@@ -20,17 +20,15 @@
 
 use agama_cli::{build_cli, run_command, CliResult};
 use agama_l10n::helpers as l10n_helpers;
-use agama_utils::runtime::run_async;
 
-fn main() -> CliResult {
-    run_async(async {
-        _ = l10n_helpers::init_locale();
-        let matches = build_cli().get_matches();
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> CliResult {
+    _ = l10n_helpers::init_locale();
+    let matches = build_cli().get_matches();
 
-        if let Err(error) = run_command(matches).await {
-            eprintln!("{:?}", error);
-            return CliResult::Error;
-        }
-        CliResult::Ok
-    })
+    if let Err(error) = run_command(matches).await {
+        eprintln!("{:?}", error);
+        return CliResult::Error;
+    }
+    CliResult::Ok
 }

--- a/rust/agama-server/src/agama-web-server.rs
+++ b/rust/agama-server/src/agama-web-server.rs
@@ -28,9 +28,10 @@ use agama_l10n::helpers as l10n_helpers;
 use agama_lib::{auth::AuthToken, connection_to};
 use agama_server::{
     cert::Certificate,
+    runtime::run_async,
     web::{self},
 };
-use agama_utils::{api::event::Receiver, logging::init_logging, runtime::run_async};
+use agama_utils::{api::event::Receiver, logging::init_logging};
 use aide::axum::ApiRouter;
 use anyhow::Context;
 use axum::{

--- a/rust/agama-server/src/lib.rs
+++ b/rust/agama-server/src/lib.rs
@@ -22,6 +22,7 @@ pub mod cert;
 pub mod dbus;
 pub mod error;
 pub mod profile;
+pub mod runtime;
 pub mod web;
 pub use web::service;
 pub mod server;

--- a/rust/agama-server/src/runtime.rs
+++ b/rust/agama-server/src/runtime.rs
@@ -23,17 +23,17 @@
 use std::future::Future;
 
 /// Maximum number of worker threads for the Tokio runtime.
-const MAX_WORKER_THREADS: usize = 32;
+const MAX_WORKER_THREADS: usize = 4;
 
 /// Creates a multi-threaded Tokio runtime with a capped number of worker threads.
 ///
-/// The runtime will use `min(available_cores, 32)` worker threads. If the number of
+/// The runtime will use `min(available_cores, 4)` worker threads. If the number of
 /// cores cannot be determined, it falls back to tokio's default behavior.
 ///
 /// # Example
 ///
 /// ```no_run
-/// use agama_utils::runtime::create_runtime;
+/// use agama_server::runtime::create_runtime;
 ///
 /// let runtime = create_runtime().expect("Failed to create Tokio runtime");
 /// runtime.block_on(async {
@@ -54,7 +54,7 @@ pub fn create_runtime() -> std::io::Result<tokio::runtime::Runtime> {
 /// Runs an async function on a custom Tokio runtime with capped worker threads.
 ///
 /// This is a convenience wrapper that creates a runtime with `create_runtime()` and
-/// executes the provided future on it. The runtime will use `min(available_cores, 32)`
+/// executes the provided future on it. The runtime will use `min(available_cores, 4)`
 /// worker threads.
 ///
 /// # Panics
@@ -64,7 +64,7 @@ pub fn create_runtime() -> std::io::Result<tokio::runtime::Runtime> {
 /// # Example
 ///
 /// ```no_run
-/// use agama_utils::runtime::run_async;
+/// use agama_server::runtime::run_async;
 ///
 /// fn main() -> std::io::Result<()> {
 ///     run_async(async {

--- a/rust/agama-utils/src/lib.rs
+++ b/rust/agama-utils/src/lib.rs
@@ -35,7 +35,6 @@ pub mod openapi;
 pub mod products;
 pub mod progress;
 pub mod question;
-pub mod runtime;
 pub mod test;
 
 mod resolvable;

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 [dependencies]
 agama-cli = { path = "../agama-cli" }
 agama-server = { path = "../agama-server" }
-agama-utils = { workspace = true }
 clap = { workspace = true }
 clap-markdown = "0.1.4"
 clap_complete = "4.5.32"

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -1,7 +1,5 @@
 use std::{env, path::PathBuf};
 
-use agama_server::runtime::run_async;
-
 mod tasks {
     use std::{fs::File, io::Write};
 
@@ -107,28 +105,27 @@ fn print_help() {
     println!("  help           Print this help message");
 }
 
-fn main() -> std::io::Result<()> {
-    run_async(async {
-        let Some(task) = env::args().nth(1) else {
-            eprintln!("You must specify a xtask");
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> std::io::Result<()> {
+    let Some(task) = env::args().nth(1) else {
+        eprintln!("You must specify a xtask");
+        print_help();
+        std::process::exit(1);
+    };
+
+    match task.as_str() {
+        "completions" => tasks::generate_completions(),
+        "markdown" => tasks::generate_markdown(),
+        "manpages" => tasks::generate_manpages(),
+        "openapi" => tasks::generate_openapi().await,
+        "help" | "-h" | "--help" => {
+            print_help();
+            Ok(())
+        }
+        other => {
+            eprintln!("Unknown task '{}'", other);
             print_help();
             std::process::exit(1);
-        };
-
-        match task.as_str() {
-            "completions" => tasks::generate_completions(),
-            "markdown" => tasks::generate_markdown(),
-            "manpages" => tasks::generate_manpages(),
-            "openapi" => tasks::generate_openapi().await,
-            "help" | "-h" | "--help" => {
-                print_help();
-                Ok(())
-            }
-            other => {
-                eprintln!("Unknown task '{}'", other);
-                print_help();
-                std::process::exit(1);
-            }
         }
-    })
+    }
 }

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-use agama_utils::runtime::run_async;
+use agama_server::runtime::run_async;
 
 mod tasks {
     use std::{fs::File, io::Write};


### PR DESCRIPTION
Match each binary's Tokio runtime to its workload:

- **agama-web-server**: cap worker threads at `min(cores, 4)` instead of 32 — the installer's web server is low-concurrency and I/O-bound.
- **agama** and **agama-autoinstall**: switch to a `current_thread` runtime via `#[tokio::main(flavor = "current_thread")]` — short-lived, sequential, I/O-bound CLIs.

The multi-threaded runtime helper is now only used by the server (and `xtask`), so the `runtime` module moves from `agama-utils` to `agama-server`.