### PR TITLE
feat(service): storage logical search operators

### DIFF
--- a/rust/share/examples/storage/search_conditions.json
+++ b/rust/share/examples/storage/search_conditions.json
@@ -1,0 +1,117 @@
+{
+  "storage": {
+    "drives": [
+      {
+        "search": {
+          "condition": {
+            "and": [
+              { "size": { "greater": "10 GiB" } },
+              { "not": { "name": "/dev/vdb" } }
+            ]
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "or": [
+              { "name": "/dev/vda" },
+              { "name": "/dev/vdb" }
+            ]
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "not": { "size": { "less": "10 GiB" } }
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "and": [
+              {
+                "or": [
+                  { "name": "/dev/vda" },
+                  { "name": "/dev/vdb" }
+                ]
+              },
+              { "not": { "size": { "less": "1 GiB" } } }
+            ]
+          },
+          "ifNotFound": "skip",
+          "max": 1
+        },
+        "partitions": [
+          {
+            "search": {
+              "condition": {
+                "and": [
+                  { "number": 1 },
+                  { "size": { "greater": "1 GiB" } }
+                ]
+              }
+            }
+          },
+          {
+            "search": {
+              "condition": {
+                "or": [
+                  { "number": 1 },
+                  { "number": 2 }
+                ]
+              }
+            }
+          },
+          {
+            "search": {
+              "condition": {
+                "not": { "name": "/dev/vda1" }
+              }
+            },
+            "delete": true
+          }
+        ]
+      }
+    ],
+    "mdRaids": [
+      {
+        "search": {
+          "condition": {
+            "and": [
+              { "name": "/dev/md0" },
+              { "not": { "size": { "less": "100 GiB" } } }
+            ]
+          }
+        }
+      }
+    ],
+    "volumeGroups": [
+      {
+        "name": "system",
+        "search": {
+          "condition": {
+            "or": [
+              { "name": "vg0" },
+              { "name": "vg1" }
+            ]
+          }
+        },
+        "logicalVolumes": [
+          {
+            "search": {
+              "condition": {
+                "and": [
+                  { "not": { "name": "root" } },
+                  { "size": { "greater": "5 GiB" } }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/rust/share/storage.schema.json
+++ b/rust/share/storage.schema.json
@@ -428,8 +428,48 @@
     "driveSearchCondition": {
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
-        { "$ref": "#/$defs/searchConditionSize" }
+        { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/driveSearchConditionAnd" },
+        { "$ref": "#/$defs/driveSearchConditionOr" },
+        { "$ref": "#/$defs/driveSearchConditionNot" }
       ]
+    },
+    "driveSearchConditionAnd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "description": "Matches when all the nested conditions match.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/driveSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "driveSearchConditionOr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "description": "Matches when any of the nested conditions matches.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/driveSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "driveSearchConditionNot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "description": "Matches when the nested condition does not match.",
+          "$ref": "#/$defs/driveSearchCondition"
+        }
+      }
     },
     "driveSearchSort": {
       "anyOf": [
@@ -479,8 +519,48 @@
     "mdRaidSearchCondition": {
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
-        { "$ref": "#/$defs/searchConditionSize" }
+        { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/mdRaidSearchConditionAnd" },
+        { "$ref": "#/$defs/mdRaidSearchConditionOr" },
+        { "$ref": "#/$defs/mdRaidSearchConditionNot" }
       ]
+    },
+    "mdRaidSearchConditionAnd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "description": "Matches when all the nested conditions match.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/mdRaidSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "mdRaidSearchConditionOr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "description": "Matches when any of the nested conditions matches.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/mdRaidSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "mdRaidSearchConditionNot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "description": "Matches when the nested condition does not match.",
+          "$ref": "#/$defs/mdRaidSearchCondition"
+        }
+      }
     },
     "mdRaidSearchSort": {
       "anyOf": [
@@ -530,8 +610,48 @@
     "volumeGroupSearchCondition": {
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
-        { "$ref": "#/$defs/searchConditionSize" }
+        { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/volumeGroupSearchConditionAnd" },
+        { "$ref": "#/$defs/volumeGroupSearchConditionOr" },
+        { "$ref": "#/$defs/volumeGroupSearchConditionNot" }
       ]
+    },
+    "volumeGroupSearchConditionAnd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "description": "Matches when all the nested conditions match.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/volumeGroupSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "volumeGroupSearchConditionOr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "description": "Matches when any of the nested conditions matches.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/volumeGroupSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "volumeGroupSearchConditionNot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "description": "Matches when the nested condition does not match.",
+          "$ref": "#/$defs/volumeGroupSearchCondition"
+        }
+      }
     },
     "volumeGroupSearchSort": {
       "anyOf": [
@@ -599,8 +719,48 @@
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" },
-        { "$ref": "#/$defs/searchConditionPartitionNumber" }
+        { "$ref": "#/$defs/searchConditionPartitionNumber" },
+        { "$ref": "#/$defs/partitionSearchConditionAnd" },
+        { "$ref": "#/$defs/partitionSearchConditionOr" },
+        { "$ref": "#/$defs/partitionSearchConditionNot" }
       ]
+    },
+    "partitionSearchConditionAnd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "description": "Matches when all the nested conditions match.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/partitionSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "partitionSearchConditionOr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "description": "Matches when any of the nested conditions matches.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/partitionSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "partitionSearchConditionNot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "description": "Matches when the nested condition does not match.",
+          "$ref": "#/$defs/partitionSearchCondition"
+        }
+      }
     },
     "logicalVolumeSearch": {
       "anyOf": [
@@ -639,8 +799,48 @@
     "logicalVolumeSearchCondition": {
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
-        { "$ref": "#/$defs/searchConditionSize" }
+        { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/logicalVolumeSearchConditionAnd" },
+        { "$ref": "#/$defs/logicalVolumeSearchConditionOr" },
+        { "$ref": "#/$defs/logicalVolumeSearchConditionNot" }
       ]
+    },
+    "logicalVolumeSearchConditionAnd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "description": "Matches when all the nested conditions match.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/logicalVolumeSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "logicalVolumeSearchConditionOr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "description": "Matches when any of the nested conditions matches.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/logicalVolumeSearchCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "logicalVolumeSearchConditionNot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "description": "Matches when the nested condition does not match.",
+          "$ref": "#/$defs/logicalVolumeSearchCondition"
+        }
+      }
     },
     "searchConditionName": {
       "type": "object",

--- a/service/lib/agama/storage/config_checkers/search.rb
+++ b/service/lib/agama/storage/config_checkers/search.rb
@@ -24,6 +24,7 @@ require "agama/storage/configs/drive"
 require "agama/storage/configs/logical_volume"
 require "agama/storage/configs/md_raid"
 require "agama/storage/configs/partition"
+require "agama/storage/configs/search_conditions"
 require "agama/storage/configs/volume_group"
 require "agama/storage/issue_classes"
 require "yast/i18n"
@@ -70,10 +71,11 @@ module Agama
           search = config.search
           return if search.device || search.create_device? || search.skip_device?
 
-          if search.name
+          name = searched_name(search)
+          if name
             error(
               # TRANSLATORS: %s is replaced by a device name (e.g., "/dev/vda").
-              format(_("Mandatory device %s not found"), search.name),
+              format(_("Mandatory device %s not found"), name),
               kind: IssueClasses::Config::SEARCH_NOT_FOUND
             )
           else
@@ -83,6 +85,20 @@ module Agama
               kind: IssueClasses::Config::SEARCH_NOT_FOUND
             )
           end
