### PR TITLE
feat(web): enhance the product theming role system with corner-radius and logo controls

### DIFF
--- a/doc/product_theming.md
+++ b/doc/product_theming.md
@@ -1,0 +1,123 @@
+# Creating a product skin
+
+A distributor can restyle the Agama web UI for their product without touching
+application code: colors, logo, and a handful of other roles are set in a
+single per-product file, loaded at runtime after Agama's own styles.
+
+> **Important**: no matter whether an AI or a human wrote it, every line
+> (color values, contrast numbers, SVG content, any role-API change) must be
+> reviewed and manually tested in the running app, in both light and dark
+> mode, before asking for the color schema to be included in the project. A
+> report of "done" or "verified" is not a substitute for someone actually
+> looking at it.
+
+## What a skin can change
+
+- **Colors and roles**: a curated set of `--agm-t--*` CSS custom properties
+  (brand color, surface/text/border colors, status colors, focus ring, corner
+  radius, product logo size/alignment, and a few typography/icon-size
+  hooks). `web/src/assets/products/example.css` is the basic reference
+  (colors only, covers most products); `example-advanced.css` documents every
+  available role with a worked example. `web/src/assets/styles/tokens/_semantic.scss`'s
+  header comment is the authoritative, up-to-date index of every role.
+- **Logo**: `<product-id>.svg` (light theme) and `<product-id>-dark.svg`
+  (dark theme), transparent background. Match the square-ish aspect ratio of
+  the existing logos in that folder: `ProductLogo` renders it at a small
+  fixed width per usage context (masthead, next to the product name, ...), so
+  a very wide or tall logo will look cramped or oversized.
+
+## Steps
+
+1. Copy `example.css` (or `example-advanced.css` for the full role set) to
+   `web/src/assets/products/<product-id>.css`. Set only the roles the brand
+   actually needs; anything left unset keeps Agama's default look.
+2. Add the logo files described above.
+3. Verify WCAG contrast for every color you set, **in both light and dark
+   theme separately** (a value that passes in one theme can fail in the
+   other, and dark-theme "elevated" surfaces like tooltips/popovers need to
+   read *lighter* than the page, not darker): run
+   `npm run check-contrast -- <foreground> <background> [--target=4.5]`
+   (`web/scripts/check-contrast.js`). Use `--target=3` for UI elements and
+   focus rings, the default 4.5 for normal text. When a pair fails, the tool
+   suggests a same-hue, same-saturation shade that passes.
+4. If you hand-edit an SVG, validate it with `xmllint --noout <file>.svg`
+   before considering it done: a stray `--` inside an XML comment silently
+   breaks rendering in browsers.
+5. If the brand needs something the current roles don't cover, that's a gap
+   in the shared token layer (`_semantic.scss` / `_patternfly-overrides.scss`),
+   not something to work around per product. See "Extending the role API"
+   below.
+
+## Extending the role API
+
+Every role is documented and resolved in one place:
+`web/src/assets/styles/tokens/_semantic.scss` maps each `--agm-t--*` role onto
+the PatternFly tokens it affects, with the current Agama value as the
+fallback default. A product file must only ever set `--agm-t--*` roles, never
+a raw PatternFly or component-level variable directly.
+
+Adding a role that's genuinely missing:
+
+1. Add the role to `_semantic.scss`'s role-index comment and resolve it at
+   its real consumption point (a PF global token in `_semantic.scss`, or a
+   component-level override in `_patternfly-overrides.scss`), with the
+   current Agama value as the fallback so leaving it unset changes nothing.
+2. Document it with a worked example in `example-advanced.css`.
+3. Before assuming one token covers a whole category (e.g. "corner radius"),
+   check whether PatternFly actually splits that concern into several
+   independent tiers under the hood; grep the component CSS for the relevant
+   property and trace each occurrence back to its root token.
+
+## Prompting an AI to do this
+
+Fill in the placeholders and paste:
+
+> Create a product skin for `<PRODUCT_ID>` (an existing product id in
+> `web/src/assets/products/`) using this brand: `<paste colors, and/or a link
+> to the brand's site or guidelines>`.
+>
+> First read `web/src/assets/products/example.css`, `example-advanced.css`,
+> and the role-index comment at the top of
+> `web/src/assets/styles/tokens/_semantic.scss`, so you know the current
+> `--agm-t--*` role set rather than assuming it. A product file only ever
+> sets these roles; never a raw PatternFly or component-level variable
+> directly.
+>
+> For every color you set: compute WCAG contrast explicitly with
+> `npm run check-contrast -- <foreground> <background> [--target=4.5]`
+> (`--target=3` for UI elements/focus rings), in both light and dark theme
+> separately, rather than eyeballing. Where a brand color fails, use the
+> tool's suggested same-hue/saturation shade rather than an unrelated
+> substitute. Dark-theme elevated surfaces (tooltips, popovers) need to read
+> lighter than the page, not darker.
+>
+> For the logo: read `ProductLogo` and its callers first to find the actual
+> rendered size/aspect ratio each usage needs, and match the square-ish shape
+> of existing logos in that folder. Validate any hand-edited SVG with
+> `xmllint --noout` and a rendered preview at the real consuming size, in
+> both themes, before calling it done.
+>
+> **If something can't be done with the current `--agm-t--*` role set, don't
+> get creative.** Do not set a raw PatternFly token or component-variable
+> override from the product CSS file, and do not work around the "products
+> only set `--agm-t--*` roles" contract. Stop and present a plan for
+> extending the shared token API instead: the new role's name, where it gets
+> documented (a role-index comment in `_semantic.scss`) and resolved (a PF
+> global token in `_semantic.scss`, or a component-level override in
+> `_patternfly-overrides.scss`, with the current Agama value as the fallback
+> default so leaving it unset changes nothing), a worked example added to
+> `example-advanced.css`, and whether PatternFly actually splits the
+> underlying concern into several independent tokens under the hood (check
+> before assuming one override reaches everywhere it should). Get that plan
+> approved before writing any code.
+
+### If you already know the API needs extending
+
+When the brand needs something you already know isn't covered (not just an
+unexpected gap found mid-task), say so upfront in the same prompt so the AI
+plans for it from the start instead of discovering it partway through:
+
+> This brand also needs `<describe the missing capability, e.g. "square
+> corners on every control, not just buttons">`, which the current
+> `--agm-t--*` role set doesn't cover. Present a plan for the new role before
+> touching any file.

