### PR TITLE
feat(service): storage search by filesystem

### DIFF
--- a/rust/share/examples/storage/search_conditions.json
+++ b/rust/share/examples/storage/search_conditions.json
@@ -72,8 +72,63 @@
               }
             },
             "delete": true
+          },
+          {
+            "search": {
+              "condition": {
+                "and": [
+                  { "size": { "greater": "10 GiB" } },
+                  { "filesystem": { "type": "xfs" } }
+                ]
+              }
+            }
+          },
+          {
+            "search": {
+              "condition": {
+                "filesystem": { "label": "data" }
+              }
+            }
           }
         ]
+      },
+      {
+        "search": {
+          "condition": {
+            "filesystem": "none"
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "filesystem": "any"
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "filesystem": { "type": "ext4" }
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "and": [
+              { "name": "/dev/vda" },
+              {
+                "filesystem": {
+                  "and": [
+                    { "type": "btrfs" },
+                    { "not": { "label": "root" } }
+                  ]
+                }
+              }
+            ]
+          }
+        }
       }
     ],
     "mdRaids": [
@@ -83,6 +138,16 @@
             "and": [
               { "name": "/dev/md0" },
               { "not": { "size": { "less": "100 GiB" } } }
+            ]
+          }
+        }
+      },
+      {
+        "search": {
+          "condition": {
+            "or": [
+              { "filesystem": "none" },
+              { "filesystem": { "type": "ext4" } }
             ]
           }
         }
@@ -106,6 +171,16 @@
                 "and": [
                   { "not": { "name": "root" } },
                   { "size": { "greater": "5 GiB" } }
+                ]
+              }
+            }
+          },
+          {
+            "search": {
+              "condition": {
+                "and": [
+                  { "filesystem": { "label": "home" } },
+                  { "not": { "filesystem": { "type": "swap" } } }
                 ]
               }
             }

--- a/rust/share/storage.schema.json
+++ b/rust/share/storage.schema.json
@@ -429,6 +429,7 @@
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/searchConditionFilesystem" },
         { "$ref": "#/$defs/driveSearchConditionAnd" },
         { "$ref": "#/$defs/driveSearchConditionOr" },
         { "$ref": "#/$defs/driveSearchConditionNot" }
@@ -520,6 +521,7 @@
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/searchConditionFilesystem" },
         { "$ref": "#/$defs/mdRaidSearchConditionAnd" },
         { "$ref": "#/$defs/mdRaidSearchConditionOr" },
         { "$ref": "#/$defs/mdRaidSearchConditionNot" }
@@ -720,6 +722,7 @@
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" },
         { "$ref": "#/$defs/searchConditionPartitionNumber" },
+        { "$ref": "#/$defs/searchConditionFilesystem" },
         { "$ref": "#/$defs/partitionSearchConditionAnd" },
         { "$ref": "#/$defs/partitionSearchConditionOr" },
         { "$ref": "#/$defs/partitionSearchConditionNot" }
@@ -800,6 +803,7 @@
       "anyOf": [
         { "$ref": "#/$defs/searchConditionName" },
         { "$ref": "#/$defs/searchConditionSize" },
+        { "$ref": "#/$defs/searchConditionFilesystem" },
         { "$ref": "#/$defs/logicalVolumeSearchConditionAnd" },
         { "$ref": "#/$defs/logicalVolumeSearchConditionOr" },
         { "$ref": "#/$defs/logicalVolumeSearchConditionNot" }
@@ -898,6 +902,89 @@
           "description": "Partition number (e.g., 1 for vda1).",
           "type": "integer",
           "minimum": 1
+        }
+      }
+    },
+    "searchConditionFilesystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filesystem"],
+      "properties": {
+        "filesystem": {
+          "anyOf": [
+            { "$ref": "#/$defs/searchFilesystemPresence" },
+            { "$ref": "#/$defs/filesystemCondition" }
+          ]
+        }
+      }
+    },
+    "searchFilesystemPresence": {
+      "description": "Shortcut to match by filesystem presence: \"any\" matches formatted devices, \"none\" matches unformatted ones.",
+      "enum": ["any", "none"]
+    },
+    "filesystemCondition": {
+      "description": "Matches formatted devices whose file system satisfies the condition.",
+      "anyOf": [
+        { "$ref": "#/$defs/filesystemConditionType" },
+        { "$ref": "#/$defs/filesystemConditionLabel" },
+        { "$ref": "#/$defs/filesystemConditionAnd" },
+        { "$ref": "#/$defs/filesystemConditionOr" },
+        { "$ref": "#/$defs/filesystemConditionNot" }
+      ]
+    },
+    "filesystemConditionType": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "$ref": "#/$defs/filesystemTypeAny" }
+      }
+    },
+    "filesystemConditionLabel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label"],
+      "properties": {
+        "label": {
+          "description": "File system label.",
+          "type": "string"
+        }
+      }
+    },
+    "filesystemConditionAnd": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "description": "Matches when all the nested conditions match.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/filesystemCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "filesystemConditionOr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "description": "Matches when any of the nested conditions matches.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/filesystemCondition" },
+          "minItems": 2
+        }
+      }
+    },
+    "filesystemConditionNot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "description": "Matches when the nested condition does not match.",
+          "$ref": "#/$defs/filesystemCondition"
         }
       }
     },

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/search.rb
@@ -85,12 +85,13 @@ module Agama
           # @return [Hash{Symbol => Proc}]
           def condition_builders
             {
-              name:   ->(j) { Configs::SearchConditions::Name.new(j[:name]) },
-              size:   ->(j) { FromJSONConversions::SearchConditions::Size.new(j[:size]).convert },
-              number: ->(j) { Configs::SearchConditions::PartitionNumber.new(j[:number]) },
-              and:    ->(j) { Configs::SearchConditions::And.new(convert_conditions(j[:and])) },
-              or:     ->(j) { Configs::SearchConditions::Or.new(convert_conditions(j[:or])) },
-              not:    ->(j) { Configs::SearchConditions::Not.new(convert_condition(j[:not])) }
+              name:       ->(j) { Configs::SearchConditions::Name.new(j[:name]) },
+              size:       ->(j) { SearchConditions::Size.new(j[:size]).convert },
+              number:     ->(j) { Configs::SearchConditions::PartitionNumber.new(j[:number]) },
+              filesystem: ->(j) { SearchConditions::Filesystem.new(j[:filesystem]).convert },
+              and:        ->(j) { Configs::SearchConditions::And.new(convert_conditions(j[:and])) },
+              or:         ->(j) { Configs::SearchConditions::Or.new(convert_conditions(j[:or])) },
+              not:        ->(j) { Configs::SearchConditions::Not.new(convert_condition(j[:not])) }
             }
           end
 

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/search_conditions.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/search_conditions.rb
@@ -32,3 +32,4 @@ module Agama
 end
 
 require "agama/storage/config_conversions/from_json_conversions/search_conditions/size"
