### PR TITLE
service: More accurate model when reusing filesystems

### DIFF
--- a/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
@@ -29,10 +29,12 @@ module Agama
         class Filesystem < Base
           # @param config [Configs::Filesystem]
           # @param volumes [VolumeTemplatesBuilder]
-          def initialize(config, volumes)
+          # @param found_device [Y2Storage::BlkDevice, nil]
+          def initialize(config, volumes, found_device = nil)
             super()
             @config = config
             @volumes = volumes
+            @found_device = found_device
           end
 
         private
@@ -40,16 +42,37 @@ module Agama
           # @return [VolumeTemplatesBuilder]
           attr_reader :volumes
 
+          # @return [Y2Storage::BlkDevice, nil]
+          attr_reader :found_device
+
           # @see Base#conversions
           def conversions
             {
-              reuse:              config.reuse?,
+              reuse:              reuse?,
               default:            convert_default,
               type:               convert_type,
               label:              config.label,
               mkfsExtraArguments: config.mkfs_args,
               mountOptions:       convert_mount_options
             }
+          end
+
+          # Checks whether reusing is wanted and looks possible
+          #
+          # FIXME: For consistency with other properties, the config solver should decide whether
+          # an existing filesystem is indeed going to be reused and should reflect that in the
+          # Config object. Thus, this would only expose that information directly.
+          # Right now, this includes temporary logic to cover the case in which reuseIfPossible is
+          # set to true but no filesystem will actually be reused.
+          #
+          # @return [Boolean]
+          def reuse?
+            config.reuse? && can_reuse?
+          end
+
+          # @return [Boolean]
+          def can_reuse?
+            !!found_device&.formatted?
           end
 
           # @return [Boolean, nil]
@@ -59,8 +82,18 @@ module Agama
             config.type.default?
           end
 
+          # Converts the type, including some conversions needed for correct UI representation
+          #
+          # FIXME: For consistency with other properties, the config solver should decide whether
+          # the filesystem is indeed going to be reused and should adjust Configs::Filesystem#type
+          # to reflect the final value. Thus, this should be a direct transformation of that value.
+          # As a temporary solution, this code guesses whether reuseIfPossible is going to be
+          # honored and tries to display the final filesystem type.
+          #
           # @return [String, nil]
           def convert_type
+            return found_device.filesystem.type.to_s if reuse?
+
             return unless config.type&.fs_type
 
             if config.type.fs_type.is?(:btrfs)

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/with_filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/with_filesystem.rb
@@ -32,7 +32,8 @@ module Agama
             filesystem = config.filesystem
             return unless filesystem
 
-            ToModelConversions::Filesystem.new(filesystem, volumes).convert
+            dev = config.respond_to?(:found_device) ? config.found_device : nil
+            ToModelConversions::Filesystem.new(filesystem, volumes, dev).convert
           end
         end
       end

--- a/service/lib/agama/storage/configs/filesystem.rb
+++ b/service/lib/agama/storage/configs/filesystem.rb
@@ -29,6 +29,12 @@ module Agama
         # @return [Pathname] Object that represents the root path.
         ROOT_PATH = Pathname.new("/").freeze
 
+        # Currently this is a direct representation of the reuseIfPossible flag
+        #
+        # FIXME: this should likely represent a more concrete information about whether an existing
+        # filesystem is actually going to be reused or not. Very likely to be calculated by the
+        # solver.
+        #
         # @return [Boolean]
         attr_accessor :reuse
         alias_method :reuse?, :reuse
@@ -36,6 +42,13 @@ module Agama
         # @return [String, nil]
         attr_accessor :path
 
+        # Currently this is a direct representation of the type to use in case the filesystem is
+        # finally created.
+        #
+        # FIXME: in case Agama ends up using a pre-existing filesystem, this class should provide
+        # information about the type of that filesystem, (in addition to/instead of) this. Very
+        # likely an information to be filled by the solver.
+        #
         # @return [Configs::FilesystemType, nil]
         attr_accessor :type
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 16 07:42:35 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- More accurate information in the UI model about reused file
+  systems (bsc#1271008).
+
+-------------------------------------------------------------------
 Tue Jun 30 14:40:25 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Always emit signals for iSCSI, DASD and zFCP (needed for

--- a/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
@@ -107,7 +107,7 @@ shared_examples "with filesystem" do
   context "if #filesystem is configured" do
     let(:filesystem) do
       {
-        reuseIfPossible:    true,
+        reuseIfPossible:    false,
         type:               "xfs",
         label:              "test",
         path:               "/test",
@@ -122,7 +122,7 @@ shared_examples "with filesystem" do
       expect(model_json[:mountPath]).to eq("/test")
       expect(model_json[:filesystem]).to eq(
         {
-          reuse:              true,
+          reuse:              false,
           default:            false,
           type:               "xfs",
           label:              "test",
@@ -204,6 +204,69 @@ shared_examples "with filesystem" do
             label:   "test"
           }
         )
+      end
+    end
+  end
+
+  context "if #filesystem is configured to reuse" do
+    let(:filesystem) do
+      {
+        reuseIfPossible: true,
+        type:            "xfs",
+        label:           "test",
+        path:            "/test"
+      }
+    end
+
+    context "and there is a device matching the search" do
+      before do
+        config.search = Agama::Storage::Configs::Search.new
+        config.search.solve(device)
+      end
+
+      let(:device) do
+        instance_double(
+          Y2Storage::BlkDevice,
+          name:       "/dev/a",
+          formatted?: !!blk_filesystem,
+          filesystem: blk_filesystem
+        )
+      end
+
+      context "and that device actually contains a filesystem" do
+        let(:blk_filesystem) do
+          instance_double(
+            Y2Storage::Filesystems::BlkFilesystem,
+            type: Y2Storage::Filesystems::Type::EXT4
+          )
+        end
+
+        it "generates the expected JSON" do
+          model_json = subject.convert
+          expect(model_json[:mountPath]).to eq("/test")
+          expect(model_json[:filesystem][:reuse]).to eq true
+          expect(model_json[:filesystem][:type]).to eq "ext4"
+        end
+      end
+
+      context "but the device is not formatted" do
+        let(:blk_filesystem) { nil }
+
+        it "generates the expected JSON" do
+          model_json = subject.convert
+          expect(model_json[:mountPath]).to eq("/test")
+          expect(model_json[:filesystem][:reuse]).to eq false
+          expect(model_json[:filesystem][:type]).to eq "xfs"
+        end
+      end
+    end
+
+    context "but there is no device to reuse" do
+      it "generates the expected JSON" do
+        model_json = subject.convert
+        expect(model_json[:mountPath]).to eq("/test")
+        expect(model_json[:filesystem][:reuse]).to eq false
+        expect(model_json[:filesystem][:type]).to eq "xfs"
       end
     end
   end


### PR DESCRIPTION
## Problem

When reusing an existing filesystem, the web UI shows a message like, for example,  "Current XFS at /dev/sb4". But the problem is that, in that example, "XFS" is not really the current file-system type (which will be kept), but the default file-system type that would be used if the device would actually be re-formatted.

It is just a "cosmetic" error, since the proper operation is actually performed.

## Solution

Fix the model to ensure it represents accurate information about reusing filesystems.

Added comments to make this better in the future (we already have a Trello card about it since a very long time).

## Testing

- Added a new unit tests
- Tested manually
