### PR TITLE
Properly detect when an AutoYaST profile is not found

### DIFF
--- a/service/bin/agama-autoyast
+++ b/service/bin/agama-autoyast
@@ -58,4 +58,7 @@ rescue Agama::Commands::CouldNotWriteAgamaConfig => e
   warn "Could not write the Agama configuration:\n\n"
   warn e.full_message
   exit 4
+rescue Agama::Commands::ProfileNotFound => e
+  warn "Could not find the AutoYaST profile"
+  exit 5
 end

--- a/service/lib/agama/commands/agama_autoyast.rb
+++ b/service/lib/agama/commands/agama_autoyast.rb
@@ -31,6 +31,7 @@ require "agama/http/clients"
 module Agama
   # :nodoc:
   module Commands
+    class ProfileNotFound < StandardError; end
     class CouldNotFetchProfile < StandardError; end
     class CouldNotWriteAgamaConfig < StandardError; end
 
@@ -51,18 +52,6 @@ module Agama
       # Run the command fetching, checking, converting and writing the Agama configuration.
       def run
         profile = fetch_profile
-
-        if profile.nil?
-          if ENV["YAST_SKIP_PROFILE_FETCH_ERROR"] == "1"
-            # Silently ignore profile fetch errors whenever underlying yast is asked to do so
-            # We need to create fake agama profile to avoid failures further in processing chain
-            profile = {}
-          else
-            logger.info("Cannot fetch profile from provided location: #{url}")
-            return false
-          end
-        end
-
         unsupported = check_profile(profile)
         return false unless report_unsupported(unsupported)
 
@@ -74,9 +63,16 @@ module Agama
       attr_reader :url, :directory, :logger
 
       # Fetch the AutoYaST profile from the given URL.
+      #
+      # @return [ProfileHash] an evaluated AutoYaST profile
+      # @raise CouldNotFetchProfile if there was an error processing the profile.
+      # @raise ProfileNotFound if the profile was not found
       def fetch_profile
-        Agama::AutoYaST::ProfileFetcher.new(url).fetch
-      rescue RuntimeError
+        profile = Agama::AutoYaST::ProfileFetcher.new(url).fetch
+        raise ProfileNotFound if profile.nil?
+
+        profile
+      rescue RuntimeError # Catch any underlying error when processing the profile
         raise CouldNotFetchProfile
       end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jul 24 08:53:15 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Detect whether an AutoYaST profile is not found (bsc#1272439).
+
+-------------------------------------------------------------------
 Mon Jul 20 11:12:31 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 23

--- a/service/test/agama/commands/agama_autoyast_test.rb
+++ b/service/test/agama/commands/agama_autoyast_test.rb
@@ -93,5 +93,15 @@ describe Agama::Commands::AgamaAutoYaST do
         expect { subject.run }.to raise_exception(Agama::Commands::CouldNotFetchProfile)
       end
     end
+
+    context "when the profile is not found" do
+      before do
+        allow(fetcher).to receive(:fetch).and_return(nil)
+      end
+
+      it "raises a ProfileNotFound exception" do
+        expect { subject.run }.to raise_exception(Agama::Commands::ProfileNotFound)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

After #3624, `agama config generate` does not return an error when processing an AutoYaST profile that does not exist. Hence, the `agama-autoinstall` binary thinks the profile was successfully loaded from `label://OEMDRV/autoinst.xml` and stops there, not processing the rest of predefined locations.

See [bsc#1272439](https://bugzilla.suse.com/show_bug.cgi?id=1272439).

## Solution

* Return an error when the profile is not found.
* Still do not process the profile if it was not found (that was the original problem that #3624 mitigated).

## Testing

* Added a unit test.
* Manually tested.
