### PR TITLE
web: Avoid displaying a wrong reused filesystem type

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jul 16 15:10:34 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Do not display the type when reusing filesystems (bsc#1271008).
+
+-------------------------------------------------------------------
 Thu Jul 16  07:06:02 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Prevent the partition and logical volume forms from flickering

--- a/web/src/components/storage/utils/partition.tsx
+++ b/web/src/components/storage/utils/partition.tsx
@@ -51,8 +51,14 @@ const typeDescription = (partition: ConfigModel.Partition | ConfigModel.LogicalV
   const fsType = partition.filesystem ? filesystemType(partition.filesystem) : undefined;
   if (partition.name) {
     if (partition.filesystem?.reuse) {
+      // FIXME: the following "if (fsType)" line is commented out as a hotfix for bsc#1271008.
+      // Turns out fsType is not the current filesystem type, but the one that would be used if
+      // reusing the current one would not be possible. Commenting out the line is a cheap
+      // mitigation that avoids displaying wrong information while we design a better mechanism.
+
       // TRANSLATORS: %1$s is a filesystem type (eg. Btrfs), %2$s is a device name (eg. /dev/sda3).
-      if (fsType) return sprintf(_("Current %1$s at %2$s"), fsType, partition.name);
+      //if (fsType) return sprintf(_("Current %1$s at %2$s"), fsType, partition.name);
+
       // TRANSLATORS: %s is a device name (eg. /dev/sda3).
       return sprintf(_("Current %s"), partition.name);
     }


### PR DESCRIPTION
## Problem

When reusing an existing filesystem, the web UI shows a message like, for example,  "Current XFS at /dev/sb4". But the problem is that, in that example, "XFS" is not really the current file-system type (which will be kept), but the default file-system type that would be used if the device would actually be re-formatted.

It is just a "cosmetic" error, since the proper operation is actually performed.

## Solution

Omit the filesystem type. So instead of "Current XFS at /dev/sb4" the string "Current /dev/sdb4" would be used. The string was already there for other cases, so there is no impact in the translations and the meaning of the sentence basically stays.

It would also be possible to inspect the current system to calculate the real filesystem type that will be re-used and display that instead. But the implemented fix is much easier and good enough for the SLE RC phase (in which we want to be conservative with the changes).

## Testing

- Tested manually

## See also

Another solution was implemented in the model layer (see #3726), but we are not sure whether is formally correct, so we opted for this simpler solution for now.
