### PR TITLE
Limit the number of Tokio worker threads

### DIFF
--- a/rust/agama-utils/src/runtime.rs
+++ b/rust/agama-utils/src/runtime.rs
@@ -23,7 +23,7 @@
 use std::future::Future;
 
 /// Maximum number of worker threads for the Tokio runtime.
-const MAX_WORKER_THREADS: usize = 32;
+const MAX_WORKER_THREADS: usize = 4;
 
 /// Creates a multi-threaded Tokio runtime with a capped number of worker threads.
 ///

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 16 10:05:13 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Limit the number of Tokio worker threads to 4
+  (gh#agama-project/agama#3729).
+
+-------------------------------------------------------------------
 Wed Jul 15 10:13:10 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when running "lshw" fails or the output cannot be

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -2,7 +2,7 @@
 Thu Jul 16 10:05:13 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Limit the number of Tokio worker threads to 4
-  (gh#agama-project/agama#3729).
+  (gh#agama-project/agama#3729, related to bsc#1265451).
 
 -------------------------------------------------------------------
 Wed Jul 15 10:13:10 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>


### PR DESCRIPTION
## Problem

The limit of Tokio worker threads is too high. For big machines, it can go up to 32 threads.

## Solution

Limit to 4 worker threads as it is more than enough.

## Testing

- Tested manually