+        end
+
+        # Device name searched by the config, if the search targets a specific name.
+        #
+        # Only a top-level name condition yields a name; operators and other leaf
+        # conditions fall back to the generic "not found" message.
+        #
+        # @param search [Configs::Search]
+        # @return [String, nil]
+        def searched_name(search)
+          condition = search.condition
+          return unless condition.is_a?(Configs::SearchConditions::Name)
+
+          condition.name
         end
 
         # Issues from a reused device.

--- a/service/lib/agama/storage/config_checkers/search.rb
+++ b/service/lib/agama/storage/config_checkers/search.rb
@@ -24,7 +24,6 @@ require "agama/storage/configs/drive"
 require "agama/storage/configs/logical_volume"
 require "agama/storage/configs/md_raid"
 require "agama/storage/configs/partition"
-require "agama/storage/configs/search_conditions"
 require "agama/storage/configs/volume_group"
 require "agama/storage/issue_classes"
 require "yast/i18n"
@@ -71,7 +70,7 @@ module Agama
           search = config.search
           return if search.device || search.create_device? || search.skip_device?
 
-          name = searched_name(search)
+          name = search.condition_name
           if name
             error(
               # TRANSLATORS: %s is replaced by a device name (e.g., "/dev/vda").
@@ -85,20 +84,6 @@ module Agama
               kind: IssueClasses::Config::SEARCH_NOT_FOUND
             )
           end
-        end
-
-        # Device name searched by the config, if the search targets a specific name.
-        #
-        # Only a top-level name condition yields a name; operators and other leaf
-        # conditions fall back to the generic "not found" message.
-        #
-        # @param search [Configs::Search]
-        # @return [String, nil]
-        def searched_name(search)
-          condition = search.condition
-          return unless condition.is_a?(Configs::SearchConditions::Name)
-
-          condition.name
         end
 
         # Issues from a reused device.

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,6 +22,7 @@
 require "agama/storage/config_conversions/from_json_conversions/base"
 require "agama/storage/config_conversions/from_json_conversions/search_conditions"
 require "agama/storage/configs/search"
+require "agama/storage/configs/search_conditions"
 require "agama/storage/configs/sort_criteria"
 
 module Agama
@@ -52,28 +53,53 @@ module Agama
             return convert_string if search_json.is_a?(String)
 
             {
-              name:             search_json.dig(:condition, :name),
-              size:             convert_size,
-              partition_number: search_json.dig(:condition, :number),
-              sort_criteria:    convert_sort,
-              max:              search_json[:max],
-              if_not_found:     search_json[:ifNotFound]&.to_sym
+              condition:     convert_condition(search_json[:condition]),
+              sort_criteria: convert_sort,
+              max:           search_json[:max],
+              if_not_found:  search_json[:ifNotFound]&.to_sym
             }
           end
 
-          # @return [String]
+          # @return [Hash]
           def convert_string
             return { if_not_found: :skip } if search_json == SEARCH_ANYTHING_STRING
 
-            { name: search_json }
+            { condition: Configs::SearchConditions::Name.new(search_json) }
           end
 
-          # @return [Configs::SearchConditions::Size, nil]
-          def convert_size
-            size_json = search_json.dig(:condition, :size)
-            return unless size_json
+          # Recursively converts a condition JSON into a condition config.
+          #
+          # @param json [Hash, nil]
+          # @return [Configs::SearchConditions::Name, Configs::SearchConditions::Size,
+          #   Configs::SearchConditions::PartitionNumber, Configs::SearchConditions::And,
+          #   Configs::SearchConditions::Or, Configs::SearchConditions::Not, nil]
+          def convert_condition(json)
+            return unless json
 
-            FromJSONConversions::SearchConditions::Size.new(size_json).convert
+            _key, builder = condition_builders.find { |k, _| json.key?(k) }
+            builder&.call(json)
+          end
+
+          # Builders for each type of condition, indexed by its JSON key.
+          #
+          # @return [Hash{Symbol => Proc}]
+          def condition_builders
+            {
+              name:   ->(j) { Configs::SearchConditions::Name.new(j[:name]) },
+              size:   ->(j) { FromJSONConversions::SearchConditions::Size.new(j[:size]).convert },
+              number: ->(j) { Configs::SearchConditions::PartitionNumber.new(j[:number]) },
+              and:    ->(j) { Configs::SearchConditions::And.new(convert_conditions(j[:and])) },
+              or:     ->(j) { Configs::SearchConditions::Or.new(convert_conditions(j[:or])) },
+              not:    ->(j) { Configs::SearchConditions::Not.new(convert_condition(j[:not])) }
+            }
+          end
+
+          # Converts a collection of condition JSONs into condition configs.
+          #
+          # @param json [Array<Hash>]
+          # @return [Array]
+          def convert_conditions(json)
+            json.map { |c| convert_condition(c) }
           end
 
           def convert_sort

--- a/service/lib/agama/storage/config_conversions/from_model_conversions/with_search.rb
+++ b/service/lib/agama/storage/config_conversions/from_model_conversions/with_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/configs/search"
+require "agama/storage/configs/search_conditions"
 
 module Agama
   module Storage
@@ -32,7 +33,9 @@ module Agama
             name = model_json[:name]
             return unless name
 
-            Configs::Search.new.tap { |c| c.name = name }
+            Configs::Search.new.tap do |c|
+              c.condition = Configs::SearchConditions::Name.new(name)
+            end
           end
         end
       end

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "agama/storage/config_conversions/to_json_conversions/base"
+require "agama/storage/configs/search_conditions"
 require "agama/storage/configs/sort_criteria"
 
 module Agama
@@ -46,37 +47,43 @@ module Agama
             }
           end
 
+          # Uses the found device's name when the search is solved with a device;
+          # otherwise serializes the condition tree.
+          #
           # @return [Hash, nil]
           def convert_condition
-            convert_condition_name ||
-              convert_condition_number ||
-              convert_condition_size
+            return { name: config.device.name } if config.device
+
+            convert_condition_node(config.condition)
           end
 
+          # Recursively serializes a condition node.
+          #
+          # @param node [Configs::SearchConditions::*, nil]
           # @return [Hash, nil]
-          def convert_condition_name
-            name = config.name || config.device&.name
-            return unless name
-
-            { name: name }
+          def convert_condition_node(node)
+            case node
+            when Configs::SearchConditions::Name
+              { name: node.name }
+            when Configs::SearchConditions::PartitionNumber
+              { number: node.number }
+            when Configs::SearchConditions::Size
+              { size: { node.operator => node.value.to_i } }
+            when Configs::SearchConditions::And
+              { and: convert_conditions(node.conditions) }
+            when Configs::SearchConditions::Or
+              { or: convert_conditions(node.conditions) }
+            when Configs::SearchConditions::Not
+              { not: convert_condition_node(node.condition) }
+            end
           end
 
-          # @return [Hash, nil]
-          def convert_condition_number
-            number = config.partition_number
-            return unless number
-
-            { number: number }
-          end
-
-          # @return [Hash, nil]
-          def convert_condition_size
-            size = config.size
-            return unless size&.value
-
-            {
-              size: { size.operator => size.value.to_i }
-            }
+          # Serializes a collection of condition nodes.
+          #
+          # @param conditions [Array<Configs::SearchConditions::*>]
+          # @return [Array<Hash>]
+          def convert_conditions(conditions)
+            conditions.map { |c| convert_condition_node(c) }
           end
 
           # @return [Hash, nil]

--- a/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/to_model_conversions/filesystem.rb
@@ -25,7 +25,7 @@ module Agama
   module Storage
     module ConfigConversions
       module ToModelConversions
-        # Drive conversion to model according to the JSON schema.
+        # Filesystem conversion to model according to the JSON schema.
         class Filesystem < Base
           # @param config [Configs::Filesystem]
           # @param volumes [VolumeTemplatesBuilder]