--- a/doc/product_theming.md
+++ b/doc/product_theming.md
@@ -1,15 +1,8 @@
 # Creating a product skin
 
-A distributor can restyle the Agama web UI for their product without touching
-application code: colors, logo, and a handful of other roles are set in a
-single per-product file, loaded at runtime after Agama's own styles.
-
-> **Important**: no matter whether an AI or a human wrote it, every line
-> (color values, contrast numbers, SVG content, any role-API change) must be
-> reviewed and manually tested in the running app, in both light and dark
-> mode, before asking for the color schema to be included in the project. A
-> report of "done" or "verified" is not a substitute for someone actually
-> looking at it.
+The Agama web UI can be restyled for a product without touching application
+code: colors, logo, and a handful of other roles are set in a single
+per-product file, loaded at runtime after Agama's own styles.
 
 ## What a skin can change
 
@@ -36,8 +29,8 @@ single per-product file, loaded at runtime after Agama's own styles.
    theme separately** (a value that passes in one theme can fail in the
    other, and dark-theme "elevated" surfaces like tooltips/popovers need to
    read *lighter* than the page, not darker): run
-   `npm run check-contrast -- <foreground> <background> [--target=4.5]`
-   (`web/scripts/check-contrast.js`). Use `--target=3` for UI elements and
+   `web/scripts/check-contrast.js <foreground> <background> [--target=4.5]`
+   (run from the repo root). Use `--target=3` for UI elements and
    focus rings, the default 4.5 for normal text. When a pair fails, the tool
    suggests a same-hue, same-saturation shade that passes.
 4. If you hand-edit an SVG, validate it with `xmllint --noout <file>.svg`
@@ -84,8 +77,8 @@ Fill in the placeholders and paste:
 > directly.
 >
 > For every color you set: compute WCAG contrast explicitly with
