### PR TITLE
Add fallback storage volumes to immutable (needed by UI)

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 24 07:03:30 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added generic storage volumes to the immutables modes, as
+  required by the web UI to work properly (bsc#1272461).
+
+-------------------------------------------------------------------
 Mon Jul 20 11:12:35 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 23

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -405,3 +405,17 @@ modes:
             required: false
             filesystems:
               - btrfs
+        - filesystem: xfs
+          size:
+            auto: false
+            min: 512 MiB
+          outline:
+            required: false
+            filesystems:
+              - btrfs
+              - ext2
+              - ext3
+              - ext4
+              - xfs
+              - vfat
+              - swap

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -395,3 +395,17 @@ modes:
             required: false
             filesystems:
               - btrfs
+        - filesystem: xfs
+          size:
+            auto: false
+            min: 512 MiB
+          outline:
+            required: false
+            filesystems:
+              - btrfs
+              - ext2
+              - ext3
+              - ext4
+              - xfs
+              - vfat
+              - swap


### PR DESCRIPTION
## Problem

The UI assumes each product (and mode) defines a generic fallback storage volume that is used to pre-fill the form when an arbitrary partition is being created. But the immutable modes of SLE and SLE for SAP do not define it. That results in this problematic form:

<img width="632" height="643" alt="no-generic" src="https://github.com/user-attachments/assets/72af663c-14f8-42ef-a96c-685a6559c3c2" />

The size is wrong and the only filesystem type is ext4, even in cases in which it makes no sense.

Even if the immutable modes want to discourage the creation of additional arbitrary partitions, omitting the fallback volume is not the way to go. It was probably intentionally left "wrong" as a way to force feedback from the stakeholders requesting the feature... but it clearly didn't work and the current state looks broken.

## Solution

Add a missing generic fallback volume, so the form looks like this (reasonable size and more filesystem options):

<img width="686" height="669" alt="with-generic" src="https://github.com/user-attachments/assets/bf96ca9e-d3cd-4850-b93c-de1902df8066" />

Note "swap" is added just as any other filesystem type. Instead, a separate volume for "swap" (not proposed by default) could be added to the product definition. But then "swap" would be offered as suggestion in the field to select the mount point, which is likely not wanted (we really do not know because we never got the mentioned feedback).

## Testing

Tested manually (see screenshots above).