--- a/service/lib/agama/storage/config_solvers/boot.rb
+++ b/service/lib/agama/storage/config_solvers/boot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -301,7 +301,6 @@ module Agama
         # @return [Configs::Drive]
         def create_drive_entry(device)
           config.drives << Configs::Drive.new.tap do |drive|
-            drive.search.name = device.name
             drive.search.solve(device)
           end
           config.drives.last
@@ -314,7 +313,6 @@ module Agama
         def create_raid_entry(device)
           config.md_raids << Configs::MdRaid.new.tap do |md|
             md.search = Configs::Search.new
-            md.search.name = device.name
             md.search.solve(device)
           end
           config.md_raids.last

--- a/service/lib/agama/storage/config_solvers/drives_search.rb
+++ b/service/lib/agama/storage/config_solvers/drives_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -53,15 +53,6 @@ module Agama
 
         # @return [Storage::System]
         attr_reader :storage_system
-
-        # @see DevicesSearch#match_condition?
-        # @param drive_config [Configs::Drive]
-        # @param drive [Y2Storage::Disk, Y2Storage::StrayBlkDevice]
-        #
-        # @return [Boolean]
-        def match_condition?(drive_config, drive)
-          match_name?(drive_config, drive) && match_size?(drive_config, drive)
-        end
       end
     end
   end

--- a/service/lib/agama/storage/config_solvers/logical_volumes_search.rb
+++ b/service/lib/agama/storage/config_solvers/logical_volumes_search.rb
@@ -43,15 +43,6 @@ module Agama
 
       private
 
-        # @see DevicesSearch#match_condition?
-        # @param lv_config [Configs::LogicalVolume]
-        # @param lvm_lv [Y2Storage::LvmLv]
-        #
-        # @return [Boolean]
-        def match_condition?(lv_config, lvm_lv)
-          match_name?(lv_config, lvm_lv) && match_size?(lv_config, lvm_lv)
-        end
-
         # @see DevicesSearch#solve_with_device
         def solve_with_device(device_config, device)
           result = super

--- a/service/lib/agama/storage/config_solvers/md_raids_search.rb
+++ b/service/lib/agama/storage/config_solvers/md_raids_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -53,15 +53,6 @@ module Agama
 
         # @return [Storage::System]
         attr_reader :storage_system
-
-        # @see DevicesSearch#match_condition?
-        # @param md_raid_config [Configs::MdRaid]
-        # @param md_raid [Y2Storage::Md]
-        #
-        # @return [Boolean]
-        def match_condition?(md_raid_config, md_raid)
-          match_name?(md_raid_config, md_raid) && match_size?(md_raid_config, md_raid)
-        end
       end
     end
   end

--- a/service/lib/agama/storage/config_solvers/partitions_search.rb
+++ b/service/lib/agama/storage/config_solvers/partitions_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -39,32 +39,6 @@ module Agama
           candidate_partitions = config.found_device&.partitions || []
           config.partitions = super(config.partitions, candidate_partitions)
           config
-        end
-
-      private
-
-        # @see DevicesSearch#match_condition?
-        # @param partition_config [Configs::Partition]
-        # @param partition [Y2Storage::Partition]
-        #
-        # @return [Boolean]
-        def match_condition?(partition_config, partition)
-          match_name?(partition_config, partition) &&
-            match_size?(partition_config, partition) &&
-            match_number?(partition_config, partition)
-        end
-
-        # Whether the number of the given partition matches the search condition.
-        #
-        # @param partition_config [Configs::Partition]
-        # @param partition [Y2Storage::Partition]
-        #
-        # @return [Boolean]
-        def match_number?(partition_config, partition)
-          search = partition_config.search
-          return true unless search&.partition_number
-
-          partition.number == search.partition_number
         end
       end
     end

--- a/service/lib/agama/storage/config_solvers/search_matchers.rb
+++ b/service/lib/agama/storage/config_solvers/search_matchers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,45 +19,110 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/storage/configs/search_conditions"
+
 module Agama
   module Storage
     module ConfigSolvers
       # Matchers for searching devices.
       module SearchMatchers
-        # Whether the name of the given device matches the search condition.
+        # Whether the given device matches the search condition of the config.
         #
         # @param config [#search]
         # @param device [Y2Storage::Device]
         #
         # @return [Boolean]
-        def match_name?(config, device)
-          search = config.search
-          return true unless search&.name
+        def match_condition?(config, device)
+          condition = config.search&.condition
+          return true unless condition
 
-          found_device = device.devicegraph.find_by_any_name(search.name)
-          found_device&.sid == device.sid
+          match_node?(condition, device)
         end
 
-        # Whether the size of the given device matches the search condition.
+      private
+
+        # Recursively evaluates a condition node against a device.
         #
-        # @param config [#search]
+        # @param node [Configs::SearchConditions::*]
         # @param device [Y2Storage::Device]
         #
         # @return [Boolean]
-        def match_size?(config, device)
-          size = config.search&.size
-          return true unless size&.value
+        def match_node?(node, device)
+          case node
+          when Configs::SearchConditions::And
+            node.conditions.all? { |c| match_node?(c, device) }
+          when Configs::SearchConditions::Or
+            node.conditions.any? { |c| match_node?(c, device) }
+          when Configs::SearchConditions::Not
+            !match_node?(node.condition, device)
+          else
+            match_leaf?(node, device)
+          end
+        end
 
-          case size.operator
-          when :equal
-            device.size == size.value
-          when :greater
-            device.size > size.value
-          when :less
-            device.size < size.value
+        # Evaluates a leaf condition node against a device.
+        #
+        # @param node [Configs::SearchConditions::*]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_leaf?(node, device)
+          case node
+          when Configs::SearchConditions::Name
+            match_name?(node, device)
+          when Configs::SearchConditions::Size
+            match_size?(node, device)
+          when Configs::SearchConditions::PartitionNumber
+            match_partition_number?(node, device)
           else
             false
           end
+        end
+
+        # Whether the name of the given device matches the condition node.
+        #
+        # @param node [Configs::SearchConditions::Name]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_name?(node, device)
+          return true unless node.name
+
+          found_device = device.devicegraph.find_by_any_name(node.name)
+          found_device&.sid == device.sid
+        end
+
+        # Whether the size of the given device matches the condition node.
+        #
+        # @param node [Configs::SearchConditions::Size]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_size?(node, device)
+          return true unless node.value
+
+          case node.operator
+          when :equal
+            device.size == node.value
+          when :greater
+            device.size > node.value
+          when :less
+            device.size < node.value
+          else
+            false
+          end
+        end
+
+        # Whether the number of the given partition matches the condition node.
+        #
+        # @param node [Configs::SearchConditions::PartitionNumber]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_partition_number?(node, device)
+          return false unless device.is?(:partition)
+
+          device.number == node.number
         end
       end
     end

--- a/service/lib/agama/storage/config_solvers/volume_groups_search.rb
+++ b/service/lib/agama/storage/config_solvers/volume_groups_search.rb
@@ -53,16 +53,6 @@ module Agama
 
         # @return [Storage::System]
         attr_reader :storage_system
-
-        # @see DevicesSearch#match_condition?
-        # @param volume_group_config [Configs::VolumeGroup]
-        # @param volume_group [Y2Storage::LvmVg]
-        #
-        # @return [Boolean]
-        def match_condition?(volume_group_config, volume_group)
-          match_name?(volume_group_config, volume_group) &&
-            match_size?(volume_group_config, volume_group)
-        end
       end
     end
   end

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -19,6 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "agama/storage/configs/search_conditions"
+
 module Agama
   module Storage
     module Configs
@@ -88,6 +90,18 @@ module Agama
         # @return [Boolean]
         def condition?
           !condition.nil?
