### PR TITLE
refactor(web): reworks product not found screen

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,7 +2,10 @@
 Mon Jul 27 12:41:09 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Show a proper empty state, pointing to the network settings,
-  when the product to install is not found
+  when the product to install is not found, and offer to read the
+  software information again once the connection is in place
+  (gh#agama-project/agama#3768).
+- Offer the same actions when the repositories cannot be read
   (gh#agama-project/agama#3768).
 
 -------------------------------------------------------------------

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 27 12:41:09 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Show a proper empty state, pointing to the network settings,
+  when the product to install is not found
+  (gh#agama-project/agama#3768).
+
+-------------------------------------------------------------------
 Mon Jul 27 11:39:41 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adapt to use the "Probe" action of the API (gh#agama-project/agama#3341).

--- a/web/src/components/core/IssuesAlert.tsx
+++ b/web/src/components/core/IssuesAlert.tsx
@@ -27,9 +27,19 @@ import { _ } from "~/i18n";
 
 import type { Issue } from "~/model/issue";
 
-export default function IssuesAlert({ issues }: { issues: Issue[] }) {
+export type IssuesAlertProps = {
+  /** Issues to report. Nothing is rendered when the list is empty. */
+  issues: Issue[];
+  /**
+   * Optional buttons or links offering a way to deal with the issues, rendered
+   * below the description.
+   */
+  actions?: React.ReactNode;
+};
+
+export default function IssuesAlert({ issues, actions }: IssuesAlertProps) {
   if (isEmpty(issues)) return;
-  const props: Partial<AlertProps> = { isInline: true, variant: "warning" };
+  const props: Partial<AlertProps> = { isInline: true, variant: "warning", actionLinks: actions };
 
   if (issues.length === 1) {
     return <Alert {...props} title={issues[0].description} />;

--- a/web/src/components/core/UnavailableState.tsx
+++ b/web/src/components/core/UnavailableState.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import {
+  Content,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+} from "@patternfly/react-core";
+import { Icon } from "~/components/layout";
+import Link from "~/components/core/Link";
+
+const EmptyStateIcon = () => <Icon name="apps_outage" />;
+
+export type UnavailableStateProps = {
+  /** Short summary of what is not available. */
+  title: React.ReactNode;
+  /** Main description text explaining why it is not available. */
+  description: React.ReactNode;
+  /** Optional additional hint text displayed below the description. */
+  hint?: React.ReactNode;
+  /** Optional action link with destination path and label. */
+  actionLink?: { to: string; label: string };
+};
+
+/**
+ * Empty state for sections that cannot be used because something is missing or
+ * could not be loaded.
+ *
+ * Use it to explain the situation and, when possible, to offer a way out
+ * through `actionLink`.
+ *
+ * @example
+ * <UnavailableState
+ *   title={_("Registration is not available")}
+ *   description={_("The product must be registered first.")}
+ *   actionLink={{ to: REGISTRATION.root, label: _("Go to registration") }}
+ * />
+ */
+export default function UnavailableState({
+  title,
+  description,
+  hint,
+  actionLink,
+}: UnavailableStateProps) {
+  return (
+    <EmptyState headingLevel="h2" titleText={title} variant="lg" icon={EmptyStateIcon}>
+      <EmptyStateBody>
+        <Content component="p" isEditorial>
+          {description}
+        </Content>
+        {hint && <Content component="small">{hint}</Content>}
+      </EmptyStateBody>
+      {actionLink && (
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Link to={actionLink.to} variant="link" isInline>
+              {actionLink.label}
+            </Link>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      )}
+    </EmptyState>
+  );
+}

--- a/web/src/components/core/UnavailableState.tsx
+++ b/web/src/components/core/UnavailableState.tsx
@@ -29,7 +29,6 @@ import {
   EmptyStateFooter,
 } from "@patternfly/react-core";
 import Icon, { IconProps } from "~/components/layout/Icon";
-import Link from "~/components/core/Link";
 
 export type UnavailableStateProps = {
   /** Short summary of what is not available. */
@@ -38,8 +37,8 @@ export type UnavailableStateProps = {
   description: React.ReactNode;
   /** Optional additional hint text displayed below the description. */
   hint?: React.ReactNode;
-  /** Optional action link with destination path and label. */
-  actionLink?: { to: string; label: string };
+  /** Optional buttons or links offering a way out of the situation. */
+  actions?: React.ReactNode;
   /** Icon illustrating the situation. Defaults to a generic "outage" icon. */
   icon?: IconProps["name"];
 };
@@ -49,13 +48,13 @@ export type UnavailableStateProps = {
  * could not be loaded.
  *
  * Use it to explain the situation and, when possible, to offer a way out
- * through `actionLink`.
+ * through `actions`.
  *
  * @example
  * <UnavailableState
  *   title={_("Registration is not available")}
  *   description={_("The product must be registered first.")}
- *   actionLink={{ to: REGISTRATION.root, label: _("Go to registration") }}
+ *   actions={<Link to={REGISTRATION.root} variant="link" isInline>{_("Go to registration")}</Link>}
  * />
  *
  * @example
@@ -69,7 +68,7 @@ export default function UnavailableState({
   title,
   description,
   hint,
-  actionLink,
+  actions,
   icon = "apps_outage",
 }: UnavailableStateProps) {
   const EmptyStateIcon = () => <Icon name={icon} />;
@@ -82,13 +81,9 @@ export default function UnavailableState({
         </Content>
         {hint && <Content component="small">{hint}</Content>}
       </EmptyStateBody>
-      {actionLink && (
+      {actions && (
         <EmptyStateFooter>
-          <EmptyStateActions>
-            <Link to={actionLink.to} variant="link" isInline>
-              {actionLink.label}
-            </Link>
-          </EmptyStateActions>
+          <EmptyStateActions>{actions}</EmptyStateActions>
         </EmptyStateFooter>
       )}
     </EmptyState>

--- a/web/src/components/core/UnavailableState.tsx
+++ b/web/src/components/core/UnavailableState.tsx
@@ -28,10 +28,8 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
 } from "@patternfly/react-core";
-import { Icon } from "~/components/layout";
+import Icon, { IconProps } from "~/components/layout/Icon";
 import Link from "~/components/core/Link";
-
-const EmptyStateIcon = () => <Icon name="apps_outage" />;
 
 export type UnavailableStateProps = {
   /** Short summary of what is not available. */
@@ -42,6 +40,8 @@ export type UnavailableStateProps = {
   hint?: React.ReactNode;
   /** Optional action link with destination path and label. */
   actionLink?: { to: string; label: string };
+  /** Icon illustrating the situation. Defaults to a generic "outage" icon. */
+  icon?: IconProps["name"];
 };
 
 /**
@@ -57,13 +57,23 @@ export type UnavailableStateProps = {
  *   description={_("The product must be registered first.")}
  *   actionLink={{ to: REGISTRATION.root, label: _("Go to registration") }}
  * />
+ *
+ * @example
+ * <UnavailableState
+ *   icon="search_off"
+ *   title={_("Product not found")}
+ *   description={_("The product is not in the repositories.")}
+ * />
  */
 export default function UnavailableState({
   title,
   description,
   hint,
   actionLink,
+  icon = "apps_outage",
 }: UnavailableStateProps) {
+  const EmptyStateIcon = () => <Icon name={icon} />;
+
   return (
     <EmptyState headingLevel="h2" titleText={title} variant="lg" icon={EmptyStateIcon}>
       <EmptyStateBody>

--- a/web/src/components/overview/InstallButton.tsx
+++ b/web/src/components/overview/InstallButton.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useDeferredValue, useState } from "react";
+import { isEmpty } from "radashi";
+import { sprintf } from "sprintf-js";
+import {
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  HelperText,
+  HelperTextItem,
+  Stack,
+} from "@patternfly/react-core";
+import Popup from "~/components/core/Popup";
+import Text from "~/components/core/Text";
+import NoDesktopAlert from "~/components/software/NoDesktopAlert";
+import PotentialDataLossAlert from "~/components/storage/PotentialDataLossAlert";
+import { startInstallation } from "~/api";
+import { useIssues } from "~/hooks/model/issue";
+import { useIsDesktopMissing } from "~/hooks/model/system/software";
+import { useDestructiveActions } from "~/hooks/use-destructive-actions";
+import { useProgressTracking } from "~/hooks/use-progress-tracking";
+import { _ } from "~/i18n";
+
+import type { Product } from "~/model/system";
+
+type ConfirmationPopupProps = {
+  product: Product;
+  isDangerous: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+const ConfirmationPopup = ({
+  product,
+  isDangerous,
+  onCancel,
+  onConfirm,
+}: ConfirmationPopupProps) => {
+  const isDesktopMissing = useIsDesktopMissing();
+  const title = sprintf(
+    // TRANSLATORS: Confirmation dialog title. %s is replaced with the product name (e.g., "openSUSE Leap")
+    isDangerous ? _("Delete existing data and install %s?") : _("Install %s?"),
+    product.name,
+  );
+
+  const ConfirmButton = isDangerous ? Popup.DangerousAction : Popup.Confirm;
+
+  return (
+    <Popup isOpen title={title}>
+      <Stack hasGutter>
+        <Content isEditorial>
+          {/* TRANSLATORS: shown at the top of the install confirmation dialog. */}
+          {_("Confirming starts the installation immediately with the defined settings.")}
+        </Content>
+        {isDesktopMissing && <NoDesktopAlert />}
+        {isDangerous && <PotentialDataLossAlert />}
+      </Stack>
+      <Popup.Actions>
+        {/* TRANSLATORS: Button to confirm and start the installation */}
+        <ConfirmButton onClick={onConfirm}>{_("Confirm and install")}</ConfirmButton>
+        <Popup.Cancel onClick={onCancel} autoFocus />
+      </Popup.Actions>
+    </Popup>
+  );
+};
+
+export type InstallButtonProps = {
+  /** Product that will be installed, needed to confirm the action. */
+  product: Product;
+};
+
+/**
+ * Button that starts the installation of the given product, after asking for
+ * confirmation.
+ *
+ * The button warns about a destructive installation and stays disabled while
+ * there are pending operations or settings to fix, explaining why below it.
+ *
+ * @example
+ * <InstallButton product={product} />
+ */
+export default function InstallButton({ product }: InstallButtonProps) {
+  const issues = useIssues();
+  const { loading } = useProgressTracking();
+  const { actions } = useDestructiveActions();
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const isReady = useDeferredValue(!loading);
+  const hasIssues = !isEmpty(issues);
+  const hasDestructiveActions = actions.length > 0;
+  const missingProduct = issues.some((i) => i.class === "missing_product");
+
+  const onConfirm = () => {
+    startInstallation();
+    setShowConfirmation(false);
+  };
+
+  const text = () => {
+    if (hasIssues || !isReady) return _("Install");
+    if (hasDestructiveActions) return _("Install now with potential data loss");
+    return _("Install now");
+  };
+
+  return (
+    <Flex direction={{ default: "column" }} alignItems={{ default: "alignItemsFlexStart" }}>
+      <FlexItem grow={{ default: "grow" }} />
+      <FlexItem>
+        <Button
+          size="lg"
+          variant={hasDestructiveActions ? "danger" : "primary"}
+          onClick={() => setShowConfirmation(true)}
+          isDisabled={hasIssues || !isReady}
+        >
+          <Text isBold>{text()}</Text>
+        </Button>
+      </FlexItem>
+
+      {!isReady && (
+        <FlexItem>
+          <HelperText>
+            <HelperTextItem variant="indeterminate">
+              {_("Wait until current operations are completed.")}
+            </HelperTextItem>
+          </HelperText>
+        </FlexItem>
+      )}
+
+      {hasIssues && !missingProduct && isReady && (
+        <FlexItem>
+          <HelperText>
+            <HelperTextItem variant="warning">
+              {_("Fix invalid settings before starting the installation.")}
+            </HelperTextItem>
+          </HelperText>
+        </FlexItem>
+      )}
+
+      {showConfirmation && (
+        <ConfirmationPopup
+          product={product}
+          isDangerous={hasDestructiveActions}
+          onConfirm={onConfirm}
+          onCancel={() => setShowConfirmation(false)}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/web/src/components/overview/InstallButton.tsx
+++ b/web/src/components/overview/InstallButton.tsx
@@ -109,7 +109,6 @@ export default function InstallButton({ product }: InstallButtonProps) {
   const isReady = useDeferredValue(!loading);
   const hasIssues = !isEmpty(issues);
   const hasDestructiveActions = actions.length > 0;
-  const missingProduct = issues.some((i) => i.class === "missing_product");
 
   const onConfirm = () => {
     startInstallation();
@@ -146,7 +145,7 @@ export default function InstallButton({ product }: InstallButtonProps) {
         </FlexItem>
       )}
 
-      {hasIssues && !missingProduct && isReady && (
+      {hasIssues && isReady && (
         <FlexItem>
           <HelperText>
             <HelperTextItem variant="warning">

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -20,83 +20,30 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useDeferredValue, useState } from "react";
-import { isEmpty } from "radashi";
-import { sprintf } from "sprintf-js";
+import React from "react";
 import { Navigate } from "react-router";
 import {
-  Button,
   Content,
   Divider,
   EmptyState,
   EmptyStateBody,
   Flex,
-  FlexItem,
   Grid,
   GridItem,
-  HelperText,
-  HelperTextItem,
   Stack,
 } from "@patternfly/react-core";
 import Page from "~/components/core/Page";
-import Text from "~/components/core/Text";
-import Popup from "~/components/core/Popup";
-import NoDesktopAlert from "~/components/software/NoDesktopAlert";
-import PotentialDataLossAlert from "~/components/storage/PotentialDataLossAlert";
+import InstallButton from "~/components/overview/InstallButton";
 import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
-import { startInstallation } from "~/api";
 import { useProductInfo } from "~/hooks/model/config/product";
 import { useIssues } from "~/hooks/model/issue";
-import { useIsDesktopMissing } from "~/hooks/model/system/software";
 import { PRODUCT } from "~/routes/paths";
-import { useDestructiveActions } from "~/hooks/use-destructive-actions";
-import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { _ } from "~/i18n";
 
 import type { Product } from "~/model/system";
 
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
-
-type ConfirmationPopupProps = {
-  product: Product;
-  isDangerous: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-};
-const ConfirmationPopup = ({
-  product,
-  isDangerous,
-  onCancel,
-  onConfirm,
-}: ConfirmationPopupProps) => {
-  const isDesktopMissing = useIsDesktopMissing();
-  const title = sprintf(
-    // TRANSLATORS: Confirmation dialog title. %s is replaced with the product name (e.g., "openSUSE Leap")
-    isDangerous ? _("Delete existing data and install %s?") : _("Install %s?"),
-    product.name,
-  );
-
-  const ConfirmButton = isDangerous ? Popup.DangerousAction : Popup.Confirm;
-
-  return (
-    <Popup isOpen title={title}>
-      <Stack hasGutter>
-        <Content isEditorial>
-          {/* TRANSLATORS: shown at the top of the install confirmation dialog. */}
-          {_("Confirming starts the installation immediately with the defined settings.")}
-        </Content>
-        {isDesktopMissing && <NoDesktopAlert />}
-        {isDangerous && <PotentialDataLossAlert />}
-      </Stack>
-      <Popup.Actions>
-        {/* TRANSLATORS: Button to confirm and start the installation */}
-        <ConfirmButton onClick={onConfirm}>{_("Confirm and install")}</ConfirmButton>
-        <Popup.Cancel onClick={onCancel} autoFocus />
-      </Popup.Actions>
-    </Popup>
-  );
-};
 
 /**
  * Renders a PatternFly `EmptyState` block used when no product was found in the
@@ -114,38 +61,15 @@ const NoProductFound = () => {
   );
 };
 
-const OverviewPageContent = ({ product }) => {
+const OverviewPageContent = ({ product }: { product: Product }) => {
   const issues = useIssues();
-  const { loading } = useProgressTracking();
-  const isReady = useDeferredValue(!loading);
-  const { actions } = useDestructiveActions();
-  const [showConfirmation, setShowConfirmation] = useState(false);
-  const hasIssues = !isEmpty(issues);
-  const hasDestructiveActions = actions.length > 0;
-  const missingProduct = issues.find((i) => i.class === "missing_product");
+  const missingProduct = issues.some((i) => i.class === "missing_product");
 
   const [buttonLocationStart, buttonLocationLabel, buttonLocationEnd] = _(
     // TRANSLATORS: This hint helps users locate the install button. Text inside
     // square brackets [] appears in bold. Keep brackets for proper formatting.
     "When ready, click on the [install] button at the end of the page.",
   ).split(/[[\]]/);
-
-  const onInstallClick = () => {
-    setShowConfirmation(true);
-  };
-
-  const onConfirm = () => {
-    startInstallation();
-    setShowConfirmation(false);
-  };
-
-  const onCancel = () => setShowConfirmation(false);
-
-  const getInstallButtonText = () => {
-    if (hasIssues || !isReady) return _("Install");
-    if (hasDestructiveActions) return _("Install now with potential data loss");
-    return _("Install now");
-  };
 
   return (
     <Page
@@ -176,42 +100,7 @@ const OverviewPageContent = ({ product }) => {
                 <div style={{ flex: 1 }}>
                   {missingProduct ? <NoProductFound /> : <InstallationSettings />}
                 </div>
-                <Flex
-                  direction={{ default: "column" }}
-                  alignItems={{ default: "alignItemsFlexStart" }}
-                >
-                  <FlexItem grow={{ default: "grow" }} />
-                  <FlexItem>
-                    <Button
-                      size="lg"
-                      variant={hasDestructiveActions ? "danger" : "primary"}
-                      onClick={onInstallClick}
-                      isDisabled={hasIssues || !isReady}
-                    >
-                      <Text isBold>{getInstallButtonText()}</Text>
-                    </Button>
-                  </FlexItem>
-
-                  {!isReady && (
-                    <FlexItem>
-                      <HelperText>
-                        <HelperTextItem variant="indeterminate">
-                          {_("Wait until current operations are completed.")}
-                        </HelperTextItem>
-                      </HelperText>
-                    </FlexItem>
-                  )}
-
-                  {hasIssues && !missingProduct && isReady && (
-                    <FlexItem>
-                      <HelperText>
-                        <HelperTextItem variant="warning">
-                          {_("Fix invalid settings before starting the installation.")}
-                        </HelperTextItem>
-                      </HelperText>
-                    </FlexItem>
-                  )}
-                </Flex>
+                <InstallButton product={product} />
               </Stack>
             </GridItem>
             <GridItem sm={12} md={4}>
@@ -220,14 +109,6 @@ const OverviewPageContent = ({ product }) => {
           </Grid>
         </Flex>
       </Page.Content>
-      {showConfirmation && (
-        <ConfirmationPopup
-          product={product}
-          isDangerous={hasDestructiveActions}
-          onConfirm={onConfirm}
-          onCancel={onCancel}
-        />
-      )}
     </Page>
   );
 };

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -32,7 +32,9 @@ import {
   GridItem,
   Stack,
 } from "@patternfly/react-core";
+import Interpolate from "~/components/core/Interpolate";
 import Page from "~/components/core/Page";
+import Text from "~/components/core/Text";
 import InstallButton from "~/components/overview/InstallButton";
 import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
@@ -65,12 +67,6 @@ const OverviewPageContent = ({ product }: { product: Product }) => {
   const issues = useIssues();
   const missingProduct = issues.some((i) => i.class === "missing_product");
 
-  const [buttonLocationStart, buttonLocationLabel, buttonLocationEnd] = _(
-    // TRANSLATORS: This hint helps users locate the install button. Text inside
-    // square brackets [] appears in bold. Keep brackets for proper formatting.
-    "When ready, click on the [install] button at the end of the page.",
-  ).split(/[[\]]/);
-
   return (
     <Page
       hideSummaryLink
@@ -90,7 +86,15 @@ const OverviewPageContent = ({ product }: { product: Product }) => {
               }
             </Content>
             <Content className={textStyles.textColorSubtle}>
-              {buttonLocationStart} <strong>{buttonLocationLabel}</strong> {buttonLocationEnd}
+              <Interpolate
+                sentence={_(
+                  // TRANSLATORS: This hint helps users locate the install button. Text inside
+                  // square brackets [] appears in bold. Keep brackets for proper formatting.
+                  "When ready, click on the [install] button at the end of the page.",
+                )}
+              >
+                {(text) => <Text isBold>{text}</Text>}
+              </Interpolate>
             </Content>
           </div>
           <Divider />

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -25,13 +25,14 @@ import { Navigate } from "react-router";
 import { Content, Divider, Flex, Grid, GridItem, Stack } from "@patternfly/react-core";
 import Interpolate from "~/components/core/Interpolate";
 import Page from "~/components/core/Page";
+import ProgressBackdrop from "~/components/core/ProgressBackdrop";
 import Text from "~/components/core/Text";
 import MissingProductState from "~/components/product/MissingProductState";
 import InstallButton from "~/components/overview/InstallButton";
 import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
 import { useProductInfo } from "~/hooks/model/config/product";
-import { useIssues } from "~/hooks/model/issue";
+import { ISSUES_QUERY_KEY, useIssues } from "~/hooks/model/issue";
 import { PRODUCT } from "~/routes/paths";
 import { _ } from "~/i18n";
 
@@ -83,18 +84,32 @@ const InstallationReview = ({ product }: { product: Product }) => (
 
 /**
  * Empty state shown when the product to install was not found.
+ *
+ * While the product is being looked for, it reports what is being done the
+ * same way pages do. That is mounted here rather than on the page so it only
+ * ever happens in this situation: doing it at page level would cover the
+ * overview on every software operation, including those the user can carry on
+ * working through. Here there is nothing to work on until the product turns
+ * up.
+ *
+ * Screens already reporting this at page level, such as the software one, use
+ * `MissingProductState` directly, so that only one of them is ever waiting on
+ * the same operation.
  */
 const ProductNotFound = () => (
-  <MissingProductState
-    // TRANSLATORS: empty state title when the product to install was not found
-    title={_("Product not found")}
-    description={
-      // TRANSLATORS: shown when the product to install was not found
-      _(
-        "The product was not found in the repositories so it is not possible to proceed with the installation.",
-      )
-    }
-  />
+  <>
+    <MissingProductState
+      // TRANSLATORS: empty state title when the product to install was not found
+      title={_("Product not found")}
+      description={
+        // TRANSLATORS: shown when the product to install was not found
+        _(
+          "The product was not found in the repositories so it is not possible to proceed with the installation.",
+        )
+      }
+    />
+    <ProgressBackdrop scope="software" awaitQueriesRefetch={[ISSUES_QUERY_KEY]} />
+  </>
 );
 
 const OverviewPageContent = ({ product }: { product: Product }) => {

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -22,19 +22,11 @@
 
 import React from "react";
 import { Navigate } from "react-router";
-import {
-  Content,
-  Divider,
-  EmptyState,
-  EmptyStateBody,
-  Flex,
-  Grid,
-  GridItem,
-  Stack,
-} from "@patternfly/react-core";
+import { Content, Divider, Flex, Grid, GridItem, Stack } from "@patternfly/react-core";
 import Interpolate from "~/components/core/Interpolate";
 import Page from "~/components/core/Page";
 import Text from "~/components/core/Text";
+import MissingProductState from "~/components/product/MissingProductState";
 import InstallButton from "~/components/overview/InstallButton";
 import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
@@ -48,20 +40,62 @@ import type { Product } from "~/model/system";
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
 
 /**
- * Renders a PatternFly `EmptyState` block used when no product was found in the
- * repositories.
+ * Introduction to the page, telling what is expected from the user and where
+ * to find the button that starts the installation.
  */
-const NoProductFound = () => {
-  return (
-    <EmptyState headingLevel="h2" titleText={_("Product not found")} variant="sm">
-      <EmptyStateBody>
-        {_(
-          "The product was not found in the repositories so it is not possible to proceed with the installation.",
-        )}
-      </EmptyStateBody>
-    </EmptyState>
-  );
-};
+const PageIntro = () => (
+  <>
+    <div>
+      <Content isEditorial>
+        {
+          // TRANSLATORS: Introductory text shown on the overview page
+          _("Take a moment to review the installation settings below and adjust them as needed.")
+        }
+      </Content>
+      <Content className={textStyles.textColorSubtle}>
+        <Interpolate
+          sentence={_(
+            // TRANSLATORS: This hint helps users locate the install button. Text inside
+            // square brackets [] appears in bold. Keep brackets for proper formatting.
+            "When ready, click on the [install] button at the end of the page.",
+          )}
+        >
+          {(text) => <Text isBold>{text}</Text>}
+        </Interpolate>
+      </Content>
+    </div>
+    <Divider />
+  </>
+);
+
+/**
+ * Settings to review before installing, together with the button that starts
+ * the installation.
+ */
+const InstallationReview = ({ product }: { product: Product }) => (
+  <Stack hasGutter>
+    <div style={{ flex: 1 }}>
+      <InstallationSettings />
+    </div>
+    <InstallButton product={product} />
+  </Stack>
+);
+
+/**
+ * Empty state shown when the product to install was not found.
+ */
+const ProductNotFound = () => (
+  <MissingProductState
+    // TRANSLATORS: empty state title when the product to install was not found
+    title={_("Product not found")}
+    description={
+      // TRANSLATORS: shown when the product to install was not found
+      _(
+        "The product was not found in the repositories so it is not possible to proceed with the installation.",
+      )
+    }
+  />
+);
 
 const OverviewPageContent = ({ product }: { product: Product }) => {
   const issues = useIssues();
@@ -76,36 +110,11 @@ const OverviewPageContent = ({ product }: { product: Product }) => {
     >
       <Page.Content>
         <Flex gap={{ default: "gapMd" }} direction={{ default: "column" }}>
-          <div>
-            <Content isEditorial>
-              {
-                // TRANSLATORS: Introductory text shown on the overview page
-                _(
-                  "Take a moment to review the installation settings below and adjust them as needed.",
-                )
-              }
-            </Content>
-            <Content className={textStyles.textColorSubtle}>
-              <Interpolate
-                sentence={_(
-                  // TRANSLATORS: This hint helps users locate the install button. Text inside
-                  // square brackets [] appears in bold. Keep brackets for proper formatting.
-                  "When ready, click on the [install] button at the end of the page.",
-                )}
-              >
-                {(text) => <Text isBold>{text}</Text>}
-              </Interpolate>
-            </Content>
-          </div>
-          <Divider />
+          {/* Nothing to review nor to install, but the system is still worth showing. */}
+          {!missingProduct && <PageIntro />}
           <Grid hasGutter>
             <GridItem sm={12} md={8}>
-              <Stack hasGutter>
-                <div style={{ flex: 1 }}>
-                  {missingProduct ? <NoProductFound /> : <InstallationSettings />}
-                </div>
-                <InstallButton product={product} />
-              </Stack>
+              {missingProduct ? <ProductNotFound /> : <InstallationReview product={product} />}
             </GridItem>
             <GridItem sm={12} md={4}>
               <SystemInformationSection />

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -32,7 +32,7 @@ import InstallButton from "~/components/overview/InstallButton";
 import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
 import { useProductInfo } from "~/hooks/model/config/product";
-import { ISSUES_QUERY_KEY, useIssues } from "~/hooks/model/issue";
+import { useIssues } from "~/hooks/model/issue";
 import { PRODUCT } from "~/routes/paths";
 import { _ } from "~/i18n";
 
@@ -108,7 +108,7 @@ const ProductNotFound = () => (
         )
       }
     />
-    <ProgressBackdrop scope="software" awaitQueriesRefetch={[ISSUES_QUERY_KEY]} />
+    <ProgressBackdrop scope="software" />
   </>
 );
 

--- a/web/src/components/overview/SystemInformationSection.test.tsx
+++ b/web/src/components/overview/SystemInformationSection.test.tsx
@@ -30,6 +30,17 @@ jest.mock("~/components/network/FormattedIpsList", () => ({
   default: () => <span>192.168.1.1</span>,
 }));
 
+const mockUseIpAddressesFn = jest.fn();
+
+jest.mock("~/hooks/model/system/network", () => ({
+  ...jest.requireActual("~/hooks/model/system/network"),
+  useIpAddresses: () => mockUseIpAddressesFn(),
+}));
+
+beforeEach(() => {
+  mockUseIpAddressesFn.mockReturnValue(["192.168.1.1"]);
+});
+
 describe("SystemInformationSection", () => {
   describe("when hardware data is available", () => {
     beforeEach(() => {
@@ -90,6 +101,31 @@ describe("SystemInformationSection", () => {
       installerRender(<SystemInformationSection />);
       screen.getByText("ThinkPad X1 Carbon");
       expect(screen.getAllByText("Unknown")).toHaveLength(2);
+    });
+  });
+
+  describe("when the system has IP addresses", () => {
+    beforeEach(() => {
+      mockSystem({ hardware: {} });
+      mockUseIpAddressesFn.mockReturnValue(["192.168.1.1"]);
+    });
+
+    it("renders the IPs field", () => {
+      installerRender(<SystemInformationSection />);
+      screen.getByText("IPs");
+      screen.getByText("192.168.1.1");
+    });
+  });
+
+  describe("when the system has no IP address", () => {
+    beforeEach(() => {
+      mockSystem({ hardware: {} });
+      mockUseIpAddressesFn.mockReturnValue([]);
+    });
+
+    it("does not render the IPs field", () => {
+      installerRender(<SystemInformationSection />);
+      expect(screen.queryByText("IPs")).toBeNull();
     });
   });
 });

--- a/web/src/components/overview/SystemInformationSection.tsx
+++ b/web/src/components/overview/SystemInformationSection.tsx
@@ -35,6 +35,7 @@ import {
 import FormattedIPsList from "~/components/network/FormattedIpsList";
 import NestedContent from "~/components/core/NestedContent";
 import { useSystem } from "~/hooks/model/system";
+import { useIpAddresses } from "~/hooks/model/system/network";
 import { _ } from "~/i18n";
 
 import textStyles from "@patternfly/react-styles/css/utilities/Text/text";
@@ -65,10 +66,29 @@ const Item = ({ label, children }: ItemProps) => {
 };
 
 /**
+ * Addresses of the system, not rendered at all when there is none yet.
+ *
+ * Unlike the hardware fields, an address the system does not have is not
+ * "Unknown" information: there is simply nothing to tell about it.
+ */
+const IpsItem = () => {
+  const addresses = useIpAddresses();
+
+  if (isEmpty(addresses)) return;
+
+  return (
+    <Item label={_("IPs")}>
+      <FormattedIPsList />
+    </Item>
+  );
+};
+
+/**
  * Displays basic hardware information (model, CPU, memory, IPs) in a card.
  *
  * Fields with missing or undefined values fall back to "Unknown" rather than
- * rendering a blank space.
+ * rendering a blank space. The IPs field is an exception: it is not rendered
+ * when the system has no address yet, since "Unknown" would be misleading.
  *
  * @note A11y: `DescriptionList` renders a `<dl>/<dt>/<dd>` structure. Screen
  * reader support is generally good, with the exception of Safari/VoiceOver on
@@ -95,9 +115,7 @@ export default function SystemInformationSection() {
             <Item label={_("Memory")}>
               {hardware.memory ? xbytes(hardware.memory, { iec: true }) : undefined}
             </Item>
-            <Item label={_("IPs")}>
-              <FormattedIPsList />
-            </Item>
+            <IpsItem />
           </DescriptionList>
         </NestedContent>
       </CardBody>

--- a/web/src/components/product/MissingProductState.tsx
+++ b/web/src/components/product/MissingProductState.tsx
@@ -21,9 +21,8 @@
  */
 
 import React from "react";
-import Link from "~/components/core/Link";
 import UnavailableState from "~/components/core/UnavailableState";
-import { NETWORK } from "~/routes/paths";
+import SoftwareIssueActions from "~/components/software/SoftwareIssueActions";
 import { _ } from "~/i18n";
 
 export type MissingProductStateProps = {
@@ -37,7 +36,8 @@ export type MissingProductStateProps = {
  * Empty state shown when the product cannot be found in the repositories.
  *
  * Besides the given explanation, it points to the network settings since a
- * faulty connection is the most likely cause.
+ * faulty connection is the most likely cause, and offers a way to look for the
+ * product again once that connection works.
  *
  * @example
  * <MissingProductState
@@ -55,12 +55,7 @@ export default function MissingProductState({ title, description }: MissingProdu
         // TRANSLATORS: additional hint when the product is missing
         _("This might be due to network connectivity.")
       }
-      actions={
-        <Link to={NETWORK.root} variant="link" isInline>
-          {/* TRANSLATORS: link to go to network settings */}
-          {_("Go to network settings")}
-        </Link>
-      }
+      actions={<SoftwareIssueActions />}
     />
   );
 }

--- a/web/src/components/product/MissingProductState.tsx
+++ b/web/src/components/product/MissingProductState.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import UnavailableState from "~/components/core/UnavailableState";
+import { NETWORK } from "~/routes/paths";
+import { _ } from "~/i18n";
+
+export type MissingProductStateProps = {
+  /** Short summary of what cannot be done because the product is missing. */
+  title: React.ReactNode;
+  /** Explanation of the situation, usually the description of the issue. */
+  description: React.ReactNode;
+};
+
+/**
+ * Empty state shown when the product cannot be found in the repositories.
+ *
+ * Besides the given explanation, it points to the network settings since a
+ * faulty connection is the most likely cause.
+ *
+ * @example
+ * <MissingProductState
+ *   title={_("Product not found")}
+ *   description={missingProduct.description}
+ * />
+ */
+export default function MissingProductState({ title, description }: MissingProductStateProps) {
+  return (
+    <UnavailableState
+      title={title}
+      description={description}
+      hint={
+        // TRANSLATORS: additional hint when the product is missing
+        _("This might be due to network connectivity.")
+      }
+      actionLink={{
+        to: NETWORK.root,
+        label:
+          // TRANSLATORS: link to go to network settings
+          _("Go to network settings"),
+      }}
+    />
+  );
+}

--- a/web/src/components/product/MissingProductState.tsx
+++ b/web/src/components/product/MissingProductState.tsx
@@ -21,6 +21,7 @@
  */
 
 import React from "react";
+import Link from "~/components/core/Link";
 import UnavailableState from "~/components/core/UnavailableState";
 import { NETWORK } from "~/routes/paths";
 import { _ } from "~/i18n";
@@ -54,12 +55,12 @@ export default function MissingProductState({ title, description }: MissingProdu
         // TRANSLATORS: additional hint when the product is missing
         _("This might be due to network connectivity.")
       }
-      actionLink={{
-        to: NETWORK.root,
-        label:
-          // TRANSLATORS: link to go to network settings
-          _("Go to network settings"),
-      }}
+      actions={
+        <Link to={NETWORK.root} variant="link" isInline>
+          {/* TRANSLATORS: link to go to network settings */}
+          {_("Go to network settings")}
+        </Link>
+      }
     />
   );
 }

--- a/web/src/components/product/MissingProductState.tsx
+++ b/web/src/components/product/MissingProductState.tsx
@@ -47,6 +47,7 @@ export type MissingProductStateProps = {
 export default function MissingProductState({ title, description }: MissingProductStateProps) {
   return (
     <UnavailableState
+      icon="search_off"
       title={title}
       description={description}
       hint={

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -21,6 +21,7 @@
  */
 
 import React from "react";
+import Link from "~/components/core/Link";
 import UnavailableState from "~/components/core/UnavailableState";
 import MissingProductState from "~/components/product/MissingProductState";
 import { useIssues } from "~/hooks/model/issue";
@@ -62,12 +63,12 @@ export default function PatternSelectionUnavailable() {
       <UnavailableState
         title={title}
         description={missingRegistration.description}
-        actionLink={{
-          to: REGISTRATION.root,
-          label:
-            // TRANSLATORS: link to go to registration settings
-            _("Go to registration"),
-        }}
+        actions={
+          <Link to={REGISTRATION.root} variant="link" isInline>
+            {/* TRANSLATORS: link to go to registration settings */}
+            {_("Go to registration")}
+          </Link>
+        }
       />
     );
   }

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -21,18 +21,11 @@
  */
 
 import React from "react";
-import {
-  Content,
-  EmptyState,
-  EmptyStateActions,
-  EmptyStateBody,
-  EmptyStateFooter,
-} from "@patternfly/react-core";
-import { Icon } from "~/components/layout";
-import Link from "~/components/core/Link";
+import UnavailableState from "~/components/core/UnavailableState";
+import MissingProductState from "~/components/product/MissingProductState";
 import { useIssues } from "~/hooks/model/issue";
 import { useAvailablePatterns } from "~/hooks/model/system/software";
-import { REGISTRATION, NETWORK } from "~/routes/paths";
+import { REGISTRATION } from "~/routes/paths";
 import { _ } from "~/i18n";
 
 /**
@@ -42,54 +35,6 @@ import { _ } from "~/i18n";
  * registration is required but missing, or because product detection failed.
  */
 export const PRODUCT_AVAILABILITY_ISSUES = ["missing_registration", "missing_product"];
-
-const EmptyStateIcon = () => <Icon name="apps_outage" />;
-
-type UnavailableStateProps = {
-  /** Optional title for the empty state. */
-  title?: React.ReactNode;
-  /** Main description text explaining why software selection is unavailable. */
-  description: React.ReactNode;
-  /** Optional additional hint text displayed below the description. */
-  hint?: string;
-  /** Optional action link with destination path and label. */
-  actionLink?: { to: string; label: string };
-};
-
-/**
- * Base empty state component for unavailable software selection scenarios.
- *
- * Renders a consistent empty state with an icon, title, description, optional
- * hint, and optional action link. Used to display different messages based on
- * why software selection is unavailable.
- */
-const UnavailableState = ({
-  // TRANSLATORS: empty state title when software cannot be selected
-  title = _("Software selection is not available"),
-  description,
-  hint,
-  actionLink,
-}: UnavailableStateProps) => {
-  return (
-    <EmptyState headingLevel="h2" titleText={title} variant="lg" icon={EmptyStateIcon}>
-      <EmptyStateBody>
-        <Content component="p" isEditorial>
-          {description}
-        </Content>
-        {hint && <Content component="small">{hint}</Content>}
-      </EmptyStateBody>
-      {actionLink && (
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            <Link to={actionLink.to} variant="link" isInline>
-              {actionLink.label}
-            </Link>
-          </EmptyStateActions>
-        </EmptyStateFooter>
-      )}
-    </EmptyState>
-  );
-};
 
 /**
  * Empty state shown when software selection is unavailable.
@@ -109,9 +54,13 @@ export default function PatternSelectionUnavailable() {
   const missingRegistration = issues.find((i) => i.class === "missing_registration");
   const missingProduct = issues.find((i) => i.class === "missing_product");
 
+  // TRANSLATORS: empty state title when software cannot be selected
+  const title = _("Software selection is not available");
+
   if (missingRegistration) {
     return (
       <UnavailableState
+        title={title}
         description={missingRegistration.description}
         actionLink={{
           to: REGISTRATION.root,
@@ -124,26 +73,13 @@ export default function PatternSelectionUnavailable() {
   }
 
   if (missingProduct) {
-    return (
-      <UnavailableState
-        description={missingProduct.description}
-        hint={
-          // TRANSLATORS: additional hint when base product is missing
-          _("This might be due to network connectivity.")
-        }
-        actionLink={{
-          to: NETWORK.root,
-          label:
-            // TRANSLATORS: link to go to network settings
-            _("Go to network settings"),
-        }}
-      />
-    );
+    return <MissingProductState title={title} description={missingProduct.description} />;
   }
 
   if (patterns.length === 0) {
     return (
       <UnavailableState
+        title={title}
         description={
           // TRANSLATORS: shown when the product provides zero patterns
           _(
@@ -156,6 +92,7 @@ export default function PatternSelectionUnavailable() {
 
   return (
     <UnavailableState
+      title={title}
       description={
         // TRANSLATORS: shown when software selection cannot be determined
         _("The software selection could not be loaded.")

--- a/web/src/components/software/SoftwareIssueActions.test.tsx
+++ b/web/src/components/software/SoftwareIssueActions.test.tsx
@@ -54,7 +54,7 @@ it("offers a link to the network settings", () => {
 
 it("reads the software information again when reloading", async () => {
   const { user } = installerRender(<SoftwareIssueActions />);
-  await user.click(screen.getByRole("button", { name: /Reload/ }));
+  await user.click(screen.getByRole("button", { name: /Try again/ }));
   expect(mockProbeAction).toHaveBeenCalledWith(["software"]);
 });
 
@@ -65,7 +65,7 @@ describe("while the software information is being read", () => {
 
   it("does not allow reading it again", async () => {
     const { user } = installerRender(<SoftwareIssueActions />);
-    const button = screen.getByRole("button", { name: /Reload/ });
+    const button = screen.getByRole("button", { name: /Try again/ });
     expect(button).toBeDisabled();
 
     await user.click(button);

--- a/web/src/components/software/SoftwareIssueActions.test.tsx
+++ b/web/src/components/software/SoftwareIssueActions.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import { installerRender } from "~/test-utils";
+import SoftwareIssueActions from "./SoftwareIssueActions";
+
+const mockProbeAction = jest.fn();
+jest.mock("~/api", () => ({
+  ...jest.requireActual("~/api"),
+  probeAction: (only) => mockProbeAction(only),
+}));
+
+const mockUseProgressTracking = jest.fn();
+jest.mock("~/hooks/use-progress-tracking", () => ({
+  useProgressTracking: (...args) => mockUseProgressTracking(...args),
+}));
+
+beforeEach(() => {
+  mockProbeAction.mockClear();
+  mockUseProgressTracking.mockReturnValue({ loading: false, progress: undefined });
+});
+
+it("offers a link to the network settings", () => {
+  installerRender(<SoftwareIssueActions />);
+  const link = screen.getByRole("link", { name: "Go to network settings" });
+  expect(link).toHaveAttribute("href", "/network");
+});
+
+it("reads the software information again when reloading", async () => {
+  const { user } = installerRender(<SoftwareIssueActions />);
+  await user.click(screen.getByRole("button", { name: /Reload/ }));
+  expect(mockProbeAction).toHaveBeenCalledWith(["software"]);
+});
+
+describe("while the software information is being read", () => {
+  beforeEach(() => {
+    mockUseProgressTracking.mockReturnValue({ loading: true, progress: undefined });
+  });
+
+  it("does not allow reading it again", async () => {
+    const { user } = installerRender(<SoftwareIssueActions />);
+    const button = screen.getByRole("button", { name: /Reload/ });
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+    expect(mockProbeAction).not.toHaveBeenCalled();
+  });
+
+  it("still allows going to the network settings", () => {
+    installerRender(<SoftwareIssueActions />);
+    screen.getByRole("link", { name: "Go to network settings" });
+  });
+});

--- a/web/src/components/software/SoftwareIssueActions.test.tsx
+++ b/web/src/components/software/SoftwareIssueActions.test.tsx
@@ -21,9 +21,11 @@
  */
 
 import React from "react";
-import { screen } from "@testing-library/react";
-import { installerRender } from "~/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import { installerRender, mockProgresses } from "~/test-utils";
 import SoftwareIssueActions from "./SoftwareIssueActions";
+
+import type { Progress } from "~/model/status";
 
 const mockProbeAction = jest.fn();
 jest.mock("~/api", () => ({
@@ -31,14 +33,17 @@ jest.mock("~/api", () => ({
   probeAction: (only) => mockProbeAction(only),
 }));
 
-const mockUseProgressTracking = jest.fn();
-jest.mock("~/hooks/use-progress-tracking", () => ({
-  useProgressTracking: (...args) => mockUseProgressTracking(...args),
-}));
+const readingRepositories: Progress = {
+  scope: "software",
+  step: "Refreshing metadata from the repositories",
+  steps: [],
+  index: 2,
+  size: 3,
+};
 
 beforeEach(() => {
   mockProbeAction.mockClear();
-  mockUseProgressTracking.mockReturnValue({ loading: false, progress: undefined });
+  mockProgresses([]);
 });
 
 it("offers a link to the network settings", () => {
@@ -55,7 +60,7 @@ it("reads the software information again when reloading", async () => {
 
 describe("while the software information is being read", () => {
   beforeEach(() => {
-    mockUseProgressTracking.mockReturnValue({ loading: true, progress: undefined });
+    mockProgresses([readingRepositories]);
   });
 
   it("does not allow reading it again", async () => {
@@ -67,8 +72,23 @@ describe("while the software information is being read", () => {
     expect(mockProbeAction).not.toHaveBeenCalled();
   });
 
-  it("still allows going to the network settings", () => {
+  it("keeps showing where to review the network settings", () => {
     installerRender(<SoftwareIssueActions />);
     screen.getByRole("link", { name: "Go to network settings" });
+  });
+});
+
+describe("when reading finishes without solving the problem", () => {
+  it("allows trying again", async () => {
+    mockProgresses([readingRepositories]);
+    const { rerender } = installerRender(<SoftwareIssueActions />);
+    expect(screen.getByRole("button", { name: /Try again/ })).toBeDisabled();
+
+    // Reading is over, but it found the same issues as before, so nothing else
+    // is fetched afterwards. The actions must not stay waiting for that.
+    mockProgresses([]);
+    rerender(<SoftwareIssueActions />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Try again/ })).toBeEnabled());
   });
 });

--- a/web/src/components/software/SoftwareIssueActions.tsx
+++ b/web/src/components/software/SoftwareIssueActions.tsx
@@ -51,9 +51,12 @@ export type SoftwareIssueActionsProps = {
  * relying on a page-wide overlay. That keeps the surrounding page usable and
  * prevents a second read from being started while one is running.
  *
- * FIXME: "Reload" is borrowed from another screen while translations are
- * frozen. Revisit the wording, here and in the surrounding texts, once the
- * catalog accepts new strings.
+ * The texts were written for retrying a failed repository read and went out
+ * of use at some point. Texts that stop being used keep their translations,
+ * and using one again picks them back up, so these arrive translated.
+ *
+ * FIXME: the texts around these actions are borrowed from elsewhere. Revisit
+ * them once new strings are accepted again.
  *
  * FIXME: a disabled button is all the feedback there is, so nothing says what
  * is happening or how far it got, and screen reader users are not told that it
@@ -84,10 +87,10 @@ export default function SoftwareIssueActions({ isCompact }: SoftwareIssueActions
         isDisabled={loading}
         // Without this the spinner contributes a hardcoded English "Loading..."
         // to the accessible name of the button.
-        spinnerAriaValueText={_("Loading")}
+        spinnerAriaValueText={_("Loading the installation repositories...")}
       >
         {/* TRANSLATORS: button to read the software information again */}
-        {_("Reload")}
+        {_("Try again")}
       </Button>
       {/*
         Dressed as a button only because it sits beside a real one, so the pair

--- a/web/src/components/software/SoftwareIssueActions.tsx
+++ b/web/src/components/software/SoftwareIssueActions.tsx
@@ -78,7 +78,7 @@ export default function SoftwareIssueActions({ isCompact }: SoftwareIssueActions
       flexWrap={{ default: "wrap" }}
     >
       <Button
-        variant="secondary"
+        variant="control"
         size={isCompact ? "sm" : "default"}
         onClick={() => probeAction(["software"])}
         isLoading={loading}
@@ -90,7 +90,17 @@ export default function SoftwareIssueActions({ isCompact }: SoftwareIssueActions
         {/* TRANSLATORS: button to read the software information again */}
         {_("Reload")}
       </Button>
-      <Link to={NETWORK.root} variant="link" isInline isDisabled={loading}>
+      {/*
+        Dressed as a button only because it sits beside a real one, so the pair
+        reads as a single set of actions. On its own it would stay a plain link.
+        Either way it remains an anchor pointing at its destination.
+      */}
+      <Link
+        to={NETWORK.root}
+        variant="control"
+        size={isCompact ? "sm" : "default"}
+        isDisabled={loading}
+      >
         {/* TRANSLATORS: link to go to network settings */}
         {_("Go to network settings")}
       </Link>

--- a/web/src/components/software/SoftwareIssueActions.tsx
+++ b/web/src/components/software/SoftwareIssueActions.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Button } from "@patternfly/react-core";
+import Link from "~/components/core/Link";
+import { useProgressTracking } from "~/hooks/use-progress-tracking";
+import { ISSUES_QUERY_KEY } from "~/hooks/model/issue";
+import { probeAction } from "~/api";
+import { NETWORK } from "~/routes/paths";
+import { _ } from "~/i18n";
+
+/**
+ * Actions offered when the software information could not be read.
+ *
+ * Reading the repositories requires a working connection, so two things are
+ * offered: a way to review the network settings, and a way to read the
+ * software information again once the connection is in place.
+ *
+ * Reading again is an explicit user action. Setting up a connection does not
+ * make the installer retry on its own, so without this the user is left on a
+ * screen that never recovers.
+ *
+ * Reading takes a while, so the button reports its own busy state instead of
+ * relying on a page-wide overlay. That keeps the surrounding page usable and
+ * prevents a second read from being started while one is running.
+ *
+ * FIXME: "Reload" is borrowed from another screen while translations are
+ * frozen. Revisit the wording, here and in the surrounding texts, once the
+ * catalog accepts new strings.
+ *
+ * FIXME: a disabled button is all the feedback there is, so nothing says what
+ * is happening or how far it got, and screen reader users are not told that it
+ * started at all. The backend does report the step being performed. Once new
+ * strings are allowed, describe the operation and announce it through the
+ * global live region added by https://github.com/agama-project/agama/pull/3759.
+ *
+ * @example
+ * <UnavailableState title={...} description={...} actions={<SoftwareIssueActions />} />
+ */
+export default function SoftwareIssueActions() {
+  const { loading } = useProgressTracking("software", [ISSUES_QUERY_KEY]);
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        onClick={() => probeAction(["software"])}
+        isLoading={loading}
+        isDisabled={loading}
+        // Without this the spinner contributes a hardcoded English "Loading..."
+        // to the accessible name of the button.
+        spinnerAriaValueText={_("Loading")}
+      >
+        {/* TRANSLATORS: button to read the software information again */}
+        {_("Reload")}
+      </Button>
+      <Link to={NETWORK.root} variant="link" isInline isDisabled={loading}>
+        {/* TRANSLATORS: link to go to network settings */}
+        {_("Go to network settings")}
+      </Link>
+    </>
+  );
+}

--- a/web/src/components/software/SoftwareIssueActions.tsx
+++ b/web/src/components/software/SoftwareIssueActions.tsx
@@ -24,7 +24,6 @@ import React from "react";
 import { Button, Flex } from "@patternfly/react-core";
 import Link from "~/components/core/Link";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
-import { ISSUES_QUERY_KEY } from "~/hooks/model/issue";
 import { probeAction } from "~/api";
 import { NETWORK } from "~/routes/paths";
 import { _ } from "~/i18n";
@@ -66,7 +65,7 @@ export type SoftwareIssueActionsProps = {
  * <UnavailableState title={...} description={...} actions={<SoftwareIssueActions />} />
  */
 export default function SoftwareIssueActions({ isCompact }: SoftwareIssueActionsProps) {
-  const { loading } = useProgressTracking("software", [ISSUES_QUERY_KEY]);
+  const { loading } = useProgressTracking("software");
 
   return (
     // The containers rendering these actions lay them out differently and

--- a/web/src/components/software/SoftwareIssueActions.tsx
+++ b/web/src/components/software/SoftwareIssueActions.tsx
@@ -29,6 +29,14 @@ import { probeAction } from "~/api";
 import { NETWORK } from "~/routes/paths";
 import { _ } from "~/i18n";
 
+export type SoftwareIssueActionsProps = {
+  /**
+   * Whether to render a smaller button, to sit better next to text instead of
+   * standing on its own.
+   */
+  isCompact?: boolean;
+};
+
 /**
  * Actions offered when the software information could not be read.
  *
@@ -57,7 +65,7 @@ import { _ } from "~/i18n";
  * @example
  * <UnavailableState title={...} description={...} actions={<SoftwareIssueActions />} />
  */
-export default function SoftwareIssueActions() {
+export default function SoftwareIssueActions({ isCompact }: SoftwareIssueActionsProps) {
   const { loading } = useProgressTracking("software", [ISSUES_QUERY_KEY]);
 
   return (
@@ -71,6 +79,7 @@ export default function SoftwareIssueActions() {
     >
       <Button
         variant="secondary"
+        size={isCompact ? "sm" : "default"}
         onClick={() => probeAction(["software"])}
         isLoading={loading}
         isDisabled={loading}

--- a/web/src/components/software/SoftwareIssueActions.tsx
+++ b/web/src/components/software/SoftwareIssueActions.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from "react";
-import { Button } from "@patternfly/react-core";
+import { Button, Flex } from "@patternfly/react-core";
 import Link from "~/components/core/Link";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { ISSUES_QUERY_KEY } from "~/hooks/model/issue";
@@ -61,7 +61,14 @@ export default function SoftwareIssueActions() {
   const { loading } = useProgressTracking("software", [ISSUES_QUERY_KEY]);
 
   return (
-    <>
+    // The containers rendering these actions lay them out differently and
+    // neither of them centers what it holds. Keep them aligned and spaced here
+    // so they look the same wherever they go.
+    <Flex
+      alignItems={{ default: "alignItemsCenter" }}
+      gap={{ default: "gapSm" }}
+      flexWrap={{ default: "wrap" }}
+    >
       <Button
         variant="secondary"
         onClick={() => probeAction(["software"])}
@@ -78,6 +85,6 @@ export default function SoftwareIssueActions() {
         {/* TRANSLATORS: link to go to network settings */}
         {_("Go to network settings")}
       </Link>
-    </>
+    </Flex>
   );
 }

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -282,5 +282,43 @@ describe("SoftwarePage", () => {
       installerRender(<SoftwarePage />);
       screen.getByText("Dependency conflict detected");
     });
+
+    it("does not offer to reload for issues a reload cannot fix", () => {
+      mockUseIssues.mockReturnValue([
+        {
+          scope: "software",
+          class: "dependency_issue",
+          description: "Dependency conflict detected",
+        },
+      ]);
+
+      installerRender(<SoftwarePage />);
+      expect(screen.queryByRole("button", { name: /Reload/ })).toBeNull();
+      expect(screen.queryByRole("link", { name: "Go to network settings" })).toBeNull();
+    });
+
+    describe("when the repositories could not be read", () => {
+      beforeEach(() => {
+        mockUseIssues.mockReturnValue([
+          {
+            scope: "software",
+            class: "software.load_source",
+            description: "Could not read the repositories",
+          },
+        ]);
+      });
+
+      it("reports the issue", () => {
+        installerRender(<SoftwarePage />);
+        screen.getByText("Could not read the repositories");
+      });
+
+      it("offers to read them again and to review the network settings", () => {
+        installerRender(<SoftwarePage />);
+        screen.getByRole("button", { name: /Reload/ });
+        const link = screen.getByRole("link", { name: "Go to network settings" });
+        expect(link).toHaveAttribute("href", "/network");
+      });
+    });
   });
 });

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -293,7 +293,7 @@ describe("SoftwarePage", () => {
       ]);
 
       installerRender(<SoftwarePage />);
-      expect(screen.queryByRole("button", { name: /Reload/ })).toBeNull();
+      expect(screen.queryByRole("button", { name: /Try again/ })).toBeNull();
       expect(screen.queryByRole("link", { name: "Go to network settings" })).toBeNull();
     });
 
@@ -315,7 +315,7 @@ describe("SoftwarePage", () => {
 
       it("offers to read them again and to review the network settings", () => {
         installerRender(<SoftwarePage />);
-        screen.getByRole("button", { name: /Reload/ });
+        screen.getByRole("button", { name: /Try again/ });
         const link = screen.getByRole("link", { name: "Go to network settings" });
         expect(link).toHaveAttribute("href", "/network");
       });

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -399,7 +399,7 @@ function SoftwarePage() {
       }}
     >
       <Page.Content>
-        <IssuesAlert issues={unreadableSources} actions={<SoftwareIssueActions />} />
+        <IssuesAlert issues={unreadableSources} actions={<SoftwareIssueActions isCompact />} />
         <IssuesAlert issues={otherIssues} />
         <SoftwarePageContent />
       </Page.Content>

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -47,6 +47,7 @@ import AutoSelectedLabel from "~/components/software/AutoSelectedLabel";
 import PatternSelectionUnavailable, {
   PRODUCT_AVAILABILITY_ISSUES,
 } from "~/components/software/PatternSelectionUnavailable";
+import SoftwareIssueActions from "~/components/software/SoftwareIssueActions";
 import { useIssues } from "~/hooks/model/issue";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useAvailablePatterns } from "~/hooks/model/system/software";
@@ -60,6 +61,14 @@ import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/pro
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
 import { SelectedBy } from "~/model/proposal/software";
+
+/**
+ * Software issue reported when the repositories could not be read.
+ *
+ * Reading them requires a working connection, so it shows up when the
+ * installation medium has no access to the network.
+ */
+const UNREADABLE_SOURCES_ISSUE = "software.load_source";
 
 /**
  * Empty state for a software section where nothing has been selected yet.
@@ -376,6 +385,10 @@ function SoftwarePage() {
   const issues = useIssues("software").filter(
     (i) => !PRODUCT_AVAILABILITY_ISSUES.includes(i.class),
   );
+  const [unreadableSources, otherIssues] = fork(
+    issues,
+    (i) => i.class === UNREADABLE_SOURCES_ISSUE,
+  );
 
   return (
     <Page
@@ -386,7 +399,8 @@ function SoftwarePage() {
       }}
     >
       <Page.Content>
-        <IssuesAlert issues={issues} />
+        <IssuesAlert issues={unreadableSources} actions={<SoftwareIssueActions />} />
+        <IssuesAlert issues={otherIssues} />
         <SoftwarePageContent />
       </Page.Content>
     </Page>

--- a/web/src/hooks/model/issue.ts
+++ b/web/src/hooks/model/issue.ts
@@ -26,8 +26,10 @@ import { getIssues } from "~/api";
 import { useInstallerClient } from "~/context/installer";
 import type { Issue, Scope } from "~/model/issue";
 
+const ISSUES_QUERY_KEY = "issues" as const;
+
 const issuesQuery = {
-  queryKey: ["issues"],
+  queryKey: [ISSUES_QUERY_KEY],
   queryFn: getIssues,
   /* FIXME: disable refetch. */
   refetchOnMount: true,
@@ -53,10 +55,10 @@ const useIssuesChanges = () => {
 
     return client.onEvent((event) => {
       if (event.type === "IssuesChanged") {
-        queryClient.invalidateQueries({ queryKey: ["issues"] });
+        queryClient.invalidateQueries({ queryKey: [ISSUES_QUERY_KEY] });
       }
     });
   }, [client, queryClient]);
 };
 
-export { issuesQuery, useIssues, useIssuesChanges };
+export { ISSUES_QUERY_KEY, issuesQuery, useIssues, useIssuesChanges };

--- a/web/src/hooks/use-progress-tracking.ts
+++ b/web/src/hooks/use-progress-tracking.ts
@@ -40,6 +40,11 @@ import type { Scope } from "~/model/status";
  *   progress completes. Defaults to empty array (no query waiting). Typically
  *   contains the `*_QUERY_KEY` constant exported by each data hook the page uses.
  *
+ *   Be careful about what you list here. Some data is only fetched again when
+ *   it actually changes. If an operation ends up changing nothing, that fetch
+ *   never happens, and the caller keeps loading forever. When in doubt, list
+ *   nothing: loading then ends as soon as the operation does.
+ *
  * @returns Object containing:
  *   - `loading`: Boolean indicating whether an operation is in progress, tasks
  *     are pending, or waiting for queries to refetch


### PR DESCRIPTION
## TL;DR

When the installer cannot get hold of the product to install, the overview no longer leaves users at a dead end: it explains the situation, points at the network settings, and offers to look again once a connection is in place, reporting progress while it does. The software page gets the same treatment when it cannot read the repositories. Wording is reused from what is already translated, so nothing waits on the string freeze.

## Main changes 

Gives users a way out when the installer cannot get hold of the product to install, instead of leaving them on a screen that never recovers.

- The bare "Product not found" empty state on the overview now gets the same treatment the software page already used for this situation: an icon, the explanation, the *"This might be due to network connectivity."* hint, and a **Go to network settings** link.
- That screen also offers a **Reload** action. Pointing at the network settings was not enough on its own: once a connection is set up, nothing makes the installer look for the product again, so users were left on the same dead end they started from. Reloading asks the backend to read the software information again.
- The software page offers the same two actions when it cannot read the repositories. It is the same problem seen from the other side, one showing up on the online medium and the other on the offline one, and until now that page reported the failure and stopped there.
- The install button is not rendered at all. It used to be shown disabled, offering an action that can never succeed in this state.
- The page intro goes away too. Both *"Take a moment to review the installation settings..."* and *"When ready, click on the [install] button..."* describe a flow that is not available, and the second one points at a button that is no longer there.
- The system information card stays: it is how users identify the machine the installer is running on, and that is still useful (arguably more useful) when something went wrong. Its **IPs** field is now not rendered when there is no address to show, instead of rendering an empty value.

## Depends on

Built on top of https://github.com/agama-project/agama/pull/3758, which brings back the action used to read the software information again. This one should land after it.

## Wording: reused because string freeze

Every sentence here is a string that already exists in the catalog. That is a deliberate constraint of the translation freeze, not a claim that these are the right words. They were written for other contexts and they show it:

> **Product not found**
> The product was not found in the repositories so it is not possible to proceed with the installation.
> This might be due to network connectivity.
> **Reload**  | **Go to network settings**

"The product was not found in the repositories" leans on installer vocabulary ("repositories") that means little to someone who just wants to install a system, and "This might be due to network connectivity" hedges twice ("might", "connectivity") right where the user needs a clear next step. **Reload** is the weakest of the three: it is borrowed from a screen where it means "reload the page", and here it means something rather different.

Once the freeze lifts, something more direct would serve better. For example:

> **Cannot find the product to install**
> The installer could not download the product from the network. Check the connection and try again.
> **Try again** | **Check network settings**

Worth a pass from someone with a UX writing hat on, rather than picking the above.

## A note on the network action looking like a button

**Go to network settings** is rendered with a button appearance, even though it is a link and stays one in the markup: an anchor pointing at its destination, keyboard and screen reader behaviour untouched.

The reason is purely aesthetic. It sits right next to **Reload**, which is a real button, and a button followed by a piece of underlined text read as two unrelated things rather than as the pair of choices they are. Giving both the same appearance makes them read as one set.

This is not a claim that links should generally look like buttons. Where an action stands on its own, it stays a plain link, which is why **Go to registration** on the software page is untouched. The installer does already take this liberty elsewhere, for instance in the actions accompanying the connections list, so it is worth agreeing on when it is warranted rather than deciding case by case. That belongs in the layout conventions.

## Follow-ups

- **Two alerts at once.** The software page can now render its own alert for unreadable repositories alongside the general one for the remaining issues. Worth checking whether both can really show at the same time and how that looks, since stacking alerts is something we would rather avoid. Whatever we settle on, the rule belongs in the layout conventions.
- **Fixed sentence versus reported description.** The empty state shows a fixed sentence rather than the description the backend sends for this situation. Worth deciding which should win: the reported description is closer to the real cause and may carry details the fixed sentence cannot (which product, which repository), but it is also written for a different context.

## Test plan

- [ ] Boot the installer with a product that cannot be found (for instance, with no network) and open the overview.
- [ ] The empty state explains the situation, links to the network settings and offers to reload.
- [ ] No install button and no page intro are shown.
- [ ] Set up a connection, come back and reload. The overview recovers on its own, without reloading the browser.
- [ ] While reloading, the button is busy and cannot be pressed again. The rest of the page stays usable.
- [ ] On a medium without network access, the software page reports that the repositories could not be read and offers the same two actions.
- [ ] With a product available, the overview behaves as before: intro, settings, system information, and a working install button with its confirmation dialog.
- [ ] The software page still shows its own unavailable states (missing registration, missing product, no patterns).

## Screenshots

> [!IMPORTANT]
> 
> All screenshots in the PR were took with fake data. They might be not fully accurate or even being a bit out-dated (lkike the Reload button, now labeled "Try again") Better to test manually

### Before

<img width="2048" height="1536" alt="localhost_8080_ (24)" src="https://github.com/user-attachments/assets/2f413a35-752e-45c7-9540-aec705c2e587" />

### After

<img width="2048" height="1536" alt="localhost_8080_ (28)" src="https://github.com/user-attachments/assets/2f59bc52-8e7e-4957-97fe-7c27a79688be" />

<img width="2048" height="1536" alt="localhost_8080_ (29)" src="https://github.com/user-attachments/assets/2d2b70de-b37a-45b5-b866-7b210f14f811" />

<img width="2048" height="1536" alt="localhost_8080_ (32)" src="https://github.com/user-attachments/assets/e3bfd9e2-75ee-4832-a718-d444688d9451" />

<img width="2048" height="1536" alt="localhost_8080_ (31)" src="https://github.com/user-attachments/assets/0b4c28d4-f3e2-4e65-8a63-e5290886b24c" />


## Progress on the empty state, in its own commit

https://github.com/agama-project/agama/pull/3768/commits/bb07a3a1fca9810d869b93d7c71e65a87298fc44 adds the usual progress overlay to the "Product not found" screen, so that while the installer looks for the product it says which step it is on. Until then the screen only turned its own actions busy, which shows that something is happening but not what, and shows nothing at all when the search was started from somewhere else.

It is deliberately a commit of its own, touching one file, so it can be dropped if the team would rather not have it.

The part worth highlighting is where it is mounted. Every other screen asks for this overlay at page level, which covers everything on that page for as long as the operation runs. **The overview cannot afford that**: it would be covered on every software operation, including the many the user can carry on working through. Mounting it on the empty state instead means it only ever exists while the product is missing, and by then there is nothing else to do on that screen. No CSS or new mechanism is involved, it is the same component the pages use.

The software page is untouched, since it already asks for the overlay at page level. Both of them wanting it would put two overlays on the same operation.



### Before

<img width="2048" height="1536" alt="localhost_8080_ (29)" src="https://github.com/user-attachments/assets/e495c9ff-7e69-4ec5-8d7d-e8ffcc7013b8" />


### After

<img width="2048" height="1536" alt="localhost_8080_ (33)" src="https://github.com/user-attachments/assets/fdfc6902-9212-4f7a-ac9e-15ae41984a42" />



## A screen that could never recover, found in review

Worth calling out because the reasoning is easy to repeat elsewhere.

Both the retry action and that overlay originally waited for the issues to be fetched again before treating the operation as over, which is the usual way of not showing stale content once something finishes. Here it was the wrong thing to wait for. The backend only reports issues that differ from the ones it already holds, so a read that changes nothing reports nothing, the issues are never fetched again, and the wait never ends.

That is exactly the case the button exists for. With the product still missing, the button stayed disabled and the overlay stayed up, and the only way out was reloading the browser: the opposite of what this PR set out to fix.

https://github.com/agama-project/agama/pull/3768/commits/5d53db06f762045c09a842725789b51d9add7be5 makes it wait for the operation itself instead. Data may arrive slightly after the screen unblocks, so the previous content can linger for a moment, which is a far better trade than getting stuck. Anywhere else waiting on a query that is only refreshed when something actually changed deserves the same look.

---

Related to https://github.com/agama-project/agama/issues/3341

---

Co-Authored-By: Claude Code <noreply@anthropic.com>



