### PR TITLE
refactor(web): improve storage device names truncation

### DIFF
--- a/web/src/components/storage/DriveHeader.tsx
+++ b/web/src/components/storage/DriveHeader.tsx
@@ -99,5 +99,5 @@ const Text = (drive: ConfigModel.Drive): string => {
 };
 
 export default function DriveHeader({ drive, device }: DriveHeaderProps) {
-  return sprintf(Text(drive), deviceLabel(device, true));
+  return sprintf(Text(drive), deviceLabel(device, { truncate: true }));
 }

--- a/web/src/components/storage/DrivesTable.tsx
+++ b/web/src/components/storage/DrivesTable.tsx
@@ -70,7 +70,7 @@ export default function DrivesTable({
   const columns = [
     {
       name: _("Device"),
-      value: (device: Storage.Device) => <TruncatedDeviceName device={device} />,
+      value: (device: Storage.Device) => <TruncatedDeviceName device={device} maxLength={13} />,
       sortingKey: "name",
       pfTdProps: { style: { width: "15ch" } },
     },

--- a/web/src/components/storage/LvmPage.tsx
+++ b/web/src/components/storage/LvmPage.tsx
@@ -225,7 +225,7 @@ export default function LvmPage() {
                 <Checkbox
                   key={device.sid}
                   id={`device${device.sid}`}
-                  label={<Content isEditorial>{deviceLabel(device, true)}</Content>}
+                  label={<Content isEditorial>{deviceLabel(device, { truncate: true })}</Content>}
                   description={
                     <Flex rowGap={{ default: "rowGapXs" }} columnGap={{ default: "columnGapSm" }}>
                       <SubtleContent>

--- a/web/src/components/storage/MdRaidHeader.tsx
+++ b/web/src/components/storage/MdRaidHeader.tsx
@@ -99,5 +99,5 @@ const Text = (raid: ConfigModel.MdRaid): string => {
 };
 
 export default function MdRaidHeader({ raid, device }: MdRaidHeaderProps) {
-  return sprintf(Text(raid), deviceLabel(device, true));
+  return sprintf(Text(raid), deviceLabel(device, { truncate: true }));
 }

--- a/web/src/components/storage/MdRaidsTable.tsx
+++ b/web/src/components/storage/MdRaidsTable.tsx
@@ -69,7 +69,7 @@ export default function MdRaidsTable({
   const columns = [
     {
       name: _("Device"),
-      value: (device: Storage.Device) => <TruncatedDeviceName device={device} />,
+      value: (device: Storage.Device) => <TruncatedDeviceName device={device} maxLength={13} />,
       sortingKey: "name",
       pfTdProps: { style: { width: "15ch" } },
     },

--- a/web/src/components/storage/NewVgMenuOption.tsx
+++ b/web/src/components/storage/NewVgMenuOption.tsx
@@ -43,7 +43,7 @@ export default function NewVgMenuOption({ device }: NewVgMenuOptionProps): React
 
   const vgs = configModel.partitionable.filterVolumeGroups(config, device);
   const paths = device.partitions.filter((p) => !p.name).map((p) => formattedPath(p.mountPath));
-  const displayName = deviceBaseName(device, true);
+  const displayName = deviceBaseName(device, { truncate: true });
 
   const titleText = () => {
     if (vgs.length) {

--- a/web/src/components/storage/SearchedDeviceMenu.tsx
+++ b/web/src/components/storage/SearchedDeviceMenu.tsx
@@ -37,7 +37,7 @@ import type { CustomToggleProps } from "~/components/core/MenuButton";
 import type { Storage } from "~/model/system";
 import type { ConfigModel } from "~/model/storage/config-model";
 
-const baseName = (device: Storage.Device): string => deviceBaseName(device, true);
+const baseName = (device: Storage.Device): string => deviceBaseName(device, { truncate: true });
 
 const targetDevices = (
   deviceConfig: ConfigModel.Drive | ConfigModel.MdRaid,

--- a/web/src/components/storage/TruncatedDeviceName.tsx
+++ b/web/src/components/storage/TruncatedDeviceName.tsx
@@ -31,10 +31,16 @@ import type { Storage } from "~/model/system";
 type TruncatedDeviceNameProps = {
   /** The device to render the name of. */
   device: Storage.Device;
+  /**
+   * Maximum characters to show before truncating. Set it to match the width of
+   * the container (e.g. a table column) so the name fits. Defaults to the shared
+   * device-name length when omitted.
+   */
+  maxLength?: number;
 };
 
 /**
- * Renders a device's base name, truncated to fit narrow table columns.
+ * Renders a device's base name, truncated to fit narrow containers.
  *
  * When the name is too long to fit, it is shortened with an ellipsis in the
  * middle and the full name becomes the element's accessible name (via a
@@ -53,9 +59,9 @@ type TruncatedDeviceNameProps = {
  *
  * Names that already fit render as plain text, with no tooltip.
  */
-export default function TruncatedDeviceName({ device }: TruncatedDeviceNameProps) {
+export default function TruncatedDeviceName({ device, maxLength }: TruncatedDeviceNameProps) {
   const name = deviceBaseName(device);
-  const truncatedName = deviceBaseName(device, true);
+  const truncatedName = deviceBaseName(device, { truncate: true, maxLength });
 
   if (truncatedName === name) return name;
 

--- a/web/src/components/storage/VolumeGroupEditor.tsx
+++ b/web/src/components/storage/VolumeGroupEditor.tsx
@@ -81,7 +81,7 @@ const DeleteVgOption = ({ vg }: { vg: ConfigModel.VolumeGroup }) => {
 
   if (lvs.length) {
     if (convert) {
-      const diskName = baseName(targetDevices[0].name, true);
+      const diskName = baseName(targetDevices[0].name, { truncate: true });
       description = sprintf(
         n_(
           // TRANSLATORS: %1$s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
@@ -205,7 +205,7 @@ const VgHeader = ({ deviceConfig, device }: VgHeaderProps) => {
   let title: string;
 
   if (device) {
-    title = sprintf(_("Use LVM volume group %s"), deviceLabel(device, true));
+    title = sprintf(_("Use LVM volume group %s"), deviceLabel(device, { truncate: true }));
   } else {
     title = deviceConfig.logicalVolumes.length
       ? _("Create LVM volume group %s")

--- a/web/src/components/storage/VolumeGroupsTable.tsx
+++ b/web/src/components/storage/VolumeGroupsTable.tsx
@@ -71,7 +71,7 @@ export default function VolumeGroupsTable({
   const columns = [
     {
       name: _("Device"),
-      value: (device: Storage.Device) => <TruncatedDeviceName device={device} />,
+      value: (device: Storage.Device) => <TruncatedDeviceName device={device} maxLength={13} />,
       sortingKey: "name",
       pfTdProps: { style: { width: "15ch" } },
     },

--- a/web/src/components/storage/logical-volume-form/LogicalVolumeSourceFields.tsx
+++ b/web/src/components/storage/logical-volume-form/LogicalVolumeSourceFields.tsx
@@ -86,7 +86,7 @@ const LogicalVolumeSourceFields = withForm({
               text={sprintf(
                 // TRANSLATORS: %s is a volume group name with its size (eg. "system (30 GiB)")
                 _("New logical volume. There are no available existing logical volumes on %s."),
-                deviceLabel(volumeGroup, true),
+                deviceLabel(volumeGroup, { truncate: true }),
               )}
             />
           )}
@@ -101,13 +101,13 @@ const LogicalVolumeSourceFields = withForm({
         description: sprintf(
           // TRANSLATORS: %s is a volume group name with its size (eg. "system (30 GiB)")
           _("Create a new logical volume on %s"),
-          deviceLabel(volumeGroup, true),
+          deviceLabel(volumeGroup, { truncate: true }),
         ),
       },
       { divider: true },
       ...availableLogicalVolumes.map((lv) => {
         const fsLabel = lv.filesystem?.label;
-        const label = [deviceLabel(lv, true), fsLabel].filter(Boolean).join(" - ");
+        const label = [deviceLabel(lv, { truncate: true }), fsLabel].filter(Boolean).join(" - ");
         // TRANSLATORS: %s is a description like "Ext4 logical volume"
         const description = sprintf(_("Use current %s"), lv.description);
         return {

--- a/web/src/components/storage/partition-form/PartitionFields.tsx
+++ b/web/src/components/storage/partition-form/PartitionFields.tsx
@@ -70,7 +70,7 @@ const PartitionFields = withForm({
               text={sprintf(
                 // TRANSLATORS: %s is a disk name with its size (eg. "sda, 10 GiB")
                 _("New partition. There are no available existing partitions on %s."),
-                deviceLabel(device, true),
+                deviceLabel(device, { truncate: true }),
               )}
             />
           )}
@@ -84,12 +84,15 @@ const PartitionFields = withForm({
         value: "",
         label: _("New partition"),
         // TRANSLATORS: %s is a disk name with its size (eg. "sda, 10 GiB")
-        description: sprintf(_("Create a new partition on %s"), deviceLabel(device, true)),
+        description: sprintf(
+          _("Create a new partition on %s"),
+          deviceLabel(device, { truncate: true }),
+        ),
       },
       { divider: true as const },
       ...availablePartitions.map((p) => {
         const fsLabel = p.filesystem?.label;
-        const label = [deviceLabel(p, true), fsLabel].filter(Boolean).join(" - ");
+        const label = [deviceLabel(p, { truncate: true }), fsLabel].filter(Boolean).join(" - ");
         // TRANSLATORS: %s is a description like "XFS partition")
         const description = sprintf(_("Use current %s"), p.description);
         return {

--- a/web/src/components/storage/utils.test.ts
+++ b/web/src/components/storage/utils.test.ts
@@ -76,12 +76,34 @@ describe("deviceSize", () => {
 });
 
 describe("deviceBaseName", () => {
-  it("returns the base name of the given device", () => {
-    const disk: Storage.Device = { sid: 1, name: "/dev/sda" };
-    expect(deviceBaseName(disk)).toEqual("sda");
+  const device = (name: string): Storage.Device => ({ sid: 1, name });
 
-    const raid: Storage.Device = { sid: 1, name: "/dev/mapper/dm332" };
-    expect(deviceBaseName(raid)).toEqual("dm332");
+  it("returns the base name of the given device", () => {
+    expect(deviceBaseName(device("/dev/sda"))).toEqual("sda");
+    expect(deviceBaseName(device("/dev/mapper/dm332"))).toEqual("dm332");
+  });
+
+  it("does not truncate by default, even for long names", () => {
+    expect(deviceBaseName(device("/dev/verylongdevicename123"))).toEqual("verylongdevicename123");
+  });
+
+  it("leaves names that fit untouched when truncating", () => {
+    expect(deviceBaseName(device("/dev/sda"), { truncate: true })).toEqual("sda");
+  });
+
+  it("truncates long names in the middle using the default length", () => {
+    const result = deviceBaseName(device("/dev/verylongdevicename123"), { truncate: true });
+    expect(result).toEqual("verylong…ename123");
+    expect(result).toHaveLength(17);
+  });
+
+  it("truncates to the given maxLength when provided", () => {
+    const result = deviceBaseName(device("/dev/verylongdevicename123"), {
+      truncate: true,
+      maxLength: 13,
+    });
+    expect(result).toEqual("verylo…ame123");
+    expect(result).toHaveLength(13);
   });
 });
 

--- a/web/src/components/storage/utils.test.ts
+++ b/web/src/components/storage/utils.test.ts
@@ -105,6 +105,37 @@ describe("deviceBaseName", () => {
     expect(result).toEqual("verylo…ame123");
     expect(result).toHaveLength(13);
   });
+
+  it("leaves names within the default tolerance of maxLength untouched", () => {
+    // 16 chars, only 3 over maxLength (13): not worth truncating
+    expect(
+      deviceBaseName(device("/dev/abcdefghijklmnop"), { truncate: true, maxLength: 13 }),
+    ).toEqual("abcdefghijklmnop");
+    // 17 chars, past the tolerance: truncated
+    expect(
+      deviceBaseName(device("/dev/abcdefghijklmnopq"), { truncate: true, maxLength: 13 }),
+    ).toEqual("abcdef…lmnopq");
+  });
+
+  it("truncates as soon as maxLength is exceeded when tolerance is 0", () => {
+    const result = deviceBaseName(device("/dev/abcdefghijklmno"), {
+      truncate: true,
+      maxLength: 13,
+      tolerance: 0,
+    });
+    expect(result).toEqual("abcdef…jklmno");
+    expect(result).toHaveLength(13);
+  });
+
+  it("uses a custom omission marker while keeping the result within maxLength", () => {
+    const result = deviceBaseName(device("/dev/verylongdevicename123"), {
+      truncate: true,
+      maxLength: 13,
+      omission: "...",
+    });
+    expect(result).toEqual("veryl...me123");
+    expect(result).toHaveLength(13);
+  });
 });
 
 describe("deviceLabel", () => {

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -186,24 +186,43 @@ const deviceSize = (size: number, options?: SizeOptions): string => {
   return `${Number(result.size)} ${result.unit}`;
 };
 
-const TRUNCATE_MAX_LENGTH = 17;
+/**
+ * Default maximum length for truncated device names in sentence text (menu
+ * entries, headers, descriptions). Fixed-width contexts such as table columns
+ * should pass a length that matches their available width instead.
+ */
+const DEFAULT_DEVICE_NAME_MAX_LENGTH = 17;
+
+/** Options controlling how a device base name is rendered. */
+type BaseNameOptions = {
+  /** Whether to shorten names that exceed `maxLength`. Defaults to `false`. */
+  truncate?: boolean;
+  /**
+   * Maximum number of characters to display when truncating. Ignored unless
+   * `truncate` is set. Defaults to {@link DEFAULT_DEVICE_NAME_MAX_LENGTH}, which
+   * fits sentence text; fixed-width contexts (e.g. table columns) should pass a
+   * length matching their available width.
+   */
+  maxLength?: number;
+};
 
 /**
- * Base name for a full path
+ * Base name for a full path.
  *
- * FIXME: The truncate param allows to generate a shorter representation that fits into
- * the interface, but that's a temporary solution. The right way to make the strings fit
- * into the responsive interface would be Patternfly's Truncate component.
+ * By default the base name is returned untouched. With `truncate`, names longer
+ * than `maxLength` are shortened by keeping their start and end and replacing the
+ * middle with an ellipsis, so both ends stay readable.
  */
-const baseName = (name: string, truncate?: boolean): string => {
+const baseName = (name: string, options?: BaseNameOptions): string => {
   const base = name.split("/").pop();
 
-  if (!truncate || base.length <= TRUNCATE_MAX_LENGTH) return base;
+  if (!options?.truncate) return base;
 
-  // Simplistic approach as a first implementation. Anyways, we plan to replace this with
-  // the usage of Patternfly's Truncate in the mid-term.
-  const limit1 = Math.ceil((TRUNCATE_MAX_LENGTH - 1) / 2.0);
-  const limit2 = base.length - Math.floor((TRUNCATE_MAX_LENGTH - 1) / 2.0);
+  const maxLength = options.maxLength ?? DEFAULT_DEVICE_NAME_MAX_LENGTH;
+  if (base.length <= maxLength) return base;
+
+  const limit1 = Math.ceil((maxLength - 1) / 2.0);
+  const limit2 = base.length - Math.floor((maxLength - 1) / 2.0);
   return base.slice(0, limit1) + "…" + base.slice(limit2);
 };
 
@@ -212,19 +231,20 @@ type DeviceWithName = System.Device | ConfigModel.Drive | ConfigModel.MdRaid;
 /**
  * Base name of a device.
  *
- * FIXME: See note at baseName about the usage of truncate.
+ * See {@link baseName} for how `options` controls truncation.
  */
-const deviceBaseName = (device: DeviceWithName, truncate?: boolean): string => {
-  return baseName(device.name, truncate);
+const deviceBaseName = (device: DeviceWithName, options?: BaseNameOptions): string => {
+  return baseName(device.name, options);
 };
 
 /**
- * Generates the label for the given device
+ * Generates the label for the given device.
  *
- * FIXME: See note at baseName about the usage of truncate.
+ * See {@link baseName} for how `options` controls truncation of the name part
+ * (the size suffix is never truncated).
  */
-const deviceLabel = (device: System.Device, truncate?: boolean): string => {
-  const name = deviceBaseName(device, truncate);
+const deviceLabel = (device: System.Device, options?: BaseNameOptions): string => {
+  const name = deviceBaseName(device, options);
   const size = device.block?.size || device.volumeGroup?.size;
 
   return size ? `${name} (${deviceSize(size)})` : name;

--- a/web/src/components/storage/utils.ts
+++ b/web/src/components/storage/utils.ts
@@ -193,6 +193,9 @@ const deviceSize = (size: number, options?: SizeOptions): string => {
  */
 const DEFAULT_DEVICE_NAME_MAX_LENGTH = 17;
 
+/** Marker inserted in place of the characters removed when truncating. */
+const DEFAULT_OMISSION = "…";
+
 /** Options controlling how a device base name is rendered. */
 type BaseNameOptions = {
   /** Whether to shorten names that exceed `maxLength`. Defaults to `false`. */
@@ -204,14 +207,29 @@ type BaseNameOptions = {
    * length matching their available width.
    */
   maxLength?: number;
+  /**
+   * Marker put in place of the removed middle characters. Ignored unless
+   * `truncate` is set. Defaults to {@link DEFAULT_OMISSION}.
+   */
+  omission?: string;
+  /**
+   * How many characters a name may exceed `maxLength` by and still be shown in
+   * full. This avoids truncating a name that is only slightly too long, since
+   * doing so would trade real characters for the omission marker while barely
+   * reducing the width. Ignored unless `truncate` is set; defaults to the
+   * omission length plus 2, so a longer marker (which saves less width) requires
+   * a longer name before truncation pays off.
+   */
+  tolerance?: number;
 };
 
 /**
  * Base name for a full path.
  *
- * By default the base name is returned untouched. With `truncate`, names longer
- * than `maxLength` are shortened by keeping their start and end and replacing the
- * middle with an ellipsis, so both ends stay readable.
+ * By default the base name is returned untouched. With `truncate`, names that
+ * exceed `maxLength` (beyond `tolerance`) are shortened by keeping their start
+ * and end and replacing the middle with the omission marker, so both ends stay
+ * readable. The result is at most `maxLength` characters long.
  */
 const baseName = (name: string, options?: BaseNameOptions): string => {
   const base = name.split("/").pop();
@@ -219,11 +237,14 @@ const baseName = (name: string, options?: BaseNameOptions): string => {
   if (!options?.truncate) return base;
 
   const maxLength = options.maxLength ?? DEFAULT_DEVICE_NAME_MAX_LENGTH;
-  if (base.length <= maxLength) return base;
+  const omission = options.omission ?? DEFAULT_OMISSION;
+  const tolerance = options.tolerance ?? omission.length + 2;
+  if (base.length <= maxLength + tolerance) return base;
 
-  const limit1 = Math.ceil((maxLength - 1) / 2.0);
-  const limit2 = base.length - Math.floor((maxLength - 1) / 2.0);
-  return base.slice(0, limit1) + "…" + base.slice(limit2);
+  const kept = maxLength - omission.length;
+  const limit1 = Math.ceil(kept / 2.0);
+  const limit2 = base.length - Math.floor(kept / 2.0);
+  return base.slice(0, limit1) + omission + base.slice(limit2);
 };
 
 type DeviceWithName = System.Device | ConfigModel.Drive | ConfigModel.MdRaid;


### PR DESCRIPTION
> [!NOTE] 
> Follow-up of https://github.com/agama-project/agama/pull/3745/, which
fixed long device names overflowing the storage tables. That fix added a
`truncate` boolean to the `baseName` / `deviceBaseName` / `deviceLabel`
helpers; this PR turns that ad-hoc flag into a small, explicit options API.
>
> #3745 must be merged first.

## Summary

- Replace the `truncate?: boolean` argument with a `{ truncate, maxLength, omission, tolerance }` options object, so call sites read clearly and can control the length, the marker, and how far a name may exceed the limit before it is shortened at all.
- Let `TruncatedDeviceName` receive `maxLength` as a prop, so each table sets it next to its own column width instead of the component hardcoding one.


## What changed

- **Options object.** `baseName`, `deviceBaseName` and `deviceLabel` take an optional `BaseNameOptions`:
  - `truncate` opts into shortening (replaces the old boolean).
  - `maxLength` is the length to truncate to; it defaults to the shared sentence-text length, so callers that want the previous behavior just pass `{ truncate: true }` and never repeat the constant.
  - `omission` is the middle marker (default `"…"`), now configurable; the truncation math accounts for its length so the result always stays within `maxLength`.
  - `tolerance` is how far a name may exceed `maxLength` and still be shown in full. It defaults to `omission.length + 2`, so truncation only kicks in when it saves clearly more width than the marker itself occupies (no swapping a few real characters for a similar-length marker).
- **`TruncatedDeviceName` takes `maxLength`.** The component no longer hardcodes a width; each storage table passes the value beside its column style, keeping the number and the width it fits within in one place.
- **Dropped a stale FIXME** pointing at PatternFly's `Truncate`, found unsuitable for the fixed-width table case in #3745.