+        end
+
+        # Name targeted by the search, if the top-level condition searches by name.
+        #
+        # Only a top-level SearchConditions::Name yields a name; operators (and/or/not) and
+        # other leaf conditions (size, partition number) return nil.
+        #
+        # @return [String, nil]
+        def condition_name
+          return unless condition.is_a?(SearchConditions::Name)
+
+          condition.name
         end
 
         # Whether the section containing the search should be skipped

--- a/service/lib/agama/storage/configs/search.rb
+++ b/service/lib/agama/storage/configs/search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -32,20 +32,16 @@ module Agama
           new.tap { |c| c.if_not_found = :skip }
         end
 
-        # Search by name.
+        # Condition used to match devices.
         #
-        # @return [String, nil]
-        attr_accessor :name
-
-        # Search by size.
+        # It holds the root node of the condition tree, which can be a leaf condition
+        # (SearchConditions::Name, ::Size or ::PartitionNumber) or a logical operator
+        # (SearchConditions::And, ::Or or ::Not) nesting other conditions.
         #
-        # @return [SearchConditions::Size, nil]
-        attr_accessor :size
-
-        # Search by partition number (only applies if searching partitions).
-        #
-        # @return [Integer, nil] e.g., 2 for "/dev/vda2".
-        attr_accessor :partition_number
+        # @return [SearchConditions::Name, SearchConditions::Size,
+        #   SearchConditions::PartitionNumber, SearchConditions::And,
+        #   SearchConditions::Or, SearchConditions::Not, nil]
+        attr_accessor :condition
 
         # Found device, if any
         #
@@ -91,7 +87,6 @@ module Agama
         #
         # @return [Boolean]
         def condition?
-          condition = name || size || partition_number
           !condition.nil?
         end
 

--- a/service/lib/agama/storage/configs/search_conditions/and.rb
+++ b/service/lib/agama/storage/configs/search_conditions/and.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,16 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition that matches when all the nested conditions match.
+        class And
+          # @return [Array<SearchConditions::*>]
+          attr_accessor :conditions
+
+          # @param conditions [Array<SearchConditions::*>]
+          def initialize(conditions = [])
+            @conditions = conditions
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/search_conditions/name.rb
+++ b/service/lib/agama/storage/configs/search_conditions/name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,16 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition for searching by name.
+        class Name
+          # @return [String, nil]
+          attr_accessor :name
+
+          # @param name [String, nil]
+          def initialize(name = nil)
+            @name = name
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/search_conditions/not.rb
+++ b/service/lib/agama/storage/configs/search_conditions/not.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,16 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition that matches when the nested condition does not match.
+        class Not
+          # @return [SearchConditions::*, nil]
+          attr_accessor :condition
+
+          # @param condition [SearchConditions::*, nil]
+          def initialize(condition = nil)
+            @condition = condition
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/search_conditions/or.rb
+++ b/service/lib/agama/storage/configs/search_conditions/or.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,16 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition that matches when any of the nested conditions matches.
+        class Or
+          # @return [Array<SearchConditions::*>]
+          attr_accessor :conditions
+
+          # @param conditions [Array<SearchConditions::*>]
+          def initialize(conditions = [])
+            @conditions = conditions
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/search_conditions/partition_number.rb
+++ b/service/lib/agama/storage/configs/search_conditions/partition_number.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,16 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition for searching by partition number.
+        class PartitionNumber
+          # @return [Integer, nil] e.g., 2 for "/dev/vda2".
+          attr_accessor :number
+
+          # @param number [Integer, nil]
+          def initialize(number = nil)
+            @number = number
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/with_search.rb
+++ b/service/lib/agama/storage/configs/with_search.rb
@@ -42,6 +42,21 @@ module Agama
           search&.device
         end
 
+        # Name of the device.
+        #
+        # If the config is not solved, then it returns the searched name (if any).
+        # If the config is solved, then it returns either the name of the found device or the
+        # searched name. But the searched name is returned only if the device is not going to be
+        # created.
+        #
+        # @return [String, nil]
+        def device_name
+          device = found_device
+          return device.name if device
+
+          search&.condition_name unless search&.create_device?
+        end
+
         # Whether the device is going to be created.
         #
         # @return [Boolean]

--- a/service/lib/agama/storage/configs/with_search.rb
+++ b/service/lib/agama/storage/configs/with_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024-2025] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -40,21 +40,6 @@ module Agama
         # @return [Y2Storage::Device, nil]
         def found_device
           search&.device
-        end
-
-        # Name of the device.
-        #
-        # If the config is not solved, then it returns the searched name (if any).
-        # If the config is solved, then it returns either the name of the found device or the
-        # searched name. But the searched name is returned only if the device is not going to be
-        # created.
-        #
-        # @return [String, nil]
-        def device_name
-          device = found_device
-          return device.name if device
-
-          search&.name unless search&.create_device?
         end
 
         # Whether the device is going to be created.

--- a/service/lib/agama/storage/model_support_checker.rb
+++ b/service/lib/agama/storage/model_support_checker.rb
@@ -90,7 +90,7 @@ module Agama
         config.supporting_partitions.any? do |device_config|
           !device_config.found_device &&
             !device_config.search&.skip_device? &&
-            !device_config.search&.name
+            !device_config.search&.condition_name
         end
       end
 

--- a/service/test/agama/storage/config_checkers/search_test.rb
+++ b/service/test/agama/storage/config_checkers/search_test.rb
@@ -80,6 +80,45 @@ describe Agama::Storage::ConfigCheckers::Search do
       end
     end
 
