### PR TITLE
Do not set the dns search list for disabled IP protocols (bsc#1271481)

### DIFF
--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -452,21 +452,20 @@ fn ip_config_to_ipv4_dbus<'a>(
         ip_config.link_local4
     };
 
+    let method4 = ip_config.method4.unwrap_or(Ipv4Method::Auto);
+
     let mut ipv4_dbus = HashMap::from([
         ("address-data", address_data),
         ("dns-data", dns_data),
-        ("dns-search", ip_config.dns_searchlist.clone().into()),
         ("ignore-auto-dns", ip_config.ignore_auto_dns.into()),
-        (
-            "method",
-            ip_config
-                .method4
-                .unwrap_or(Ipv4Method::Auto)
-                .to_string()
-                .into(),
-        ),
+        ("method", method4.to_string().into()),
         ("link-local", (link_local as i32).into()),
     ]);
+
+    // Only set dns-search if IPv4 is not disabled to avoid NetworkManager errors
+    if method4 != Ipv4Method::Disabled {
+        ipv4_dbus.insert("dns-search", ip_config.dns_searchlist.clone().into());
+    }
 
     if !ip_config.routes4.is_empty() {
         ipv4_dbus.insert(
@@ -568,20 +567,19 @@ fn ip_config_to_ipv6_dbus<'a>(
         .collect::<Vec<_>>()
         .into();
 
+    let method6 = ip_config.method6.unwrap_or(Ipv6Method::Auto);
+
     let mut ipv6_dbus = HashMap::from([
         ("address-data", address_data),
         ("dns-data", dns_data),
-        ("dns-search", ip_config.dns_searchlist.clone().into()),
         ("ignore-auto-dns", ip_config.ignore_auto_dns.into()),
-        (
-            "method",
-            ip_config
-                .method6
-                .unwrap_or(Ipv6Method::Auto)
-                .to_string()
-                .into(),
-        ),
+        ("method", method6.to_string().into()),
     ]);
+
+    // Only set dns-search if IPv6 is not disabled to avoid NetworkManager errors
+    if method6 != Ipv6Method::Disabled {
+        ipv6_dbus.insert("dns-search", ip_config.dns_searchlist.clone().into());
+    }
 
     if !ip_config.routes6.is_empty() {
         ipv6_dbus.insert(
@@ -2889,5 +2887,58 @@ mod test {
         assert_eq!(*ipv6_dbus.get("never-default").unwrap(), Value::new(true));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_dbus_dns_search_omitted_when_protocol_disabled() {
+        let nm_version = semver::Version::new(1, 44, 0);
+
+        // Test with IPv4 disabled
+        let mut conn = Connection::new("eth0".to_string(), DeviceType::Ethernet);
+        conn.ip_config.method4 = Some(Ipv4Method::Disabled);
+        conn.ip_config.method6 = Some(Ipv6Method::Auto);
+        conn.ip_config.dns_searchlist = vec!["example.com".to_string()];
+
+        let dbus = connection_to_dbus(&conn, None, nm_version.clone());
+
+        let ipv4_dbus = dbus.get("ipv4").unwrap();
+        // dns-search should NOT be present when IPv4 is disabled
+        assert!(!ipv4_dbus.contains_key("dns-search"));
+
+        let ipv6_dbus = dbus.get("ipv6").unwrap();
+        // dns-search should be present when IPv6 is not disabled
+        assert!(ipv6_dbus.contains_key("dns-search"));
+
+        // Test with IPv6 disabled
+        let mut conn2 = Connection::new("eth1".to_string(), DeviceType::Ethernet);
+        conn2.ip_config.method4 = Some(Ipv4Method::Auto);
+        conn2.ip_config.method6 = Some(Ipv6Method::Disabled);
+        conn2.ip_config.dns_searchlist = vec!["example.com".to_string()];
+
+        let dbus2 = connection_to_dbus(&conn2, None, nm_version.clone());
+
+        let ipv4_dbus2 = dbus2.get("ipv4").unwrap();
+        // dns-search should be present when IPv4 is not disabled
+        assert!(ipv4_dbus2.contains_key("dns-search"));
+
+        let ipv6_dbus2 = dbus2.get("ipv6").unwrap();
+        // dns-search should NOT be present when IPv6 is disabled
+        assert!(!ipv6_dbus2.contains_key("dns-search"));
+
+        // Test with both disabled
+        let mut conn3 = Connection::new("eth2".to_string(), DeviceType::Ethernet);
+        conn3.ip_config.method4 = Some(Ipv4Method::Disabled);
+        conn3.ip_config.method6 = Some(Ipv6Method::Disabled);
+        conn3.ip_config.dns_searchlist = vec!["example.com".to_string()];
+
+        let dbus3 = connection_to_dbus(&conn3, None, nm_version);
+
+        let ipv4_dbus3 = dbus3.get("ipv4").unwrap();
+        // dns-search should NOT be present when IPv4 is disabled
+        assert!(!ipv4_dbus3.contains_key("dns-search"));
+
+        let ipv6_dbus3 = dbus3.get("ipv6").unwrap();
+        // dns-search should NOT be present when IPv6 is disabled
+        assert!(!ipv6_dbus3.contains_key("dns-search"));
     }
 }

--- a/rust/agama-network/src/nm/dbus.rs
+++ b/rust/agama-network/src/nm/dbus.rs
@@ -348,8 +348,11 @@ fn is_bridge_port(conn: &NestedHash) -> bool {
 /// It also removes empty files from the "connection" object like the "interface-name", "master",
 /// "slave-type", "port-type" keys.
 ///
-/// Finally, it removes removes the "addresses" and "dns" keys from the "ipv4" and "ipv6" objects,
-/// which are replaced with "address-data".
+/// It removes the "addresses" and "dns" keys from the "ipv4" and "ipv6" objects, which are replaced
+/// with "address-data".
+///
+/// Finally, it empties any "ipv4" or "ipv6" section whose method is "disabled", keeping only the
+/// "method" attribute (see [cleanup_disabled_ip_config]).
 ///
 /// * `conn`: connection represented as a NestedHash.
 pub fn cleanup_dbus_connection(conn: &mut NestedHash) {
@@ -390,6 +393,7 @@ pub fn cleanup_dbus_connection(conn: &mut NestedHash) {
         if ipv4.get("address-data").is_some_and(is_empty_value) {
             ipv4.remove("gateway");
         }
+        cleanup_disabled_ip_config(ipv4);
     }
 
     if let Some(ipv6) = conn.get_mut("ipv6") {
@@ -398,6 +402,7 @@ pub fn cleanup_dbus_connection(conn: &mut NestedHash) {
         if ipv6.get("address-data").is_some_and(is_empty_value) {
             ipv6.remove("gateway");
         }
+        cleanup_disabled_ip_config(ipv6);
     }
 
     if let Some(vlan) = conn.get_mut("vlan") {
@@ -408,6 +413,26 @@ pub fn cleanup_dbus_connection(conn: &mut NestedHash) {
                 VlanFlag::to_bitmask(&[VlanFlag::ReorderHeaders]).into(),
             );
         }
+    }
+}
+
+/// Empties the IP configuration when its method is "disabled".
+///
+/// When the IPv4 or IPv6 method is disabled, any other attribute (e.g. "address-data",
+/// "dns-search", "gateway", ...) is meaningless and could even be contradictory. As this runs
+/// after merging the current configuration with the given one, it drops any such value that could
+/// have been kept from the original connection, leaving only the "method" attribute.
+///
+/// * `ip`: IPv4 or IPv6 section of a connection.
+fn cleanup_disabled_ip_config(ip: &mut HashMap<&str, zbus::zvariant::Value>) {
+    // Both Ipv4Method::Disabled and Ipv6Method::Disabled serialize to "disabled".
+    let is_disabled = ip
+        .get("method")
+        .and_then(|method| TryInto::<&str>::try_into(method).ok())
+        .is_some_and(|method| method == "disabled");
+
+    if is_disabled {
+        ip.retain(|key, _| *key == "method");
     }
 }
 
@@ -462,10 +487,7 @@ fn ip_config_to_ipv4_dbus<'a>(
         ("link-local", (link_local as i32).into()),
     ]);
 
-    // Only set dns-search if IPv4 is not disabled to avoid NetworkManager errors
-    if method4 != Ipv4Method::Disabled {
-        ipv4_dbus.insert("dns-search", ip_config.dns_searchlist.clone().into());
-    }
+    ipv4_dbus.insert("dns-search", ip_config.dns_searchlist.clone().into());
 
     if !ip_config.routes4.is_empty() {
         ipv4_dbus.insert(
@@ -576,10 +598,7 @@ fn ip_config_to_ipv6_dbus<'a>(
         ("method", method6.to_string().into()),
     ]);
 
-    // Only set dns-search if IPv6 is not disabled to avoid NetworkManager errors
-    if method6 != Ipv6Method::Disabled {
-        ipv6_dbus.insert("dns-search", ip_config.dns_searchlist.clone().into());
-    }
+    ipv6_dbus.insert("dns-search", ip_config.dns_searchlist.clone().into());
 
     if !ip_config.routes6.is_empty() {
         ipv6_dbus.insert(
@@ -2890,55 +2909,74 @@ mod test {
     }
 
     #[test]
-    fn test_dbus_dns_search_omitted_when_protocol_disabled() {
-        let nm_version = semver::Version::new(1, 44, 0);
+    fn test_ip_config_emptied_when_disabled() -> anyhow::Result<()> {
+        // The original connection carries values that would be contradictory once the method is
+        // disabled (dns-search, address-data, gateway, ...).
+        let mut original = OwnedNestedHash::new();
+        let ipv4 = HashMap::from([
+            hi("method", "manual")?,
+            hi("gateway", "192.168.1.1")?,
+            hi("address-data", vec!["192.168.1.10"])?,
+            hi("dns-search", vec!["example.com"])?,
+        ]);
+        let ipv6 = HashMap::from([
+            hi("method", "manual")?,
+            hi("gateway", "::ffff:c0a8:101")?,
+            hi("address-data", vec!["::ffff:c0a8:102"])?,
+            hi("dns-search", vec!["example.com"])?,
+        ]);
+        original.insert("ipv4".to_string(), ipv4);
+        original.insert("ipv6".to_string(), ipv6);
 
-        // Test with IPv4 disabled
+        // The given connection disables both IPv4 and IPv6.
         let mut conn = Connection::new("eth0".to_string(), DeviceType::Ethernet);
         conn.ip_config.method4 = Some(Ipv4Method::Disabled);
+        conn.ip_config.method6 = Some(Ipv6Method::Disabled);
+        conn.ip_config.dns_searchlist = vec!["example.com".to_string()];
+        let updated = connection_to_dbus(&conn, None, semver::Version::new(1, 44, 0));
+
+        let merged = merge_dbus_connections(&original, &updated)?;
+
+        // Once disabled, only the "method" attribute is kept.
+        let ipv4 = merged.get("ipv4").unwrap();
+        assert_eq!(
+            *ipv4.get("method").unwrap(),
+            Value::new("disabled".to_string())
+        );
+        assert_eq!(ipv4.len(), 1);
+
+        let ipv6 = merged.get("ipv6").unwrap();
+        assert_eq!(
+            *ipv6.get("method").unwrap(),
+            Value::new("disabled".to_string())
+        );
+        assert_eq!(ipv6.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ip_config_kept_when_not_disabled() -> anyhow::Result<()> {
+        // A non-disabled method must keep its configuration, including dns-search.
+        let mut conn = Connection::new("eth0".to_string(), DeviceType::Ethernet);
+        conn.ip_config.method4 = Some(Ipv4Method::Auto);
         conn.ip_config.method6 = Some(Ipv6Method::Auto);
         conn.ip_config.dns_searchlist = vec!["example.com".to_string()];
+        let mut dbus = connection_to_dbus(&conn, None, semver::Version::new(1, 44, 0));
+        super::cleanup_dbus_connection(&mut dbus);
 
-        let dbus = connection_to_dbus(&conn, None, nm_version.clone());
+        for section in ["ipv4", "ipv6"] {
+            let ip = dbus.get(section).unwrap();
+            let dns_search: Array = ip
+                .get("dns-search")
+                .unwrap()
+                .downcast_ref::<Value>()
+                .unwrap()
+                .try_into()
+                .unwrap();
+            assert_eq!(dns_search.len(), 1);
+        }
 
-        let ipv4_dbus = dbus.get("ipv4").unwrap();
-        // dns-search should NOT be present when IPv4 is disabled
-        assert!(!ipv4_dbus.contains_key("dns-search"));
-
-        let ipv6_dbus = dbus.get("ipv6").unwrap();
-        // dns-search should be present when IPv6 is not disabled
-        assert!(ipv6_dbus.contains_key("dns-search"));
-
-        // Test with IPv6 disabled
-        let mut conn2 = Connection::new("eth1".to_string(), DeviceType::Ethernet);
-        conn2.ip_config.method4 = Some(Ipv4Method::Auto);
-        conn2.ip_config.method6 = Some(Ipv6Method::Disabled);
-        conn2.ip_config.dns_searchlist = vec!["example.com".to_string()];
-
-        let dbus2 = connection_to_dbus(&conn2, None, nm_version.clone());
-
-        let ipv4_dbus2 = dbus2.get("ipv4").unwrap();
-        // dns-search should be present when IPv4 is not disabled
-        assert!(ipv4_dbus2.contains_key("dns-search"));
-
-        let ipv6_dbus2 = dbus2.get("ipv6").unwrap();
-        // dns-search should NOT be present when IPv6 is disabled
-        assert!(!ipv6_dbus2.contains_key("dns-search"));
-
-        // Test with both disabled
-        let mut conn3 = Connection::new("eth2".to_string(), DeviceType::Ethernet);
-        conn3.ip_config.method4 = Some(Ipv4Method::Disabled);
-        conn3.ip_config.method6 = Some(Ipv6Method::Disabled);
-        conn3.ip_config.dns_searchlist = vec!["example.com".to_string()];
-
-        let dbus3 = connection_to_dbus(&conn3, None, nm_version);
-
-        let ipv4_dbus3 = dbus3.get("ipv4").unwrap();
-        // dns-search should NOT be present when IPv4 is disabled
-        assert!(!ipv4_dbus3.contains_key("dns-search"));
-
-        let ipv6_dbus3 = dbus3.get("ipv6").unwrap();
-        // dns-search should NOT be present when IPv6 is disabled
-        assert!(!ipv6_dbus3.contains_key("dns-search"));
+        Ok(())
     }
 }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,8 +1,10 @@
 -------------------------------------------------------------------
 Thu Jul 16 11:15:11 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
-- Do not set the dns-search list for disabled IP protocols to avoid
-  errors in NetworkManager (gh#agama-project/agama#3731, bsc#127481).
+- Clear the IP configuration (dns-search, addresses, gateway, ...) for
+  disabled IP protocols, including values kept from the existing
+  connection, to avoid errors in NetworkManager
+  (gh#agama-project/agama#3731, bsc#127481).
 
 -------------------------------------------------------------------
 Wed Jul 15 10:13:10 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 16 11:15:11 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not set the dns-search list for disabled IP protocols to avoid
+  errors in NetworkManager (gh#agama-project/agama#3731, bsc#127481).
+
+-------------------------------------------------------------------
 Wed Jul 15 10:13:10 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when running "lshw" fails or the output cannot be

--- a/service/lib/agama/autoyast/network_reader.rb
+++ b/service/lib/agama/autoyast/network_reader.rb
@@ -71,7 +71,7 @@ module Agama
         dns = {}
         return dns if dns_section.nil?
 
-        dns["dns_searchlist"] = dns_section.searchlist unless dns_section.searchlist.empty?
+        dns["dnsSearchList"] = dns_section.searchlist unless dns_section.searchlist.empty?
         dns["nameservers"] = dns_section.nameservers unless dns_section.nameservers.empty?
         dns
       end

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 16 11:15:11 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix AutoYaST dns-search conversion (gh#agama-project/agama#3731,
+  bsc#127481).
+
+-------------------------------------------------------------------
 Tue Jun 30 14:40:25 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Always emit signals for iSCSI, DASD and zFCP (needed for

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -164,7 +164,7 @@
           {
             "key": "searchlist",
             "support": "yes",
-            "agama": "network.connections[].dns_searchlist",
+            "agama": "network.connections[].dnsSearchList",
             "notes": "Copied to each connection."
           }
         ]

--- a/service/test/agama/autoyast/connections_reader_test.rb
+++ b/service/test/agama/autoyast/connections_reader_test.rb
@@ -30,7 +30,7 @@ describe Agama::AutoYaST::ConnectionsReader do
     { "bootproto" => eth0_bootproto, "name" => "eth0" }
   end
   let(:ipv6?) { true }
-  let(:dns) { { "nameservers" => ["1.1.1.1"], "dns_searchlist" => ["example.lan"] } }
+  let(:dns) { { "nameservers" => ["1.1.1.1"], "dnsSearchList" => ["example.lan"] } }
   let(:eth0_bootproto) { "dhcp" }
 
   subject do

--- a/service/test/agama/autoyast/network_reader_test.rb
+++ b/service/test/agama/autoyast/network_reader_test.rb
@@ -57,7 +57,7 @@ describe Agama::AutoYaST::NetworkReader do
         expect(network["network"].keys).to include("connections")
         network["network"]["connections"].each do |conn|
           expect(conn).to include(
-            "nameservers" => ["1.1.1.1"], "dns_searchlist" => ["example.lan"]
+            "nameservers" => ["1.1.1.1"], "dnsSearchList" => ["example.lan"]
           )
         end
       end


### PR DESCRIPTION
### Summary

This PR resolves an issue where configuring a connection with disabled IP protocols failed in NetworkManager if a DNS search list was defined (`bsc#1271481`). Additionally, it corrects a conversion mismatch for `dnsSearchList` in the AutoYaST network reader.

- SUSE Bugzilla: [bsc#1271481](https://bugzilla.suse.com/show_bug.cgi?id=1271481)


### Problem
1. **NetworkManager Validation Failure:** NetworkManager validates settings and throws an error if IP-specific attributes (such as `dns-search`) are present on a protocol whose method is set to `disabled` (e.g., when disabling IPv6 entirely). The problem is not limited to what Agama serializes: when updating a connection, Agama merges its output on top of the connection already stored by NetworkManager, so contradictory values (e.g. a `dns-search` or `address-data` left over from a previous `manual` configuration) can be inherited from the existing connection and re-sent even though the method is now `disabled`.
2. **AutoYaST Conversion Error:** The AutoYaST parser was translating the `searchlist` key to snake_case (`dns_searchlist`) instead of the camelCase (`dnsSearchList`) expected by Agama's connection models, causing DNS search configurations from profiles to be ignored or improperly mapped.

### Solution
- **Rust (NetworkManager Client):**
  - Added `cleanup_disabled_ip_config` in `rust/agama-network/src/nm/dbus.rs`, called from `cleanup_dbus_connection`. When an `ipv4`/`ipv6` section has its method set to `disabled`, it drops every attribute except `method`. Because `cleanup_dbus_connection` runs *after* merging with the existing connection, this also removes contradictory values inherited from it, not just the ones Agama would serialize.
  - This centralizes the "disabled means empty" invariant in a single place, covering `dns-search` as well as `address-data`, `gateway`, `dns-data`, routes, etc.
- **Service (AutoYaST compatibility):**
  - Corrected the mapping from `dns_searchlist` to `dnsSearchList` in `service/lib/agama/autoyast/network_reader.rb` and `service/share/autoyast-compat.json`.

### Testing
- **Rust:** Added unit tests to `rust/agama-network/src/nm/dbus.rs`:
  - `test_ip_config_emptied_when_disabled` merges an updated connection that disables both protocols on top of an existing connection carrying `manual` values, and asserts that only the `method` attribute survives for both `ipv4` and `ipv6`.
  - `test_ip_config_kept_when_not_disabled` verifies that a non-disabled method keeps its configuration, including `dns-search`.
- **Service:** Updated AutoYaST integration unit tests (`connections_reader_test.rb` and `network_reader_test.rb`) to assert the correct mapping using `dnsSearchList`.
- **Manual Verification:** Performed manual installations ensuring NetworkManager correctly applies settings without errors when protocols are disabled.


### TODO

The current solution will fix the problem if the IPv{4,6} protocols are disabled but would be nice we validate also a profile with the method4 or method6 as disabled and conflicting configuration like the gateway{4,6} as well as addresses for the disabled protocol but that is by now out of the scope of this PR.