### PR TITLE
refactor(web): drop leftover route handle metadata

### DIFF
--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -39,7 +39,6 @@ import storageRoutes from "~/routes/storage";
 import softwareRoutes from "~/routes/software";
 import usersRoutes from "~/routes/users";
 import { SYSTEM, USER, ROOT as PATHS } from "./routes/paths";
-import { N_ } from "~/i18n";
 
 // Redirects for legacy routes that have been consolidated or renamed. These
 // help prevent 404s for bookmarked URLs or external links after route
@@ -77,7 +76,6 @@ const rootRoutes = () => [
   {
     path: SYSTEM.root,
     element: <SystemPage />,
-    handle: { name: N_("System"), icon: "server" },
   },
   registrationRoutes(),
   l10nRoutes(),
@@ -140,4 +138,4 @@ const router = () =>
     },
   ]);
 
-export { router, rootRoutes, PATHS };
+export { router, PATHS };

--- a/web/src/routes/l10n.tsx
+++ b/web/src/routes/l10n.tsx
@@ -24,14 +24,9 @@ import React from "react";
 import L10nPage from "~/components/l10n/L10nPage";
 import { Route } from "~/types/routes";
 import { L10N as PATHS } from "~/routes/paths";
-import { N_ } from "~/i18n";
 
 const routes = (): Route => ({
   path: PATHS.root,
-  handle: {
-    name: N_("Localization"),
-    icon: "globe",
-  },
   children: [
     {
       index: true,

--- a/web/src/routes/network.tsx
+++ b/web/src/routes/network.tsx
@@ -27,14 +27,9 @@ import WifiConnectionForm from "~/components/network/WifiConnectionForm";
 import ConnectionPage from "~/components/network/ConnectionPage";
 import { Route } from "~/types/routes";
 import { NETWORK as PATHS } from "~/routes/paths";
-import { N_ } from "~/i18n";
 
 const routes = (): Route => ({
   path: PATHS.root,
-  handle: {
-    name: N_("Network"),
-    icon: "settings_ethernet",
-  },
   children: [
     { index: true, element: <NetworkPage /> },
     {

--- a/web/src/routes/registration.tsx
+++ b/web/src/routes/registration.tsx
@@ -24,11 +24,9 @@ import React from "react";
 import { ProductRegistrationPage } from "~/components/product";
 import { Route } from "~/types/routes";
 import { REGISTRATION as PATHS } from "~/routes/paths";
-import { N_ } from "~/i18n";
 
 const routes = (): Route => ({
   path: PATHS.root,
-  handle: { name: N_("Registration"), icon: "app_registration", needsRegistrableProduct: true },
   children: [
     {
       index: true,

--- a/web/src/routes/software.tsx
+++ b/web/src/routes/software.tsx
@@ -25,14 +25,9 @@ import SoftwarePage from "~/components/software/SoftwarePage";
 import SoftwarePatternsSelection from "~/components/software/patterns-form/Form";
 import { Route } from "~/types/routes";
 import { SOFTWARE as PATHS } from "~/routes/paths";
-import { N_ } from "~/i18n";
 
 const routes = (): Route => ({
   path: PATHS.root,
-  handle: {
-    name: N_("Software"),
-    icon: "apps",
-  },
   children: [
     {
       index: true,

--- a/web/src/routes/storage.tsx
+++ b/web/src/routes/storage.tsx
@@ -21,7 +21,6 @@
  */
 
 import React from "react";
-import { N_ } from "~/i18n";
 import { Route } from "~/types/routes";
 import BootSelectionPage from "~/components/storage/BootSelectionPage";
 import EncryptionSettingsPage from "~/components/storage/EncryptionSettingsPage";
@@ -43,7 +42,6 @@ import InitiatorFormPage from "~/components/storage/iscsi/InitiatorFormPage";
 
 const routes = (): Route => ({
   path: PATHS.root,
-  handle: { name: N_("Storage"), icon: "hard_drive" },
   children: [
     {
       index: true,
@@ -112,12 +110,10 @@ const routes = (): Route => ({
     {
       path: PATHS.dasd,
       element: <DASDPage />,
-      handle: { name: N_("DASD") },
     },
     {
       path: PATHS.zfcp.root,
       element: <ZFCPPage />,
-      handle: { name: N_("ZFCP") },
     },
     {
       path: PATHS.zfcp.controllers,

--- a/web/src/routes/users.tsx
+++ b/web/src/routes/users.tsx
@@ -24,14 +24,9 @@ import React from "react";
 import UsersPage from "~/components/users/UsersPage";
 import { Route } from "~/types/routes";
 import { USER as PATHS } from "~/routes/paths";
-import { N_ } from "~/i18n";
 
 const routes = (): Route => ({
   path: PATHS.root,
-  handle: {
-    name: N_("Authentication"),
-    icon: "manage_accounts",
-  },
   children: [{ index: true, element: <UsersPage /> }],
 });
 

--- a/web/src/types/routes.ts
+++ b/web/src/types/routes.ts
@@ -22,17 +22,6 @@
 
 import { RouteObject } from "react-router";
 
-type RouteHandle = {
-  /** Text to be used as label when building a link from route information */
-  name: string;
-  /** Text to be shown in the layout header as an h1 */
-  title?: string;
-  /** Icon for representing the route in some places, like a menu entry */
-  icon?: string;
-  /** Whether the route link will be rendered for registrable products only */
-  needsRegistrableProduct?: boolean;
-};
-
-type Route = RouteObject & { handle?: RouteHandle };
+type Route = RouteObject;
 
 export type { Route };


### PR DESCRIPTION
## Problem

The installer used to have a sidebar. It walked the route tree and rendered one link per top level route, taking the label and the icon straight from the metadata attached to each route. That is what the metadata was for, and while the sidebar existed it was the single source for those labels.

The interface revamp (#3009, January 2026) replaced that navigation with today's overview page and breadcrumbs, taking the sidebar with it. The metadata was only partially removed then, and the rest was left in place on every route, where it has stayed ever since.

It has had no reader in all that time: no screen inspects the metadata of the matched route, and the route list that used to be handed to the sidebar has no callers outside the router itself. In practice this left a second, hand copied set of page names and icons sitting next to the real ones, with nobody to consume it and no signal when the two drifted apart.

## Solution

Delete these left overs. If a future screen wants page titles derived from the route tree, it will need a fresh design anyway: most routes never had this metadata to begin with, so there was never enough here to build on.

> [!NOTE]
> 
> Yet another PR that does not deserve an entry in the changes file.

## About the translated strings

Deleting the metadata also deletes nine strings that were marked for translation: System, Localization, Network, Authentication, Software, Registration, Storage, DASD, and ZFCP.

This is safe, and worth spelling out:

- Eight of the nine appear elsewhere in the interface, in breadcrumbs and overview cards. Those references keep the strings in the catalog, so existing translations stay in use exactly as before.
- Only "ZFCP" loses its last reference. That one was never displayed: the page users reach spells it "zFCP", which is a separate entry and stays untouched. Its translations are also identical to the original in every language that has one, since it is an acronym.

No text visible in the interface loses a translation, and no visible text changes, so this is safe to land during a string freeze. Translators see one obsolete entry retired, nothing more.