+    context "if the search condition is not a device name" do
+      let(:search) do
+        {
+          condition:  { size: { greater: "10 TiB" } },
+          ifNotFound: "error"
+        }
+      end
+
+      it "includes a generic not found issue" do
+        issues = subject.issues
+        expect(issues).to include an_object_having_attributes(
+          kind:        Agama::Storage::IssueClasses::Config::SEARCH_NOT_FOUND,
+          description: "Mandatory drive not found"
+        )
+      end
+    end
+
+    context "if the search condition is an operator" do
+      let(:search) do
+        {
+          condition:  {
+            and: [
+              { name: "/dev/unknown" },
+              { size: { greater: "1 GiB" } }
+            ]
+          },
+          ifNotFound: "error"
+        }
+      end
+
+      it "includes a generic not found issue without the nested name" do
+        issues = subject.issues
+        expect(issues).to include an_object_having_attributes(
+          kind:        Agama::Storage::IssueClasses::Config::SEARCH_NOT_FOUND,
+          description: "Mandatory drive not found"
+        )
+      end
+    end
+
     context "if a MD RAID is reused" do
       let(:config_json) do
         {

--- a/service/test/agama/storage/config_conversions/from_json_conversions/drive_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/drive_test.rb
@@ -69,7 +69,7 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Drive do
       it "sets #search to the expected value" do
         drive = subject.convert
         expect(drive.search).to be_a(Agama::Storage::Configs::Search)
-        expect(drive.search.name).to be_nil
+        expect(drive.search.condition_name).to be_nil
         expect(drive.search.if_not_found).to eq(:error)
       end
     end

--- a/service/test/agama/storage/config_conversions/from_json_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/examples.rb
@@ -142,7 +142,7 @@ shared_examples "with search" do
     it "sets #search to the expected value" do
       config = subject.convert
       expect(config.search).to be_a(Agama::Storage::Configs::Search)
-      expect(config.search.name).to eq("/dev/vda1")
+      expect(config.search.condition_name).to eq("/dev/vda1")
       expect(config.search.if_not_found).to eq(:error)
     end
   end

--- a/service/test/agama/storage/config_conversions/from_json_conversions/search_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/search_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,6 +22,7 @@
 require_relative "../../../../test_helper"
 require "agama/storage/config_conversions/from_json_conversions/search"
 require "agama/storage/configs/search"
+require "agama/storage/configs/search_conditions"
 require "y2storage/refinements"
 
 using Y2Storage::Refinements::SizeCasts
@@ -52,19 +53,11 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Search do
     context "with a device name" do
       let(:config_json) { "/dev/vda1" }
 
-      it "sets #name to the expected value" do
+      it "sets #condition to the expected value" do
         config = subject.convert
-        expect(config.name).to eq("/dev/vda1")
-      end
-
-      it "sets #size to the expected value" do
-        config = subject.convert
-        expect(config.size).to be_nil
-      end
-
-      it "sets #partition_number to the expected value" do
-        config = subject.convert
-        expect(config.partition_number).to be_nil
+        expect(config.condition)
+          .to be_a(Agama::Storage::Configs::SearchConditions::Name)
+        expect(config.condition.name).to eq("/dev/vda1")
       end
 
       it "sets #max to the expected value" do
@@ -81,19 +74,9 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Search do
     context "with an asterisk" do
       let(:config_json) { "*" }
 
-      it "sets #name to the expected value" do
+      it "sets #condition to the expected value" do
         config = subject.convert
-        expect(config.name).to be_nil
-      end
-
-      it "sets #size to the expected value" do
-        config = subject.convert
-        expect(config.size).to be_nil
-      end
-
-      it "sets #partition_number to the expected value" do
-        config = subject.convert
-        expect(config.partition_number).to be_nil
+        expect(config.condition).to be_nil
       end
 
       it "sets #max to the expected value" do
@@ -111,19 +94,9 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Search do
       context "if 'condition' is not specefied" do
         let(:condition) { nil }
 
-        it "sets #name to the expected value" do
+        it "sets #condition to the expected value" do
           config = subject.convert
-          expect(config.name).to be_nil
-        end
-
-        it "sets #size to the expected value" do
-          config = subject.convert
-          expect(config.size).to be_nil
-        end
-
-        it "sets #partition_number to the expected value" do
-          config = subject.convert
-          expect(config.partition_number).to be_nil
+          expect(config.condition).to be_nil
         end
       end
 
@@ -149,9 +122,11 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Search do
         context "and 'name' is specified" do
           let(:condition) { { name: "/dev/vda" } }
 
-          it "sets #name to the expected value" do
+          it "sets #condition to the expected value" do
             config = subject.convert
-            expect(config.name).to eq("/dev/vda")
+            expect(config.condition)
+              .to be_a(Agama::Storage::Configs::SearchConditions::Name)
+            expect(config.condition.name).to eq("/dev/vda")
           end
         end
 
@@ -161,53 +136,144 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Search do
           context "without operator" do
             let(:size) { "2 GiB" }
 
-            it "sets #size to the expected value" do
+            it "sets #condition to the expected value" do
               config = subject.convert
-              expect(config.size).to be_a(Agama::Storage::Configs::SearchConditions::Size)
-              expect(config.size.value).to eq(2.GiB)
-              expect(config.size.operator).to eq(:equal)
+              expect(config.condition).to be_a(Agama::Storage::Configs::SearchConditions::Size)
+              expect(config.condition.value).to eq(2.GiB)
+              expect(config.condition.operator).to eq(:equal)
             end
           end
 
           context "with 'equal' operator" do
             let(:size) { { equal: "2 GiB" } }
 
-            it "sets #size to the expected value" do
+            it "sets #condition to the expected value" do
               config = subject.convert
-              expect(config.size).to be_a(Agama::Storage::Configs::SearchConditions::Size)
-              expect(config.size.value).to eq(2.GiB)
-              expect(config.size.operator).to eq(:equal)
+              expect(config.condition).to be_a(Agama::Storage::Configs::SearchConditions::Size)
+              expect(config.condition.value).to eq(2.GiB)
+              expect(config.condition.operator).to eq(:equal)
             end
           end
 
           context "with 'greater' operator" do
             let(:size) { { greater: "2 GiB" } }
 
-            it "sets #size to the expected value" do
+            it "sets #condition to the expected value" do
               config = subject.convert
-              expect(config.size).to be_a(Agama::Storage::Configs::SearchConditions::Size)
-              expect(config.size.value).to eq(2.GiB)
-              expect(config.size.operator).to eq(:greater)
+              expect(config.condition).to be_a(Agama::Storage::Configs::SearchConditions::Size)
+              expect(config.condition.value).to eq(2.GiB)
+              expect(config.condition.operator).to eq(:greater)
             end
           end
 
           context "with 'less' operator" do
             let(:size) { { less: "2 GiB" } }
 
-            it "sets #size to the expected value" do
+            it "sets #condition to the expected value" do
               config = subject.convert
-              expect(config.size).to be_a(Agama::Storage::Configs::SearchConditions::Size)
-              expect(config.size.value).to eq(2.GiB)
-              expect(config.size.operator).to eq(:less)
+              expect(config.condition).to be_a(Agama::Storage::Configs::SearchConditions::Size)
+              expect(config.condition.value).to eq(2.GiB)
+              expect(config.condition.operator).to eq(:less)
             end
           end
         end
 
         context "and 'number' is specified" do
           let(:condition) { { number: 2 } }
-          it "sets #partition_number to the expected value" do
+
+          it "sets #condition to the expected value" do
             config = subject.convert
-            expect(config.partition_number).to eq(2)
+            expect(config.condition)
+              .to be_a(Agama::Storage::Configs::SearchConditions::PartitionNumber)
+            expect(config.condition.number).to eq(2)
+          end
+        end
+
+        context "and an 'and' operator is specified" do
+          let(:condition) do
+            { and: [{ name: "/dev/vda" }, { size: { less: "1 TiB" } }] }
+          end
+
+          it "sets #condition to the expected value" do
+            config = subject.convert
+            expect(config.condition)
+              .to be_a(Agama::Storage::Configs::SearchConditions::And)
+
+            conditions = config.condition.conditions
+            expect(conditions.size).to eq(2)
+
+            expect(conditions[0])
+              .to be_a(Agama::Storage::Configs::SearchConditions::Name)
+            expect(conditions[0].name).to eq("/dev/vda")
+
+            expect(conditions[1])
+              .to be_a(Agama::Storage::Configs::SearchConditions::Size)
+            expect(conditions[1].value).to eq(1.TiB)
+            expect(conditions[1].operator).to eq(:less)
+          end
+        end
+
+        context "and an 'or' operator is specified" do
+          let(:condition) do
+            { or: [{ number: 1 }, { number: 2 }] }
+          end
+
+          it "sets #condition to the expected value" do
+            config = subject.convert
+            expect(config.condition)
+              .to be_a(Agama::Storage::Configs::SearchConditions::Or)
+
+            conditions = config.condition.conditions
+            expect(conditions.size).to eq(2)
+            expect(conditions).to all(
+              be_a(Agama::Storage::Configs::SearchConditions::PartitionNumber)
+            )
+            expect(conditions.map(&:number)).to contain_exactly(1, 2)
+          end
+        end
+
+        context "and a 'not' operator is specified" do
+          let(:condition) { { not: { name: "/dev/vda" } } }
+
+          it "sets #condition to the expected value" do
+            config = subject.convert
+            expect(config.condition)
+              .to be_a(Agama::Storage::Configs::SearchConditions::Not)
+
+            inner = config.condition.condition
+            expect(inner).to be_a(Agama::Storage::Configs::SearchConditions::Name)
+            expect(inner.name).to eq("/dev/vda")
+          end
+        end
+
+        context "and nested operators are specified" do
+          let(:condition) do
+            {
+              and: [
+                { size: { less: "1 TiB" } },
+                { not: { name: "/dev/vda" } }
+              ]
+            }
+          end
+
+          it "sets #condition to the expected value" do
+            config = subject.convert
+            expect(config.condition)
+              .to be_a(Agama::Storage::Configs::SearchConditions::And)
+
+            conditions = config.condition.conditions
+            expect(conditions.size).to eq(2)
+
+            expect(conditions[0])
+              .to be_a(Agama::Storage::Configs::SearchConditions::Size)
+            expect(conditions[0].value).to eq(1.TiB)
+            expect(conditions[0].operator).to eq(:less)
+
+            expect(conditions[1])
+              .to be_a(Agama::Storage::Configs::SearchConditions::Not)
+            inner = conditions[1].condition
+            expect(inner).to be_a(Agama::Storage::Configs::SearchConditions::Name)
+            expect(inner.name).to eq("/dev/vda")
           end
         end
       end

--- a/service/test/agama/storage/config_conversions/from_model_conversions/boot_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/boot_test.rb
@@ -102,7 +102,9 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Boot do
 
             let(:drive) do
               Agama::Storage::Configs::Drive.new.tap do |drive|
-                drive.search = Agama::Storage::Configs::Search.new.tap { |s| s.name = name }
+                drive.search = Agama::Storage::Configs::Search.new.tap do |s|
+                  s.condition = Agama::Storage::Configs::SearchConditions::Name.new(name)
+                end
               end
             end
 

--- a/service/test/agama/storage/config_conversions/from_model_conversions/config_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/config_test.rb
@@ -139,7 +139,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
         it "does not add more drives" do
           config = subject.convert
           expect(config.drives.size).to eq(1)
-          expect(config.drives.first.search.name).to eq("/dev/vda")
+          expect(config.drives.first.search.condition_name).to eq("/dev/vda")
         end
 
         it "sets an alias to the drive config" do
@@ -179,7 +179,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
           config = subject.convert
           expect(config.drives.size).to eq(2)
 
-          drive = config.drives.find { |d| d.search.name == "/dev/vda" }
+          drive = config.drives.find { |d| d.search.condition_name == "/dev/vda" }
           expect(drive.alias).to_not be_nil
           expect(drive.partitions).to be_empty
         end
@@ -187,7 +187,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
         it "sets #boot to the expected value" do
           config = subject.convert
           boot = config.boot
-          drive = config.drives.find { |d| d.search.name == "/dev/vda" }
+          drive = config.drives.find { |d| d.search.condition_name == "/dev/vda" }
           expect(boot.configure?).to eq(true)
           expect(boot.device.default?).to eq(false)
           expect(boot.device.device_alias).to eq(drive.alias)
@@ -214,7 +214,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
         it "does not add more MD RAIDs" do
           config = subject.convert
           expect(config.md_raids.size).to eq(1)
-          expect(config.md_raids.first.search.name).to eq("/dev/md0")
+          expect(config.md_raids.first.search.condition_name).to eq("/dev/md0")
         end
 
         it "sets an alias to the MD RAID config" do
@@ -256,7 +256,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
           config = subject.convert
           expect(config.md_raids.size).to eq(2)
 
-          md = config.md_raids.find { |d| d.search.name == "/dev/md0" }
+          md = config.md_raids.find { |d| d.search.condition_name == "/dev/md0" }
           expect(md.alias).to_not be_nil
           expect(md.partitions).to be_empty
         end
@@ -264,7 +264,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
         it "sets #boot to the expected value" do
           config = subject.convert
           boot = config.boot
-          md = config.md_raids.find { |d| d.search.name == "/dev/md0" }
+          md = config.md_raids.find { |d| d.search.condition_name == "/dev/md0" }
           expect(boot.configure?).to eq(true)
           expect(boot.device.default?).to eq(false)
           expect(boot.device.device_alias).to eq(md.alias)
@@ -296,9 +296,9 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
           expect(config.drives).to all(be_a(Agama::Storage::Configs::Drive))
 
           drive1, drive2 = config.drives
-          expect(drive1.search.name).to eq("/dev/vda")
+          expect(drive1.search.condition_name).to eq("/dev/vda")
           expect(drive1.partitions).to eq([])
-          expect(drive2.search.name).to eq("/dev/vdb")
+          expect(drive2.search.condition_name).to eq("/dev/vdb")
           expect(drive2.partitions).to eq([])
         end
       end
@@ -328,9 +328,9 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
           expect(config.md_raids).to all(be_a(Agama::Storage::Configs::MdRaid))
 
           md_raid1, md_raid2 = config.md_raids
-          expect(md_raid1.search.name).to eq("/dev/md0")
+          expect(md_raid1.search.condition_name).to eq("/dev/md0")
           expect(md_raid1.partitions).to eq([])
-          expect(md_raid2.search.name).to eq("/dev/md1")
+          expect(md_raid2.search.condition_name).to eq("/dev/md1")
           expect(md_raid2.partitions).to eq([])
         end
       end
@@ -360,9 +360,9 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Config do
           expect(config.volume_groups).to all(be_a(Agama::Storage::Configs::VolumeGroup))
 
           vg1, vg2 = config.volume_groups
-          expect(vg1.search.name).to eq("/dev/vg0")
+          expect(vg1.search.condition_name).to eq("/dev/vg0")
           expect(vg1.logical_volumes).to eq([])
-          expect(vg2.search.name).to eq("/dev/vg1")
+          expect(vg2.search.condition_name).to eq("/dev/vg1")
           expect(vg2.logical_volumes).to eq([])
         end
       end

--- a/service/test/agama/storage/config_conversions/from_model_conversions/drive_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/drive_test.rb
@@ -49,7 +49,7 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::Drive do
       it "sets #search to the expected value" do
         config = subject.convert
         expect(config.search).to be_a(Agama::Storage::Configs::Search)
-        expect(config.search.name).to be_nil
+        expect(config.search.condition_name).to be_nil
         expect(config.search.if_not_found).to eq(:error)
       end
     end

--- a/service/test/agama/storage/config_conversions/from_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/examples.rb
@@ -64,7 +64,7 @@ shared_examples "without spacePolicy" do |volumes_property|
       expect(volumes.size).to eq(1)
 
       volume = volumes.first
-      expect(volume.search.name).to be_nil
+      expect(volume.search.condition_name).to be_nil
       expect(volume.search.if_not_found).to eq(:skip)
       expect(volume.search.max).to be_nil
       expect(volume.delete?).to eq(true)
@@ -80,7 +80,7 @@ shared_examples "without spacePolicy" do |volumes_property|
       expect(volumes.size).to eq(1)
 
       volume = volumes.first
-      expect(volume.search.name).to be_nil
+      expect(volume.search.condition_name).to be_nil
       expect(volume.search.if_not_found).to eq(:skip)
       expect(volume.search.max).to be_nil
       expect(volume.delete?).to eq(false)
@@ -130,7 +130,7 @@ shared_examples "with name" do
   it "sets #search to the expected value" do
     config = subject.convert
     expect(config.search).to be_a(Agama::Storage::Configs::Search)
-    expect(config.search.name).to eq("/dev/vda")
+    expect(config.search.condition_name).to eq("/dev/vda")
     expect(config.search.max).to be_nil
     expect(config.search.if_not_found).to eq(:error)
   end
@@ -528,7 +528,7 @@ shared_examples "with spacePolicy" do
       expect(volumes.size).to eq(1)
 
       volume = volumes.first
-      expect(volume.search.name).to be_nil
+      expect(volume.search.condition_name).to be_nil
       expect(volume.search.if_not_found).to eq(:skip)
       expect(volume.search.max).to be_nil
       expect(volume.delete?).to eq(true)
@@ -544,7 +544,7 @@ shared_examples "with spacePolicy" do
       expect(volumes.size).to eq(1)
 
       volume = volumes.first
-      expect(volume.search.name).to be_nil
+      expect(volume.search.condition_name).to be_nil
       expect(volume.search.if_not_found).to eq(:skip)
       expect(volume.search.max).to be_nil
       expect(volume.delete?).to eq(false)
@@ -640,9 +640,9 @@ shared_examples "with spacePolicy and volumes" do
       config = subject.convert
       volumes = volumes_config(config)
       expect(volumes.size).to eq(5)
-      expect(volumes[0].search.name).to eq("/dev/vol1")
-      expect(volumes[1].search.name).to eq("/dev/vol2")
-      expect(volumes[2].search.name).to eq("/dev/vol3")
+      expect(volumes[0].search.condition_name).to eq("/dev/vol1")
+      expect(volumes[1].search.condition_name).to eq("/dev/vol2")
+      expect(volumes[2].search.condition_name).to eq("/dev/vol3")
       expect(volumes[3].filesystem).to be_nil
       expect(volumes[4].filesystem.path).to eq("/")
     end
@@ -655,12 +655,12 @@ shared_examples "with spacePolicy and volumes" do
       config = subject.convert
       volumes = volumes_config(config)
       expect(volumes.size).to eq(6)
-      expect(volumes[0].search.name).to eq("/dev/vol1")
-      expect(volumes[1].search.name).to eq("/dev/vol2")
-      expect(volumes[2].search.name).to eq("/dev/vol3")
+      expect(volumes[0].search.condition_name).to eq("/dev/vol1")
+      expect(volumes[1].search.condition_name).to eq("/dev/vol2")
+      expect(volumes[2].search.condition_name).to eq("/dev/vol3")
       expect(volumes[3].filesystem).to be_nil
       expect(volumes[4].filesystem.path).to eq("/")
-      expect(volumes[5].search.name).to be_nil
+      expect(volumes[5].search.condition_name).to be_nil
       expect(volumes[5].search.max).to be_nil
       expect(volumes[5].delete).to eq(true)
     end
@@ -673,12 +673,12 @@ shared_examples "with spacePolicy and volumes" do
       config = subject.convert
       volumes = volumes_config(config)
       expect(volumes.size).to eq(6)
-      expect(volumes[0].search.name).to eq("/dev/vol1")
-      expect(volumes[1].search.name).to eq("/dev/vol2")
-      expect(volumes[2].search.name).to eq("/dev/vol3")
+      expect(volumes[0].search.condition_name).to eq("/dev/vol1")
+      expect(volumes[1].search.condition_name).to eq("/dev/vol2")
+      expect(volumes[2].search.condition_name).to eq("/dev/vol3")
       expect(volumes[3].filesystem).to be_nil
       expect(volumes[4].filesystem.path).to eq("/")
-      expect(volumes[5].search.name).to be_nil
+      expect(volumes[5].search.condition_name).to be_nil
       expect(volumes[5].search.max).to be_nil
       expect(volumes[5].size.default?).to eq(false)
       expect(volumes[5].size.min).to eq(Y2Storage::DiskSize.zero)
@@ -693,15 +693,15 @@ shared_examples "with spacePolicy and volumes" do
       config = subject.convert
       volumes = volumes_config(config)
       expect(volumes.size).to eq(9)
-      expect(volumes[0].search.name).to eq("/dev/vol1")
-      expect(volumes[1].search.name).to eq("/dev/vol2")
-      expect(volumes[2].search.name).to eq("/dev/vol3")
+      expect(volumes[0].search.condition_name).to eq("/dev/vol1")
+      expect(volumes[1].search.condition_name).to eq("/dev/vol2")
+      expect(volumes[2].search.condition_name).to eq("/dev/vol3")
       expect(volumes[3].filesystem).to be_nil
       expect(volumes[4].filesystem.path).to eq("/")
-      expect(volumes[5].search.name).to eq("/dev/vol4")
-      expect(volumes[6].search.name).to eq("/dev/vol5")
-      expect(volumes[7].search.name).to eq("/dev/vol6")
-      expect(volumes[8].search.name).to eq("/dev/vol7")
+      expect(volumes[5].search.condition_name).to eq("/dev/vol4")
+      expect(volumes[6].search.condition_name).to eq("/dev/vol5")
+      expect(volumes[7].search.condition_name).to eq("/dev/vol6")
+      expect(volumes[8].search.condition_name).to eq("/dev/vol7")
     end
   end
 end

--- a/service/test/agama/storage/config_conversions/from_model_conversions/volume_group_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_conversions/volume_group_test.rb
@@ -123,13 +123,17 @@ describe Agama::Storage::ConfigConversions::FromModelConversions::VolumeGroup do
 
       let(:drive) do
         Agama::Storage::Configs::Drive.new.tap do |drive|
-          drive.search = Agama::Storage::Configs::Search.new.tap { |s| s.name = "/dev/vda" }
+          drive.search = Agama::Storage::Configs::Search.new.tap do |s|
+            s.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/vda")
+          end
         end
       end
 
       let(:md_raid) do
         Agama::Storage::Configs::MdRaid.new.tap do |md_raid|
-          md_raid.search = Agama::Storage::Configs::Search.new.tap { |s| s.name = "/dev/md0" }
+          md_raid.search = Agama::Storage::Configs::Search.new.tap do |s|
+            s.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/md0")
+          end
         end
       end
 

--- a/service/test/agama/storage/config_conversions/from_model_test.rb
+++ b/service/test/agama/storage/config_conversions/from_model_test.rb
@@ -60,21 +60,21 @@ describe Agama::Storage::ConfigConversions::FromModel do
       expect(drives.size).to eq(1)
 
       drive = drives.first
-      expect(drive.search.name).to eq("/dev/vda")
+      expect(drive.search.condition_name).to eq("/dev/vda")
       expect(drive.partitions).to be_empty
 
       md_raids = config.md_raids
       expect(md_raids.size).to eq(1)
 
       md_raid = md_raids.first
-      expect(md_raid.search.name).to eq("/dev/md0")
+      expect(md_raid.search.condition_name).to eq("/dev/md0")
       expect(md_raid.partitions).to be_empty
 
       volume_groups = config.volume_groups
       expect(volume_groups.size).to eq(1)
 
       volume_group = volume_groups.first
-      expect(volume_group.search.name).to eq("/dev/vg0")
+      expect(volume_group.search.condition_name).to eq("/dev/vg0")
       expect(volume_group.logical_volumes).to be_empty
     end
   end

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -143,6 +143,27 @@ describe Agama::Storage::ModelSupportChecker do
       include_examples "partitionable without name"
     end
 
+    # The search only combines conditions with an operator, so it has no top-level name.
+    context "if there is a drive searched with an operator condition" do
+      let(:scenario) { "empty-hd-50GiB.yaml" }
+
+      let(:config_json) do
+        {
+          drives: [
+            {},
+            {
+              search: {
+                condition:  { and: [{ name: "/dev/vdb" }, { size: { greater: "1 GiB" } }] },
+                ifNotFound: if_not_found
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "partitionable without name"
+    end
+
     shared_examples "partitionable with encryption" do
       context "and the device is going to be skipped" do
         let(:condition) { { name: "/not/found" } }

--- a/service/test/agama/storage/config_conversions/to_json_conversions/search_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/search_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -133,6 +133,64 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Search do
       end
 
       include_examples "with device"
+    end
+
+    context "if #condition is configured with an 'and' operator" do
+      let(:condition) do
+        { and: [{ name: "/dev/vda" }, { size: { less: "1 TiB" } }] }
+      end
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq(
+          { and: [{ name: "/dev/vda" }, { size: { less: 1.TiB.to_i } }] }
+        )
+      end
+    end
+
+    context "if #condition is configured with an 'or' operator" do
+      let(:condition) do
+        { or: [{ number: 1 }, { number: 2 }] }
+      end
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq(
+          { or: [{ number: 1 }, { number: 2 }] }
+        )
+      end
+    end
+
+    context "if #condition is configured with a 'not' operator" do
+      let(:condition) { { not: { name: "/dev/vda" } } }
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq({ not: { name: "/dev/vda" } })
+      end
+    end
+
+    context "if #condition is configured with nested operators" do
+      let(:condition) do
+        {
+          and: [
+            { size: { less: "1 TiB" } },
+            { not: { name: "/dev/vda" } }
+          ]
+        }
+      end
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq(
+          {
+            and: [
+              { size: { less: 1.TiB.to_i } },
+              { not: { name: "/dev/vda" } }
+            ]
+          }
+        )
+      end
     end
 
     context "if #if_not_found is configured" do

--- a/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
@@ -444,6 +444,41 @@ shared_examples "device name" do |device_config_fn = nil|
           end
         end
       end
+
+      context "and the device is searched by an operator condition" do
+        let(:condition) { { not: { name: "/dev/test" } } }
+
+        context "if the device is not found" do
+          before { device_config.search.solve }
+
+          context "and the device does not have to be created" do
+            let(:if_not_found) { "error" }
+
+            it "generates the expected JSON" do
+              model_json = subject.convert
+              expect(model_json.keys).to_not include(:name)
+            end
+          end
+
+          context "and the device has to be created" do
+            let(:if_not_found) { "create" }
+
+            it "generates the expected JSON" do
+              model_json = subject.convert
+              expect(model_json.keys).to_not include(:name)
+            end
+          end
+        end
+
+        context "if the device is found" do
+          before { device_config.search.solve(device) }
+
+          it "generates the expected JSON" do
+            model_json = subject.convert
+            expect(model_json[:name]).to eq(device.name)
+          end
+        end
+      end
     end
   end
 end

--- a/service/test/agama/storage/config_solvers/partitions_search_test.rb
+++ b/service/test/agama/storage/config_solvers/partitions_search_test.rb
@@ -336,6 +336,66 @@ describe Agama::Storage::ConfigSolvers::PartitionsSearch do
         end
       end
 
+      context "if a partition config has a search with logical operators" do
+        let(:scenario) { "sizes.yaml" }
+
+        let(:partitions) do
+          [
+            {
+              search: {
+                condition: condition
+              }
+            }
+          ]
+        end
+
+        context "with an 'and' operator" do
+          context "and all the nested conditions match a partition" do
+            let(:condition) { { and: [{ number: 2 }, { size: { greater: "15 GiB" } }] } }
+            include_examples "find device", "/dev/vda2"
+          end
+
+          context "and any of the nested conditions does not match" do
+            let(:condition) { { and: [{ number: 2 }, { size: { less: "15 GiB" } }] } }
+            include_examples "do not find device"
+          end
+        end
+
+        context "with an 'or' operator" do
+          let(:condition) { { or: [{ number: 1 }, { number: 3 }] } }
+
+          it "sets a device to each partition config matching any nested condition" do
+            subject.solve(drive)
+            partitions = drive.partitions
+            expect(partitions.size).to eq(2)
+            expect(partitions.map { |p| p.search.device.name }).to contain_exactly(
+              "/dev/vda1", "/dev/vda3"
+            )
+          end
+        end
+
+        context "with a 'not' operator" do
+          let(:condition) { { not: { number: 2 } } }
+
+          it "sets a device to each partition config not matching the nested condition" do
+            subject.solve(drive)
+            partitions = drive.partitions
+            expect(partitions.size).to eq(2)
+            expect(partitions.map { |p| p.search.device.name }).to contain_exactly(
+              "/dev/vda1", "/dev/vda3"
+            )
+          end
+        end
+
+        context "with nested operators" do
+          let(:condition) do
+            { and: [{ or: [{ number: 1 }, { number: 3 }] }, { size: { greater: "15 GiB" } }] }
+          end
+
+          include_examples "find device", "/dev/vda3"
+        end
+      end
+
       context "if a partition config has a search with sorting" do
         let(:scenario) { "sizes.yaml" }
         let(:disk) { devicegraph.find_by_name("/dev/vdb") }

--- a/service/test/y2storage/agama_proposal_test.rb
+++ b/service/test/y2storage/agama_proposal_test.rb
@@ -31,7 +31,7 @@ using Y2Storage::Refinements::SizeCasts
 def block_device_config(config, name: nil, filesystem: nil)
   if name
     config.search = Agama::Storage::Configs::Search.new.tap do |search_config|
-      search_config.name = name
+      search_config.condition = Agama::Storage::Configs::SearchConditions::Name.new(name)
     end
   end
 
@@ -585,7 +585,7 @@ describe Y2Storage::AgamaProposal do
       let(:config) { default_config }
 
       before do
-        drive0.search.name = "/dev/vdb"
+        drive0.search.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/vdb")
       end
 
       it "uses the drive" do
@@ -703,7 +703,7 @@ describe Y2Storage::AgamaProposal do
 
       before do
         home_partition.search = Agama::Storage::Configs::Search.new.tap do |search|
-          search.name = "/dev/vda3"
+          search.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/vda3")
         end
       end
 
@@ -768,7 +768,7 @@ describe Y2Storage::AgamaProposal do
       end
 
       before do
-        drive0.search.name = "/dev/vda"
+        drive0.search.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/vda")
       end
 
       it "deletes the partitions" do
@@ -799,7 +799,7 @@ describe Y2Storage::AgamaProposal do
 
       before do
         # vda has 18 GiB of free space.
-        drive0.search.name = "/dev/vda"
+        drive0.search.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/vda")
       end
 
       context "if deleting the partition is not needed" do
@@ -850,7 +850,7 @@ describe Y2Storage::AgamaProposal do
       end
 
       before do
-        drive0.search.name = "/dev/vda"
+        drive0.search.condition = Agama::Storage::Configs::SearchConditions::Name.new("/dev/vda")
       end
 
       it "deletes the partition" do


### PR DESCRIPTION
## Storage logical search operators

Extends the storage search `condition` to support the logical operators **`and`**, **`or`**, and **`not`**, so device searches can combine multiple criteria instead of a single flat match.

Previously a `condition` accepted only a single leaf (`name`, `size`, or partition `number`). Now those leaves can be freely nested inside operator nodes, evaluated recursively across the full pipeline: JSON import/export, model conversions, config solvers, and config/model checkers. The schema and a full set of examples are updated accordingly.

### Operators

- **`and`** — array of conditions; all must match.
- **`or`** — array of conditions; at least one must match.
- **`not`** — single condition; matches when it does *not*.
- Operators nest arbitrarily and wrap the existing leaves (`name`, `size`, `number`).

### JSON examples

Match drives larger than 10 GiB, excluding `/dev/vdb`:

```json
{
  "search": {
    "condition": {
      "and": [
        { "size": { "greater": "10 GiB" } },
        { "not": { "name": "/dev/vdb" } }
      ]
    }
  }
}
```

Match either of two drives:

```json
{
  "search": {
    "condition": {
      "or": [
        { "name": "/dev/vda" },
        { "name": "/dev/vdb" }
      ]
    }
  }
}
```

Negate a size condition:

```json
{
  "search": {
    "condition": {
      "not": { "size": { "less": "10 GiB" } }
    }
  }
}
```

Nested operators (one of two drives, and not smaller than 1 GiB):

```json
{
  "search": {
    "condition": {
      "and": [
        { "or": [ { "name": "/dev/vda" }, { "name": "/dev/vdb" } ] },
        { "not": { "size": { "less": "1 GiB" } } }
      ]
    }
  }
}
```

Operators also apply to partition searches (using the `number` leaf):

```json
{
  "search": {
    "condition": {
      "and": [
        { "number": 1 },
        { "size": { "greater": "1 GiB" } }
      ]
    }
  }
}
```