+require "agama/storage/config_conversions/from_json_conversions/search_conditions/filesystem"

--- a/service/lib/agama/storage/config_conversions/from_json_conversions/search_conditions/filesystem.rb
+++ b/service/lib/agama/storage/config_conversions/from_json_conversions/search_conditions/filesystem.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "agama/storage/config_conversions/from_json_conversions/base"
+require "agama/storage/configs/search_conditions"
+require "y2storage/filesystems/type"
+
+module Agama
+  module Storage
+    module ConfigConversions
+      module FromJSONConversions
+        module SearchConditions
+          # Filesystem condition conversion from JSON according to schema.
+          class Filesystem < Base
+          private
+
+            # @see Base
+            # @return [Configs::SearchConditions::Filesystem]
+            def default_config
+              Configs::SearchConditions::Filesystem.new
+            end
+
+            alias_method :filesystem_json, :config_json
+
+            # @see Base#conversions
+            # @return [Hash]
+            def conversions
+              {
+                presence:  convert_presence,
+                condition: convert_condition
+              }
+            end
+
+            # @return [Symbol, nil] :any or :none for the presence shortcut, nil otherwise.
+            def convert_presence
+              return unless filesystem_json.is_a?(String)
+
+              filesystem_json.to_sym
+            end
+
+            # Recursively converts a filesystem condition JSON into a condition config.
+            #
+            # @param json [Hash, nil] defaults to the top-level condition object.
+            # @return [Configs::SearchConditions::FilesystemType,
+            #   Configs::SearchConditions::FilesystemLabel, Configs::SearchConditions::And,
+            #   Configs::SearchConditions::Or, Configs::SearchConditions::Not, nil]
+            def convert_condition(json = filesystem_json)
+              return if json.is_a?(String) || json.nil?
+
+              _key, builder = condition_builders.find { |k, _| json.key?(k) }
+              builder&.call(json)
+            end
+
+            # Builders for each type of filesystem condition, indexed by its JSON key.
+            #
+            # @return [Hash{Symbol => Proc}]
+            def condition_builders
+              {
+                type:  ->(j) { type_condition(j[:type]) },
+                label: ->(j) { Configs::SearchConditions::FilesystemLabel.new(j[:label]) },
+                and:   ->(j) { Configs::SearchConditions::And.new(convert_conditions(j[:and])) },
+                or:    ->(j) { Configs::SearchConditions::Or.new(convert_conditions(j[:or])) },
+                not:   ->(j) { Configs::SearchConditions::Not.new(convert_condition(j[:not])) }
+              }
+            end
+
+            # Converts a collection of filesystem condition JSONs into condition configs.
+            #
+            # @param json [Array<Hash>]
+            # @return [Array]
+            def convert_conditions(json)
+              json.map { |c| convert_condition(c) }
+            end
+
+            # @param value [String]
+            # @return [Configs::SearchConditions::FilesystemType]
+            def type_condition(value)
+              fs_type = Y2Storage::Filesystems::Type.find(value.to_sym)
+              Configs::SearchConditions::FilesystemType.new(fs_type)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
+++ b/service/lib/agama/storage/config_conversions/to_json_conversions/search.rb
@@ -62,6 +62,14 @@ module Agama
           # @param node [Configs::SearchConditions::*, nil]
           # @return [Hash, nil]
           def convert_condition_node(node)
