### PR TITLE
Fix for s390x & ppc64le ISO build

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,12 +1,13 @@
 -------------------------------------------------------------------
 Mon Aug  3 10:50:00 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
+Fixes related to bsc#1272445 ISO building and testing
+(gh#agama-project/agama#3782).
 - Fix ppc64le and s390x ISO build issues in fix_bootconfig by
   ensuring the xorriso wrapper acts as a transparent pass-through
-  for read-only reporting and probing commands (gh#agama-project/agama#3782).
+  for read-only reporting and probing commands.
 - Clean up redundant ppc64le bootloader options, relying on KIWI-NG's
-  native support for making OFW ISOs bootable (gh#agama-project/agama#3782).
-- Related to bsc#1272445.
+  native support for making OFW ISOs bootable.
 
 -------------------------------------------------------------------
 Thu Jul 23 19:40:00 UTC 2026 - Knut Anderssen <kanderssen@suse.com>

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Aug  3 10:50:00 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix ppc64le and s390x ISO build issues in fix_bootconfig by
+  ensuring the xorriso wrapper acts as a transparent pass-through
+  for read-only reporting and probing commands (gh#agama-project/agama#3782).
+- Clean up redundant ppc64le bootloader options, relying on KIWI-NG's
+  native support for making OFW ISOs bootable (gh#agama-project/agama#3782).
+- Related to bsc#1272445.
+
+-------------------------------------------------------------------
 Thu Jul 23 19:40:00 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix multiple IP/route assignments in multi-bond setups with

--- a/live/src/fix_bootconfig
+++ b/live/src/fix_bootconfig
@@ -115,20 +115,21 @@ systemd.mask=agama-certificate-wait.service"
 [ -x $bootfix ] && $bootfix $dst
 rm -f $dst/fix_bootconfig.* $dst/.profile
 
-case $arch in
-  s390x)
-    /usr/bin/xorriso "\$@" -volid "\$volid" -boot_image any bin_path=boot/s390x/loader/cd.ikr -boot_image any boot_info_table=off -boot_image any load_size=512
-    err=\$?
-    [ -x /usr/bin/isozipl ] && isozipl "\$iso"
-    ;;
-  ppc64le)
-    /usr/bin/xorriso "\$@" -volid "\$volid" -boot_image any chrp_boot_part=on
-    err=\$?
-    ;;
-  *)
-    /usr/bin/xorriso "\$@" -volid "\$volid"
-    err=\$?
-esac
+if [ -z "\$iso" ] ; then
+  /usr/bin/xorriso "\$@"
+  err=\$?
+else
+  case $arch in
+    s390x)
+      /usr/bin/xorriso "\$@" -volid "\$volid" -boot_image any bin_path=boot/s390x/loader/cd.ikr -boot_image any boot_info_table=off -boot_image any load_size=512
+      err=\$?
+      [ -x /usr/bin/isozipl ] && isozipl "\$iso"
+      ;;
+    *)
+      /usr/bin/xorriso "\$@" -volid "\$volid"
+      err=\$?
+  esac
+fi
 
 exit \$err
 XXX


### PR DESCRIPTION
## Problem

During the `ppc64le` and `s390x` ISO build process, KIWI-NG executes read-only/reporting commands to inspect and verify the newly generated ISO image. An example of such a command is:
```bash
/usr/local/bin/xorriso -indev /usr/src/packages/KIWI-iso/agama-installer.ppc64le-23.0.0.iso -report_system_area plain
```

Our custom `xorriso` wrapper script at `/usr/local/bin/xorriso` (injected via `live/src/fix_bootconfig`) was unconditionally intercepting all calls to `xorriso` and appending modification and boot flags:
- **PPC64le:** Appended `-volid "Install-openSUSE-ppc64le" -boot_image any chrp_boot_part=on`
- **S390x:** Appended `-volid ... -boot_image any bin_path=boot/s390x/...`

Because these modification options were appended to a read-only reporting command that lacks an output target (`-outdev`), `xorriso` attempted to prepare a write/modification operation but had no target destination. This resulted in the following build-blocking failure:
```text
xorriso : FAILURE : No output drive acquired on attempt to write
xorriso : NOTE : -return_with SORRY 32 triggered by problem severity FAILURE
```

- **Related to  this bug:** [bsc#1272445](https://bugzilla.suse.com/show_bug.cgi?id=1272445)
- **Related Jira issue:** `jsc#PED-14533`
- **Requires**: `https://src.opensuse.org/GNOME/NetworkManager/pulls/9`
- **Original implementation:** `https://github.com/agama-project/agama/pull/3563`

---

## Solution

This pull request refactors the `xorriso` wrapper script in `live/src/fix_bootconfig` with two major improvements:

1. **Conditional Modification (`-outdev` Check):**
   The wrapper now parses arguments to check if an output target (`$iso`) was specified via `-outdev`.
   - **Pass-through mode:** If no output ISO is defined (as in read-only reporting/probing queries), the wrapper acts as a simple pass-through to `/usr/bin/xorriso "$@"` without appending any volume or boot-image modifications, preventing write-failures.
   - **Modification mode:** If an output ISO is target-bound, it safely applies the required volume and boot-image options.

2. **PPC64le Bootloader Cleanup:**
   Removed the custom `ppc64le` block that appended `chrp_boot_part=on`. Since KIWI-NG's Open Firmware (`firmware="ofw"`) target natively supports and configures CHRP bootloader arguments for PPC64, the manual `xorriso` modification was redundant and has been removed.
   - **S390x** custom handling remains intact as it uses a `custom` bootloader that requires specialized arguments and post-processing with `isozipl` (not natively handled by KIWI-NG).

---

## Testing

- **Manual Verification:** Verified that non-ISO-writing runs of `xorriso` (like queries and system-area reporting) act as transparent pass-throughs without appending modification/boot arguments.