-> `npm run check-contrast -- <foreground> <background> [--target=4.5]`
-> (`--target=3` for UI elements/focus rings), in both light and dark theme
+> `web/scripts/check-contrast.js <foreground> <background> [--target=4.5]`
+> (run from the repo root; `--target=3` for UI elements/focus rings), in both light and dark theme
 > separately, rather than eyeballing. Where a brand color fails, use the
 > tool's suggested same-hue/saturation shade rather than an unrelated
 > substitute. Dark-theme elevated surfaces (tooltips, popovers) need to read
@@ -121,3 +114,11 @@ plans for it from the start instead of discovering it partway through:
 > corners on every control, not just buttons">`, which the current
 > `--agm-t--*` role set doesn't cover. Present a plan for the new role before
 > touching any file.
+
+> [!IMPORTANT]
+> No matter whether an AI or a human wrote it, every line (color values,
+> contrast numbers, SVG content, any role-API change) must be reviewed and
+> manually tested in the running app, in both light and dark mode, before
+> asking for the color schema to be included in the project. A report of
+> "done" or "verified" is not a substitute for someone actually looking at
+> it.

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "stylelint": "stylelint 'src/**/*.{css,scss}'",
     "stylelint:fix": "stylelint --fix 'src/**/*.{css,scss}'",
     "check-types": "tsc --skipLibCheck",