+            convert_leaf_node(node) || convert_operator_node(node)
+          end
+
+          # Serializes a leaf condition node.
+          #
+          # @param node [Configs::SearchConditions::*, nil]
+          # @return [Hash, nil]
+          def convert_leaf_node(node)
             case node
             when Configs::SearchConditions::Name
               { name: node.name }
@@ -69,6 +77,21 @@ module Agama
               { number: node.number }
             when Configs::SearchConditions::Size
               { size: { node.operator => node.value.to_i } }
+            when Configs::SearchConditions::Filesystem
+              { filesystem: convert_filesystem_value(node) }
+            when Configs::SearchConditions::FilesystemType
+              { type: node.fs_type.to_s }
+            when Configs::SearchConditions::FilesystemLabel
+              { label: node.label }
+            end
+          end
+
+          # Serializes an operator condition node.
+          #
+          # @param node [Configs::SearchConditions::*, nil]
+          # @return [Hash, nil]
+          def convert_operator_node(node)
+            case node
             when Configs::SearchConditions::And
               { and: convert_conditions(node.conditions) }
             when Configs::SearchConditions::Or
@@ -76,6 +99,17 @@ module Agama
             when Configs::SearchConditions::Not
               { not: convert_condition_node(node.condition) }
             end
+          end
+
+          # Serializes the value of a Filesystem condition: the presence shortcut
+          # ("any"/"none") or the nested filesystem condition object.
+          #
+          # @param node [Configs::SearchConditions::Filesystem]
+          # @return [String, Hash, nil]
+          def convert_filesystem_value(node)
+            return convert_condition_node(node.condition) if node.condition
+
+            node.presence&.to_s
           end
 
           # Serializes a collection of condition nodes.

--- a/service/lib/agama/storage/config_solvers/search_matchers.rb
+++ b/service/lib/agama/storage/config_solvers/search_matchers.rb
@@ -75,6 +75,25 @@ module Agama
           when Configs::SearchConditions::PartitionNumber
             match_partition_number?(node, device)
           else
+            match_filesystem_leaf?(node, device)
+          end
+        end
+
+        # Evaluates a filesystem leaf condition node against a device.
+        #
+        # @param node [Configs::SearchConditions::*]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_filesystem_leaf?(node, device)
+          case node
+          when Configs::SearchConditions::Filesystem
+            match_filesystem?(node, device)
+          when Configs::SearchConditions::FilesystemType
+            match_filesystem_type?(node, device)
+          when Configs::SearchConditions::FilesystemLabel
+            match_filesystem_label?(node, device)
+          else
             false
           end
         end
@@ -123,6 +142,70 @@ module Agama
           return false unless device.is?(:partition)
 
           device.number == node.number
+        end
+
+        # Whether the filesystem of the given device matches the condition node.
+        #
+        # The object (condition) form implies "formatted", so it requires a filesystem
+        # before evaluating the nested condition. The presence shortcut checks whether the
+        # device is formatted (:any) or unformatted (:none).
+        #
+        # @param node [Configs::SearchConditions::Filesystem]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_filesystem?(node, device)
+          filesystem = device_filesystem(device)
+          return !filesystem.nil? && match_node?(node.condition, device) if node.condition
+
+          case node.presence
+          when :any
+            !filesystem.nil?
+          when :none
+            filesystem.nil?
+          else
+            true
+          end
+        end
+
+        # Whether the filesystem type of the given device matches the condition node.
+        #
+        # @param node [Configs::SearchConditions::FilesystemType]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_filesystem_type?(node, device)
+          return true unless node.fs_type
+
+          filesystem = device_filesystem(device)
+          return false unless filesystem
+
+          filesystem.type == node.fs_type
+        end
+
+        # Whether the filesystem label of the given device matches the condition node.
+        #
+        # @param node [Configs::SearchConditions::FilesystemLabel]
+        # @param device [Y2Storage::Device]
+        #
+        # @return [Boolean]
+        def match_filesystem_label?(node, device)
+          return true unless node.label
+
+          filesystem = device_filesystem(device)
+          return false unless filesystem
+
+          filesystem.label == node.label
+        end
+
+        # Filesystem of the given device, if any.
+        #
+        # @param device [Y2Storage::Device]
+        # @return [Y2Storage::Filesystems::Base, nil]
+        def device_filesystem(device)
+          return unless device.respond_to?(:filesystem)
+
+          device.filesystem
         end
       end
     end

