### PR TITLE
fix(web): reserve masthead space in Page's minimal layout

### DIFF
--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -39,6 +39,17 @@
   }
 }
 
+// Minimal-variant pages (see core/Page) mount an empty masthead, which
+// otherwise collapses to near-zero height. That leaves the main container's
+// block-start edge flush against the viewport, unlike its inline-start/
+// inline-end edges, which already get the page inset as margin (and its
+// block-end edge, which gets it via the default max-height). Give the empty
+// masthead that same inset as a real height, the same mechanism a populated
+// masthead already uses to create top space, so it stays even on every side.
+.agm-minimal-page .pf-v6-c-masthead {
+  min-block-size: var(--pf-v6-c-page--inset);
+}
+
 // Tooltip background and text. PatternFly sets these tokens on the component
 // itself, so the roles are mapped here (not at :root) to take effect. Both
 // default to PF's theme-aware inverse colors; override the roles to retune.

--- a/web/src/components/core/Page.tsx
+++ b/web/src/components/core/Page.tsx
@@ -364,10 +364,13 @@ type PageProps = (StandardPageProps | MinimalPageProps) & {
 
 /**
  * Minimal page layout with empty masthead.
+ *
+ * `agm-minimal-page` keeps the content area evenly spaced on all sides; see
+ * that class in `_patternfly-overrides.scss` for why it's needed.
  */
 const MinimalLayout = ({ children }: Omit<MinimalPageProps, "variant">) => {
   return (
-    <PFPage isContentFilled masthead={<Masthead />}>
+    <PFPage isContentFilled masthead={<Masthead />} className="agm-minimal-page">
       <PageGroup tabIndex={-1} id="main-content">
         {children}
       </PageGroup>


### PR DESCRIPTION
Pages using the minimal layout (login, error pages, installation exit/failed) mount an empty masthead that collapses to near-zero height, so their content sits flush against the top of the viewport while the other edges already get PatternFly's page inset as spacing. Give the empty masthead that same inset as a minimum height.


> [!NOTE]
> 
> No big impact, does not deserve changelog entry
> 

## Screenshots

| Before | After |
|-|-|
| <img width="2048" height="1530" alt="login_before" src="https://github.com/user-attachments/assets/030c9335-ded9-4bb8-9334-0950316fc2c4" /> | <img width="2048" height="1530" alt="__1 _8080_ (2)" src="https://github.com/user-attachments/assets/bc8d3e9a-9308-4cad-a49c-2e556051c931" /> |
| <img width="2048" height="1530" alt="404_before" src="https://github.com/user-attachments/assets/8aae2ea2-1702-4564-9f78-b3806dc4b7a2" /> | <img width="2048" height="1530" alt="__1 _8080_ (4)" src="https://github.com/user-attachments/assets/05bd089f-1719-4631-aa90-1fd09a554f2b" /> |
| <img width="2048" height="1530" alt="exit_before" src="https://github.com/user-attachments/assets/e6c07e68-b6dd-4700-8ebf-d1f8638ab0ce" /> | <img width="2048" height="1530" alt="__1 _8080_ (3)" src="https://github.com/user-attachments/assets/8cbd8f22-e4f1-4dd3-a426-6850c232c1c8" /> |


