### PR TITLE
fix: properly handle offline installations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum",
  "tempfile",
  "test-context",
  "thiserror 2.0.18",

--- a/rust/agama-lib/src/manager/http_client.rs
+++ b/rust/agama-lib/src/manager/http_client.rs
@@ -45,16 +45,10 @@ impl ManagerHTTPClient {
 
     /// Starts a "probing".
     pub async fn probe(&self) -> Result<(), ManagerHTTPClientError> {
-        // BaseHTTPClient did not anticipate POST without request body
-        // so we pass () which is rendered as `null`
-        Ok(self.client.post_void("/manager/probe_sync", &()).await?)
-    }
-
-    /// Starts a "reprobing".
-    pub async fn reprobe(&self) -> Result<(), ManagerHTTPClientError> {
-        // BaseHTTPClient did not anticipate POST without request body
-        // so we pass () which is rendered as `null`
-        Ok(self.client.post_void("/manager/reprobe_sync", &()).await?)
+        self.client
+            .post_void("/action", &api::Action::Probe { scopes: None })
+            .await?;
+        Ok(())
     }
 
     /// Starts the installation.

--- a/rust/agama-lib/src/manager/http_client.rs
+++ b/rust/agama-lib/src/manager/http_client.rs
@@ -46,7 +46,7 @@ impl ManagerHTTPClient {
     /// Starts a "probing".
     pub async fn probe(&self) -> Result<(), ManagerHTTPClientError> {
         self.client
-            .post_void("/action", &api::Action::Probe { scopes: None })
+            .post_void("/action", &api::Action::Probe { only: None })
             .await?;
         Ok(())
     }

--- a/rust/agama-manager/Cargo.toml
+++ b/rust/agama-manager/Cargo.toml
@@ -26,6 +26,7 @@ merge = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+strum = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -44,6 +44,7 @@ use merge::Merge;
 use network::NetworkSystemClient;
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
+use strum::VariantArray;
 use tokio::sync::{broadcast, RwLock};
 
 #[derive(Debug, thiserror::Error)]
@@ -578,6 +579,13 @@ impl Service {
         Ok(())
     }
 
+    async fn probe(&self, scopes: &[Scope]) -> Result<(), Error> {
+        if scopes.contains(&Scope::Software) {
+            self.software.call(software::message::Probe).await?;
+        }
+        Ok(())
+    }
+
     fn set_product(&mut self, config: &Config) -> Result<(), Error> {
         self.product = None;
         self.update_product(config)
@@ -867,6 +875,11 @@ impl MessageHandler<message::RunAction> for Service {
             Action::ProbeStorage => {
                 checks::check_stage(&self.progress, Stage::Configuring).await?;
                 self.probe_storage().await?;
+            }
+            Action::Probe { scopes } => {
+                checks::check_stage(&self.progress, Stage::Configuring).await?;
+                let scopes = scopes.unwrap_or_else(|| Scope::VARIANTS.to_vec());
+                self.probe(&scopes).await?;
             }
             Action::ProbeDASD => {
                 checks::check_stage(&self.progress, Stage::Configuring).await?;

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -567,20 +567,16 @@ impl Service {
         Ok(())
     }
 
-    async fn probe_storage(&self) -> Result<(), Error> {
-        self.storage.call(storage::message::Probe).await?;
-        Ok(())
-    }
-
-    async fn probe_dasd(&self) -> Result<(), Error> {
-        if let Some(s390) = &self.s390 {
-            s390.call(s390::message::ProbeDASD).await?;
+    async fn probe(&self, only: &[Scope]) -> Result<(), Error> {
+        if only.contains(&Scope::Storage) {
+            self.storage.call(storage::message::Probe).await?;
         }
-        Ok(())
-    }
-
-    async fn probe(&self, scopes: &[Scope]) -> Result<(), Error> {
-        if scopes.contains(&Scope::Software) {
+        if only.contains(&Scope::DASD) {
+            if let Some(s390) = &self.s390 {
+                s390.call(s390::message::ProbeDASD).await?;
+            }
+        }
+        if only.contains(&Scope::Software) {
             self.software.call(software::message::Probe).await?;
         }
         Ok(())
@@ -872,18 +868,10 @@ impl MessageHandler<message::RunAction> for Service {
                 checks::check_stage(&self.progress, Stage::Configuring).await?;
                 self.activate_storage().await?;
             }
-            Action::ProbeStorage => {
+            Action::Probe { only } => {
                 checks::check_stage(&self.progress, Stage::Configuring).await?;
-                self.probe_storage().await?;
-            }
-            Action::Probe { scopes } => {
-                checks::check_stage(&self.progress, Stage::Configuring).await?;
-                let scopes = scopes.unwrap_or_else(|| Scope::VARIANTS.to_vec());
-                self.probe(&scopes).await?;
-            }
-            Action::ProbeDASD => {
-                checks::check_stage(&self.progress, Stage::Configuring).await?;
-                self.probe_dasd().await?;
+                let only = only.unwrap_or_else(|| Scope::VARIANTS.to_vec());
+                self.probe(&only).await?;
             }
             Action::Install => {
                 let ipmi = ipmi::Ipmi::default();

--- a/rust/agama-software/src/message.rs
+++ b/rust/agama-software/src/message.rs
@@ -89,9 +89,9 @@ impl Message for Install {
     type Reply = ();
 }
 
-pub struct Refresh;
+pub struct Probe;
 
-impl Message for Refresh {
+impl Message for Probe {
     type Reply = ();
 }
 

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -78,6 +78,11 @@ impl SoftwareState {
     }
 }
 
+/// Alias prefix reserved for the installation repositories created by Agama corresponding to the
+/// product definition (see [`SoftwareStateBuilder::build_repo`]). They are named `agama-0`,
+/// `agama-1`, etc. and must not be copied to the target system.
+pub(crate) const AGAMA_REPO_PREFIX: &str = "agama-";
+
 /// Builder to create a [SoftwareState] struct from different sources.
 ///
 /// At this point it uses the following sources:
@@ -280,7 +285,7 @@ impl<'a> SoftwareStateBuilder<'a> {
     }
 
     fn build_repo(i: usize, url: String) -> Repository {
-        let alias = format!("agama-{}", i);
+        let alias = format!("{AGAMA_REPO_PREFIX}{i}");
         Repository {
             name: alias.clone(),
             alias,

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -290,6 +290,13 @@ impl<'a> SoftwareStateBuilder<'a> {
         }
     }
 
+    /// Whether a predefined repository for the local (off-line) installation media is present.
+    fn has_local_install_media(&self) -> bool {
+        self.predefined_repositories
+            .iter()
+            .any(|repo| repo.alias == crate::service::INSTALLATION_REPO_ALIAS)
+    }
+
     fn build_repositories(&self) -> Vec<Repository> {
         let software = &self.product.software;
         let kernel_repos = self.kernel_cmdline.get_last("inst.install_url");
@@ -299,6 +306,11 @@ impl<'a> SoftwareStateBuilder<'a> {
                 .enumerate()
                 .map(|(i, url)| Self::build_repo(i, url.to_string()))
                 .collect()
+        } else if self.has_local_install_media() {
+            tracing::info!(
+                "Local installation media found; skipping the product's remote repositories"
+            );
+            vec![]
         } else {
             software
                 .repositories()
@@ -1014,6 +1026,89 @@ mod tests {
             "user-repo-0".to_string(),
         ];
         assert_eq!(expected_aliases, aliases);
+    }
+
+    #[test]
+    fn test_skips_product_repositories_when_installation_media_present() {
+        let product = build_product_spec("tumbleweed", None);
+        let config = Config::default();
+
+        let install_repo = Repository {
+            alias: crate::service::INSTALLATION_REPO_ALIAS.to_string(),
+            name: crate::service::INSTALLATION_REPO_ALIAS.to_string(),
+            url: "hd:/install".to_string(),
+            enabled: true,
+            predefined: true,
+        };
+
+        let state = SoftwareStateBuilder::for_product(&product)
+            .with_config(&config)
+            .with_predefined_repositories(vec![install_repo])
+            .build();
+
+        let aliases: Vec<_> = state.repositories.iter().map(|r| r.alias.clone()).collect();
+        assert_eq!(
+            aliases,
+            vec![crate::service::INSTALLATION_REPO_ALIAS.to_string()]
+        );
+    }
+
+    #[test]
+    fn test_keeps_product_repositories_without_installation_media() {
+        let product = build_product_spec("tumbleweed", None);
+        let config = Config::default();
+
+        let dud_repo = Repository {
+            alias: "AgamaDriverUpdate".to_string(),
+            name: "AgamaDriverUpdate".to_string(),
+            url: "hd:/dud".to_string(),
+            enabled: true,
+            predefined: true,
+        };
+
+        let state = SoftwareStateBuilder::for_product(&product)
+            .with_config(&config)
+            .with_predefined_repositories(vec![dud_repo])
+            .build();
+
+        let aliases: Vec<_> = state.repositories.iter().map(|r| r.alias.clone()).collect();
+        assert_eq!(
+            aliases,
+            vec![
+                "agama-0".to_string(),
+                "agama-1".to_string(),
+                "agama-2".to_string(),
+                "AgamaDriverUpdate".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_keeps_kernel_cmdline_repositories_with_installation_media_present() {
+        let product = build_product_spec("tumbleweed", None);
+        let kernel_cmdline = KernelCmdline::parse_str("inst.install_url=http://example.com/repo1");
+
+        let install_repo = Repository {
+            alias: crate::service::INSTALLATION_REPO_ALIAS.to_string(),
+            name: crate::service::INSTALLATION_REPO_ALIAS.to_string(),
+            url: "hd:/install".to_string(),
+            enabled: true,
+            predefined: true,
+        };
+
+        let state = SoftwareStateBuilder::for_product(&product)
+            .with_kernel_cmdline(kernel_cmdline)
+            .with_predefined_repositories(vec![install_repo])
+            .build();
+
+        let aliases: Vec<_> = state.repositories.iter().map(|r| r.alias.clone()).collect();
+        assert_eq!(
+            aliases,
+            vec![
+                "agama-0".to_string(),
+                crate::service::INSTALLATION_REPO_ALIAS.to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -208,11 +208,12 @@ impl Service {
         Ok(())
     }
 
-    async fn update_system(&mut self) -> Result<(), Error> {
-        // TODO: add system information (repositories, patterns, etc.).
-        self.events.send(Event::SystemChanged {
-            scope: Scope::Software,
-        })?;
+    async fn apply_config(&mut self) -> Result<(), Error> {
+        // calculate the wanted state
+        self.calculate_wanted_state().await?;
+
+        // and then update the proposal (in a separate task).
+        self.update_proposal().await?;
 
         Ok(())
     }
@@ -437,13 +438,7 @@ impl MessageHandler<message::SetConfig<Config>> for Service {
             scope: Scope::Software,
         })?;
 
-        // calculate the wanted state
-        self.calculate_wanted_state().await?;
-
-        // and then update the proposal (in a separate task).
-        self.update_proposal().await?;
-
-        Ok(())
+        self.apply_config().await
     }
 }
 
@@ -456,11 +451,9 @@ impl MessageHandler<message::GetProposal> for Service {
 }
 
 #[async_trait]
-impl MessageHandler<message::Refresh> for Service {
-    async fn handle(&mut self, _message: message::Refresh) -> Result<(), Error> {
-        self.model.lock().await.refresh().await?;
-        self.update_system().await?;
-        Ok(())
+impl MessageHandler<message::Probe> for Service {
+    async fn handle(&mut self, _message: message::Probe) -> Result<(), Error> {
+        self.apply_config().await
     }
 }
 

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -518,6 +518,9 @@ const DUD_REPO_DIR: &str = "var/lib/agama/dud/repo";
 /// Alias used for the predefined repository pointing to the local (off-line) installation media.
 pub(crate) const INSTALLATION_REPO_ALIAS: &str = "Installation";
 
+/// Alias of the repository holding the Driver Update Disk (DUD) packages.
+pub(crate) const DUD_REPO_ALIAS: &str = "AgamaDriverUpdate";
+
 /// Returns the local repositories that will be used during installation.
 ///
 /// By now it considers:
@@ -538,7 +541,7 @@ fn find_mandatory_repositories<P: Into<PathBuf>>(root: P) -> Vec<Repository> {
     }
 
     let dud_repo_dir = base.join(DUD_REPO_DIR);
-    if let Some(dud) = find_repository(&dud_repo_dir, "AgamaDriverUpdate") {
+    if let Some(dud) = find_repository(&dud_repo_dir, DUD_REPO_ALIAS) {
         repos.push(dud)
     }
 

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -515,6 +515,9 @@ impl MessageHandler<message::IsPatternSelected> for Service {
 const LIVE_REPO_DIR: &str = "run/initramfs/live/install";
 const DUD_REPO_DIR: &str = "var/lib/agama/dud/repo";
 
+/// Alias used for the predefined repository pointing to the local (off-line) installation media.
+pub(crate) const INSTALLATION_REPO_ALIAS: &str = "Installation";
+
 /// Returns the local repositories that will be used during installation.
 ///
 /// By now it considers:
@@ -526,7 +529,7 @@ fn find_mandatory_repositories<P: Into<PathBuf>>(root: P) -> Vec<Repository> {
     let mut repos = vec![];
 
     let live_repo_dir = base.join(LIVE_REPO_DIR);
-    if let Some(mut install) = find_repository(&live_repo_dir, "Installation") {
+    if let Some(mut install) = find_repository(&live_repo_dir, INSTALLATION_REPO_ALIAS) {
         let mount_point = live_repo_dir.display().to_string();
         if let Some(normalized_url) = normalize_repository_url(&mount_point, "/install") {
             install.url = normalized_url;

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -462,21 +462,19 @@ impl ZyppServer {
 
         // all repos are added or removed as needed
         progress.cast(progress::message::Next::new(Scope::Software))?;
-        if !to_add.is_empty() || !to_remove.is_empty() {
-            let result = zypp.load_source(
-                |percent, alias| {
-                    tracing::info!("Refreshing repositories: {} ({}%)", alias, percent);
-                    true
-                },
-                security,
-            );
+        let result = zypp.load_source(
+            |percent, alias| {
+                tracing::info!("Refreshing repositories: {} ({}%)", alias, percent);
+                true
+            },
+            security,
+        );
 
-            if let Err(error) = result {
-                let message = gettext("Could not read the repositories");
-                issues.software.push(
-                    Issue::new("software.load_source", &message).with_details(&error.to_string()),
-                );
-            }
+        if let Err(error) = result {
+            let message = gettext("Could not read the repositories");
+            issues.software.push(
+                Issue::new("software.load_source", &message).with_details(&error.to_string()),
+            );
         }
 
         // repositories refresh finished

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -46,7 +46,7 @@ use crate::{
     model::{
         packages::ResolvableTypeExt,
         registration::RegistrationError,
-        state::{self, SoftwareState},
+        state::{self, SoftwareState, AGAMA_REPO_PREFIX},
         WriteIssues,
     },
     service::DUD_REPO_ALIAS,
@@ -55,11 +55,6 @@ use crate::{
 };
 
 const GPG_KEYS: &str = "/usr/lib/rpm/gnupg/keys/gpg-*";
-
-/// Alias prefix reserved for the installation repositories created by Agama corresponding to the
-/// product definition (see `build_repo` in `model::state`). They are named `agama-0`, `agama-1`,
-/// etc. and must not be copied to the target system.
-const AGAMA_REPO_PREFIX: &str = "agama-";
 
 /// Whether the repository with the given alias is an installer-only repository
 /// that must not end up in the target system.

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -49,6 +49,7 @@ use crate::{
         state::{self, SoftwareState},
         WriteIssues,
     },
+    service::DUD_REPO_ALIAS,
     state::{Addon, RegistrationState, RepoKey, ResolvableSelection, ResolvablesState},
     Registration, ResolvableType,
 };
@@ -59,10 +60,6 @@ const GPG_KEYS: &str = "/usr/lib/rpm/gnupg/keys/gpg-*";
 /// product definition (see `build_repo` in `model::state`). They are named `agama-0`, `agama-1`,
 /// etc. and must not be copied to the target system.
 const AGAMA_REPO_PREFIX: &str = "agama-";
-
-/// Alias of the repository holding the Driver Update Disk (DUD) packages. It is only relevant
-/// during the installation, so it must not reach the target.
-const DUD_REPO_ALIAS: &str = "AgamaDriverUpdate";
 
 /// Whether the repository with the given alias is an installer-only repository
 /// that must not end up in the target system.

--- a/rust/agama-utils/src/api/action.rs
+++ b/rust/agama-utils/src/api/action.rs
@@ -21,7 +21,7 @@
 use std::str::FromStr;
 
 use crate::{
-    api::{iscsi, l10n},
+    api::{iscsi, l10n, Scope},
     kernel_cmdline::KernelCmdline,
 };
 use schemars::JsonSchema;
@@ -39,6 +39,8 @@ pub enum Action {
     /// Performs a DASD probing on demand.
     #[serde(rename = "probeDASD")]
     ProbeDASD,
+    #[serde(rename = "probe")]
+    Probe { scopes: Option<Vec<Scope>> },
     #[serde(rename = "configureL10n")]
     ConfigureL10n(l10n::SystemConfig),
     #[serde(rename = "install")]

--- a/rust/agama-utils/src/api/action.rs
+++ b/rust/agama-utils/src/api/action.rs
@@ -34,13 +34,11 @@ pub enum Action {
     DiscoverISCSI(iscsi::DiscoverConfig),
     #[serde(rename = "activateStorage")]
     ActivateStorage,
-    #[serde(rename = "probeStorage")]
-    ProbeStorage,
-    /// Performs a DASD probing on demand.
-    #[serde(rename = "probeDASD")]
-    ProbeDASD,
+    /// Probes hardware and refreshes services (storage, DASD, software, etc).
+    ///
+    /// If `only` is not given, it probes everything.
     #[serde(rename = "probe")]
-    Probe { scopes: Option<Vec<Scope>> },
+    Probe { only: Option<Vec<Scope>> },
     #[serde(rename = "configureL10n")]
     ConfigureL10n(l10n::SystemConfig),
     #[serde(rename = "install")]

--- a/rust/agama-utils/src/api/scope.rs
+++ b/rust/agama-utils/src/api/scope.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
     Hash,
     strum::EnumString,
     strum::Display,
+    strum::VariantArray,
     Deserialize,
     Serialize,
     JsonSchema,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 28 12:00:00 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not use the product's remote repositories when a local
+  installation repository (off-line media) is already available.
+
+-------------------------------------------------------------------
 Mon Jul 27 11:23:53 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add an action to "probe" the software service (gh#agama-project/agama#3341).

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,15 +1,11 @@
 -------------------------------------------------------------------
-Tue Jul 28 12:00:00 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
-
-- Do not use the product's remote repositories when a local
-  installation repository (off-line media) is already available.
-
--------------------------------------------------------------------
 Mon Jul 27 11:23:53 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add an action to "probe" the software service (gh#agama-project/agama#3341).
 - Unify storage, software and DASD probing.
 - Fix the "agama probe" command.
+- Do not use the product's remote repositories when a local
+  installation repository (off-line media) is already available.
 
 -------------------------------------------------------------------
 Thu Jul 23 13:44:55 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 27 11:23:53 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add an action to "probe" the software service (gh#agama-project/agama#3341).
+- Unify storage, software and DASD probing.
+- Fix the "agama probe" command.
+
+-------------------------------------------------------------------
 Thu Jul 23 12:08:50 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not copy the installatoin repositories (agama-0, agama-1, etc.)

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -15,7 +15,7 @@ Thu Jul 23 13:44:55 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 -------------------------------------------------------------------
 Thu Jul 23 12:08:50 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Do not copy the installatoin repositories (agama-0, agama-1, etc.)
+- Do not copy the installation repositories (agama-0, agama-1, etc.)
   to the installed system (bsc#1264277 gh#agama-project/agama#1458).
 
 -------------------------------------------------------------------

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jul 27 11:39:41 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Adapt to use the "Probe" action of the API (gh#agama-project/agama#3341).
+
+-------------------------------------------------------------------
 Tue Jul 21 17:37:15 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Add themeable roles for corner radius and product logo size and

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -30,6 +30,7 @@ import type { Question } from "~/model/question";
 import type { Status } from "~/model/status";
 import type { System, LicenseContent } from "~/model/system";
 import type { Action, L10nSystemConfig, DiscoverISCSIConfig } from "~/model/action";
+import type { Scope } from "~/model/status";
 import type { AxiosResponse } from "axios";
 
 type Response = Promise<AxiosResponse>;
@@ -79,7 +80,7 @@ const configureL10nAction = (config: L10nSystemConfig) => postAction({ configure
 
 const activateStorageAction = () => postAction({ activateStorage: null });
 
-const probeStorageAction = () => postAction({ probeStorage: null });
+const probeAction = (only?: Scope[]) => postAction({ probe: { only } });
 
 const discoverISCSIAction = (config: DiscoverISCSIConfig) => postAction({ discoverISCSI: config });
 
@@ -116,7 +117,7 @@ export {
   patchQuestion,
   configureL10nAction,
   activateStorageAction,
-  probeStorageAction,
+  probeAction,
   discoverISCSIAction,
   startInstallation,
   finishInstallation,

--- a/web/src/model/action.ts
+++ b/web/src/model/action.ts
@@ -20,7 +20,9 @@
  * find current contact information at www.suse.com.
  */
 
-type Action = ConfigureL10n | ActivateStorage | ProbeStorage | DiscoverISCSI | Install | Finish;
+import type { Scope } from "~/model/status";
+
+type Action = ConfigureL10n | ActivateStorage | Probe | DiscoverISCSI | Install | Finish;
 
 type ConfigureL10n = {
   configureL10n: L10nSystemConfig;
@@ -35,8 +37,8 @@ type ActivateStorage = {
   activateStorage: null;
 };
 
-type ProbeStorage = {
-  probeStorage: null;
+type Probe = {
+  probe: { only?: Scope[] | null };
 };
 
 type DiscoverISCSI = {


### PR DESCRIPTION
## Problem

If the network is not available, Agama does not work properly (#3341):

1. Online medium: Agama complains that it cannot read the product. That's actually true, but it does not allow to set up the network to read the repositories.
2. Offline medium: Agama complains that it cannot read the remote repositories, even if it does not need them for installing the product.

## Solution

- Bring back the method "Probe" action (it was there in pre-APIv2 times) to refresh the software metadata. Merge it with the existing "ProbeStorage" and "ProbeDASD". It would allow us to solve problem 1.
- Do not use the remote repositories when using the off-line medium.

The solution is quite conservative because we are in RC phase, so we wanted to explictly avoid introducing any API change (e.g., a mechanism to allow telling Agama to "ignore" something). Let's work on that for the 16.2 cycle.

## Technical details

- Replace the separate `Refresh`/`ProbeStorage`/`ProbeDASD` actions with a single generic `Probe` action (`Action::Probe { only: Option<Vec<Scope>> }`), used to refresh storage, DASD and software state through one HTTP action/CLI command
- Adapt `ManagerHTTPClient` and the web UI (`api.ts`, `model/action.ts`) to the new `Probe` action.
- Make sure the software service attempts to load the repositories on every `SetConfig` call, so the `software.load_source` issue is always kept up to date. It implies adding some delay on each `SetConfig` call.
- Skip the product's remote repositories entirely when a local installation repository (off-line/full media) is already present. This is an explicit trade-off: package updates that would only come from the remote repos won't be applied in that scenario.

Additionall, we did a small internal cleanup: consolidate the "well-known" predefined repository alias constants (`INSTALLATION_REPO_ALIAS`, `DUD_REPO_ALIAS`) in `agama-software::service`, and move `AGAMA_REPO_PREFIX` next to `build_repo()` in `model::state`, deriving the generated alias from that constant instead of a separate hardcoded literal.

## Testing

- Tested manually

## Follow up

- Allow to start a probing from the UI (on a separate PR).