### PR TITLE
NPM CVEs of 2026-07: react-router

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,7 +23,7 @@
         "radashi": "^12.7.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router": "7.14.0",
+        "react-router": "7.15.1",
         "sprintf-js": "^1.1.3",
         "stacktracey": "^2.1.8",
         "xbytes": "^1.9.1"
@@ -15917,9 +15917,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -108,7 +108,7 @@
     "radashi": "^12.7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "7.14.0",
+    "react-router": "7.15.1",
     "sprintf-js": "^1.1.3",
     "stacktracey": "^2.1.8",
     "xbytes": "^1.9.1"

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul 17 08:42:50 UTC 2026 - Martin Vidner <mvidner@suse.com>
+
+- update runtime dependencies:
+  - react-router to 7.15.1, CVE-2026-53663 (bsc#1268993)
+- consequently, update call sites for stricter types of
+  generatePath, generateEncodedPath
+
+-------------------------------------------------------------------
 Thu Jul 16 15:10:34 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Do not display the type when reusing filesystems (bsc#1271008).

--- a/web/src/components/storage/FilesystemMenu.test.tsx
+++ b/web/src/components/storage/FilesystemMenu.test.tsx
@@ -80,7 +80,7 @@ describe("FilesystemMenu", () => {
     const editItem = screen.getByText("Edit");
     await user.click(editItem);
 
-    const expectedPath = generatePath(PATHS.formatDevice, { collection: "drives", index: 0 });
+    const expectedPath = generatePath(PATHS.formatDevice, { collection: "drives", index: "0" });
     expect(mockNavigateFn).toHaveBeenCalledWith(expectedPath);
   });
 

--- a/web/src/components/storage/FilesystemMenu.tsx
+++ b/web/src/components/storage/FilesystemMenu.tsx
@@ -92,7 +92,7 @@ export default function FilesystemMenu({
 }: FilesystemMenuProps): React.ReactNode {
   const navigate = useNavigate();
   const deviceModel = usePartitionable(collection, index);
-  const editFilesystemPath = generatePath(PATHS.formatDevice, { collection, index });
+  const editFilesystemPath = generatePath(PATHS.formatDevice, { collection, index: String(index) });
 
   return (
     <MenuButton

--- a/web/src/components/storage/PartitionsSection.tsx
+++ b/web/src/components/storage/PartitionsSection.tsx
@@ -67,7 +67,7 @@ const PartitionMenuItem = ({ device, mountPath, collection, index }: PartitionMe
   const partition = configModel.partitionable.findPartition(device, mountPath);
   const editPath = generateEncodedPath(PATHS.editPartition, {
     collection,
-    index,
+    index: String(index),
     partitionId: mountPath,
   });
   const deletePartition = useDeletePartition();
@@ -139,7 +139,7 @@ type PartitionRowProps = {
 const PartitionRow = ({ partition, collection, index }: PartitionRowProps) => {
   const editPath = generateEncodedPath(PATHS.editPartition, {
     collection,
-    index,
+    index: String(index),
     partitionId: partition.mountPath,
   });
   const deletePartition = useDeletePartition();
@@ -227,7 +227,10 @@ export default function PartitionsSection({ collection, index }: PartitionsSecti
   const device = usePartitionable(collection, index);
   const uiIndex = `${collection[0]}${index}`;
   const isExpanded = isExpandedInState(uiState, uiIndex);
-  const newPartitionPath = generateEncodedPath(PATHS.addPartition, { collection, index });
+  const newPartitionPath = generateEncodedPath(PATHS.addPartition, {
+    collection,
+    index: String(index),
+  });
   const hasPartitions = device.partitions.some((p) => p.mountPath);
 
   const onToggle = () => {

--- a/web/src/components/storage/SpacePolicyMenu.tsx
+++ b/web/src/components/storage/SpacePolicyMenu.tsx
@@ -55,7 +55,9 @@ const PolicyItem = ({ policyId, collection, index }: PolicyItemProps) => {
 
   const changePolicy = () => {
     if (policyId === "custom") {
-      return navigate(generateEncodedPath(PATHS.editSpacePolicy, { collection, index }));
+      return navigate(
+        generateEncodedPath(PATHS.editSpacePolicy, { collection, index: String(index) }),
+      );
     } else {
       setSpacePolicy(collection, index, { type: policyId });
     }

--- a/web/src/components/storage/UnusedMenu.test.tsx
+++ b/web/src/components/storage/UnusedMenu.test.tsx
@@ -62,7 +62,7 @@ describe("UnusedMenu", () => {
 
     const expectedPath = generateEncodedPath(PATHS.addPartition, {
       collection: "drives",
-      index: 0,
+      index: "0",
     });
     expect(mockNavigateFn).toHaveBeenCalledWith(expectedPath);
   });
@@ -78,7 +78,7 @@ describe("UnusedMenu", () => {
 
     const expectedPath = generateEncodedPath(PATHS.formatDevice, {
       collection: "drives",
-      index: 0,
+      index: "0",
     });
     expect(mockNavigateFn).toHaveBeenCalledWith(expectedPath);
   });
@@ -94,7 +94,7 @@ describe("UnusedMenu", () => {
 
     const expectedPath = generateEncodedPath(PATHS.formatDevice, {
       collection: "mdRaids",
-      index: 1,
+      index: "1",
     });
     expect(mockNavigateFn).toHaveBeenCalledWith(expectedPath);
   });

--- a/web/src/components/storage/UnusedMenu.tsx
+++ b/web/src/components/storage/UnusedMenu.tsx
@@ -56,8 +56,14 @@ type UnusedMenuProps = {
 
 export default function UnusedMenu({ collection, index }: UnusedMenuProps): React.ReactNode {
   const navigate = useNavigate();
-  const newPartitionPath = generateEncodedPath(PATHS.addPartition, { collection, index });
-  const formatDevicePath = generateEncodedPath(PATHS.formatDevice, { collection, index });
+  const newPartitionPath = generateEncodedPath(PATHS.addPartition, {
+    collection,
+    index: String(index),
+  });
+  const formatDevicePath = generateEncodedPath(PATHS.formatDevice, {
+    collection,
+    index: String(index),
+  });
   const filesystemLabel =
     collection === "drives"
       ? _("Use the disk without partitions")

--- a/web/src/components/storage/VolumeGroupEditor.tsx
+++ b/web/src/components/storage/VolumeGroupEditor.tsx
@@ -124,7 +124,7 @@ const EditVgOption = ({ index }: { index: number }) => {
       itemId="edit-volume-group"
       description={_("Modify settings and physical volumes")}
       role="menuitem"
-      onClick={() => navigate(generateEncodedPath(PATHS.volumeGroup.edit, { id: index }))}
+      onClick={() => navigate(generateEncodedPath(PATHS.volumeGroup.edit, { id: String(index) }))}
     >
       {_("Edit volume group")}
     </MenuButton.Item>
@@ -286,7 +286,7 @@ const AddLvButton = ({ index }: { index: number }) => {
   const navigate = useNavigate();
   const volumeGroupConfig = useVolumeGroup(index);
 
-  const newLvPath = generateEncodedPath(PATHS.volumeGroup.logicalVolume.add, { id: index });
+  const newLvPath = generateEncodedPath(PATHS.volumeGroup.logicalVolume.add, { id: String(index) });
 
   return (
     <Button variant="plain" key="add-logical-volume" onClick={() => navigate(newLvPath)}>

--- a/web/src/components/storage/iscsi/TargetsTable.tsx
+++ b/web/src/components/storage/iscsi/TargetsTable.tsx
@@ -584,7 +584,7 @@ export default function TargetsTable() {
                 generatePath(STORAGE.iscsi.login, {
                   name: target.name,
                   address: target.address,
-                  port: target.port,
+                  port: String(target.port),
                 }),
               ),
             onDisconnect: () => removeTarget(target.name, target.address, target.port),


### PR DESCRIPTION
## Problem

Security scans found vulnerabilities in the NPM libraries that agama-web-ui uses. 

- https://trello.com/c/dI8FBjDz

- Bugs:
  - [bsc#1268993](https://bugzilla.suse.com/show_bug.cgi?id=1268993) CVE-2026-53663 react-router

## Solution

Update the dependencies:
- by running `npm update $NPM_PKG`
- react-router had an incompatible change, requiring stricter types. I have changed occurrences of `number` to `String(number)`

## Testing

Manual: I have manually navigated to https://localhost:10443/#/storage/drives/0/partitions/%252F/edit to test a path with a number in it.

## Screenshots

No

## Documentation

- [x] .changes
