### PR TITLE
add Bugzilla references to the CVEs fixed in #3730

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,15 +2,16 @@
 Fri Jul 17 12:14:14 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
 - update runtime dependencies to:
-  - form-data 4.0.6, CVE-2025-7783 CVE-2026-12143 (bsc#1246822)
-  - react-router and react-router-dom 6.30.4, CVE-2026-40181
+  - form-data 4.0.6, CVE-2025-7783 CVE-2026-12143 (bsc#1246822, bsc#1272310)
+  - react-router and react-router-dom 6.30.4, CVE-2026-40181 (bsc#1272311)
 - update development dependencies to:
-  - @babel/core 7.29.7, CVE-2026-49356
-  - http-proxy-middleware 2.0.10, CVE-2026-55602
+  - @babel/core 7.29.7, CVE-2026-49356 (bsc#1272317)
+  - http-proxy-middleware 2.0.10, CVE-2026-55602 (bsc#1272318)
   - js-yaml 4.3.0 and 3.15.0, CVE-2026-53550 (bsc#1268851)
-  - launch-editor 2.14.1, CVE-2026-53632
+  - launch-editor 2.14.1, CVE-2026-53632 (bsc#1272319)
   - shell-quote 1.10.0, CVE-2026-13311 (bsc#1269359)
   - websocket-driver 0.7.5, CVE-2026-54490 CVE-2026-54466
+    (bsc#1272313, bsc#1272312)
   - fast-uri 3.1.3, CVE-2026-13676 (bsc#1269595)
   - brace-expansion 5.0.7, CVE-2026-13149 (bsc#1269927)
 - updated on May 25 already, listing its references for tracking:


### PR DESCRIPTION

## Problem

In the review of IBS submission https://src.suse.de/pool/agama-web-ui/pulls/35 which corresponds to #3730, it turned out that the security team likes to have specific bug references even though Bugzilla does handle CVEs (example: https://bugzilla.suse.com/show_bug.cgi?id=CVE-2026-49356 )

## Solution

Add the references. (Automatically, the Gemini prompt is in the commit message)

## Testing

- Manually clicked through the referenced bugs to double check that they are correct.
- Gemini (by the original prompt) reported that one of the bugs is a duplicate, [bsc#1272316](https://bugzilla.suse.com/show_bug.cgi?id=1272316)

## Screenshots

No

## Documentation

No