### PR TITLE
Fix the "agama logs list" command

### DIFF
--- a/rust/agama-lib/src/manager/http_client.rs
+++ b/rust/agama-lib/src/manager/http_client.rs
@@ -120,7 +120,7 @@ impl ManagerHTTPClient {
     /// Asks backend for lists of log files and commands used for creating logs archive returned by
     /// store (/logs/store) backed HTTP API command
     pub async fn list(&self) -> Result<LogsLists, ManagerHTTPClientError> {
-        Ok(self.client.get("/manager/logs/list").await?)
+        Ok(self.client.get("/private/list_logs").await?)
     }
 
     /// Returns the installer status.

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -174,6 +174,7 @@ pub fn server_with_state(
         )
         .route("/private/solve_storage_model", get(solve_storage_model))
         .route("/private/download_logs", get(download_logs))
+        .route("/private/list_logs", get(list_logs))
         .route("/private/password_check", post(check_password))
         .nest_service("/private/profile", profile_routes)
         .with_state(state))
@@ -703,6 +704,10 @@ async fn download_logs() -> impl IntoResponse {
         }
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, err_response),
     }
+}
+
+async fn list_logs() -> impl IntoResponse {
+    Json(logs::list())
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jul 23 13:44:55 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the "agama logs list" command (bsc#1261037).
+
+-------------------------------------------------------------------
 Thu Jul 23 12:08:50 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not copy the installatoin repositories (agama-0, agama-1, etc.)


### PR DESCRIPTION
## Problem

The `agama logs list` command returns an error [bsc#1261037](https://bugzilla.suse.com/show_bug.cgi?id=1261037). The problem is that the endpoint was removed when moving to API v2.

## Solution

Bring back the endpoint and fix the client.