### PR TITLE
refactor(web): split the installer client from the connection guard

### DIFF
--- a/web/src/Connected.test.tsx
+++ b/web/src/Connected.test.tsx
@@ -38,7 +38,7 @@ jest.mock("~/client", () => ({
   onInstallerClientChange: () => () => undefined,
 }));
 
-import { InstallerClientProvider } from "./installer";
+import Connected from "./Connected";
 
 /**
  * Builds a client in the given connection state, recording the handlers
@@ -61,16 +61,16 @@ const buildClient = ({
 
 const Content = () => <>Content</>;
 
-const renderProvider = () =>
+const renderConnection = () =>
   plainRender(
-    <InstallerClientProvider>
+    <Connected>
       <Content />
-    </InstallerClientProvider>,
+    </Connected>,
   );
 
 const loseConnection = () => act(() => closeHandlers.forEach((handler) => handler()));
 
-describe("InstallerClientProvider", () => {
+describe("Connected", () => {
   beforeEach(() => {
     closeHandlers = [];
   });
@@ -81,7 +81,7 @@ describe("InstallerClientProvider", () => {
     });
 
     it("renders the children", async () => {
-      renderProvider();
+      renderConnection();
       await screen.findByText("Content");
     });
   });
@@ -92,7 +92,7 @@ describe("InstallerClientProvider", () => {
     });
 
     it("renders a loading indicator", async () => {
-      renderProvider();
+      renderConnection();
       await screen.findByText("Loading Mock");
     });
   });
@@ -103,7 +103,7 @@ describe("InstallerClientProvider", () => {
     });
 
     it("renders a loading indicator", async () => {
-      renderProvider();
+      renderConnection();
       await screen.findByText("Content");
 
       loseConnection();
@@ -118,7 +118,7 @@ describe("InstallerClientProvider", () => {
     });
 
     it("reports that the server cannot be reached", async () => {
-      renderProvider();
+      renderConnection();
       await screen.findByText("Content");
 
       loseConnection();

--- a/web/src/Connected.tsx
+++ b/web/src/Connected.tsx
@@ -26,7 +26,16 @@ import { useInstallerClient } from "~/hooks/use-installer-client";
 import Loading from "~/components/layout/Loading";
 import ServerError from "~/components/core/ServerError";
 
-function InstallerClientProvider({ children }: React.PropsWithChildren) {
+/**
+ * Renders its children only while the server is reachable.
+ *
+ * Until the connection is established it shows a loading indicator, and it
+ * reports the problem when the connection drops and cannot be recovered.
+ *
+ * Companion of {@link Protected}, which guards the same tree on being logged
+ * in.
+ */
+export default function Connected({ children }: React.PropsWithChildren) {
   const client = useInstallerClient();
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState(false);
@@ -72,5 +81,3 @@ function InstallerClientProvider({ children }: React.PropsWithChildren) {
 
   return children;
 }
-
-export { InstallerClientProvider };

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -83,4 +83,70 @@ const createDefaultClient = async () => {
   return createClient(httpUrl);
 };
 
-export { createClient, createDefaultClient };
+/**
+ * There is one connection to the server for the whole application, kept here
+ * instead of in a component so that any module can reach it.
+ */
+let client: InstallerClient | null = null;
+let creation: Promise<InstallerClient> | null = null;
+const listeners = new Set<VoidFn>();
+
+const notify = () => listeners.forEach((listener) => listener());
+
+/**
+ * Returns the client, creating it the first time it is asked for.
+ *
+ * Concurrent calls made before the client exists share the same creation, so
+ * there is never more than one connection.
+ */
+const getInstallerClient = async (): Promise<InstallerClient> => {
+  if (client) return client;
+
+  creation ||= createDefaultClient().then((newClient) => {
+    newClient.onEvent((event) => {
+      if (event.type === "ClientConnected") newClient.id = event.clientId;
+    });
+    client = newClient;
+    notify();
+    return newClient;
+  });
+
+  return creation;
+};
+
+/**
+ * The client, or null while it is still being created.
+ */
+const installerClient = (): InstallerClient | null => client;
+
+/**
+ * Registers a handler to run when the client is replaced. It returns a
+ * function for deregistering the handler.
+ */
+const onInstallerClientChange = (handler: VoidFn): VoidFn => {
+  listeners.add(handler);
+  return () => {
+    listeners.delete(handler);
+  };
+};
+
+/**
+ * Forgets the current client, so the next request for it creates a new one.
+ *
+ * Needed by hot module replacement and by tests; the application itself keeps
+ * one client for its whole life.
+ */
+const resetInstallerClient = () => {
+  client = null;
+  creation = null;
+  notify();
+};
+
+export {
+  createClient,
+  createDefaultClient,
+  getInstallerClient,
+  installerClient,
+  onInstallerClientChange,
+  resetInstallerClient,
+};

--- a/web/src/components/form/MaskedField.tsx
+++ b/web/src/components/form/MaskedField.tsx
@@ -32,7 +32,7 @@ import {
   InputGroupItem,
   TextInput,
 } from "@patternfly/react-core";
-import { Icon } from "~/components/layout";
+import Icon from "~/components/layout/Icon";
 import Interpolate from "~/components/core/Interpolate";
 import Text from "~/components/core/Text";
 import { useFieldLabel } from "~/hooks/use-field-label";

--- a/web/src/components/storage/dasd/DASDFormatProgress.test.tsx
+++ b/web/src/components/storage/dasd/DASDFormatProgress.test.tsx
@@ -27,7 +27,7 @@ import DASDFormatProgress from "./DASDFormatProgress";
 
 const mockOnEvent = jest.fn();
 
-jest.mock("~/context/installer", () => ({
+jest.mock("~/hooks/use-installer-client", () => ({
   useInstallerClient: () => ({
     onEvent: mockOnEvent,
   }),

--- a/web/src/components/storage/dasd/DASDFormatProgress.tsx
+++ b/web/src/components/storage/dasd/DASDFormatProgress.tsx
@@ -22,7 +22,7 @@
 
 import React, { useEffect, useState } from "react";
 import { Card, CardBody, CardTitle, Progress, Stack } from "@patternfly/react-core";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import { sortCollection } from "~/utils";
 import { _ } from "~/i18n";
 

--- a/web/src/context/app.tsx
+++ b/web/src/context/app.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { InstallerClientProvider } from "./installer";
+import Connected from "~/Connected";
 import { InstallerL10nProvider } from "./installerL10n";
 import { StorageUiStateProvider } from "./storage-ui-state";
 import { TerminalProvider } from "./terminal";
@@ -111,7 +111,7 @@ const queryClient = new QueryClient({
  */
 function AppProviders({ children }: React.PropsWithChildren) {
   return (
-    <InstallerClientProvider>
+    <Connected>
       <QueryClientProvider client={queryClient}>
         <InstallerL10nProvider>
           <StorageUiStateProvider>
@@ -119,7 +119,7 @@ function AppProviders({ children }: React.PropsWithChildren) {
           </StorageUiStateProvider>
         </InstallerL10nProvider>
       </QueryClientProvider>
-    </InstallerClientProvider>
+    </Connected>
   );
 }
 

--- a/web/src/context/installer.test.tsx
+++ b/web/src/context/installer.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2023-2025] SUSE LLC
+ * Copyright (c) [2023-2026] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -21,45 +21,109 @@
  */
 
 import React from "react";
-import { screen } from "@testing-library/react";
-import { createClient } from "~/client";
+import { act, screen } from "@testing-library/react";
 import { plainRender } from "~/test-utils";
-import { InstallerClientProvider } from "./installer";
-import { DummyWSClient } from "~/client/ws";
+
+import type { InstallerClient } from "~/client";
 
 jest.mock("~/components/layout/Loading", () => () => <div>Loading Mock</div>);
 
-// Helper component to check the client status.
-const Content = () => {
-  return <>Content</>;
-};
+let client: InstallerClient | null = null;
+let closeHandlers: (() => void)[] = [];
 
-describe("installer context", () => {
-  describe("when the WebSocket is connected", () => {
+jest.mock("~/client", () => ({
+  ...jest.requireActual("~/client"),
+  getInstallerClient: () => Promise.resolve(client),
+  installerClient: () => client,
+  onInstallerClientChange: () => () => undefined,
+}));
+
+import { InstallerClientProvider } from "./installer";
+
+/**
+ * Builds a client in the given connection state, recording the handlers
+ * registered for a connection loss so tests can trigger one.
+ */
+const buildClient = ({
+  isConnected = true,
+  isRecoverable = true,
+}: { isConnected?: boolean; isRecoverable?: boolean } = {}): InstallerClient => ({
+  isConnected: () => isConnected,
+  isRecoverable: () => isRecoverable,
+  onConnect: () => () => undefined,
+  onClose: (handler) => {
+    closeHandlers.push(handler);
+    return () => undefined;
+  },
+  onError: () => () => undefined,
+  onEvent: () => () => undefined,
+});
+
+const Content = () => <>Content</>;
+
+const renderProvider = () =>
+  plainRender(
+    <InstallerClientProvider>
+      <Content />
+    </InstallerClientProvider>,
+  );
+
+const loseConnection = () => act(() => closeHandlers.forEach((handler) => handler()));
+
+describe("InstallerClientProvider", () => {
+  beforeEach(() => {
+    closeHandlers = [];
+  });
+
+  describe("when the client is connected", () => {
+    beforeEach(() => {
+      client = buildClient();
+    });
+
     it("renders the children", async () => {
-      const ws = new DummyWSClient();
-      const client = createClient(new URL("https://localhost"), ws);
-
-      plainRender(
-        <InstallerClientProvider client={client}>
-          <Content />
-        </InstallerClientProvider>,
-      );
-
+      renderProvider();
       await screen.findByText("Content");
     });
   });
 
-  describe("when the WebSocket is not connected", () => {
-    it("renders the a loading indicator", async () => {
-      const client = createClient(new URL("https://localhost"));
+  describe("when the client is not connected yet", () => {
+    beforeEach(() => {
+      client = buildClient({ isConnected: false });
+    });
 
-      plainRender(
-        <InstallerClientProvider client={client}>
-          <Content />
-        </InstallerClientProvider>,
-      );
+    it("renders a loading indicator", async () => {
+      renderProvider();
       await screen.findByText("Loading Mock");
+    });
+  });
+
+  describe("when the connection is lost but can be recovered", () => {
+    beforeEach(() => {
+      client = buildClient({ isRecoverable: true });
+    });
+
+    it("renders a loading indicator", async () => {
+      renderProvider();
+      await screen.findByText("Content");
+
+      loseConnection();
+
+      await screen.findByText("Loading Mock");
+    });
+  });
+
+  describe("when the connection is lost for good", () => {
+    beforeEach(() => {
+      client = buildClient({ isRecoverable: false });
+    });
+
+    it("reports that the server cannot be reached", async () => {
+      renderProvider();
+      await screen.findByText("Content");
+
+      loseConnection();
+
+      await screen.findByText("Cannot connect");
     });
   });
 });

--- a/web/src/context/installer.tsx
+++ b/web/src/context/installer.tsx
@@ -21,89 +21,56 @@
  */
 
 import React, { useState, useEffect } from "react";
-import { createDefaultClient, InstallerClient } from "~/client";
+import { getInstallerClient, resetInstallerClient } from "~/client";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import Loading from "~/components/layout/Loading";
 import ServerError from "~/components/core/ServerError";
 
-type InstallerClientProviderProps = React.PropsWithChildren<{
-  /** Client to connect to Agama service; if it is undefined, it instantiates a
-   * new one using the address registered in /run/agama/bus.address. */
-  client?: InstallerClient;
-}>;
-
-const InstallerClientContext = React.createContext(null);
-
-/**
- * Returns the installer client
- */
-function useInstallerClient(): InstallerClient {
-  const context = React.useContext(InstallerClientContext);
-  if (context === undefined) {
-    throw new Error("useInstallerClient must be used within a InstallerClientProvider");
-  }
-
-  return context;
-}
-
-function InstallerClientProvider({ children, client = null }: InstallerClientProviderProps) {
-  const [value, setValue] = useState(client);
-  const [connected, setConnected] = useState(!!client?.isConnected());
+function InstallerClientProvider({ children }: React.PropsWithChildren) {
+  const client = useInstallerClient();
+  const [connected, setConnected] = useState(false);
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    const connectClient = async () => {
-      const client = await createDefaultClient();
-
-      client.onEvent((event) => {
-        if (event.type === "ClientConnected") {
-          client.id = event.clientId;
-        }
-      });
-
-      setValue(client);
-    };
+    getInstallerClient();
 
     // allow hot replacement for the clients code
     if (module.hot) {
       // if anything coming from `import ... from "~/client"` is updated then this hook is called
-      module.hot.accept("~/client", async function () {
+      module.hot.accept("~/client", function () {
         console.log("[Agama HMR] A client module has been updated");
-
-        const updated_client = await createDefaultClient();
+        resetInstallerClient();
+        getInstallerClient();
         console.log("[Agama HMR] Using new clients");
-        setValue(updated_client);
       });
     }
-
-    if (!value) connectClient();
-  }, [setValue, value]);
+  }, []);
 
   useEffect(() => {
-    if (!value) return;
+    if (!client) return;
 
-    value.onConnect(() => {
+    setConnected(client.isConnected());
+
+    const forgetConnect = client.onConnect(() => {
       setConnected(true);
       setError(false);
     });
 
-    value.onClose(() => {
+    const forgetClose = client.onClose(() => {
       setConnected(false);
-      setError(!value.isRecoverable());
+      setError(!client.isRecoverable());
     });
-  }, [value]);
 
-  const Content = () => {
-    if (error) return <ServerError />;
-    if (!connected) return <Loading />;
+    return () => {
+      forgetConnect();
+      forgetClose();
+    };
+  }, [client]);
 
-    return children;
-  };
+  if (error) return <ServerError />;
+  if (!connected) return <Loading />;
 
-  return (
-    <InstallerClientContext.Provider value={value}>
-      <Content />
-    </InstallerClientContext.Provider>
-  );
+  return children;
 }
 
-export { InstallerClientProvider, useInstallerClient };
+export { InstallerClientProvider };

--- a/web/src/context/installerL10n.test.tsx
+++ b/web/src/context/installerL10n.test.tsx
@@ -26,7 +26,6 @@ import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/reac
 import { _ } from "~/i18n";
 import agama from "~/agama";
 import { InstallerL10nProvider, useInstallerL10n } from "~/context/installerL10n";
-import { InstallerClientProvider } from "./installer";
 import { plainRender } from "~/test-utils";
 
 jest.unmock("~/context/installerL10n");
@@ -35,11 +34,6 @@ jest.unmock("~/context/installerL10n");
 // to emulate the backend persisting the change.
 let currentLocale = "en_US.UTF-8";
 const mockConfigureL10nFn = jest.fn();
-
-jest.mock("~/context/installer", () => ({
-  ...jest.requireActual("~/context/installer"),
-  useInstallerClientStatus: () => ({ connected: true, error: false }),
-}));
 
 jest.mock("~/api", () => ({
   ...jest.requireActual("~/api"),
@@ -51,15 +45,6 @@ jest.mock("~/languages.json", () => ({
   "en-US": "English (US)",
   "es-ES": "Español",
 }));
-
-const client = {
-  isConnected: jest.fn().mockResolvedValue(true),
-  isRecoverable: jest.fn(),
-  onConnect: jest.fn(),
-  onClose: jest.fn(),
-  onError: jest.fn(),
-  onEvent: jest.fn(),
-};
 
 // "Cancel" is translated as "Cancelar" in the Spanish catalog, so its rendered
 // value reveals which catalog is currently applied to the global translations.
@@ -99,12 +84,10 @@ const renderProvider = () => {
   return plainRender(
     <QueryClientProvider client={queryClient}>
       <Suspense fallback="Loading...">
-        <InstallerClientProvider client={client}>
-          <InstallerL10nProvider>
-            <Heading />
-            <Controls />
-          </InstallerL10nProvider>
-        </InstallerClientProvider>
+        <InstallerL10nProvider>
+          <Heading />
+          <Controls />
+        </InstallerL10nProvider>
       </Suspense>
     </QueryClientProvider>,
   );

--- a/web/src/hooks/form.loading.test.ts
+++ b/web/src/hooks/form.loading.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Guards against files importing each other in a circle around the form tools.
+ *
+ * `withForm` builds a component while its file is being read, before anything
+ * renders. That works only if the form tools are fully loaded by then, which
+ * stops being true when their own imports lead back to a component that uses
+ * them. Files in a circle load in an order nobody chose, so one of them runs
+ * too early and fails with "withForm is not a function", pointing at that
+ * component instead of at the imports responsible for it.
+ *
+ * Asking for the form tools before anything else, as the first thing a fresh
+ * test does, recreates exactly that situation. This stays quiet until an
+ * import closes the circle again.
+ */
+describe("the form tools", () => {
+  it("are ready for the components that build fields as they load", async () => {
+    const { useAppForm, withForm } = await import("~/hooks/form");
+
+    expect(typeof withForm).toBe("function");
+    expect(typeof useAppForm).toBe("function");
+  });
+});

--- a/web/src/hooks/model/issue.ts
+++ b/web/src/hooks/model/issue.ts
@@ -23,7 +23,7 @@
 import React, { useCallback } from "react";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { getIssues } from "~/api";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import type { Issue, Scope } from "~/model/issue";
 
 const ISSUES_QUERY_KEY = "issues" as const;

--- a/web/src/hooks/model/proposal.test.ts
+++ b/web/src/hooks/model/proposal.test.ts
@@ -25,7 +25,7 @@ import { installerRenderHook, createCallbackMock } from "~/test-utils";
 
 const [mockOnEvent, eventCallbacks] = createCallbackMock();
 
-jest.mock("~/context/installer", () => ({
+jest.mock("~/hooks/use-installer-client", () => ({
   useInstallerClient: () => ({ onEvent: mockOnEvent }),
 }));
 

--- a/web/src/hooks/model/proposal.ts
+++ b/web/src/hooks/model/proposal.ts
@@ -23,7 +23,7 @@
 import React from "react";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { getProposal } from "~/api";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import type { Proposal } from "~/model/proposal";
 import { CONFIG_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/config";
 import { STORAGE_MODEL_QUERY_KEY } from "~/hooks/model/storage/config-model";

--- a/web/src/hooks/model/question.ts
+++ b/web/src/hooks/model/question.ts
@@ -22,7 +22,7 @@
 
 import { useEffect } from "react";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import { getQuestions } from "~/api";
 import type { Question } from "~/model/question";
 

--- a/web/src/hooks/model/status.ts
+++ b/web/src/hooks/model/status.ts
@@ -23,7 +23,7 @@
 import { useEffect } from "react";
 import { isArrayEqual, remove, replaceOrAppend } from "radashi";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import { getStatus } from "~/api";
 
 import type { Status, Progress, Task } from "~/model/status";

--- a/web/src/hooks/model/system.ts
+++ b/web/src/hooks/model/system.ts
@@ -23,7 +23,7 @@
 import React from "react";
 import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { getSystem } from "~/api";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import type { System } from "~/model/system";
 
 const SYSTEM_QUERY_KEY = "system" as const;

--- a/web/src/hooks/model/system/network.ts
+++ b/web/src/hooks/model/system/network.ts
@@ -36,7 +36,7 @@ import {
   IPAddress,
   ConnectionMethod,
 } from "~/types/network";
-import { useInstallerClient } from "~/context/installer";
+import { useInstallerClient } from "~/hooks/use-installer-client";
 import React, { useCallback } from "react";
 import { formatIp } from "~/utils/network";
 import { isEmpty } from "radashi";

--- a/web/src/hooks/use-installer-client.ts
+++ b/web/src/hooks/use-installer-client.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { useSyncExternalStore } from "react";
+import { installerClient, onInstallerClientChange } from "~/client";
+
+import type { InstallerClient } from "~/client";
+
+/**
+ * Returns the client for talking to the server, or null while it is still
+ * being created. Components re-render as soon as it is available.
+ *
+ * @example
+ * const client = useInstallerClient();
+ *
+ * useEffect(() => {
+ *   if (!client) return;
+ *
+ *   return client.onEvent(handleEvent);
+ * }, [client]);
+ */
+export function useInstallerClient(): InstallerClient | null {
+  return useSyncExternalStore(onInstallerClientChange, installerClient);
+}


### PR DESCRIPTION
## Summary

- `client/index.ts` now creates and keeps the connection, so any file can ask
  for it with `getInstallerClient()` instead of having to sit under a provider.
- Deciding what to show while the server is unreachable moves to
  `src/Connected.tsx`, next to `src/Protected.tsx`, which guards the same tree
  on being logged in.
- `MaskedField` imports `Icon` from its own file, and a new test fails if the
  circular import this removes ever comes back.

## What it improves

`InstallerClientProvider` did three things: create the connection to the
server, hold it, and decide whether to render the app, `Loading` or
`ServerError`. Splitting them means:

- The connection is what it always was, a single value created once. Now it
  reads like one, and reaching it no longer depends on where a file sits in
  the component tree.
- Deciding what the user sees is a component with a name. `Connected` and
  `Protected` now sit side by side, one guarding on the server answering, the
  other on being logged in, and they read the same way.
- That gating gets tested for the first time: connection lost and recovered,
  connection lost for good.
- One less provider wrapping the whole application.
- Contexts stop importing pages and fields stop importing whole folders, which
  is what had quietly tangled the imports below.

## Where the tangle showed up

Migrating `InstallerL10nOptions`, the language and keyboard dialog in the
header, to the TanStack Form stack. `components/form/conventions.md` says to
build field groups with `withForm`, 24 files already do, and doing it here
broke the build:

```
TypeError: (0 , form_1.withForm) is not a function
  at Object.<anonymous> (src/components/core/InstallerL10nOptions.tsx:86:31)
```

The dialog is not at fault. Because the context imported the pages it might
render, and because `MaskedField` imported `~/components/layout` to get one
icon, `hooks/form.ts` sat in a circular import:

```
hooks/form.ts                      registers every field component
  -> components/form/MaskedField.tsx
    -> components/layout (index)
      -> components/layout/Header.tsx
        -> components/core (index)
          -> components/core/Page.tsx
            -> components/core/InstallerL10nOptions.tsx
              -> hooks/form.ts     back to the start
```

`withForm()` runs while a file is being read, not when a component renders, so
`hooks/form.ts` had not finished exporting by the time the dialog asked for
it. Every form written so far lives outside that cycle, which is why this had
never come up. The components being migrated next do not.

## What changed

- `client/index.ts`: `getInstallerClient()` creates the client once and hands
  the same one to everyone afterwards, with `resetInstallerClient()` for hot
  reloading. `hooks/use-installer-client.ts` exposes it to components.
- `context/installer.tsx` is gone. Its gating moved to `src/Connected.tsx`,
  showing `Loading` until connected and `ServerError` when the connection drops
  for good. `AppProviders` mounts it where the provider used to be. Same
  indicator, same error page, same recovery, and the connection handlers are
  now released on unmount.
- `components/form/MaskedField.tsx` imports `~/components/layout/Icon`.
- `hooks/form.loading.test.ts` asks for `~/hooks/form` as the first file of a
  fresh test and checks `withForm` is usable, so a future import closing the
  cycle fails a check instead of puzzling whoever hits it.

## What it means for callers

|  | before | after |
| --- | --- | --- |
| `useInstallerClient()` call sites | 7 | 8 |
| defined in | `context/installer.tsx`, 109 lines of context and provider | `hooks/use-installer-client.ts`, a two line hook |
| entry points on the client module | none | 4, called 5 times in total |

The seven callers are `hooks/model/{issue,proposal,question,status,system}.ts`,
`hooks/model/system/network.ts` and `DASDFormatProgress.tsx`. All of them keep
the same call and the same null check, and only their import line changes. The
eighth caller is `Connected` itself, which watches the connection it guards on.
The four entry points (`getInstallerClient`, `installerClient`,
`onInstallerClientChange`, `resetInstallerClient`) are called only from
`Connected` and from the hook.

What changes for them is not the call, it is that none of the seven depend on
being rendered under a provider any more.

Worth mentioning since it disappears here: `context/installerL10n.test.tsx`
mocked `useInstallerClientStatus`, which exists nowhere in the codebase and
did nothing.

## Test plan

- [x] `npm run test`, `npm run eslint`, `npm run check-types`
- [x] Verified the guard test fails when the two imports are put back
- [x] Manual: first load, service stopped, service restarted, and a
      recoverable drop
- [x] Confirm hot reloading still picks up client changes during development

## Follow-up

The language dialog can now finish its migration with `withForm`, like every
other form, which is the branch waiting behind this one.

---

Co-Authored-By: Claude Code <noreply@anthropic.com>