--- a/service/lib/agama/storage/configs/search_conditions/filesystem.rb
+++ b/service/lib/agama/storage/configs/search_conditions/filesystem.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,19 +22,26 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition for searching by filesystem presence or properties.
+        #
+        # Either a presence shortcut (:any for formatted, :none for unformatted) or a
+        # nested condition over the filesystem properties (which implies "formatted").
+        class Filesystem
+          # @return [:any, :none, nil]
+          attr_accessor :presence
+
+          # @return [SearchConditions::*, nil]
+          attr_accessor :condition
+
+          # @param presence [:any, :none, nil]
+          # @param condition [SearchConditions::*, nil]
+          def initialize(presence: nil, condition: nil)
+            @presence = presence
+            @condition = condition
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/filesystem"
-require "agama/storage/configs/search_conditions/filesystem_type"
-require "agama/storage/configs/search_conditions/filesystem_label"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/search_conditions/filesystem_label.rb
+++ b/service/lib/agama/storage/configs/search_conditions/filesystem_label.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,19 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition for searching by filesystem label.
+        class FilesystemLabel
+          # @return [String, nil]
+          attr_accessor :label
+
+          # @param label [String, nil]
+          def initialize(label = nil)
+            @label = label
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/filesystem"
-require "agama/storage/configs/search_conditions/filesystem_type"
-require "agama/storage/configs/search_conditions/filesystem_label"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/lib/agama/storage/configs/search_conditions/filesystem_type.rb
+++ b/service/lib/agama/storage/configs/search_conditions/filesystem_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025-2026] SUSE LLC
+# Copyright (c) [2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,19 +22,18 @@
 module Agama
   module Storage
     module Configs
-      # Namespace for conditions used for searching devices.
       module SearchConditions
+        # Condition for searching by filesystem type.
+        class FilesystemType
+          # @return [Y2Storage::Filesystems::Type, nil]
+          attr_accessor :fs_type
+
+          # @param fs_type [Y2Storage::Filesystems::Type, nil]
+          def initialize(fs_type = nil)
+            @fs_type = fs_type
+          end
+        end
       end
     end
   end
 end
-
-require "agama/storage/configs/search_conditions/size"
-require "agama/storage/configs/search_conditions/name"
-require "agama/storage/configs/search_conditions/partition_number"
-require "agama/storage/configs/search_conditions/filesystem"
-require "agama/storage/configs/search_conditions/filesystem_type"
-require "agama/storage/configs/search_conditions/filesystem_label"
-require "agama/storage/configs/search_conditions/and"
-require "agama/storage/configs/search_conditions/or"
-require "agama/storage/configs/search_conditions/not"

--- a/service/test/agama/storage/config_checkers/search_test.rb
+++ b/service/test/agama/storage/config_checkers/search_test.rb
@@ -119,6 +119,23 @@ describe Agama::Storage::ConfigCheckers::Search do
       end
     end
 
