### PR TITLE
fix(web): prevent storage forms from flickering when changing mount point or filesystem

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 16  07:06:02 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Prevent the partition and logical volume forms from flickering
+  when changing the mount point or file system
+  (gh#agama-project/agama#3728).
+
+-------------------------------------------------------------------
 Tue Jul 14 16:59:31 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Require translated text in user-facing component props, ensuring

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -3,7 +3,7 @@ Thu Jul 16  07:06:02 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Prevent the partition and logical volume forms from flickering
   when changing the mount point or file system
-  (gh#agama-project/agama#3728).
+  (gh#agama-project/agama#3728, bsc#1271524).
 
 -------------------------------------------------------------------
 Tue Jul 14 16:59:31 UTC 2026 - David Diaz <dgonzalez@suse.com>

--- a/web/src/components/form/conventions.md
+++ b/web/src/components/form/conventions.md
@@ -41,6 +41,10 @@ examples and refined patterns.
   - [Why shake Lives in useUpdateConfig, Not the Caller](#why-shake-lives-in-useupdateconfig-not-the-caller)
   - [Putting It Together](#putting-it-together)
   - [Trade-offs and When Not to Use This Pattern](#trade-offs-and-when-not-to-use-this-pattern)
+- [Derived Suspense Data Without Flicker](#derived-suspense-data-without-flicker)
+  - [The Problem](#the-problem-1)
+  - [The Solution: useDeferredValue + a Local Suspense Boundary](#the-solution-usedeferredvalue--a-local-suspense-boundary)
+  - [When to Use This Pattern](#when-to-use-this-pattern)
 - [Code Organization](#code-organization)
   - [Directory Structure](#directory-structure)
   - [File Naming](#file-naming)
@@ -1336,6 +1340,107 @@ initialization, and background updates do not interrupt editing.
 - TanStack Form issue [#1681](https://github.com/TanStack/form/issues/1681): `form.reset` during `onSubmit` ignores new values
 - TanStack Form issue [#1798](https://github.com/TanStack/form/issues/1798): reset + `useStore` subscription bug
 - TanStack Query discussion [#3754](https://github.com/TanStack/query/discussions/3754): `fetchQuery` in event handlers
+
+---
+
+## Derived Suspense Data Without Flicker
+
+`withFrozenQuery` protects a form from refetches of its **initial** data. A
+different problem appears when a field derives read-only data from a
+`useSuspenseQuery` that is **re-keyed by what the user types**: size hints
+solved by the backend, availability checks, previews, etc.
+
+The running example is the size hint in `shared/SizeFields.tsx`, which solves
+min/max sizes for the chosen mount point and filesystem.
+
+### The Problem
+
+The derived query key depends on a field value:
+
+```tsx
+// key changes every time the mount point or filesystem changes
+useSuspenseQuery({ queryKey: ["solvedStorageModel", JSON.stringify(config)], ... });
+```
+
+When the value changes, the key changes, and there is no cached data for the
+new key. `useSuspenseQuery` suspends. If the nearest `<Suspense>` boundary is
+the page shell (`Page.Content`), React swaps the **entire form** for the
+loading fallback and back on every change: the form visibly blinks.
+
+> Note: `placeholderData: keepPreviousData` (TanStack Query v5's replacement
+> for the removed `keepPreviousData: true` option, see the
+> [v5 migration guide](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function))
+> does not solve this: `useSuspenseQuery` ignores the `placeholderData` option
+> (verified against v5.101.2, which hard-codes it to `undefined`) and suspends on every key change anyway. Honoring
+> it would mean switching to plain `useQuery` with manual loading handling; the
+> pattern below keeps suspense instead.
+
+### The Solution: useDeferredValue + a Local Suspense Boundary
+
+Two pieces, each solving one half of the problem:
+
+1. **`useDeferredValue`** on the inputs that drive the query. The urgent render
+   uses the previous (cached) value, so it never suspends. React then re-renders
+   in the background with the new value; if that suspends, React keeps the
+   already-committed content on screen instead of the fallback. This makes every
+   change **after the first** show stale data until the fresh data is ready: no
+   fallback, no blink.
+
+2. **A local `<Suspense>` boundary** wrapping only the suspending content. The
+   first time the content mounts there is nothing to defer to, so it does
+   suspend once. The local boundary contains that first suspension to the small
+   derived area instead of letting it reach the page shell.
+
+Isolate the suspending work into its own component so the boundary sits directly
+above it (a boundary cannot catch a component suspending in its own body), and
+so that sibling fields that do not need the derived data never suspend:
+
+```tsx
+// Only this component consults the solver, and it defers its inputs.
+function AutomaticSizeNote({ committedMountPoint, filesystem, useSolvedSizes }) {
+  const deferredMountPoint = useDeferredValue(committedMountPoint);
+  const deferredFilesystem = useDeferredValue(filesystem);
+  const volume = useVolumeTemplate(deferredMountPoint);
+  const solvedSizes = useSolvedSizes(deferredMountPoint, deferredFilesystem);
+  // ...render the note from volume + solvedSizes
+}
+
+// The boundary lives right above the suspending component. Fallback is null:
+// only the first solve reaches it, and the derived content has no fixed shape
+// to placeholder without misrepresenting it.
+case SIZE_MODE.AUTO:
+  return (
+    <Suspense fallback={null}>
+      <AutomaticSizeNote
+        committedMountPoint={committedMountPoint}
+        filesystem={filesystem}
+        useSolvedSizes={useSolvedSizes}
+      />
+    </Suspense>
+  );
+```
+
+Choose the fallback deliberately. Because `useDeferredValue` keeps previous
+content on screen for every change after the first, the fallback is only ever
+seen once (initial mount). Prefer `null` when the derived content has no fixed
+shape; use a skeleton only when the final content has a single, stable layout.
+
+### When to Use This Pattern
+
+- Read-only data derived from a `useSuspenseQuery` whose key changes as the user
+  edits a field, **and** the nearest Suspense boundary wraps enough UI that
+  re-suspending is visually disruptive.
+
+Do not reach for it when:
+
+- The derived query key is stable (it will not re-suspend after the first load).
+- The data is editable form state, not read-only derived data (use TanStack Form
+  listeners and field synchronization instead).
+
+**References:**
+
+- React: [`useDeferredValue` — showing stale content while fresh content loads](https://react.dev/reference/react/useDeferredValue#showing-stale-content-while-fresh-content-is-loading)
+- React: [`<Suspense>`](https://react.dev/reference/react/Suspense)
 
 ---
 

--- a/web/src/components/storage/shared/SizeFields.tsx
+++ b/web/src/components/storage/shared/SizeFields.tsx
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
+import React, { Suspense, useDeferredValue } from "react";
 import { sprintf } from "sprintf-js";
 import { Flex } from "@patternfly/react-core";
 import Text from "~/components/core/Text";
@@ -269,6 +269,53 @@ const SizeInputHelp = ({ singular = false }: { singular?: boolean }) => (
 );
 
 /**
+ * Automatic size note: the only content that depends on the backend size solver.
+ *
+ * Isolated into its own component (rendered inside a Suspense boundary by
+ * {@link SizeFieldsContent}) so that solving never suspends the whole form. The
+ * solve is a suspense query keyed by mount point + filesystem, so a change
+ * produces a new key with no cached data and re-suspends. The page hosts a
+ * single Suspense boundary (Page.Content), which would otherwise swap the entire
+ * form for the loading spinner and back, causing a visible flicker.
+ *
+ * useDeferredValue renders first with the previous (cached) values so the urgent
+ * render never suspends, then re-solves in the background. While the new solve is
+ * pending, React keeps the already-committed note on screen instead of the
+ * fallback. Only the very first solve (initial mount) reaches the fallback.
+ */
+function AutomaticSizeNote({
+  committedMountPoint,
+  filesystem,
+  useSolvedSizes,
+}: {
+  committedMountPoint: string;
+  filesystem: string;
+  useSolvedSizes: UseSolvedSizes;
+}) {
+  const deferredMountPoint = useDeferredValue(committedMountPoint);
+  const deferredFilesystem = useDeferredValue(filesystem);
+
+  // Use committedMountPoint (not live mountPoint) to avoid reacting to incomplete input.
+  // This prevents showing misleading size hints while user types "/ho..." and avoids
+  // expensive useVolumeTemplate recalculations on every keystroke.
+  const volume = useVolumeTemplate(deferredMountPoint);
+
+  // Calculate solved sizes - only recalculates when committedMountPoint or filesystem change.
+  // The host form provides the size-solving logic (partition vs logical volume).
+  const solvedSizes = useSolvedSizes(deferredMountPoint, deferredFilesystem);
+  const automaticSizeNote = useAutomaticSizeNote(volume, solvedSizes);
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapXs" }}>
+      <Text isBold textStyle="textColorSubtle">
+        {automaticSizeNote.sizeLabel}
+      </Text>
+      <Text component="small">{automaticSizeNote.rationale}</Text>
+    </Flex>
+  );
+}
+
+/**
  * Inner component that renders size mode-specific inputs and info notes.
  */
 const SizeFieldsContent = withForm({
@@ -279,25 +326,21 @@ const SizeFieldsContent = withForm({
     sizeMode: SIZE_MODE.AUTO,
   } as SizeFieldsContentProps,
   render: function Render({ form, committedMountPoint, filesystem, sizeMode, useSolvedSizes }) {
-    // Use committedMountPoint (not live mountPoint) to avoid reacting to incomplete input.
-    // This prevents showing misleading size hints while user types "/ho..." and avoids
-    // expensive useVolumeTemplate recalculations on every keystroke.
-    const volume = useVolumeTemplate(committedMountPoint);
-
-    // Calculate solved sizes - only recalculates when committedMountPoint or filesystem change.
-    // The host form provides the size-solving logic (partition vs logical volume).
-    const solvedSizes = useSolvedSizes(committedMountPoint, filesystem);
-    const automaticSizeNote = useAutomaticSizeNote(volume, solvedSizes);
-
     switch (sizeMode) {
       case SIZE_MODE.AUTO:
+        // Only AUTO consults the backend solver. It renders inside a local
+        // Suspense boundary so the first solve stays contained here (see
+        // AutomaticSizeNote, which defers its inputs via useDeferredValue to keep
+        // the previous note visible on later changes). Fallback is null: only the
+        // first solve reaches it and the note has no fixed shape to placeholder.
         return (
-          <Flex direction={{ default: "column" }} gap={{ default: "gapXs" }}>
-            <Text isBold textStyle="textColorSubtle">
-              {automaticSizeNote.sizeLabel}
-            </Text>
-            <Text component="small">{automaticSizeNote.rationale}</Text>
-          </Flex>
+          <Suspense fallback={null}>
+            <AutomaticSizeNote
+              committedMountPoint={committedMountPoint}
+              filesystem={filesystem}
+              useSolvedSizes={useSolvedSizes}
+            />
+          </Suspense>
         );
 
       case SIZE_MODE.FIXED:

--- a/web/src/components/storage/shared/SizeFields.tsx
+++ b/web/src/components/storage/shared/SizeFields.tsx
@@ -269,19 +269,20 @@ const SizeInputHelp = ({ singular = false }: { singular?: boolean }) => (
 );
 
 /**
- * Automatic size note: the only content that depends on the backend size solver.
+ * Automatic size note: the only content that depends on the backend size
+ * solver.
  *
  * Isolated into its own component (rendered inside a Suspense boundary by
- * {@link SizeFieldsContent}) so that solving never suspends the whole form. The
- * solve is a suspense query keyed by mount point + filesystem, so a change
- * produces a new key with no cached data and re-suspends. The page hosts a
- * single Suspense boundary (Page.Content), which would otherwise swap the entire
- * form for the loading spinner and back, causing a visible flicker.
+ * {@link SizeFieldsContent}) so that solving never suspends unrelated UI. The
+ * solve is a suspense query keyed by mount point + filesystem, so changing
+ * either creates a new query with no cached data and would normally trigger the
+ * nearest Suspense fallback.
  *
- * useDeferredValue renders first with the previous (cached) values so the urgent
- * render never suspends, then re-solves in the background. While the new solve is
- * pending, React keeps the already-committed note on screen instead of the
- * fallback. Only the very first solve (initial mount) reaches the fallback.
+ * useDeferredValue lets React render first with the previous (cached) values,
+ * so the urgent update does not suspend. The new solve then runs in the
+ * background while React keeps the previously committed note visible instead of
+ * showing the Suspense fallback. Only the initial solve (when no cached result
+ * exists) reaches the fallback.
  */
 function AutomaticSizeNote({
   committedMountPoint,


### PR DESCRIPTION
## Summary

Changing the mount point or filesystem in the partition and logical volume forms caused the entire form to briefly disappear and show the page loading spinner. This happened because the automatic size hint is backed by a `useSuspenseQuery` whose query key depends on those values. Every key change triggered a new suspension that propagated to the page-level `Suspense` boundary.

This PR isolates the solver-dependent UI into its own component and wraps it in a local `Suspense` boundary. The query inputs are deferred using React's `useDeferredValue`, allowing the previous size hint to remain visible while the updated data is fetched. Since the solver is expected to respond quickly and the size hint is read-only guidance rather than editable state, briefly showing the previous value provides a smoother UX without compromising correctness.

## Implementation

Initially, it was explored a TanStack Query solution using [`placeholderData`/`keepPreviousData`](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function). Unfortunately, this does not work with `useSuspenseQuery`, as `placeholderData` is ignored and the hook still suspends whenever the query key changes.

The implementation therefore follows the same approach already used in the Overview page:

- Existing pattern:
  <https://github.com/agama-project/agama/blob/5c4ee6f4cf1355e26be2f1654b287329eb5f4d97/web/src/components/overview/OverviewPage.tsx#L23>
- React documentation for `useDeferredValue`:
  <https://react.dev/reference/react/useDeferredValue#showing-stale-content-while-fresh-content-is-loading>

Specifically, this PR:

- Extracts the automatic size note into its own component.
- Defers the mount point and filesystem values with `useDeferredValue`.
- Wraps only the solver-dependent content in a local `Suspense` boundary so the initial load remains localized while subsequent updates keep the previous content visible until the new result is available.

## Screencasts

### Before

https://github.com/user-attachments/assets/97124d8c-c21a-4eed-8c54-1917c967f189

### After


https://github.com/user-attachments/assets/50357368-0258-4f05-ac8d-c3727e7331b4




## Documentation

The PR also documents this pattern in `web/src/components/form/conventions.md`, explaining:

- why the TanStack Query approach does not work with `useSuspenseQuery`,
- when `useDeferredValue` is the appropriate solution,
- and when this pattern should (and should not) be used in future forms.

---

Related to https://trello.com/c/RjALCqek (protected link)


---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>