### PR TITLE
refactor(web): migrate installer l10n options to new forms stack

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug  3 10:25:04 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Improve the installer language and keyboard layout dialog,
+  rebuilt with the new form stack (gh#agama-project/agama#3770).
+
+-------------------------------------------------------------------
 Fri Jul 31 08:19:29 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
 - dependency updated on Jul 7 already, listing its references
@@ -25,7 +31,7 @@ Tue Jul 21 22:00:01 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Avoid a flash from Agama colors to a product's own palette
   (gh#agama-project/agama#3749).
-  
+
 -------------------------------------------------------------------
 Tue Jul 21 19:07:07 UTC 2026 - David Diaz <dgonzalez@suse.com>
 

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -144,6 +144,12 @@ describe("InstallerL10nOptions", () => {
       expect(toggle).not.toHaveTextContent("us");
     });
 
+    it("renders a button that tells it opens a dialog", () => {
+      installerRender(<InstallerL10nOptions />);
+      const toggle = screen.getByRole("button", { name: "Language and Keyboard" });
+      expect(toggle).toHaveAttribute("aria-haspopup", "dialog");
+    });
+
     describe("the visual tooltip", () => {
       it("does not add a second source for the accessible name", () => {
         installerRender(<InstallerL10nOptions />);
@@ -286,6 +292,12 @@ describe("InstallerL10nOptions", () => {
       expect(toggle).not.toHaveTextContent("us");
     });
 
+    it("renders a button that tells it opens a dialog", () => {
+      installerRender(<InstallerL10nOptions variant="language" />);
+      const toggle = screen.getByRole("button", { name: "Language" });
+      expect(toggle).toHaveAttribute("aria-haspopup", "dialog");
+    });
+
     it("allows setting only language", async () => {
       const { user } = await renderAndOpen({ variant: "language" });
       const dialog = screen.getByRole("dialog", { name: "Change Language" });
@@ -372,6 +384,12 @@ describe("InstallerL10nOptions", () => {
       });
       expect(toggle).not.toHaveTextContent("Deutsch");
       expect(toggle).toHaveTextContent("us");
+    });
+
+    it("renders a button that tells it opens a dialog", () => {
+      installerRender(<InstallerL10nOptions variant="keyboard" />);
+      const toggle = screen.getByRole("button", { name: "Keyboard" });
+      expect(toggle).toHaveAttribute("aria-haspopup", "dialog");
     });
 
     it("allows setting only keyboard layout", async () => {

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -80,6 +80,17 @@ const renderAndOpen = async (props: InstallerL10nOptionsProps = {}) => {
   return { user };
 };
 
+type User = ReturnType<typeof installerRender>["user"];
+
+/**
+ * Picks a value from one of the dialog selectors, which take two steps: open
+ * the list of options, then choose one.
+ */
+const chooseOption = async (user: User, dialog: HTMLElement, field: string, option: string) => {
+  await user.click(within(dialog).getByRole("button", { name: field }));
+  await user.click(await screen.findByRole("option", { name: option }));
+};
+
 describe("InstallerL10nOptions", () => {
   beforeEach(() => {
     jest.spyOn(utils, "localConnection").mockReturnValue(true);
@@ -170,14 +181,10 @@ describe("InstallerL10nOptions", () => {
     it("allows setting display language and keyboard layout", async () => {
       const { user } = await renderAndOpen();
       const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
-      const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
-      const keymapSelector = await within(dialog).findByRole("combobox", {
-        name: "Keyboard layout",
-      });
       const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
 
-      await user.selectOptions(languageSelector, "Español");
-      await user.selectOptions(keymapSelector, "English (UK)");
+      await chooseOption(user, dialog, "Language", "Español");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
 
       await user.click(acceptButton);
       expect(mockChangeUIL10n).toHaveBeenCalledWith({ language: "es-ES", keymap: "gb" });
@@ -186,10 +193,6 @@ describe("InstallerL10nOptions", () => {
     it("allows reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen();
       const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
-      const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
-      const keymapSelector = await within(dialog).findByRole("combobox", {
-        name: "Keyboard layout",
-      });
       const reuseSettings = within(dialog).getByRole("checkbox", {
         name: /Use these same settings/,
       });
@@ -197,8 +200,8 @@ describe("InstallerL10nOptions", () => {
 
       expect(reuseSettings).toBeChecked();
 
-      await user.selectOptions(languageSelector, "Español");
-      await user.selectOptions(keymapSelector, "English (UK)");
+      await chooseOption(user, dialog, "Language", "Español");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
 
       await user.click(acceptButton);
       expect(mockPatchConfigFn).toHaveBeenCalledWith({
@@ -212,10 +215,6 @@ describe("InstallerL10nOptions", () => {
     it("allows not reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen();
       const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
-      const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
-      const keymapSelector = await within(dialog).findByRole("combobox", {
-        name: "Keyboard layout",
-      });
       const reuseSettings = within(dialog).getByRole("checkbox", {
         name: /Use these same settings/,
       });
@@ -224,8 +223,8 @@ describe("InstallerL10nOptions", () => {
       expect(reuseSettings).toBeChecked();
       await user.click(reuseSettings);
       expect(reuseSettings).not.toBeChecked();
-      await user.selectOptions(languageSelector, "Español");
-      await user.selectOptions(keymapSelector, "English (UK)");
+      await chooseOption(user, dialog, "Language", "Español");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
       await user.click(acceptButton);
       expect(mockPatchConfigFn).not.toHaveBeenCalled();
     });
@@ -233,6 +232,25 @@ describe("InstallerL10nOptions", () => {
     it("includes a link to localization page", async () => {
       await renderAndOpen();
       screen.getByRole("link", { name: "language and region" });
+    });
+
+    it("starts from the settings in use when reopened after a dismissed change", async () => {
+      const { user } = await renderAndOpen();
+      const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
+
+      await chooseOption(user, dialog, "Language", "Español");
+      await user.click(within(dialog).getByRole("checkbox", { name: /Use these same settings/ }));
+      await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+      await user.click(screen.getByRole("button", { name: "Language and Keyboard" }));
+      const reopened = screen.getByRole("dialog", { name: "Language and keyboard" });
+
+      expect(within(reopened).getByRole("button", { name: "Language" })).toHaveTextContent(
+        "Deutsch",
+      );
+      expect(
+        within(reopened).getByRole("checkbox", { name: /Use these same settings/ }),
+      ).toBeChecked();
     });
 
     describe("but a product is not selected yet", () => {
@@ -270,11 +288,10 @@ describe("InstallerL10nOptions", () => {
       it("does not allow setting the keyboard layout", async () => {
         const { user } = await renderAndOpen();
         const dialog = screen.getByRole("dialog");
-        const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
-        const keymapSelector = within(dialog).queryByRole("combobox", { name: "Keyboard layout" });
+        const keymapSelector = within(dialog).queryByRole("button", { name: "Keyboard layout" });
         expect(keymapSelector).toBeNull();
         await within(dialog).findByText("Cannot be changed in remote installation");
-        await user.selectOptions(languageSelector, "Español");
+        await chooseOption(user, dialog, "Language", "Español");
         const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
         await user.click(acceptButton);
         expect(mockChangeUIL10n).toHaveBeenCalledWith({ language: "es-ES" });
@@ -301,14 +318,11 @@ describe("InstallerL10nOptions", () => {
     it("allows setting only language", async () => {
       const { user } = await renderAndOpen({ variant: "language" });
       const dialog = screen.getByRole("dialog", { name: "Change Language" });
-      const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
-      const keymapSelector = within(dialog).queryByRole("combobox", {
-        name: "Keyboard layout",
-      });
+      const keymapSelector = within(dialog).queryByRole("button", { name: "Keyboard layout" });
       expect(keymapSelector).toBeNull();
       const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
 
-      await user.selectOptions(languageSelector, "Español");
+      await chooseOption(user, dialog, "Language", "Español");
 
       await user.click(acceptButton);
       expect(mockChangeUIL10n).toHaveBeenCalledWith({ language: "es-ES" });
@@ -317,7 +331,6 @@ describe("InstallerL10nOptions", () => {
     it("allows reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen({ variant: "language" });
       const dialog = screen.getByRole("dialog", { name: "Change Language" });
-      const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
       const reuseSettings = within(dialog).getByRole("checkbox", {
         name: /Use for the selected product too/,
       });
@@ -325,7 +338,7 @@ describe("InstallerL10nOptions", () => {
 
       expect(reuseSettings).toBeChecked();
 
-      await user.selectOptions(languageSelector, "Español");
+      await chooseOption(user, dialog, "Language", "Español");
 
       await user.click(acceptButton);
       expect(mockPatchConfigFn).toHaveBeenCalledWith({
@@ -338,7 +351,6 @@ describe("InstallerL10nOptions", () => {
     it("allows not reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen({ variant: "language" });
       const dialog = screen.getByRole("dialog", { name: "Change Language" });
-      const languageSelector = within(dialog).getByRole("combobox", { name: "Language" });
       const reuseSettings = within(dialog).getByRole("checkbox", {
         name: /Use for the selected product too/,
       });
@@ -347,7 +359,7 @@ describe("InstallerL10nOptions", () => {
       expect(reuseSettings).toBeChecked();
       await user.click(reuseSettings);
       expect(reuseSettings).not.toBeChecked();
-      await user.selectOptions(languageSelector, "Español");
+      await chooseOption(user, dialog, "Language", "Español");
       await user.click(acceptButton);
       expect(mockPatchConfigFn).not.toHaveBeenCalled();
     });
@@ -395,14 +407,11 @@ describe("InstallerL10nOptions", () => {
     it("allows setting only keyboard layout", async () => {
       const { user } = await renderAndOpen({ variant: "keyboard" });
       const dialog = screen.getByRole("dialog", { name: "Change keyboard" });
-      const languageSelector = within(dialog).queryByRole("combobox", { name: "Language" });
-      const keymapSelector = await within(dialog).findByRole("combobox", {
-        name: "Keyboard layout",
-      });
+      const languageSelector = within(dialog).queryByRole("button", { name: "Language" });
       expect(languageSelector).toBeNull();
       const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
 
-      await user.selectOptions(keymapSelector, "English (UK)");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
 
       await user.click(acceptButton);
       expect(mockChangeUIL10n).toHaveBeenCalledWith({ keymap: "gb" });
@@ -411,9 +420,6 @@ describe("InstallerL10nOptions", () => {
     it("allows reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen({ variant: "keyboard" });
       const dialog = screen.getByRole("dialog", { name: "Change keyboard" });
-      const keymapSelector = await within(dialog).findByRole("combobox", {
-        name: "Keyboard layout",
-      });
       const reuseSettings = within(dialog).getByRole("checkbox", {
         name: /Use for the selected product too/,
       });
@@ -421,7 +427,7 @@ describe("InstallerL10nOptions", () => {
 
       expect(reuseSettings).toBeChecked();
 
-      await user.selectOptions(keymapSelector, "English (UK)");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
 
       await user.click(acceptButton);
       expect(mockPatchConfigFn).toHaveBeenCalledWith({
@@ -434,9 +440,6 @@ describe("InstallerL10nOptions", () => {
     it("allows not reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen({ variant: "keyboard" });
       const dialog = screen.getByRole("dialog", { name: "Change keyboard" });
-      const keymapSelector = await within(dialog).findByRole("combobox", {
-        name: "Keyboard layout",
-      });
       const reuseSettings = within(dialog).getByRole("checkbox", {
         name: /Use for the selected product too/,
       });
@@ -445,7 +448,7 @@ describe("InstallerL10nOptions", () => {
       expect(reuseSettings).toBeChecked();
       await user.click(reuseSettings);
       expect(reuseSettings).not.toBeChecked();
-      await user.selectOptions(keymapSelector, "English (UK)");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
       await user.click(acceptButton);
       expect(mockPatchConfigFn).not.toHaveBeenCalled();
     });

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -217,6 +217,20 @@ describe("InstallerL10nOptions", () => {
       });
     });
 
+    it("keeps the product locale when it offers none for the chosen language", async () => {
+      const { user } = await renderAndOpen();
+      const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
+      const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
+
+      // Catalan is offered for the interface, but the product locales above do
+      // not include it.
+      await chooseOption(user, dialog, "Language", "Català");
+      await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
+
+      await user.click(acceptButton);
+      expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { keymap: "gb" } });
+    });
+
     it("allows not reusing settings for the selected product", async () => {
       const { user } = await renderAndOpen();
       const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
@@ -363,6 +377,19 @@ describe("InstallerL10nOptions", () => {
           locale: "es_ES.UTF-8",
         },
       });
+    });
+
+    it("changes nothing when the product offers no locale for the chosen language", async () => {
+      const { user } = await renderAndOpen({ variant: "language" });
+      const dialog = screen.getByRole("dialog", { name: "Change Language" });
+      const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
+
+      // Catalan is offered for the interface, but the product locales above do
+      // not include it.
+      await chooseOption(user, dialog, "Language", "Català");
+
+      await user.click(acceptButton);
+      expect(mockPatchConfigFn).not.toHaveBeenCalled();
     });
 
     it("allows not reusing settings for the selected product", async () => {

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -85,10 +85,15 @@ type User = ReturnType<typeof installerRender>["user"];
 /**
  * Picks a value from one of the dialog selectors, which take two steps: open
  * the list of options, then choose one.
+ *
+ * Each option is named after its label plus the code shown below it, so the
+ * option is matched by a substring of that name.
  */
 const chooseOption = async (user: User, dialog: HTMLElement, field: string, option: string) => {
-  await user.click(within(dialog).getByRole("button", { name: field }));
-  await user.click(await screen.findByRole("option", { name: option }));
+  await user.click(within(dialog).getByRole("combobox", { name: field }));
+  await user.click(
+    await screen.findByRole("option", { name: (name: string) => name.startsWith(option) }),
+  );
 };
 
 describe("InstallerL10nOptions", () => {
@@ -238,10 +243,14 @@ describe("InstallerL10nOptions", () => {
       const { user } = await renderAndOpen();
       const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
 
-      await user.click(within(dialog).getByRole("button", { name: "Language" }));
+      await user.click(within(dialog).getByRole("combobox", { name: "Language" }));
 
-      expect(await screen.findByText("日本語")).toHaveAttribute("lang", "ja-JP");
-      expect(screen.getByText("Català")).toHaveAttribute("lang", "ca-ES");
+      // The language is stated on the list item wrapping the option, so it
+      // applies to the option text it contains.
+      const japanese = await screen.findByRole("option", { name: /日本語/ });
+      expect(japanese.closest("li")).toHaveAttribute("lang", "ja-JP");
+      const catalan = screen.getByRole("option", { name: /Català/ });
+      expect(catalan.closest("li")).toHaveAttribute("lang", "ca-ES");
     });
 
     it("starts from the settings in use when reopened after a dismissed change", async () => {
@@ -255,9 +264,7 @@ describe("InstallerL10nOptions", () => {
       await user.click(screen.getByRole("button", { name: "Language and Keyboard" }));
       const reopened = screen.getByRole("dialog", { name: "Language and keyboard" });
 
-      expect(within(reopened).getByRole("button", { name: "Language" })).toHaveTextContent(
-        "Deutsch",
-      );
+      expect(within(reopened).getByRole("combobox", { name: "Language" })).toHaveValue("Deutsch");
       expect(
         within(reopened).getByRole("checkbox", { name: /Use these same settings/ }),
       ).toBeChecked();
@@ -298,7 +305,7 @@ describe("InstallerL10nOptions", () => {
       it("does not allow setting the keyboard layout", async () => {
         const { user } = await renderAndOpen();
         const dialog = screen.getByRole("dialog");
-        const keymapSelector = within(dialog).queryByRole("button", { name: "Keyboard layout" });
+        const keymapSelector = within(dialog).queryByRole("combobox", { name: "Keyboard layout" });
         expect(keymapSelector).toBeNull();
         await within(dialog).findByText("Cannot be changed in remote installation");
         await chooseOption(user, dialog, "Language", "Español");
@@ -328,7 +335,7 @@ describe("InstallerL10nOptions", () => {
     it("allows setting only language", async () => {
       const { user } = await renderAndOpen({ variant: "language" });
       const dialog = screen.getByRole("dialog", { name: "Change Language" });
-      const keymapSelector = within(dialog).queryByRole("button", { name: "Keyboard layout" });
+      const keymapSelector = within(dialog).queryByRole("combobox", { name: "Keyboard layout" });
       expect(keymapSelector).toBeNull();
       const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
 
@@ -417,7 +424,7 @@ describe("InstallerL10nOptions", () => {
     it("allows setting only keyboard layout", async () => {
       const { user } = await renderAndOpen({ variant: "keyboard" });
       const dialog = screen.getByRole("dialog", { name: "Change keyboard" });
-      const languageSelector = within(dialog).queryByRole("button", { name: "Language" });
+      const languageSelector = within(dialog).queryByRole("combobox", { name: "Language" });
       expect(languageSelector).toBeNull();
       const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
 

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -234,6 +234,16 @@ describe("InstallerL10nOptions", () => {
       screen.getByRole("link", { name: "language and region" });
     });
 
+    it("states the language of each option", async () => {
+      const { user } = await renderAndOpen();
+      const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
+
+      await user.click(within(dialog).getByRole("button", { name: "Language" }));
+
+      expect(await screen.findByText("日本語")).toHaveAttribute("lang", "ja-JP");
+      expect(screen.getByText("Català")).toHaveAttribute("lang", "ca-ES");
+    });
+
     it("starts from the settings in use when reopened after a dismissed change", async () => {
       const { user } = await renderAndOpen();
       const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -33,11 +33,12 @@
 
 import React, { useReducer } from "react";
 import { useHref, useLocation } from "react-router";
-import { Button, ButtonProps, Flex, FlexProps, Form, FormGroup } from "@patternfly/react-core";
+import { Button, ButtonProps, Flex, FlexProps, Form } from "@patternfly/react-core";
+import { formOptions } from "@tanstack/react-form";
 import Popup from "~/components/core/Popup";
 import VisualTooltip from "~/components/core/VisualTooltip";
 import Icon from "~/components/layout/Icon";
-import { useAppForm } from "~/hooks/form";
+import { mergeFormDefaults, useAppForm, withForm } from "~/hooks/form";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { localConnection } from "~/utils";
 import { _ } from "~/i18n";
@@ -64,30 +65,22 @@ type FormFields = {
 };
 
 /**
- * Builds the form driving the dialog.
- *
- * Written as a factory so its return type names the form instance shared by
- * every piece of the dialog. The `withForm` helper used by other forms does
- * not fit here: it runs while the module loads, and this module sits in an
- * import cycle that comes back to the form helpers before they are ready.
+ * Fallbacks for the settings. The language and the keymap in use replace them
+ * when the component builds its form, since both are only known at runtime.
  */
-const useL10nOptionsForm = (
-  defaultValues: FormFields,
-  onSubmit: (values: FormFields) => Promise<void>,
-) => useAppForm({ defaultValues, onSubmit: ({ value }) => onSubmit(value) });
+const defaultValues: FormFields = { language: "", keymap: "", reuseSettings: true };
 
-type L10nOptionsForm = ReturnType<typeof useL10nOptionsForm>;
-
-/** Props for every piece of the dialog that reads or writes the settings. */
-type FormProps = { form: L10nOptionsForm };
+/** Shared options, giving every piece of the dialog the same field types. */
+const defaultOptions = formOptions({ defaultValues });
 
 /**
  * Submits the settings instead of letting the browser handle the form.
  */
-const submitHandler = (form: L10nOptionsForm) => (event: React.FormEvent<HTMLFormElement>) => {
-  event.preventDefault();
-  form.handleSubmit();
-};
+const submitHandler =
+  (form: { handleSubmit: () => void }) => (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    form.handleSubmit();
+  };
 
 /**
  * Renders a dropdown for language selection.
@@ -95,48 +88,60 @@ const submitHandler = (form: L10nOptionsForm) => (event: React.FormEvent<HTMLFor
  * Each option states its own language, so it is read aloud with the right
  * pronunciation instead of the one currently in use.
  */
-const LanguageField = ({ form }: FormProps) => {
-  const options = Object.keys(supportedLanguages)
-    .sort()
-    .map((id) => ({ value: id, label: <span lang={id}>{supportedLanguages[id]}</span> }));
+const LanguageField = withForm({
+  ...defaultOptions,
+  render: function Render({ form }) {
+    const options = Object.keys(supportedLanguages)
+      .sort()
+      .map((id) => ({ value: id, label: <span lang={id}>{supportedLanguages[id]}</span> }));
 
-  return (
-    <form.AppField name="language">
-      {(field) => (
-        // TRANSLATORS: label for the installer interface language selector
-        <field.DropdownField label={_("Language")} options={options} />
-      )}
-    </form.AppField>
-  );
-};
+    return (
+      <form.AppField name="language">
+        {(field) => (
+          // TRANSLATORS: label for the installer interface language selector
+          <field.DropdownField label={_("Language")} options={options} />
+        )}
+      </form.AppField>
+    );
+  },
+});
 
 /**
  * Renders a dropdown for keyboard layout selection.
  *
  * Not available in remote installations.
  */
-const KeyboardField = ({ form }: FormProps) => {
-  const keymaps = useSystem()?.l10n?.keymaps ?? [];
+const KeyboardField = withForm({
+  ...defaultOptions,
+  render: function Render({ form }) {
+    const keymaps = useSystem()?.l10n?.keymaps ?? [];
 
-  if (!localConnection()) {
+    if (!localConnection()) {
+      return (
+        <form.AppField name="keymap">
+          {(field) => (
+            <field.ReadOnlyField
+              // TRANSLATORS: label for the installer interface keyboard layout selector
+              label={_("Keyboard layout")}
+              text={_("Cannot be changed in remote installation")}
+            />
+          )}
+        </form.AppField>
+      );
+    }
+
+    const options = keymaps.map((keymap) => ({ value: keymap.id, label: keymap.description }));
+
     return (
-      <FormGroup label={_("Keyboard layout")}>
-        {_("Cannot be changed in remote installation")}
-      </FormGroup>
+      <form.AppField name="keymap">
+        {(field) => (
+          // TRANSLATORS: label for the installer interface keyboard layout selector
+          <field.DropdownField label={_("Keyboard layout")} options={options} />
+        )}
+      </form.AppField>
     );
-  }
-
-  const options = keymaps.map((keymap) => ({ value: keymap.id, label: keymap.description }));
-
-  return (
-    <form.AppField name="keymap">
-      {(field) => (
-        // TRANSLATORS: label for the installer interface keyboard layout selector
-        <field.DropdownField label={_("Keyboard layout")} options={options} />
-      )}
-    </form.AppField>
-  );
-};
+  },
+});
 
 /**
  * Supported dialog actions.
@@ -168,7 +173,7 @@ const dialogReducer = (state: DialogState, action: DialogAction): DialogState =>
 /**
  * Props passed to each dialog variant.
  */
-type DialogProps = FormProps & {
+type DialogProps = {
   isOpen: boolean;
   /** Whether the settings can also be applied to the product to install. */
   allowReusingSettings: boolean;
@@ -267,119 +272,149 @@ const TextWithLinkToL10n = ({ text, onClick }: TextWithLinkToL10nProps) => {
  * Renders the checkbox for applying the chosen settings to the product to
  * install too, with a link to the page where they can be fine tuned.
  */
-const ReuseSettingsField = ({
-  form,
-  label,
-  onLinkClick,
-}: FormProps & { label: TranslatedString; onLinkClick?: ButtonProps["onClick"] }) => {
-  const description = _(
-    // TRANSLATORS: Explains where users can find more language and keyboard
-    // options for the product to install. The text in square brackets [] is a
-    // link to the localization page; keep the brackets.
-    "The [language and region] settings for the product may offer more options to choose from.",
-  );
+const ReuseSettingsField = withForm({
+  ...defaultOptions,
+  props: {} as {
+    /** Wording for the checkbox, which depends on the dialog variant. */
+    label: TranslatedString;
+    /** Called when the user activates the link to the localization page. */
+    onLinkClick?: ButtonProps["onClick"];
+  },
+  render: function Render({ form, label, onLinkClick }) {
+    const description = _(
+      // TRANSLATORS: Explains where users can find more language and keyboard
+      // options for the product to install. The text in square brackets [] is a
+      // link to the localization page; keep the brackets.
+      "The [language and region] settings for the product may offer more options to choose from.",
+    );
 
-  return (
-    <form.AppField name="reuseSettings">
-      {(field) => (
-        <field.CheckboxField
-          label={label}
-          description={<TextWithLinkToL10n text={description} onClick={onLinkClick} />}
-        />
-      )}
-    </form.AppField>
-  );
-};
+    return (
+      <form.AppField name="reuseSettings">
+        {(field) => (
+          <field.CheckboxField
+            label={label}
+            description={<TextWithLinkToL10n text={description} onClick={onLinkClick} />}
+          />
+        )}
+      </form.AppField>
+    );
+  },
+});
 
 /**
  * Renders the dialog buttons, keeping them unavailable while the settings are
  * being applied.
  */
-const DialogActions = ({ form, onCancel }: FormProps & { onCancel: () => void }) => (
-  <Popup.Actions>
-    <form.Subscribe selector={(state) => state.isSubmitting}>
-      {(isSubmitting) => (
-        <>
-          <Popup.Confirm
-            form="installer-l10n"
-            type="submit"
-            autoFocus
-            isDisabled={isSubmitting}
-            isLoading={isSubmitting}
-          >
-            {_("Accept")}
-          </Popup.Confirm>
-          <Popup.Cancel onClick={onCancel} isDisabled={isSubmitting} />
-        </>
-      )}
-    </form.Subscribe>
-  </Popup.Actions>
-);
-
-const AllSettingsDialog = ({ form, isOpen, allowReusingSettings, onCancel }: DialogProps) => (
-  <Popup isOpen={isOpen} variant="small" title={_("Language and keyboard")}>
-    <Form id="installer-l10n" onSubmit={submitHandler(form)}>
-      <LanguageField form={form} />
-      <KeyboardField form={form} />
-      <ReusableSettings isReuseAllowed={allowReusingSettings}>
-        <ReuseSettingsField
-          form={form}
-          label={_("Use these same settings for the selected product")}
-          onLinkClick={onCancel}
-        />
-      </ReusableSettings>
-    </Form>
-
-    <DialogActions form={form} onCancel={onCancel} />
-  </Popup>
-);
-
-const LanguageOnlyDialog = ({ form, isOpen, allowReusingSettings, onCancel }: DialogProps) => (
-  <Popup isOpen={isOpen} variant="small" title={_("Change Language")}>
-    <Form id="installer-l10n" onSubmit={submitHandler(form)}>
-      <LanguageField form={form} />
-      <ReusableSettings isReuseAllowed={allowReusingSettings}>
-        <ReuseSettingsField
-          form={form}
-          label={_("Use for the selected product too")}
-          onLinkClick={onCancel}
-        />
-      </ReusableSettings>
-    </Form>
-
-    <DialogActions form={form} onCancel={onCancel} />
-  </Popup>
-);
-
-const KeyboardOnlyDialog = ({ form, isOpen, allowReusingSettings, onCancel }: DialogProps) => {
-  if (!localConnection()) {
+const DialogActions = withForm({
+  ...defaultOptions,
+  props: {} as {
+    /** Called when the user dismisses the dialog. */
+    onCancel: () => void;
+  },
+  render: function Render({ form, onCancel }) {
     return (
-      <Popup isOpen={isOpen} variant="small" title={_("Change keyboard")}>
-        {_("Cannot be changed in remote installation")}
-        <Popup.Actions>
-          <Popup.Confirm onClick={onCancel}>{_("Accept")}</Popup.Confirm>
-        </Popup.Actions>
+      <Popup.Actions>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <>
+              <Popup.Confirm
+                form="installer-l10n"
+                type="submit"
+                autoFocus
+                isDisabled={isSubmitting}
+                isLoading={isSubmitting}
+              >
+                {_("Accept")}
+              </Popup.Confirm>
+              <Popup.Cancel onClick={onCancel} isDisabled={isSubmitting} />
+            </>
+          )}
+        </form.Subscribe>
+      </Popup.Actions>
+    );
+  },
+});
+
+const AllSettingsDialog = withForm({
+  ...defaultOptions,
+  props: {} as DialogProps,
+  render: function Render({ form, isOpen, allowReusingSettings, onCancel }) {
+    return (
+      <Popup isOpen={isOpen} variant="small" title={_("Language and keyboard")}>
+        <Form id="installer-l10n" onSubmit={submitHandler(form)}>
+          <LanguageField form={form} />
+          <KeyboardField form={form} />
+          <ReusableSettings isReuseAllowed={allowReusingSettings}>
+            <ReuseSettingsField
+              form={form}
+              label={_("Use these same settings for the selected product")}
+              onLinkClick={onCancel}
+            />
+          </ReusableSettings>
+        </Form>
+
+        <DialogActions form={form} onCancel={onCancel} />
       </Popup>
     );
-  }
+  },
+});
 
-  return (
-    <Popup isOpen={isOpen} variant="small" title={_("Change keyboard")}>
-      <Form id="installer-l10n" onSubmit={submitHandler(form)}>
-        <KeyboardField form={form} />
-        <ReusableSettings isReuseAllowed={allowReusingSettings}>
-          <ReuseSettingsField
-            form={form}
-            label={_("Use for the selected product too")}
-            onLinkClick={onCancel}
-          />
-        </ReusableSettings>
-      </Form>
+const LanguageOnlyDialog = withForm({
+  ...defaultOptions,
+  props: {} as DialogProps,
+  render: function Render({ form, isOpen, allowReusingSettings, onCancel }) {
+    return (
+      <Popup isOpen={isOpen} variant="small" title={_("Change Language")}>
+        <Form id="installer-l10n" onSubmit={submitHandler(form)}>
+          <LanguageField form={form} />
+          <ReusableSettings isReuseAllowed={allowReusingSettings}>
+            <ReuseSettingsField
+              form={form}
+              label={_("Use for the selected product too")}
+              onLinkClick={onCancel}
+            />
+          </ReusableSettings>
+        </Form>
 
-      <DialogActions form={form} onCancel={onCancel} />
-    </Popup>
-  );
-};
+        <DialogActions form={form} onCancel={onCancel} />
+      </Popup>
+    );
+  },
+});
+
+const KeyboardOnlyDialog = withForm({
+  ...defaultOptions,
+  props: {} as DialogProps,
+  render: function Render({ form, isOpen, allowReusingSettings, onCancel }) {
+    if (!localConnection()) {
+      return (
+        <Popup isOpen={isOpen} variant="small" title={_("Change keyboard")}>
+          {_("Cannot be changed in remote installation")}
+          <Popup.Actions>
+            <Popup.Confirm onClick={onCancel}>{_("Accept")}</Popup.Confirm>
+          </Popup.Actions>
+        </Popup>
+      );
+    }
+
+    return (
+      <Popup isOpen={isOpen} variant="small" title={_("Change keyboard")}>
+        <Form id="installer-l10n" onSubmit={submitHandler(form)}>
+          <KeyboardField form={form} />
+          <ReusableSettings isReuseAllowed={allowReusingSettings}>
+            <ReuseSettingsField
+              form={form}
+              label={_("Use for the selected product too")}
+              onLinkClick={onCancel}
+            />
+          </ReusableSettings>
+        </Form>
+
+        <DialogActions form={form} onCancel={onCancel} />
+      </Popup>
+    );
+  },
+});
 
 /** Icon representing the language settings. Used in toggle buttons. */
 const LanguageIcon = () => <Icon isMiddleAligned name="translate" />;
@@ -552,7 +587,10 @@ export default function InstallerL10nOptions({
     }
   };
 
-  const form = useL10nOptionsForm({ language, keymap, reuseSettings: true }, applySettings);
+  const form = useAppForm({
+    ...mergeFormDefaults(defaultOptions, { language, keymap }),
+    onSubmit: ({ value }) => applySettings(value),
+  });
 
   // Skip rendering if any of the following conditions are met
   const skip =

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -304,8 +304,11 @@ const ReuseSettingsField = withForm({
 /**
  * Renders the dialog buttons, keeping them unavailable while the settings are
  * being applied.
+ *
+ * Meant to be placed inside a `Popup.Actions`, which is what puts the buttons
+ * in the dialog footer.
  */
-const DialogActions = withForm({
+const DialogButtons = withForm({
   ...defaultOptions,
   props: {} as {
     /** Called when the user dismisses the dialog. */
@@ -313,24 +316,22 @@ const DialogActions = withForm({
   },
   render: function Render({ form, onCancel }) {
     return (
-      <Popup.Actions>
-        <form.Subscribe selector={(state) => state.isSubmitting}>
-          {(isSubmitting) => (
-            <>
-              <Popup.Confirm
-                form="installer-l10n"
-                type="submit"
-                autoFocus
-                isDisabled={isSubmitting}
-                isLoading={isSubmitting}
-              >
-                {_("Accept")}
-              </Popup.Confirm>
-              <Popup.Cancel onClick={onCancel} isDisabled={isSubmitting} />
-            </>
-          )}
-        </form.Subscribe>
-      </Popup.Actions>
+      <form.Subscribe selector={(state) => state.isSubmitting}>
+        {(isSubmitting) => (
+          <>
+            <Popup.Confirm
+              form="installer-l10n"
+              type="submit"
+              autoFocus
+              isDisabled={isSubmitting}
+              isLoading={isSubmitting}
+            >
+              {_("Accept")}
+            </Popup.Confirm>
+            <Popup.Cancel onClick={onCancel} isDisabled={isSubmitting} />
+          </>
+        )}
+      </form.Subscribe>
     );
   },
 });
@@ -353,7 +354,9 @@ const AllSettingsDialog = withForm({
           </ReusableSettings>
         </Form>
 
-        <DialogActions form={form} onCancel={onCancel} />
+        <Popup.Actions>
+          <DialogButtons form={form} onCancel={onCancel} />
+        </Popup.Actions>
       </Popup>
     );
   },
@@ -376,7 +379,9 @@ const LanguageOnlyDialog = withForm({
           </ReusableSettings>
         </Form>
 
-        <DialogActions form={form} onCancel={onCancel} />
+        <Popup.Actions>
+          <DialogButtons form={form} onCancel={onCancel} />
+        </Popup.Actions>
       </Popup>
     );
   },
@@ -410,7 +415,9 @@ const KeyboardOnlyDialog = withForm({
           </ReusableSettings>
         </Form>
 
-        <DialogActions form={form} onCancel={onCancel} />
+        <Popup.Actions>
+          <DialogButtons form={form} onCancel={onCancel} />
+        </Popup.Actions>
       </Popup>
     );
   },

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -91,11 +91,14 @@ const submitHandler = (form: L10nOptionsForm) => (event: React.FormEvent<HTMLFor
 
 /**
  * Renders a dropdown for language selection.
+ *
+ * Each option states its own language, so it is read aloud with the right
+ * pronunciation instead of the one currently in use.
  */
 const LanguageField = ({ form }: FormProps) => {
   const options = Object.keys(supportedLanguages)
     .sort()
-    .map((id) => ({ value: id, label: supportedLanguages[id] }));
+    .map((id) => ({ value: id, label: <span lang={id}>{supportedLanguages[id]}</span> }));
 
   return (
     <form.AppField name="language">

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -42,6 +42,7 @@ import Icon from "~/components/layout/Icon";
 import { mergeFormDefaults, useAppForm, withForm } from "~/hooks/form";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { localConnection } from "~/utils";
+import { languageToLocale } from "~/utils/l10n";
 import { _ } from "~/i18n";
 
 import type { TranslatedString } from "~/i18n";
@@ -589,14 +590,20 @@ export default function InstallerL10nOptions({
 
   /**
    * Copies selected localization settings to the product to install settings,
+   * as far as the product supports them.
+   *
+   * The product offers its own list of locales, which does not have to include
+   * one for the chosen interface language. When it does not, its localization
+   * settings are left as they are.
    **/
   const reuseSettings = (values: FormFields) => {
-    // FIXME: export and use languageToLocale from context/installerL10n
-    const systemLocale = locales.find((l) => l.id.startsWith(values.language.replace("-", "_")));
+    const systemLocale = locales.find((l) => l.id === languageToLocale(values.language));
     const systemL10n: { locale?: Locale["id"]; keymap?: Keymap["id"] } = {};
-    // FIXME: use a fallback if no system locale was found ?
-    if (variant !== "keyboard") systemL10n.locale = systemLocale?.id;
+
+    if (variant !== "keyboard" && systemLocale) systemL10n.locale = systemLocale.id;
     if (variant !== "language" && localConnection()) systemL10n.keymap = values.keymap;
+
+    if (Object.keys(systemL10n).length === 0) return;
 
     patchConfig({ l10n: systemL10n });
   };

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -33,21 +33,11 @@
 
 import React, { useReducer } from "react";
 import { useHref, useLocation } from "react-router";
-import {
-  Button,
-  ButtonProps,
-  Checkbox,
-  Flex,
-  FlexProps,
-  Form,
-  FormGroup,
-  FormSelect,
-  FormSelectOption,
-  FormSelectProps,
-} from "@patternfly/react-core";
+import { Button, ButtonProps, Flex, FlexProps, Form, FormGroup } from "@patternfly/react-core";
 import { Popup } from "~/components/core";
 import VisualTooltip from "~/components/core/VisualTooltip";
 import { Icon } from "~/components/layout";
+import { useAppForm } from "~/hooks/form";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { localConnection } from "~/utils";
 import { _ } from "~/i18n";
@@ -62,34 +52,67 @@ import { patchConfig } from "~/api";
 import type { Keymap, Locale } from "~/model/system/l10n";
 
 /**
- * Props for select inputs
+ * Settings the user can change in the dialog.
  */
-type SelectProps = {
-  value: string;
-  onChange: FormSelectProps["onChange"];
+type FormFields = {
+  /** The language code */
+  language: string;
+  /** The keymap code */
+  keymap: string;
+  /** Whether to use these settings for the product localization settings too */
+  reuseSettings: boolean;
+};
+
+/**
+ * Builds the form driving the dialog.
+ *
+ * Written as a factory so its return type names the form instance shared by
+ * every piece of the dialog. The `withForm` helper used by other forms does
+ * not fit here: it runs while the module loads, and this module sits in an
+ * import cycle that comes back to the form helpers before they are ready.
+ */
+const useL10nOptionsForm = (
+  defaultValues: FormFields,
+  onSubmit: (values: FormFields) => Promise<void>,
+) => useAppForm({ defaultValues, onSubmit: ({ value }) => onSubmit(value) });
+
+type L10nOptionsForm = ReturnType<typeof useL10nOptionsForm>;
+
+/** Props for every piece of the dialog that reads or writes the settings. */
+type FormProps = { form: L10nOptionsForm };
+
+/**
+ * Submits the settings instead of letting the browser handle the form.
+ */
+const submitHandler = (form: L10nOptionsForm) => (event: React.FormEvent<HTMLFormElement>) => {
+  event.preventDefault();
+  form.handleSubmit();
 };
 
 /**
  * Renders a dropdown for language selection.
  */
-const LangaugeFormInput = ({ value, onChange }: SelectProps) => (
-  <FormGroup fieldId="language" label={_("Language")}>
-    <FormSelect id="language" name="language" value={value} onChange={onChange}>
-      {Object.keys(supportedLanguages)
-        .sort()
-        .map((id, index) => (
-          <FormSelectOption key={index} value={id} label={supportedLanguages[id]} />
-        ))}
-    </FormSelect>
-  </FormGroup>
-);
+const LanguageField = ({ form }: FormProps) => {
+  const options = Object.keys(supportedLanguages)
+    .sort()
+    .map((id) => ({ value: id, label: supportedLanguages[id] }));
+
+  return (
+    <form.AppField name="language">
+      {(field) => (
+        // TRANSLATORS: label for the installer interface language selector
+        <field.DropdownField label={_("Language")} options={options} />
+      )}
+    </form.AppField>
+  );
+};
 
 /**
  * Renders a dropdown for keyboard layout selection.
  *
  * Not available in remote installations.
  */
-const KeyboardFormInput = ({ value, onChange }: SelectProps) => {
+const KeyboardField = ({ form }: FormProps) => {
   const keymaps = useSystem()?.l10n?.keymaps ?? [];
 
   if (!localConnection()) {
@@ -100,85 +123,32 @@ const KeyboardFormInput = ({ value, onChange }: SelectProps) => {
     );
   }
 
+  const options = keymaps.map((keymap) => ({ value: keymap.id, label: keymap.description }));
+
   return (
-    <FormGroup fieldId="keymap" label={_("Keyboard layout")}>
-      <FormSelect
-        id="keymap"
-        name="keymap"
-        label={_("Keyboard layout")}
-        value={value}
-        onChange={onChange}
-      >
-        {keymaps.map((keymap, index) => (
-          <FormSelectOption key={index} value={keymap.id} label={keymap.description} />
-        ))}
-      </FormSelect>
-    </FormGroup>
+    <form.AppField name="keymap">
+      {(field) => (
+        // TRANSLATORS: label for the installer interface keyboard layout selector
+        <field.DropdownField label={_("Keyboard layout")} options={options} />
+      )}
+    </form.AppField>
   );
-};
-
-/**
- * Represents the form state.
- */
-type FormState = {
-  /** The language code */
-  language: string;
-  /** The keymap code */
-  keymap: string;
-  /** Whether reusing settings for the product feature is availabler or not */
-  allowReusingSettings: boolean;
-  /** Whether reuse these settings for the product localization settings too */
-  reuseSettings: boolean;
-};
-
-/**
- * Supported form actions.
- */
-type FormAction =
-  | { type: "SET_SELECTED_LANGUAGE"; language: string }
-  | { type: "SET_SELECTED_KEYMAP"; keymap: string }
-  | { type: "TOGGLE_REUSE_SETTINGS" }
-  | { type: "RESET"; state: FormState };
-
-/**
- * Reducer for form state updates.
- */
-const formReducer = (state: FormState, action: FormAction): FormState => {
-  switch (action.type) {
-    case "SET_SELECTED_LANGUAGE": {
-      return { ...state, language: action.language };
-    }
-
-    case "SET_SELECTED_KEYMAP": {
-      return { ...state, keymap: action.keymap };
-    }
-
-    case "TOGGLE_REUSE_SETTINGS": {
-      return { ...state, reuseSettings: !state.reuseSettings };
-    }
-
-    case "RESET": {
-      return { ...action.state };
-    }
-  }
 };
 
 /**
  * Supported dialog actions.
  */
-type DialogAction =
-  { type: "OPEN" } | { type: "CLOSE" } | { type: "SET_BUSY" } | { type: "SET_IDLE" };
+type DialogAction = { type: "OPEN" } | { type: "CLOSE" };
 
 /**
  * Represents the dialog state
  */
 type DialogState = {
   isOpen: boolean;
-  isBusy: boolean;
 };
 
 /**
- * Reducer for form state updates.
+ * Reducer for dialog state updates.
  */
 const dialogReducer = (state: DialogState, action: DialogAction): DialogState => {
   switch (action.type) {
@@ -187,37 +157,20 @@ const dialogReducer = (state: DialogState, action: DialogAction): DialogState =>
     }
 
     case "CLOSE": {
-      return { isOpen: false, isBusy: false };
-    }
-
-    case "SET_BUSY": {
-      return { ...state, isBusy: true };
-    }
-
-    case "SET_IDLE": {
-      return { ...state, isBusy: false };
+      return { ...state, isOpen: false };
     }
   }
 };
 
 /**
- * Available actions for handling dialog and form events.
- */
-type Actions = {
-  handleLanguageChange: (_, v: string) => void;
-  handleKeymapChange: (_, v: string) => void;
-  handleCopyToSystemToggle: (_, v: boolean) => void;
-  handleSubmission: (e: React.FormEvent<HTMLFormElement>) => void;
-  handleCancellation: () => void;
-};
-
-/**
  * Props passed to each dialog variant.
  */
-type DialogProps = {
-  state: DialogState;
-  formState: FormState;
-  actions: Actions;
+type DialogProps = FormProps & {
+  isOpen: boolean;
+  /** Whether the settings can also be applied to the product to install. */
+  allowReusingSettings: boolean;
+  /** Called when the user dismisses the dialog. */
+  onCancel: () => void;
 };
 
 /**
@@ -307,152 +260,120 @@ const TextWithLinkToL10n = ({ text, onClick }: TextWithLinkToL10nProps) => {
   );
 };
 
-const AllSettingsDialog = ({ state, formState, actions }: DialogProps) => {
-  const checkboxDescription = _(
-    // TRANSLATORS: Explains where users can find more language and keymap
+/**
+ * Renders the checkbox for applying the chosen settings to the product to
+ * install too, with a link to the page where they can be fine tuned.
+ */
+const ReuseSettingsField = ({
+  form,
+  label,
+  onLinkClick,
+}: FormProps & { label: TranslatedString; onLinkClick?: ButtonProps["onClick"] }) => {
+  const description = _(
+    // TRANSLATORS: Explains where users can find more language and keyboard
     // options for the product to install. The text in square brackets [] is a
     // link to the localization page; keep the brackets.
     "The [language and region] settings for the product may offer more options to choose from.",
   );
 
   return (
-    <Popup isOpen={state.isOpen} variant="small" title={_("Language and keyboard")}>
-      <Form id="installer-l10n" onSubmit={actions.handleSubmission}>
-        <LangaugeFormInput value={formState.language} onChange={actions.handleLanguageChange} />
-        <KeyboardFormInput value={formState.keymap} onChange={actions.handleKeymapChange} />
-        <ReusableSettings isReuseAllowed={formState.allowReusingSettings}>
-          <FormGroup fieldId="reuse-settings">
-            <Checkbox
-              id="reuse-settings"
-              label={_("Use these same settings for the selected product")}
-              description={
-                <TextWithLinkToL10n
-                  text={checkboxDescription}
-                  onClick={actions.handleCancellation}
-                />
-              }
-              isChecked={formState.reuseSettings}
-              onChange={actions.handleCopyToSystemToggle}
-            />
-          </FormGroup>
-        </ReusableSettings>
-      </Form>
-
-      <Popup.Actions>
-        <Popup.Confirm
-          form="installer-l10n"
-          type="submit"
-          autoFocus
-          isDisabled={state.isBusy}
-          isLoading={state.isBusy}
-        >
-          {_("Accept")}
-        </Popup.Confirm>
-        <Popup.Cancel onClick={actions.handleCancellation} isDisabled={state.isBusy} />
-      </Popup.Actions>
-    </Popup>
+    <form.AppField name="reuseSettings">
+      {(field) => (
+        <field.CheckboxField
+          label={label}
+          description={<TextWithLinkToL10n text={description} onClick={onLinkClick} />}
+        />
+      )}
+    </form.AppField>
   );
 };
 
-const LanguageOnlyDialog = ({ state, formState, actions }: DialogProps) => {
-  const checkboxDescription = _(
-    // TRANSLATORS: Explains where users can find more language options for the
-    // product to install. The text in square brackets [] is a link to the
-    // localization page; keep the brackets.
-    "The [language and region] settings for the product may offer more options to choose from.",
-  );
+/**
+ * Renders the dialog buttons, keeping them unavailable while the settings are
+ * being applied.
+ */
+const DialogActions = ({ form, onCancel }: FormProps & { onCancel: () => void }) => (
+  <Popup.Actions>
+    <form.Subscribe selector={(state) => state.isSubmitting}>
+      {(isSubmitting) => (
+        <>
+          <Popup.Confirm
+            form="installer-l10n"
+            type="submit"
+            autoFocus
+            isDisabled={isSubmitting}
+            isLoading={isSubmitting}
+          >
+            {_("Accept")}
+          </Popup.Confirm>
+          <Popup.Cancel onClick={onCancel} isDisabled={isSubmitting} />
+        </>
+      )}
+    </form.Subscribe>
+  </Popup.Actions>
+);
 
-  return (
-    <Popup isOpen={state.isOpen} variant="small" title={_("Change Language")}>
-      <Form id="installer-l10n" onSubmit={actions.handleSubmission}>
-        <LangaugeFormInput value={formState.language} onChange={actions.handleLanguageChange} />
-        <ReusableSettings isReuseAllowed={formState.allowReusingSettings}>
-          <FormGroup fieldId="reuse-settings">
-            <Checkbox
-              id="reuse-settings"
-              label={_("Use for the selected product too")}
-              description={
-                <TextWithLinkToL10n
-                  text={checkboxDescription}
-                  onClick={actions.handleCancellation}
-                />
-              }
-              isChecked={formState.reuseSettings}
-              onChange={actions.handleCopyToSystemToggle}
-            />
-          </FormGroup>
-        </ReusableSettings>
-      </Form>
+const AllSettingsDialog = ({ form, isOpen, allowReusingSettings, onCancel }: DialogProps) => (
+  <Popup isOpen={isOpen} variant="small" title={_("Language and keyboard")}>
+    <Form id="installer-l10n" onSubmit={submitHandler(form)}>
+      <LanguageField form={form} />
+      <KeyboardField form={form} />
+      <ReusableSettings isReuseAllowed={allowReusingSettings}>
+        <ReuseSettingsField
+          form={form}
+          label={_("Use these same settings for the selected product")}
+          onLinkClick={onCancel}
+        />
+      </ReusableSettings>
+    </Form>
 
-      <Popup.Actions>
-        <Popup.Confirm
-          form="installer-l10n"
-          type="submit"
-          autoFocus
-          isDisabled={state.isBusy}
-          isLoading={state.isBusy}
-        >
-          {_("Accept")}
-        </Popup.Confirm>
-        <Popup.Cancel onClick={actions.handleCancellation} isDisabled={state.isBusy} />
-      </Popup.Actions>
-    </Popup>
-  );
-};
+    <DialogActions form={form} onCancel={onCancel} />
+  </Popup>
+);
 
-const KeyboardOnlyDialog = ({ state, formState, actions }: DialogProps) => {
+const LanguageOnlyDialog = ({ form, isOpen, allowReusingSettings, onCancel }: DialogProps) => (
+  <Popup isOpen={isOpen} variant="small" title={_("Change Language")}>
+    <Form id="installer-l10n" onSubmit={submitHandler(form)}>
+      <LanguageField form={form} />
+      <ReusableSettings isReuseAllowed={allowReusingSettings}>
+        <ReuseSettingsField
+          form={form}
+          label={_("Use for the selected product too")}
+          onLinkClick={onCancel}
+        />
+      </ReusableSettings>
+    </Form>
+
+    <DialogActions form={form} onCancel={onCancel} />
+  </Popup>
+);
+
+const KeyboardOnlyDialog = ({ form, isOpen, allowReusingSettings, onCancel }: DialogProps) => {
   if (!localConnection()) {
     return (
-      <Popup isOpen={state.isOpen} variant="small" title={_("Change keyboard")}>
+      <Popup isOpen={isOpen} variant="small" title={_("Change keyboard")}>
         {_("Cannot be changed in remote installation")}
         <Popup.Actions>
-          <Popup.Confirm onClick={actions.handleCancellation}>{_("Accept")}</Popup.Confirm>
+          <Popup.Confirm onClick={onCancel}>{_("Accept")}</Popup.Confirm>
         </Popup.Actions>
       </Popup>
     );
   }
 
-  const checkboxDescription = _(
-    // TRANSLATORS: Explains where users can find more keymap options for the
-    // product to install. The text in square brackets [] is a link to the
-    // localization page; keep the brackets.
-    "The [language and region] settings for the product may offer more options to choose from.",
-  );
-
   return (
-    <Popup isOpen={state.isOpen} variant="small" title={_("Change keyboard")}>
-      <Form id="installer-l10n" onSubmit={actions.handleSubmission}>
-        <KeyboardFormInput value={formState.keymap} onChange={actions.handleKeymapChange} />
-        <ReusableSettings isReuseAllowed={formState.allowReusingSettings}>
-          <FormGroup fieldId="reuse-settings">
-            <Checkbox
-              id="reuse-settings"
-              label={_("Use for the selected product too")}
-              description={
-                <TextWithLinkToL10n
-                  text={checkboxDescription}
-                  onClick={actions.handleCancellation}
-                />
-              }
-              isChecked={formState.reuseSettings}
-              onChange={actions.handleCopyToSystemToggle}
-            />
-          </FormGroup>
+    <Popup isOpen={isOpen} variant="small" title={_("Change keyboard")}>
+      <Form id="installer-l10n" onSubmit={submitHandler(form)}>
+        <KeyboardField form={form} />
+        <ReusableSettings isReuseAllowed={allowReusingSettings}>
+          <ReuseSettingsField
+            form={form}
+            label={_("Use for the selected product too")}
+            onLinkClick={onCancel}
+          />
         </ReusableSettings>
       </Form>
 
-      <Popup.Actions>
-        <Popup.Confirm
-          form="installer-l10n"
-          type="submit"
-          autoFocus
-          isDisabled={state.isBusy}
-          isLoading={state.isBusy}
-        >
-          {_("Accept")}
-        </Popup.Confirm>
-        <Popup.Cancel onClick={actions.handleCancellation} isDisabled={state.isBusy} />
-      </Popup.Actions>
+      <DialogActions form={form} onCancel={onCancel} />
     </Popup>
   );
 };
@@ -530,7 +451,7 @@ const AllSettingsToggle = ({ onClick, language, keymap, showValues }: ToggleProp
 /**
  * Maps each dialog variant to its corresponding React component.
  */
-const dialogs: { [key in InstallerL10nOptionsVariants]: React.FC<DialogProps> } = {
+const dialogs: { [key in InstallerL10nOptionsVariants]: typeof AllSettingsDialog } = {
   all: AllSettingsDialog,
   language: LanguageOnlyDialog,
   keyboard: KeyboardOnlyDialog,
@@ -584,17 +505,51 @@ export default function InstallerL10nOptions({
   const { language, keymap, changeL10n } = useInstallerL10n();
   const { stage } = useStatus();
   const selectedProduct = useProductInfo();
-  const initialFormState = {
-    language,
-    keymap,
-    allowReusingSettings: !!selectedProduct,
-    reuseSettings: true,
+  const allowReusingSettings = !!selectedProduct;
+  const [dialogState, dispatchDialogAction] = useReducer(dialogReducer, { isOpen: false });
+
+  /**
+   * Copies selected localization settings to the product to install settings,
+   **/
+  const reuseSettings = (values: FormFields) => {
+    // FIXME: export and use languageToLocale from context/installerL10n
+    const systemLocale = locales.find((l) => l.id.startsWith(values.language.replace("-", "_")));
+    const systemL10n: { locale?: Locale["id"]; keymap?: Keymap["id"] } = {};
+    // FIXME: use a fallback if no system locale was found ?
+    if (variant !== "keyboard") systemL10n.locale = systemLocale?.id;
+    if (variant !== "language" && localConnection()) systemL10n.keymap = values.keymap;
+
+    patchConfig({ l10n: systemL10n });
   };
-  const [formState, dispatch] = useReducer(formReducer, initialFormState);
-  const [dialogState, dispatchDialogAction] = useReducer(dialogReducer, {
-    isOpen: false,
-    isBusy: false,
-  });
+
+  const close = () => {
+    dispatchDialogAction({ type: "CLOSE" });
+    typeof onClose === "function" && onClose();
+  };
+
+  const applySettings = async (values: FormFields) => {
+    try {
+      const l10nOptions: { language?: string; keymap?: string } = {};
+
+      if (variant !== "keyboard") {
+        l10nOptions.language = values.language;
+      }
+
+      if (variant !== "language" && localConnection()) {
+        l10nOptions.keymap = values.keymap;
+      }
+
+      await changeL10n(l10nOptions);
+
+      allowReusingSettings && values.reuseSettings && reuseSettings(values);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      close();
+    }
+  };
+
+  const form = useL10nOptionsForm({ language, keymap, reuseSettings: true }, applySettings);
 
   // Skip rendering if any of the following conditions are met
   const skip =
@@ -606,62 +561,6 @@ export default function InstallerL10nOptions({
 
   if (skip) return;
 
-  /**
-   * Copies selected localization settings to the product to install settings,
-   **/
-  const reuseSettings = () => {
-    // FIXME: export and use languageToLocale from context/installerL10n
-    const systemLocale = locales.find((l) => l.id.startsWith(formState.language.replace("-", "_")));
-    const systemL10n: { locale?: Locale["id"]; keymap?: Keymap["id"] } = {};
-    // FIXME: use a fallback if no system locale was found ?
-    if (variant !== "keyboard") systemL10n.locale = systemLocale?.id;
-    if (variant !== "language" && localConnection()) systemL10n.keymap = formState.keymap;
-
-    patchConfig({ l10n: systemL10n });
-  };
-
-  const close = () => {
-    dispatchDialogAction({ type: "CLOSE" });
-    typeof onClose === "function" && onClose();
-  };
-
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    dispatchDialogAction({ type: "SET_BUSY" });
-
-    try {
-      const l10nOptions: { language?: string; keymap?: string } = {};
-
-      if (variant !== "keyboard") {
-        l10nOptions.language = formState.language;
-      }
-
-      if (variant !== "language" && localConnection()) {
-        l10nOptions.keymap = formState.keymap;
-      }
-
-      await changeL10n(l10nOptions);
-
-      formState.allowReusingSettings && formState.reuseSettings && reuseSettings();
-    } catch (e) {
-      console.error(e);
-      dispatchDialogAction({ type: "SET_IDLE" });
-    } finally {
-      close();
-    }
-  };
-
-  const actions: Actions = {
-    handleLanguageChange: (_, v) => dispatch({ type: "SET_SELECTED_LANGUAGE", language: v }),
-    handleKeymapChange: (_, v) => dispatch({ type: "SET_SELECTED_KEYMAP", keymap: v }),
-    handleCopyToSystemToggle: () => dispatch({ type: "TOGGLE_REUSE_SETTINGS" }),
-    handleSubmission: onSubmit,
-    handleCancellation: () => {
-      dispatch({ type: "RESET", state: initialFormState });
-      close();
-    },
-  };
-
   const Toggle = toggle ?? toggles[variant];
   const Dialog = dialogs[variant];
 
@@ -671,9 +570,19 @@ export default function InstallerL10nOptions({
         showValues={showValues}
         language={supportedLanguages[language]}
         keymap={keymap}
-        onClick={() => dispatchDialogAction({ type: "OPEN" })}
+        onClick={() => {
+          // Start from the settings currently in use, no matter what a previous
+          // visit to the dialog left behind.
+          form.reset({ language, keymap, reuseSettings: true });
+          dispatchDialogAction({ type: "OPEN" });
+        }}
       />
-      <Dialog state={dialogState} formState={formState} actions={actions} />
+      <Dialog
+        form={form}
+        isOpen={dialogState.isOpen}
+        allowReusingSettings={allowReusingSettings}
+        onCancel={close}
+      />
     </>
   );
 }

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -36,6 +36,7 @@ import { useHref, useLocation } from "react-router";
 import { Button, ButtonProps, Flex, FlexProps, Form } from "@patternfly/react-core";
 import { formOptions } from "@tanstack/react-form";
 import Popup from "~/components/core/Popup";
+import Text from "~/components/core/Text";
 import VisualTooltip from "~/components/core/VisualTooltip";
 import Icon from "~/components/layout/Icon";
 import { mergeFormDefaults, useAppForm, withForm } from "~/hooks/form";
@@ -83,7 +84,8 @@ const submitHandler =
   };
 
 /**
- * Renders a dropdown for language selection.
+ * Language selector for the installer interface. Each option shows the language
+ * name, with its code below; both are searchable.
  *
  * Each option states its own language, so it is read aloud with the right
  * pronunciation instead of the one currently in use.
@@ -93,13 +95,28 @@ const LanguageField = withForm({
   render: function Render({ form }) {
     const options = Object.keys(supportedLanguages)
       .sort()
-      .map((id) => ({ value: id, label: <span lang={id}>{supportedLanguages[id]}</span> }));
+      .map((id) => ({
+        value: id,
+        label: supportedLanguages[id],
+        description: (
+          <Text textStyle={["fontSizeXs", "textColorDisabled", "fontFamilyMonospace"]}>{id}</Text>
+        ),
+        filterText: `${supportedLanguages[id]} ${id}`,
+        lang: id,
+      }));
 
     return (
       <form.AppField name="language">
         {(field) => (
-          // TRANSLATORS: label for the installer interface language selector
-          <field.DropdownField label={_("Language")} options={options} />
+          <field.SearchableSelectField
+            // TRANSLATORS: label for the installer interface language selector
+            label={_("Language")}
+            // TRANSLATORS: hint for the language filter input
+            placeholder={_("Filter by language, territory or locale code")}
+            // TRANSLATORS: shown when no language matches the filter
+            noResultsText={_("None of the locales match the filter.")}
+            options={options}
+          />
         )}
       </form.AppField>
     );
@@ -107,7 +124,8 @@ const LanguageField = withForm({
 });
 
 /**
- * Renders a dropdown for keyboard layout selection.
+ * Keyboard layout selector for the installer interface. Each option shows the
+ * layout description, with the keymap code below; both are searchable.
  *
  * Not available in remote installations.
  */
@@ -130,13 +148,29 @@ const KeyboardField = withForm({
       );
     }
 
-    const options = keymaps.map((keymap) => ({ value: keymap.id, label: keymap.description }));
+    const options = keymaps.map((keymap) => ({
+      value: keymap.id,
+      label: keymap.description,
+      description: (
+        <Text textStyle={["fontSizeXs", "textColorDisabled", "fontFamilyMonospace"]}>
+          {keymap.id}
+        </Text>
+      ),
+      filterText: `${keymap.description} ${keymap.id}`,
+    }));
 
     return (
       <form.AppField name="keymap">
         {(field) => (
-          // TRANSLATORS: label for the installer interface keyboard layout selector
-          <field.DropdownField label={_("Keyboard layout")} options={options} />
+          <field.SearchableSelectField
+            // TRANSLATORS: label for the installer interface keyboard layout selector
+            label={_("Keyboard layout")}
+            // TRANSLATORS: hint for the keyboard filter input
+            placeholder={_("Filter by description or keymap code")}
+            // TRANSLATORS: shown when no keyboard layout matches the filter
+            noResultsText={_("None of the keymaps match the filter.")}
+            options={options}
+          />
         )}
       </form.AppField>
     );

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -34,9 +34,9 @@
 import React, { useReducer } from "react";
 import { useHref, useLocation } from "react-router";
 import { Button, ButtonProps, Flex, FlexProps, Form, FormGroup } from "@patternfly/react-core";
-import { Popup } from "~/components/core";
+import Popup from "~/components/core/Popup";
 import VisualTooltip from "~/components/core/VisualTooltip";
-import { Icon } from "~/components/layout";
+import Icon from "~/components/layout/Icon";
 import { useAppForm } from "~/hooks/form";
 import { useInstallerL10n } from "~/context/installerL10n";
 import { localConnection } from "~/utils";

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -479,7 +479,7 @@ const LanguageOnlyToggle = ({ onClick, language, showValues }: ToggleProps) => {
   const label = _("Language");
   return (
     <VisualTooltip content={label}>
-      <Button onClick={onClick} aria-label={label} variant="plain">
+      <Button onClick={onClick} aria-label={label} aria-haspopup="dialog" variant="plain">
         <CenteredContent>
           <LanguageIcon />
           {showValues && language}
@@ -495,7 +495,7 @@ const KeyboardOnlyToggle = ({ onClick, keymap, showValues }: ToggleProps) => {
   const label = _("Keyboard");
   return (
     <VisualTooltip content={label}>
-      <Button onClick={onClick} aria-label={label} variant="plain">
+      <Button onClick={onClick} aria-label={label} aria-haspopup="dialog" variant="plain">
         <CenteredContent alignItems="alignItemsFlexEnd">
           <KeyboardIcon />
           {showValues && <code>{keymap}</code>}
@@ -515,7 +515,7 @@ const AllSettingsToggle = ({ onClick, language, keymap, showValues }: ToggleProp
   const label = _("Language and Keyboard");
   return (
     <VisualTooltip content={label}>
-      <Button onClick={onClick} aria-label={label} variant="plain">
+      <Button onClick={onClick} aria-label={label} aria-haspopup="dialog" variant="plain">
         <CenteredContent>
           <LanguageIcon />
           {showValues && language}

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -644,8 +644,6 @@ export default function InstallerL10nOptions({
   const skip =
     (variant === "keyboard" && !localConnection()) ||
     stage === "installing" ||
-    // FIXME: below condition could be a problem for a question appearing while
-    // product progress
     [ROOT.login, ROOT.installationProgress, ROOT.installationFinished].includes(location.pathname);
 
   if (skip) return;

--- a/web/src/components/form/SearchableSelectField.test.tsx
+++ b/web/src/components/form/SearchableSelectField.test.tsx
@@ -126,12 +126,6 @@ function RequiredForm() {
 
 const combobox = () => screen.getByRole("combobox", { name: "Language" });
 
-beforeAll(() => {
-  // jsdom does not implement scrollIntoView; the field calls it when opening.
-  // https://github.com/jsdom/jsdom/issues/1695
-  window.HTMLElement.prototype.scrollIntoView = jest.fn();
-});
-
 describe("SearchableSelectField", () => {
   it("renders an accessible combobox labelled by the field label", () => {
     installerRender(<TestForm />);

--- a/web/src/components/form/SearchableSelectField.tsx
+++ b/web/src/components/form/SearchableSelectField.tsx
@@ -69,6 +69,10 @@ type Option = {
   // code or territory not present in the label). When omitted, the visible
   // `label` is used. The `description` node is never part of the match.
   filterText?: string;
+  // BCP 47 tag for the option's own text, when it is not written in the
+  // interface language (e.g. a language picker listing "日本語"). Screen readers
+  // use it to pronounce the option with the right voice.
+  lang?: string;
 };
 
 type SearchableSelectFieldProps = FieldLabelOptions & {
@@ -490,10 +494,13 @@ export default function SearchableSelectField({
           placeholder={inputPlaceholder}
           autoComplete="off"
           // PF spreads unknown props onto the wrapper, not the input; invalid
-          // state must reach the input itself, so it goes through inputProps.
-          inputProps={
-            error ? { "aria-invalid": true, "aria-describedby": `${idPrefix}-error` } : undefined
-          }
+          // state and the selection's language must reach the input itself, so
+          // they go through inputProps. While filtering the text is whatever the
+          // user typed, so the option's `lang` no longer describes it.
+          inputProps={{
+            ...(error && { "aria-invalid": true, "aria-describedby": `${idPrefix}-error` }),
+            lang: isFiltering ? undefined : selectedOption?.lang,
+          }}
         />
       </TextInputGroup>
     </MenuToggle>
@@ -538,6 +545,7 @@ export default function SearchableSelectField({
                 id={optionId(index)}
                 value={option.value}
                 description={option.description}
+                lang={option.lang}
                 // isFocused applies PF's own highlight class, giving sighted
                 // users the same visual cue AT users get via aria-activedescendant.
                 // Hover does not drive this highlight: while filtering the list

--- a/web/src/components/l10n/l10n-form/Form.test.tsx
+++ b/web/src/components/l10n/l10n-form/Form.test.tsx
@@ -70,11 +70,6 @@ const PROPOSAL = {
 const combobox = (name: string) => screen.getByRole("combobox", { name });
 const accept = () => screen.getByRole("button", { name: "Accept" });
 
-beforeAll(() => {
-  // jsdom does not implement scrollIntoView; the field calls it when opening.
-  window.HTMLElement.prototype.scrollIntoView = jest.fn();
-});
-
 beforeEach(() => {
   mockSystem.mockReturnValue(SYSTEM);
   mockProposal.mockReturnValue(PROPOSAL);

--- a/web/src/context/installerL10n.tsx
+++ b/web/src/context/installerL10n.tsx
@@ -25,6 +25,7 @@ import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import agama from "~/agama";
 import supportedLanguages from "~/languages.json";
 import { useSystem } from "~/hooks/model/system";
+import { languageFromLocale, languageToLocale } from "~/utils/l10n";
 import { configureL10nAction } from "~/api";
 
 const L10nContext = React.createContext(null);
@@ -52,39 +53,6 @@ function useInstallerL10n(): L10nContext {
   }
 
   return context;
-}
-
-/**
- * Generates a RFC 5646 (or BCP 78) language tag from a locale.
- *
- * @param locale
- * @return RFC 5646 language tag (e.g., "en-US")
- *
- * @private
- * @see https://datatracker.ietf.org/doc/html/rfc5646
- * @see https://www.rfc-editor.org/info/bcp78
- */
-function languageFromLocale(locale: string): string {
-  const [language] = locale.split(".");
-  return language.replace("_", "-");
-}
-
-/**
- * Converts a RFC 5646 language tag to a locale.
- *
- * It forces the encoding to "UTF-8".
- *
- * @param language as a RFC 5646 language tag (e.g., "en-US")
- * @return locale (e.g., "en_US.UTF-8")
- *
- * @private
- * @see https://datatracker.ietf.org/doc/html/rfc5646
- * @see https://www.rfc-editor.org/info/bcp78
- */
-function languageToLocale(language: string): string {
-  const [lang, country] = language.split("-");
-  const locale = country ? `${lang}_${country.toUpperCase()}` : lang;
-  return `${locale}.UTF-8`;
 }
 
 /**

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -28,4 +28,11 @@ if (!window.matchMedia) {
     }) as unknown as MediaQueryList;
 }
 
+// jsdom does not implement scrollIntoView, and components that keep an active
+// option or section in view call it. A no-op keeps them from throwing; tests
+// that need to assert the calls can still install their own spy.
+if (!window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 jest.mock("~/context/installerL10n");

--- a/web/src/utils/l10n.test.ts
+++ b/web/src/utils/l10n.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { languageFromLocale, languageToLocale } from "~/utils/l10n";
+
+describe("languageFromLocale", () => {
+  it("returns the language tag of the given locale", () => {
+    expect(languageFromLocale("en_US.UTF-8")).toEqual("en-US");
+    expect(languageFromLocale("pt_BR.UTF-8")).toEqual("pt-BR");
+  });
+
+  describe("when the locale carries no encoding", () => {
+    it("returns the language tag anyway", () => {
+      expect(languageFromLocale("es_ES")).toEqual("es-ES");
+    });
+  });
+
+  describe("when the locale carries no territory", () => {
+    it("returns just the language", () => {
+      expect(languageFromLocale("ca.UTF-8")).toEqual("ca");
+    });
+  });
+});
+
+describe("languageToLocale", () => {
+  it("returns the UTF-8 locale for the given language tag", () => {
+    expect(languageToLocale("en-US")).toEqual("en_US.UTF-8");
+    expect(languageToLocale("pt-BR")).toEqual("pt_BR.UTF-8");
+  });
+
+  describe("when the territory is not uppercase", () => {
+    it("uppercases it", () => {
+      expect(languageToLocale("es-es")).toEqual("es_ES.UTF-8");
+    });
+  });
+
+  describe("when the language tag carries no territory", () => {
+    it("returns the language with the encoding", () => {
+      expect(languageToLocale("ca")).toEqual("ca.UTF-8");
+    });
+  });
+});

--- a/web/src/utils/l10n.ts
+++ b/web/src/utils/l10n.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Generates a RFC 5646 (or BCP 78) language tag from a locale.
+ *
+ * @param locale (e.g., "en_US.UTF-8")
+ * @return RFC 5646 language tag (e.g., "en-US")
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc5646
+ * @see https://www.rfc-editor.org/info/bcp78
+ */
+function languageFromLocale(locale: string): string {
+  const [language] = locale.split(".");
+  return language.replace("_", "-");
+}
+
+/**
+ * Converts a RFC 5646 language tag to a locale.
+ *
+ * It forces the encoding to "UTF-8".
+ *
+ * @param language as a RFC 5646 language tag (e.g., "en-US")
+ * @return locale (e.g., "en_US.UTF-8")
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc5646
+ * @see https://www.rfc-editor.org/info/bcp78
+ */
+function languageToLocale(language: string): string {
+  const [lang, country] = language.split("-");
+  const locale = country ? `${lang}_${country.toUpperCase()}` : lang;
+  return `${locale}.UTF-8`;
+}
+
+export { languageFromLocale, languageToLocale };


### PR DESCRIPTION
## TL;DR

Choosing the installer language or keyboard layout is now a matter of typing a few letters instead of scrolling through a long dropdown, each language is read aloud in its own voice, and the dialog always opens showing the settings actually in use. Underneath, the dialog stops keeping its own hand-rolled state and is built with the same form tools as the rest of the application.


<img width="2048" height="1536" alt="localhost_8080_ (35)" src="https://github.com/user-attachments/assets/ca96ef11-1469-45f4-9f7e-120c96e0e004" />


## Related to

* https://bugzilla.suse.com/show_bug.cgi?id=1253665


## Summary

- The language and keyboard selectors are now filterable, matching what the localization page already offers for the product settings.
- Screen readers announce each language with the pronunciation of that language, so entries like 日本語 or Українська are read as names instead of noise.
- The header toggles announce that they open a dialog, instead of presenting themselves as plain buttons that do who knows what.
- The dialog reopens with the settings currently in use, no matter what a previous visit left behind.
- The dialog is rebuilt on the shared form tools (TanStack Form through `withForm`), replacing a local reducer, a local form factory and selectors no other form uses anymore.
- Reusing the chosen language for the product now picks the locale that really corresponds to it, and leaves the product settings alone when it offers none, instead of matching by prefix and sending an empty change.


## Why

The dialog was doing forms its own way: a reducer with four action types for three fields, a duplicated `Popup` and buttons block per variant, and PatternFly's plain `FormSelect` where the migrated forms use the shared field components. It is one more step of the ongoing TanStack Form migration.

That was not only a style difference. It is what kept the improvements below out of reach:

- The searchable selector is a shared form field. Using it means being a form.
- "Open with the settings in use" is one call to reset the form. With the reducer it was a hand-written `RESET` action that the dialog had to remember to fire, and it was fired on cancel only
- The busy state was tracked by hand, in a dialog state that also had to know whether it was open. The form already knows whether it is submitting.

There was found one problem. `withForm` builds its component as the file is being loaded, which means the form tools must already be fully initialized. Importing `Popup` or `Icon` through a barrel (`index`) file pulled in enough related modules to create a circular dependency back to the form tools.

The fix, spread across two commits, imports those components directly from their own modules instead. That's consistent with the project's direction of moving away from barrel files, since they can obscure dependencies and make circular imports like this much easier to create. Importing the modules directly removes the cycle.

## The a11y part

Two separate problems, each in its own commit:

- **Toggles gave no clue what they do.** The buttons in the header leading to the language and keyboard settings announced themselves as buttons and nothing more. They now report that they open a dialog, so the outcome is known before pressing.
- **Languages were pronounced with the wrong voice.** A list of language names is text in many languages, read out with the pronunciation rules of the interface language. Every option now states the language it is written in, and the selector's own text follows the selection, except while the user is typing a filter, when the text is theirs and not the option's.

## Test suite

`scrollIntoView` is not implemented by jsdom, and every test file rendering a component that keeps an option or a section in view had to install its own stub. It is now done once in the setup file, and the copies are gone. Tests that want to assert the calls can still install their own spy.

## Follow-ups

- **Nothing announces the outcome.** Applying the settings closes the dialog with no message to screen reader users. That belongs in the global live region proposed in https://github.com/agama-project/agama/pull/3759.
- **Failure is only logged.** If applying the settings fails, the error goes to the console and the dialog closes as if nothing happened. Reporting it needs new text, so it waits for the string freeze to lift.
- **The reuse checkbox promises more than it can deliver.** Ticking it turns the chosen interface language (say, `es-ES`) into the matching product locale (`es_ES.UTF-8`), which this PR now does properly. But the product ships its own list of locales, and it does not have to include one for the chosen language: pick Catalan for the interface and a product offering no Catalan locale keeps whatever it had. The checkbox says nothing about that. New text is needed to say it is applied where possible, so it waits for the string freeze to lift.


## Test plan

- [ ] Open the language dialog from the header. It offers a filter; typing a few letters of a language name or a code narrows the list.
- [ ] Pick a language, accept, and confirm the interface changes.
- [ ] Reopen the dialog. It shows the language in use, not the previous selection.
- [ ] Open it, change the selection, dismiss with **Cancel**. Reopening shows the settings in use.
- [ ] In a remote installation, the keyboard toggle is not offered, and the dialog says the layout cannot be changed.
- [ ] With a product selected, the reuse checkbox is offered and its link leads to the localization page; with none, it is not rendered.
- [ ] With the checkbox ticked, pick a language the product has a locale for, accept, and check the localization page shows it. Pick one it has no locale for, and check the product settings are left untouched.

## Screenshots

### Before

<img width="2048" height="1536" alt="localhost_8080_ (36)" src="https://github.com/user-attachments/assets/955b4731-5710-4954-913f-72053815011a" />

<img width="1078" height="691" alt="Screenshot_2026-07-29_14-00-11" src="https://github.com/user-attachments/assets/717546ae-f8dd-4669-9ce7-c0011f9f2353" />


### After

<img width="2048" height="1536" alt="localhost_8080_ (34)" src="https://github.com/user-attachments/assets/21b08a70-1004-4502-9acb-725bb98ce5e7" />


<img width="2048" height="1536" alt="localhost_8080_ (35)" src="https://github.com/user-attachments/assets/0efd3ff1-ab09-411e-b8c7-7c917a1c6aba" />
