### PR TITLE
skip benches and examples when running tarpaulin as it is dependendin…

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -215,7 +215,8 @@ jobs:
       # flags, to avoid reusing the previous builds it always starts from scratch.
       # The --skip-clean skips the cleanup and allows using the cached results.
       # See https://github.com/xd009642/tarpaulin/discussions/772
-      run: cargo tarpaulin --workspace --all-targets --doc --engine llvm --out xml --target-dir target-coverage --skip-clean -- --nocapture
+      # Explicitly omit examples and benches as it depends on opensuse infrastructure and can fail due to network issues
+      run: cargo tarpaulin --workspace --lib --bins --tests --doc --engine llvm --out xml --target-dir target-coverage --skip-clean -- --nocapture
       working-directory: ./rust
       env:
         # use the "stable" tool chain (installed by default) instead of the "nightly" default in tarpaulin


### PR DESCRIPTION
… infrastructure

only CI is affected.