+    context "if the search condition is a filesystem" do
+      let(:search) do
+        {
+          condition:  { filesystem: { type: "xfs" } },
+          ifNotFound: "error"
+        }
+      end
+
+      it "includes a generic not found issue without any device name" do
+        issues = subject.issues
+        expect(issues).to include an_object_having_attributes(
+          kind:        Agama::Storage::IssueClasses::Config::SEARCH_NOT_FOUND,
+          description: "Mandatory drive not found"
+        )
+      end
+    end
+
     context "if a MD RAID is reused" do
       let(:config_json) do
         {

--- a/service/test/agama/storage/config_conversions/from_json_conversions/search_test.rb
+++ b/service/test/agama/storage/config_conversions/from_json_conversions/search_test.rb
@@ -23,6 +23,7 @@ require_relative "../../../../test_helper"
 require "agama/storage/config_conversions/from_json_conversions/search"
 require "agama/storage/configs/search"
 require "agama/storage/configs/search_conditions"
+require "y2storage/filesystems/type"
 require "y2storage/refinements"
 
 using Y2Storage::Refinements::SizeCasts
@@ -186,6 +187,111 @@ describe Agama::Storage::ConfigConversions::FromJSONConversions::Search do
             expect(config.condition)
               .to be_a(Agama::Storage::Configs::SearchConditions::PartitionNumber)
             expect(config.condition.number).to eq(2)
+          end
+        end
+
+        context "and 'filesystem' is specified" do
+          context "with the 'any' presence shortcut" do
+            let(:condition) { { filesystem: "any" } }
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              expect(config.condition)
+                .to be_a(Agama::Storage::Configs::SearchConditions::Filesystem)
+              expect(config.condition.presence).to eq(:any)
+              expect(config.condition.condition).to be_nil
+            end
+          end
+
+          context "with the 'none' presence shortcut" do
+            let(:condition) { { filesystem: "none" } }
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              expect(config.condition)
+                .to be_a(Agama::Storage::Configs::SearchConditions::Filesystem)
+              expect(config.condition.presence).to eq(:none)
+              expect(config.condition.condition).to be_nil
+            end
+          end
+
+          context "with a filesystem type condition" do
+            let(:condition) { { filesystem: { type: "ext4" } } }
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              expect(config.condition)
+                .to be_a(Agama::Storage::Configs::SearchConditions::Filesystem)
+              expect(config.condition.presence).to be_nil
+
+              inner = config.condition.condition
+              expect(inner).to be_a(Agama::Storage::Configs::SearchConditions::FilesystemType)
+              expect(inner.fs_type).to eq(Y2Storage::Filesystems::Type::EXT4)
+            end
+          end
+
+          context "with a filesystem label condition" do
+            let(:condition) { { filesystem: { label: "data" } } }
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              inner = config.condition.condition
+              expect(inner).to be_a(Agama::Storage::Configs::SearchConditions::FilesystemLabel)
+              expect(inner.label).to eq("data")
+            end
+          end
+
+          context "with an 'and' operator over filesystem conditions" do
+            let(:condition) do
+              { filesystem: { and: [{ type: "btrfs" }, { label: "root" }] } }
+            end
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              inner = config.condition.condition
+              expect(inner).to be_a(Agama::Storage::Configs::SearchConditions::And)
+
+              conditions = inner.conditions
+              expect(conditions.size).to eq(2)
+
+              expect(conditions[0])
+                .to be_a(Agama::Storage::Configs::SearchConditions::FilesystemType)
+              expect(conditions[0].fs_type).to eq(Y2Storage::Filesystems::Type::BTRFS)
+
+              expect(conditions[1])
+                .to be_a(Agama::Storage::Configs::SearchConditions::FilesystemLabel)
+              expect(conditions[1].label).to eq("root")
+            end
+          end
+
+          context "with a 'not' operator over a filesystem condition" do
+            let(:condition) { { filesystem: { not: { type: "swap" } } } }
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              inner = config.condition.condition
+              expect(inner).to be_a(Agama::Storage::Configs::SearchConditions::Not)
+
+              type_condition = inner.condition
+              expect(type_condition)
+                .to be_a(Agama::Storage::Configs::SearchConditions::FilesystemType)
+              expect(type_condition.fs_type).to eq(Y2Storage::Filesystems::Type::SWAP)
+            end
+          end
+
+          context "nested inside a device-level operator" do
+            let(:condition) do
+              { and: [{ name: "/dev/vda" }, { filesystem: "none" }] }
+            end
+
+            it "sets #condition to the expected value" do
+              config = subject.convert
+              conditions = config.condition.conditions
+
+              expect(conditions[1])
+                .to be_a(Agama::Storage::Configs::SearchConditions::Filesystem)
+              expect(conditions[1].presence).to eq(:none)
+            end
           end
         end
 

--- a/service/test/agama/storage/config_conversions/model_support_checker_test.rb
+++ b/service/test/agama/storage/config_conversions/model_support_checker_test.rb
@@ -144,7 +144,7 @@ describe Agama::Storage::ModelSupportChecker do
     end
 
     # The search only combines conditions with an operator, so it has no top-level name.
-    context "if there is a drive searched with an operator condition" do
+    context "if a drive searched with an operator condition is not found" do
       let(:scenario) { "empty-hd-50GiB.yaml" }
 
       let(:config_json) do
@@ -154,6 +154,27 @@ describe Agama::Storage::ModelSupportChecker do
             {
               search: {
                 condition:  { and: [{ name: "/dev/vdb" }, { size: { greater: "1 GiB" } }] },
+                ifNotFound: if_not_found
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "partitionable without name"
+    end
+
+    # The search matches by filesystem, so it has no top-level name.
+    context "if a drive searched with a filesystem condition is not found" do
+      let(:scenario) { "empty-hd-50GiB.yaml" }
+
+      let(:config_json) do
+        {
+          drives: [
+            {},
+            {
+              search: {
+                condition:  { filesystem: { type: "ext4" } },
                 ifNotFound: if_not_found
               }
             }

--- a/service/test/agama/storage/config_conversions/to_json_conversions/search_test.rb
+++ b/service/test/agama/storage/config_conversions/to_json_conversions/search_test.rb
@@ -170,6 +170,57 @@ describe Agama::Storage::ConfigConversions::ToJSONConversions::Search do
       end
     end
 
+    context "if #condition is configured to search by filesystem presence" do
+      context "with the 'any' shortcut" do
+        let(:condition) { { filesystem: "any" } }
+
+        it "generates the expected JSON" do
+          config_json = subject.convert
+          expect(config_json[:condition]).to eq({ filesystem: "any" })
+        end
+      end
+
+      context "with the 'none' shortcut" do
+        let(:condition) { { filesystem: "none" } }
+
+        it "generates the expected JSON" do
+          config_json = subject.convert
+          expect(config_json[:condition]).to eq({ filesystem: "none" })
+        end
+      end
+    end
+
+    context "if #condition is configured to search by filesystem type" do
+      let(:condition) { { filesystem: { type: "ext4" } } }
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq({ filesystem: { type: "ext4" } })
+      end
+    end
+
+    context "if #condition is configured to search by filesystem label" do
+      let(:condition) { { filesystem: { label: "data" } } }
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq({ filesystem: { label: "data" } })
+      end
+    end
+
+    context "if #condition is configured with a filesystem operator" do
+      let(:condition) do
+        { filesystem: { and: [{ type: "btrfs" }, { not: { label: "root" } }] } }
+      end
+
+      it "generates the expected JSON" do
+        config_json = subject.convert
+        expect(config_json[:condition]).to eq(
+          { filesystem: { and: [{ type: "btrfs" }, { not: { label: "root" } }] } }
+        )
+      end
+    end
+
     context "if #condition is configured with nested operators" do
       let(:condition) do
         {

--- a/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
+++ b/service/test/agama/storage/config_conversions/to_model_conversions/examples.rb
@@ -479,6 +479,41 @@ shared_examples "device name" do |device_config_fn = nil|
           end
         end
       end
+
+      context "and the device is searched by a filesystem condition" do
+        let(:condition) { { filesystem: { type: "ext4" } } }
+
+        context "if the device is not found" do
+          before { device_config.search.solve }
+
+          context "and the device does not have to be created" do
+            let(:if_not_found) { "error" }
+
+            it "generates the expected JSON" do
+              model_json = subject.convert
+              expect(model_json.keys).to_not include(:name)
+            end
+          end
+
+          context "and the device has to be created" do
+            let(:if_not_found) { "create" }
+
+            it "generates the expected JSON" do
+              model_json = subject.convert
+              expect(model_json.keys).to_not include(:name)
+            end
+          end
+        end
+
+        context "if the device is found" do
+          before { device_config.search.solve(device) }
+
+          it "generates the expected JSON" do
+            model_json = subject.convert
+            expect(model_json[:name]).to eq(device.name)
+          end
+        end
+      end
     end
   end
 end

--- a/service/test/agama/storage/config_solvers/drives_search_test.rb
+++ b/service/test/agama/storage/config_solvers/drives_search_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -370,6 +370,76 @@ describe Agama::Storage::ConfigSolvers::DrivesSearch do
           let(:value) { "100 GiB" }
           include_examples "do not find device"
         end
+      end
+    end
+
+    context "if a drive config has a search with a filesystem" do
+      let(:drives) do
+        [
+          {
+            search: {
+              condition: condition
+            }
+          }
+        ]
+      end
+
+      shared_examples "find device" do |device|
+        it "sets the device to the drive config" do
+          subject.solve(config)
+          expect(config.drives.size).to eq(1)
+
+          drive1 = config.drives.first
+          expect(drive1.search.solved?).to eq(true)
+          expect(drive1.search.device.name).to eq(device)
+        end
+      end
+
+      shared_examples "do not find device" do
+        it "does not set a device to the drive config" do
+          subject.solve(config)
+          expect(config.drives.size).to eq(1)
+
+          drive1 = config.drives.first
+          expect(drive1.search.solved?).to eq(true)
+          expect(drive1.search.device).to be_nil
+        end
+      end
+
+      context "and the presence is 'any'" do
+        let(:condition) { { filesystem: "any" } }
+        include_examples "find device", "/dev/vdc"
+      end
+
+      context "and the presence is 'none'" do
+        let(:condition) { { filesystem: "none" } }
+
+        it "sets a device to each unformatted disk config" do
+          subject.solve(config)
+          expect(config.drives.map(&:search).map(&:device).map(&:name)).to contain_exactly(
+            "/dev/vda", "/dev/vdb"
+          )
+        end
+      end
+
+      context "and a filesystem type is given" do
+        context "and there is a disk with that type" do
+          let(:condition) { { filesystem: { type: "ext4" } } }
+          include_examples "find device", "/dev/vdc"
+        end
+
+        context "and there is no disk with that type" do
+          let(:condition) { { filesystem: { type: "xfs" } } }
+          include_examples "do not find device"
+        end
+      end
+
+      context "and it is combined with a device condition" do
+        let(:condition) do
+          { and: [{ name: "/dev/vdc" }, { filesystem: { type: "ext4" } }] }
+        end
+
+        include_examples "find device", "/dev/vdc"
       end
     end
 

--- a/service/test/agama/storage/config_solvers/logical_volumes_search_test.rb
+++ b/service/test/agama/storage/config_solvers/logical_volumes_search_test.rb
@@ -123,6 +123,49 @@ describe Agama::Storage::ConfigSolvers::LogicalVolumesSearch do
           end
         end
       end
+
+      context "if a logical volume config has a search with a filesystem" do
+        let(:logical_volumes) do
+          [
+            { search: { condition: condition } }
+          ]
+        end
+
+        context "and a filesystem type is given" do
+          let(:condition) { { filesystem: { type: "btrfs" } } }
+
+          it "sets the matching LV to the logical volume config" do
+            subject.solve(volume_group)
+            logical_volumes = volume_group.logical_volumes
+            expect(logical_volumes.size).to eq(1)
+            expect(logical_volumes.first.search.device.name).to eq("/dev/system/root")
+          end
+        end
+
+        context "and a 'not' filesystem operator is given" do
+          let(:condition) { { filesystem: { not: { type: "swap" } } } }
+
+          it "sets the non-swap LVs to the logical volume configs" do
+            subject.solve(volume_group)
+            logical_volumes = volume_group.logical_volumes
+            expect(logical_volumes.map { |l| l.search.device.name }).to contain_exactly(
+              "/dev/system/root"
+            )
+          end
+        end
+
+        context "and the presence is 'any'" do
+          let(:condition) { { filesystem: "any" } }
+
+          it "sets all the formatted LVs to the logical volume configs" do
+            subject.solve(volume_group)
+            logical_volumes = volume_group.logical_volumes
+            expect(logical_volumes.map { |l| l.search.device.name }).to contain_exactly(
+              "/dev/system/root", "/dev/system/swap"
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/service/test/agama/storage/config_solvers/md_raids_search_test.rb
+++ b/service/test/agama/storage/config_solvers/md_raids_search_test.rb
@@ -368,6 +368,63 @@ describe Agama::Storage::ConfigSolvers::MdRaidsSearch do
       end
     end
 
+    context "if a MD RAID config has a search with a filesystem" do
+      let(:scenario) { "md_raids_formatted.yaml" }
+
+      let(:md_raids) do
+        [
+          {
+            search: {
+              condition: condition
+            }
+          }
+        ]
+      end
+
+      context "and a filesystem type is given" do
+        let(:condition) { { filesystem: { type: "ext4" } } }
+
+        it "sets the matching MD RAID to the config" do
+          subject.solve(config)
+          expect(config.md_raids.size).to eq(1)
+          expect(config.md_raids.first.search.device.name).to eq("/dev/md1")
+        end
+      end
+
+      context "and a filesystem label is given" do
+        let(:condition) { { filesystem: { label: "data" } } }
+
+        it "sets the matching MD RAID to the config" do
+          subject.solve(config)
+          expect(config.md_raids.size).to eq(1)
+          expect(config.md_raids.first.search.device.name).to eq("/dev/md2")
+        end
+      end
+
+      context "and the presence is 'none'" do
+        let(:condition) { { filesystem: "none" } }
+
+        it "sets the unformatted MD RAID to the config" do
+          subject.solve(config)
+          expect(config.md_raids.size).to eq(1)
+          expect(config.md_raids.first.search.device.name).to eq("/dev/md0")
+        end
+      end
+
+      context "and it is combined with an 'or' operator" do
+        let(:condition) do
+          { or: [{ filesystem: "none" }, { filesystem: { type: "xfs" } }] }
+        end
+
+        it "sets a device to each MD RAID config matching any nested condition" do
+          subject.solve(config)
+          expect(config.md_raids.map(&:search).map(&:device).map(&:name)).to contain_exactly(
+            "/dev/md0", "/dev/md2"
+          )
+        end
+      end
+    end
+
     context "if a MD RAID config has partitions with search" do
       let(:md_raids) do
         [

--- a/service/test/agama/storage/config_solvers/partitions_search_test.rb
+++ b/service/test/agama/storage/config_solvers/partitions_search_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -333,6 +333,41 @@ describe Agama::Storage::ConfigSolvers::PartitionsSearch do
         context "and the device is not found" do
           let(:number) { 20 }
           include_examples "do not find device"
+        end
+      end
+
+      context "if a partition config has a search with a filesystem" do
+        let(:partitions) do
+          [
+            {
+              search: {
+                condition: condition
+              }
+            }
+          ]
+        end
+
+        context "and a filesystem type is given" do
+          let(:condition) { { filesystem: { type: "btrfs" } } }
+          include_examples "find device", "/dev/vda2"
+        end
+
+        context "and a filesystem label is given" do
+          let(:condition) { { filesystem: { label: "previous_home" } } }
+          include_examples "find device", "/dev/vda3"
+        end
+
+        context "and the presence is 'none'" do
+          let(:condition) { { filesystem: "none" } }
+          include_examples "find device", "/dev/vda1"
+        end
+
+        context "and the filesystem condition combines operators" do
+          let(:condition) do
+            { filesystem: { and: [{ type: "xfs" }, { not: { label: "previous_root" } }] } }
+          end
+
+          include_examples "find device", "/dev/vda3"
         end
       end
 

--- a/service/test/fixtures/md_raids_formatted.yaml
+++ b/service/test/fixtures/md_raids_formatted.yaml
@@ -1,0 +1,64 @@
+---
+- disk:
+    name: /dev/vda
+    size: 500 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 10 GiB
+        name: /dev/vda1
+    - partition:
+        size: 10 GiB
+        name: /dev/vda2
+    - partition:
+        size: 10 GiB
+        name: /dev/vda3
+- disk:
+    name: /dev/vdb
+    size: 500 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 10 GiB
+        name: /dev/vdb1
+    - partition:
+        size: 10 GiB
+        name: /dev/vdb2
+    - partition:
+        size: 10 GiB
+        name: /dev/vdb3
+- md:
+    name: "/dev/md0"
+    chunk_size: 16 KiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 1 GiB
+        name: /dev/md0p1
+    - partition:
+        size: 1 GiB
+        name: /dev/md0p2
+    md_devices:
+    - md_device:
+        blk_device: /dev/vda1
+    - md_device:
+        blk_device: /dev/vdb1
+- md:
+    name: "/dev/md1"
+    chunk_size: 16 KiB
+    file_system: ext4
+    md_devices:
+    - md_device:
+        blk_device: /dev/vda2
+    - md_device:
+        blk_device: /dev/vdb2
+- md:
+    name: "/dev/md2"
+    chunk_size: 16 KiB
+    file_system: xfs
+    label: "data"
+    md_devices:
+    - md_device:
+        blk_device: /dev/vda3
+    - md_device:
+        blk_device: /dev/vdb3


### PR DESCRIPTION
## Storage search: `filesystem` condition

Adding a new `filesystem` search leaf so devices can be matched by their **filesystem**: presence, type, or label. Implemented end-to-end for the new leaf: JSON schema, from/to JSON conversions, config solversm checkers, and the model layer.

### The `filesystem` condition

A `filesystem` leaf can appear in the search condition of `drives`, `mdRaids`, `partitions`, and `logicalVolumes` (not `volumeGroups` — they have no filesystem). It takes one of three shapes:

| Shape | Matches |
|-------|---------|
| `"any"` | any **formatted** device |
| `"none"` | any **unformatted** device |
| object (`type` / `label` / nested `and`/`or`/`not`) | a formatted device meeting the condition |

The object form always implies "is formatted".

```jsonc
// Formatted vs. unformatted
{ "search": { "condition": { "filesystem": "any" } } }
{ "search": { "condition": { "filesystem": "none" } } }

// By filesystem type
{ "search": { "condition": { "filesystem": { "type": "ext4" } } } }

// By filesystem label
{ "search": { "condition": { "filesystem": { "label": "data" } } } }
```

The `filesystem` object supports its own nested boolean tree:

```jsonc
{
  "search": {
    "condition": {
      "filesystem": {
        "and": [
          { "type": "btrfs" },
          { "not": { "label": "root" } }
        ]
      }
    }
  }
}
```

And it composes with the device-level operators — e.g. "a partition larger than 10 GiB formatted as xfs":

```jsonc
{
  "search": {
    "condition": {
      "and": [
        { "size": { "greater": "10 GiB" } },
        { "filesystem": { "type": "xfs" } }
      ]
    }
  }
}
```