-    "test": "jest"
+    "test": "jest",
+    "check-contrast": "node scripts/check-contrast.js"
   },
   "engines": {
     "node": ">=18"

--- a/web/package.json
+++ b/web/package.json
@@ -17,8 +17,7 @@
     "stylelint": "stylelint 'src/**/*.{css,scss}'",
     "stylelint:fix": "stylelint --fix 'src/**/*.{css,scss}'",
     "check-types": "tsc --skipLibCheck",
-    "test": "jest",
-    "check-contrast": "node scripts/check-contrast.js"
+    "test": "jest"
   },
   "engines": {
     "node": ">=18"

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 21 17:37:15 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Add themeable roles for corner radius and product logo size and
+  alignment, plus a script for checking WCAG contrast when picking
+  role values (gh#agama-project/agama#3748).
+
+-------------------------------------------------------------------
 Mon Jul 20 11:12:34 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 23

--- a/web/scripts/check-contrast.js
+++ b/web/scripts/check-contrast.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/*
+ * Computes the WCAG contrast ratio between pairs of colors, e.g. when
+ * picking --agm-t--* role values for a product override
+ * (web/src/assets/products/<id>.css). Usage:
+ *
+ *   npm run check-contrast -- <hex1> <hex2> [<hex3> <hex4> ...] [--target=4.5]
+ *
+ * Each pair prints its ratio and whether it clears the common WCAG 2.x
+ * thresholds: 3:1 (UI components / focus rings / large text, SC 1.4.11 and
+ * 1.4.3), 4.5:1 (normal text, SC 1.4.3 AA), 7:1 (normal text, SC 1.4.6 AAA).
+ * When a pair fails --target (default 4.5), it also recommends a same-hue,
+ * same-saturation shade of the first color (lighter or darker, whichever is
+ * the smaller adjustment) that clears it against the fixed second color.
+ *
+ * Formula: WCAG 2.x relative luminance and contrast ratio, as specified at
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance and
+ * https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio. The sRGB-to-linear
+ * coefficients (0.2126 / 0.7152 / 0.0722) and the two-part linearization
+ * threshold (0.03928 / 12.92) come directly from that definition.
+ *
+ * Existing libraries such as https://www.npmjs.com/package/wcag-contrast and
+ * https://colorjs.io/ already implement this formula and could have been
+ * reused, with the same-hue/saturation shade suggestion added on top; this
+ * script reimplements it standalone instead, to avoid adding a dependency
+ * used only by this one theming script.
+ */
+
+function hexToRgb(hex) {
+  const clean = hex.replace(/^#/, "");
+  return [0, 2, 4].map((i) => parseInt(clean.slice(i, i + 2), 16));
+}
+
+function rgbToHex([r, g, b]) {
+  return [r, g, b].map((c) => Math.round(c).toString(16).padStart(2, "0")).join("");
+}
+
+function relativeLuminance([r, g, b]) {
+  const linearize = (channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+function contrastRatio(rgbA, rgbB) {
+  const [lighter, darker] = [relativeLuminance(rgbA), relativeLuminance(rgbB)].sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// Standard RGB <-> HSL conversions (each channel 0-255 in, 0-255 out; h/s/l
+// internally 0-1), used to hold hue and saturation fixed while scanning
+// lightness for a passing shade.
+function rgbToHsl([r, g, b]) {
+  [r, g, b] = [r, g, b].map((c) => c / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h;
+  switch (max) {
+    case r:
+      h = (g - b) / d + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / d + 2;
+      break;
+    default:
+      h = (r - g) / d + 4;
+  }
+  return [h / 6, s, l];
+}
+
+function hslToRgb([h, s, l]) {
+  if (s === 0) return [l * 255, l * 255, l * 255];
+  const hue2rgb = (p, q, t) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return [hue2rgb(p, q, h + 1 / 3) * 255, hue2rgb(p, q, h) * 255, hue2rgb(p, q, h - 1 / 3) * 255];
+}
+
+// Scans lightness (same hue/saturation as rgbA) in both directions from its
+// current value, returning the closest shade that clears `target` against
+// the fixed rgbB, or null if neither direction reaches it even at the
+// extremes (0 or 1).
+function recommendShade(rgbA, rgbB, target) {
+  const [h, s, l0] = rgbToHsl(rgbA);
+  const step = 0.005;
+  const passes = (l) => contrastRatio(hslToRgb([h, s, l]), rgbB) >= target;
+
+  let darker = null;
+  for (let l = l0; l >= 0; l -= step) {
+    if (passes(l)) {
+      darker = l;
+      break;
+    }
+  }
+  let lighter = null;
+  for (let l = l0; l <= 1; l += step) {
+    if (passes(l)) {
+      lighter = l;
+      break;
+    }
+  }
+  if (darker === null && lighter === null) return null;
+  const chosen =
+    darker === null ? lighter : lighter === null ? darker : Math.abs(darker - l0) <= Math.abs(lighter - l0) ? darker : lighter;
+  const rgb = hslToRgb([h, s, chosen]);
+  return { hex: rgbToHex(rgb), ratio: contrastRatio(rgb, rgbB) };
+}
+
+function report(hexA, hexB, target) {
+  const rgbA = hexToRgb(hexA);
+  const rgbB = hexToRgb(hexB);
+  const ratio = contrastRatio(rgbA, rgbB);
+  const verdict = (threshold, label) => `${ratio >= threshold ? "PASS" : "fail"} ${label}`;
+  console.log(
+    `${hexA} vs ${hexB}: ${ratio.toFixed(2)}:1  ` +
+      `[${verdict(3, "3:1 UI/large-text")}]  ` +
+      `[${verdict(4.5, "4.5:1 text AA")}]  ` +
+      `[${verdict(7, "7:1 text AAA")}]`,
+  );
+  if (ratio < target) {
+    const suggestion = recommendShade(rgbA, rgbB, target);
+    if (suggestion) {
+      console.log(
+        `  suggestion: #${suggestion.hex} instead of #${hexA} reaches ` +
+          `${suggestion.ratio.toFixed(2)}:1 against #${hexB} (same hue/saturation, ${target}:1 target)`,
+      );
+    } else {
+      console.log(`  no same-hue/saturation shade of #${hexA} reaches ${target}:1 against #${hexB}`);
+    }
+  }
+}
+
+const rawArgs = process.argv.slice(2);
+const targetArg = rawArgs.find((a) => a.startsWith("--target="));
+const target = targetArg ? parseFloat(targetArg.slice("--target=".length)) : 4.5;
+const args = rawArgs.filter((a) => !a.startsWith("--target="));
+
+if (args.length < 2 || args.length % 2 !== 0) {
+  console.error("Usage: npm run check-contrast -- <hex1> <hex2> [<hex3> <hex4> ...] [--target=4.5]");
+  process.exit(1);
+}
+for (let i = 0; i < args.length; i += 2) report(args[i], args[i + 1], target);

--- a/web/scripts/check-contrast.js
+++ b/web/scripts/check-contrast.js
@@ -26,7 +26,7 @@
  * picking --agm-t--* role values for a product override
  * (web/src/assets/products/<id>.css). Usage:
  *
- *   npm run check-contrast -- <hex1> <hex2> [<hex3> <hex4> ...] [--target=4.5]
+ *   check-contrast.js <hex1> <hex2> [<hex3> <hex4> ...] [--target=4.5]
  *
  * Each pair prints its ratio and whether it clears the common WCAG 2.x
  * thresholds: 3:1 (UI components / focus rings / large text, SC 1.4.11 and
@@ -170,7 +170,9 @@ const target = targetArg ? parseFloat(targetArg.slice("--target=".length)) : 4.5
 const args = rawArgs.filter((a) => !a.startsWith("--target="));
 
 if (args.length < 2 || args.length % 2 !== 0) {
-  console.error("Usage: npm run check-contrast -- <hex1> <hex2> [<hex3> <hex4> ...] [--target=4.5]");
+  console.error(
+    "Usage: check-contrast.js <hex1> <hex2> [<hex3> <hex4> ...] [--target=4.5]",
+  );
   process.exit(1);
 }
 for (let i = 0; i < args.length; i += 2) report(args[i], args[i + 1], target);

--- a/web/src/assets/products/example-advanced.css
+++ b/web/src/assets/products/example-advanced.css
@@ -54,6 +54,17 @@
   --agm-t--icon--size--600: 1.75rem;
   --agm-t--icon--size--700: 2rem;
   --agm-t--icon--size--800: 2.25rem;
+
+  /* Corner radius, two layers. --agm-t--border-radius is the base: it
+     redefines all three PF radius tiers at once (small: buttons, text inputs,
+     selects, tables, tooltips, menus; medium: cards, popovers, expandable
+     sections; large: modal dialogs). --agm-t--control--border-radius layers
+     on top for just the interactive controls (buttons, text inputs/textareas,
+     selects/dropdowns), letting a product give controls a different radius
+     than cards/dialogs; set only the base if everything should match. Both
+     unset keep PatternFly's stock radius. */
+  --agm-t--border-radius: 6px;
+  --agm-t--control--border-radius: 6px;
 }
 
 /* Light theme. */

--- a/web/src/assets/products/example-advanced.css
+++ b/web/src/assets/products/example-advanced.css
@@ -65,6 +65,15 @@
      unset keep PatternFly's stock radius. */
   --agm-t--border-radius: 6px;
   --agm-t--control--border-radius: 6px;
+
+  /* Product logo (see components/product/ProductLogo). Two size roles per
+     usage context (each unset keeps that usage's own current default), plus
+     a shared max inline size applied on top of whichever one resolves, and
+     vertical alignment (unset keeps the logo middle-aligned). */
+  --agm-t--logo--size--header: 35px;
+  --agm-t--logo--size--inline: 1.5em;
+  --agm-t--logo--max-size: 48px;
+  --agm-t--logo--align: middle;
 }
 
 /* Light theme. */

--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -133,7 +133,13 @@
 }
 
 .pf-v6-c-button {
-  --pf-v6-c-button--BorderRadius: var(--pf-t--global--border--radius--small);
+  // Buttons follow the same controls role as text inputs and selects (see
+  // tokens/_semantic.scss), so a product retunes --agm-t--control--border-radius
+  // once for all three instead of each separately.
+  --pf-v6-c-button--BorderRadius: var(
+    --agm-t--control--border-radius,
+    var(--pf-t--global--border--radius--small)
+  );
 
   &:disabled {
     fill: currentcolor;

--- a/web/src/assets/styles/tokens/_semantic.scss
+++ b/web/src/assets/styles/tokens/_semantic.scss
@@ -34,6 +34,17 @@
 //   --agm-t--status--{info,caution,danger,success,custom}--color
 //                                                 alert / status variants
 //                                                 (caution maps to PF "warning")
+//   --agm-t--border-radius                        base corner radius: every PF
+//                                                 component across all three PF
+//                                                 radius tiers (small: buttons,
+//                                                 controls, tables, tooltips,
+//                                                 menus; medium: cards, popovers,
+//                                                 expandable sections; large:
+//                                                 modal dialogs)
+//   --agm-t--control--border-radius               narrower override for just
+//                                                 buttons, text inputs/textareas
+//                                                 and selects/dropdowns, layered
+//                                                 on top of --agm-t--border-radius
 //
 // Typography roles (convenience; not needed to reskin, override only with strong
 // reasons):
@@ -107,7 +118,39 @@
   // it instead of dropping to the narrower layout.
   --pf-t--global--breakpoint--lg: 64rem;
   --pf-t--global--font--size--body--sm: var(--pf-t--global--font--size--sm);
+
+  // Base corner radius override hook. PatternFly splits radius into three
+  // independent tiers (small: buttons/controls/tables/tooltips/menus; medium:
+  // cards/popovers/expandable sections; large: modal dialogs), so this
+  // redefines all three from the one role. Unset by default, so every
+  // component keeps its stock look; redefine --agm-t--border-radius (e.g. to
+  // 0) from a product override to reskin all of them in one shot.
+  --pf-t--global--border--radius--small: var(
+    --agm-t--border-radius,
+    var(--pf-t--global--border--radius--200)
+  );
+  --pf-t--global--border--radius--medium: var(
+    --agm-t--border-radius,
+    var(--pf-t--global--border--radius--300)
+  );
+  --pf-t--global--border--radius--large: var(
+    --agm-t--border-radius,
+    var(--pf-t--global--border--radius--400)
+  );
+  // Pill-shaped controls (primary/secondary buttons, split-button children)
+  // follow the same small radius rather than PF's default fully-rounded pill.
   --pf-t--global--border--radius--pill: var(--pf-t--global--border--radius--small);
+  // Narrower override for just the interactive controls (buttons, text
+  // inputs/textareas, selects/dropdowns), layered on top of the base above so
+  // a product can give controls a different radius than containers.
+  --pf-t--global--border--radius--control--default: var(
+    --agm-t--control--border-radius,
+    var(--pf-t--global--border--radius--small)
+  );
+  --pf-t--global--border--radius--control--form-element: var(
+    --agm-t--control--border-radius,
+    var(--pf-t--global--border--radius--small)
+  );
 
   // Icon size scale (theme-independent), consumed by the Icon `size` prop via
   // its CSS classes. Each step defaults to the matching font size, so icons stay

--- a/web/src/assets/styles/tokens/_semantic.scss
+++ b/web/src/assets/styles/tokens/_semantic.scss
@@ -45,6 +45,15 @@
 //                                                 buttons, text inputs/textareas
 //                                                 and selects/dropdowns, layered
 //                                                 on top of --agm-t--border-radius
+//   --agm-t--logo--size--header                   product logo width in the masthead
+//                                                 (see layout/Header)
+//   --agm-t--logo--size--inline                   product logo width next to the
+//                                                 product name (see core/InstallationProgress,
+//                                                 product/ProductSelectionPage)
+//   --agm-t--logo--max-size                        product logo max inline size, applied
+//                                                 on top of either size role above (see
+//                                                 components/product/ProductLogo)
+//   --agm-t--logo--align                          product logo vertical alignment
 //
 // Typography roles (convenience; not needed to reskin, override only with strong
 // reasons):

--- a/web/src/components/core/InstallationProgress.tsx
+++ b/web/src/components/core/InstallationProgress.tsx
@@ -39,7 +39,8 @@ export default function InstallationProgress() {
           icon="deployed_code_update"
           firstRowStart={
             <>
-              <ProductLogo product={product} width="1.25em" /> {product?.name}
+              <ProductLogo product={product} width="var(--agm-t--logo--size--inline, 1.25em)" />{" "}
+              {product?.name}
             </>
           }
           firstRowEnd={<ProgressReport />}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -130,7 +130,7 @@ function MainBreadcrumbs({
 
   return (
     <Flex alignItems={{ default: "alignItemsCenter" }} gap={{ default: "gapSm" }}>
-      <ProductLogo product={product} width="35px" />
+      <ProductLogo product={product} width="var(--agm-t--logo--size--header, 35px)" />
       <Flex direction={{ default: "column" }} gap={{ default: "gapNone" }}>
         {product && (
           <Text textStyle="textColorSubtle" className={textStyles.fontSizeXs}>

--- a/web/src/components/product/ProductLogo.test.tsx
+++ b/web/src/components/product/ProductLogo.test.tsx
@@ -58,7 +58,7 @@ describe("ProductLogo", () => {
     plainRender(<ProductLogo product={product} />);
 
     const img = screen.getByRole("img", { hidden: true });
-    expect(img).toHaveAttribute("width", "80px");
+    expect(img).not.toHaveAttribute("width");
     expect(img).toHaveStyle({ width: "80px" });
   });
 
@@ -66,14 +66,14 @@ describe("ProductLogo", () => {
     plainRender(<ProductLogo product={product} width="120px" />);
 
     const img = screen.getByRole("img", { hidden: true });
-    expect(img).toHaveAttribute("width", "120px");
     expect(img).toHaveStyle({ width: "120px" });
   });
 
-  it("applies vertical align middle style", () => {
+  it("applies the themeable vertical align and max size roles", () => {
     plainRender(<ProductLogo product={product} />);
 
     const img = screen.getByRole("img", { hidden: true });
-    expect(img).toHaveStyle({ verticalAlign: "middle" });
+    expect(img.style.verticalAlign).toBe("var(--agm-t--logo--align, middle)");
+    expect(img.style.maxInlineSize).toBe("var(--agm-t--logo--max-size, none)");
   });
 });

--- a/web/src/components/product/ProductLogo.tsx
+++ b/web/src/components/product/ProductLogo.tsx
@@ -53,9 +53,12 @@ export default function ProductLogo({ product, width = "80px" }) {
       aria-hidden
       src={useDark ? darkSrc : lightSrc}
       alt={logoAltText}
-      width={width}
       onError={() => useDark && setUseDark(false)}
-      style={{ verticalAlign: "middle", width }}
+      style={{
+        verticalAlign: "var(--agm-t--logo--align, middle)",
+        maxInlineSize: "var(--agm-t--logo--max-size, none)",
+        width,
+      }}
     />
   );
 }

--- a/web/src/components/product/ProductSelectionPage.tsx
+++ b/web/src/components/product/ProductSelectionPage.tsx
@@ -124,7 +124,8 @@ const ProductFormProductOption = ({
                 aria-details={detailsId}
                 label={
                   <Text isBold className={pfTextStyles.fontSizeLg}>
-                    <ProductLogo product={product} width="2em" /> {product.name}
+                    <ProductLogo product={product} width="var(--agm-t--logo--size--inline, 2em)" />{" "}
+                    {product.name}
                   </Text>
                 }
                 body={
@@ -581,7 +582,8 @@ const CurrentProductInfo = ({ product, modeId }: CurrentProductInfoProps) => {
       <CardBody>
         <Stack hasGutter>
           <Title headingLevel="h3">
-            <ProductLogo product={product} width="2em" /> {product.name}
+            <ProductLogo product={product} width="var(--agm-t--logo--size--inline, 2em)" />{" "}
+            {product.name}
           </Title>
           <Divider />
           <SubtleContent>{product.description}</SubtleContent>


### PR DESCRIPTION
Extends the `--agm-t--*` product-override role system with two roles that weren't exposed yet, and adds a script plus a doc to support the rest of the theming workflow.

- **Corner radius** now has its own roles: `--agm-t--border-radius` sets all three PatternFly radius tiers at once (buttons/controls/tables/tooltips/menus, cards/popovers/expandable sections, modal dialogs), and `--agm-t--control--border-radius` layers a narrower override on top for just buttons/inputs/selects. Previously a product wanting a different radius had no role to hook into and would have had to touch PatternFly's own tokens directly, outside the semantic-role layer the rest of the override API goes through.
- **The product logo** gets `--agm-t--logo--size--header` and `--agm-t--logo--size--inline` for its two usages, `--agm-t--logo--max-size` as a shared cap on top of either, and `--agm-t--logo--align`. Sizing previously came only from a hardcoded literal per usage; a duplicate `width=` HTML attribute on the `<img>` also came out, since it can't hold a CSS variable and was just carrying a stale value once the sizing moved to `var(...)`.
- **`check-contrast.js`**, a standalone script (not wired into `npm run`) that computes the WCAG contrast ratio between a color pair and checks it against the 3:1 / 4.5:1 / 7:1 thresholds, suggesting a same-hue shade when a pair falls short. Meant to be reached for while choosing role values for a new product skin, not part of the regular test/lint loop.
- **`doc/product_theming.md`**, walking through skinning a product end to end and extending the role API when a brand needs something not yet covered.

Every new role keeps the current literal as its CSS fallback, so leaving it unset changes nothing.
