### PR TITLE
Fix AutoYaST support

### DIFF
--- a/service/lib/agama/autoyast/connections_reader.rb
+++ b/service/lib/agama/autoyast/connections_reader.rb
@@ -61,6 +61,7 @@ module Agama
       #
       # @param interface [Y2Network::AutoinstProfile::InterfaceSection] Interface section.
       # @return [Hash]
+      # rubocop:disable Metrics/AbcSize
       def read_connection(interface)
         conn = {}
         if !interface.device.to_s.empty?
@@ -74,6 +75,7 @@ module Agama
         conn["method4"] = method4
         conn["method6"] = method6
         conn["addresses"] = addresses
+        conn["macAddress"] = interface.lladdr unless interface.lladdr.to_s.empty?
         wireless = Agama::AutoYaST::WirelessReader.new(interface).read
         conn.merge!(wireless) unless wireless.empty?
         bond = Agama::AutoYaST::BondReader.new(interface).read
@@ -82,6 +84,7 @@ module Agama
 
         conn
       end
+      # rubocop:enable Metrics/AbcSize
 
       # Reads the addresses from an AutoYaST interface section.
       #

--- a/service/lib/agama/autoyast/wireless_reader.rb
+++ b/service/lib/agama/autoyast/wireless_reader.rb
@@ -69,9 +69,9 @@ module Agama
       # @return [String, nil] Name of Agama's security protocol
       def security_from(auth_mode)
         case auth_mode
-        when Y2Network::WirelessAuthMode::WPA_PSK
+        when Y2Network::WirelessAuthMode::WPA_PSK.short_name
           "wpa-psk"
-        when Y2Network::WirelessAuthMode::WPA_EAP
+        when Y2Network::WirelessAuthMode::WPA_EAP.short_name
           "wpa-eap"
         else
           "none"
@@ -84,11 +84,11 @@ module Agama
       # @return [String, nil] Name of Agama's wireless mode
       def mode_from(mode)
         case mode
-        when Y2Network::WirelessMode::AD_HOC
+        when Y2Network::WirelessMode::AD_HOC.short_name
           "adhoc"
-        when Y2Network::WirelessMode::MASTER
+        when Y2Network::WirelessMode::MASTER.short_name
           "ap"
-        when Y2Network::WirelessMode::MANAGED
+        when Y2Network::WirelessMode::MANAGED.short_name
           "infrastructure"
         end
       end

--- a/service/lib/agama/autoyast/zfcp_reader.rb
+++ b/service/lib/agama/autoyast/zfcp_reader.rb
@@ -39,7 +39,7 @@ module Agama
           {
             "channel" => device["controller_id"],
             "wwpn"    => device["wwpn"],
-            "lun"     => device["lun"]
+            "lun"     => device["fcp_lun"]
           }
         end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Aug  4 14:02:00 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix AutoYaST conversion (gh#agama-project/agama#3794):
+  - Import the network "lladdr" element.
+  - Fix the handling of "wireless_auth_mode" and "wireless_mode".
+  - Use the correct name "fcp_lun" instead of "lun".
+- Fix and extend the AutoYaST compatibility specification.
+
+-------------------------------------------------------------------
 Fri Jul 24 08:53:15 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Detect whether an AutoYaST profile is not found (bsc#1272439).
@@ -18,7 +27,7 @@ Thu Jul 16 12:15:11 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 Thu Jul 16 11:01:58 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - AutoYaST to Agama profile conversion doesn't crash when empty
-  profile is provided. 
+  profile is provided.
 
 -------------------------------------------------------------------
 Tue Jun 30 14:40:25 UTC 2026 - José Iván López González <jlopez@suse.com>

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -5,27 +5,68 @@
       {
         "key": "add_on_products",
         "children": [
-          { "key": "media_url", "support": "yes", "agama": "url" },
-          { "key": "product_dir", "support": "yes", "agama": "productDir" },
+          {
+            "key": "media_url",
+            "support": "yes",
+            "agama": "software.extraRepositories[].url"
+          },
+          {
+            "key": "product_dir",
+            "support": "yes",
+            "agama": "software.extraRepositories[].productDir"
+          },
+          {
+            "key": "alias",
+            "support": "yes",
+            "agama": "software.extraRepositories[].alias"
+          },
+          {
+            "key": "priority",
+            "support": "yes",
+            "agama": "software.extraRepositories[].priority"
+          },
+          {
+            "key": "name",
+            "support": "yes",
+            "agama": "software.extraRepositories[].name"
+          },
           { "key": "product", "support": "no" },
-          { "key": "alias", "support": "yes" },
-          { "key": "priority", "support": "yes" },
           { "key": "ask_on_error", "support": "no" },
-          { "key": "confirm_license", "support": "no" },
-          { "key": "name", "support": "yes" }
+          { "key": "confirm_license", "support": "no" }
         ]
       },
       {
         "key": "add_on_others",
         "children": [
-          { "key": "media_url", "support": "yes", "agama": "url" },
-          { "key": "product_dir", "support": "yes", "agama": "productDir" },
+          {
+            "key": "media_url",
+            "support": "yes",
+            "agama": "software.extraRepositories[].url"
+          },
+          {
+            "key": "product_dir",
+            "support": "yes",
+            "agama": "software.extraRepositories[].productDir",
+            "notes": "Agama ignores this value."
+          },
+          {
+            "key": "alias",
+            "support": "yes",
+            "agama": "software.extraRepositories[].alias"
+          },
+          {
+            "key": "priority",
+            "support": "yes",
+            "agama": "software.extraRepositories[].priority"
+          },
+          {
+            "key": "name",
+            "support": "yes",
+            "agama": "software.extraRepositories[].name"
+          },
           { "key": "product", "support": "no" },
-          { "key": "alias", "support": "yes" },
-          { "key": "priority", "support": "yes" },
           { "key": "ask_on_error", "support": "no" },
-          { "key": "confirm_license", "support": "no" },
-          { "key": "name", "support": "yes" }
+          { "key": "confirm_license", "support": "no" }
         ]
       }
     ]
@@ -89,17 +130,17 @@
       {
         "key": "file_path",
         "support": "yes",
-        "agama": "files.destination",
+        "agama": "files[].destination",
         "notes": "Creating directories by using trailing slash is not yet supported."
       },
-      { "key": "file_contents", "support": "yes", "agama": "files.content" },
-      { "key": "file_location", "support": "yes", "agama": "files.url" },
+      { "key": "file_contents", "support": "yes", "agama": "files[].content" },
+      { "key": "file_location", "support": "yes", "agama": "files[].url" },
       {
         "key": "file_owner",
         "support": "yes",
-        "notes": "In agama it is split to files.user and files.group"
+        "notes": "In agama it is split to files[].user and files[].group"
       },
-      { "key": "file_permissions", "support": "yes" },
+      { "key": "file_permissions", "support": "yes", "agama": "files[].permissions" },
       { "key": "file_script", "support": "planned" }
     ]
   },
@@ -113,7 +154,7 @@
   {
     "key": "keyboard",
     "children": [
-      { "key": "keymap", "support": "yes", "agama": "localization.keyboard" },
+      { "key": "keymap", "support": "yes", "agama": "l10n.keyboard" },
       { "key": "capslock", "support": "no" },
       { "key": "delay", "support": "no" },
       { "key": "discaps", "support": "no" },
@@ -126,7 +167,7 @@
   {
     "key": "language",
     "children": [
-      { "key": "language", "support": "yes", "agama": "localization.language" },
+      { "key": "language", "support": "yes", "agama": "l10n.language" },
       { "key": "languages", "support": "no" }
     ]
   },
@@ -188,13 +229,12 @@
         "agama": "connections",
         "notes": "It corresponds to Agama `connections`, but the format is not exactly the same.",
         "children": [
-          { "key": "device", "agama": "interface", "support": "yes" },
-          { "key": "name", "agama": "id", "support": "yes" },
+          { "key": "device", "agama": "network.connections[].interface", "support": "yes" },
+          { "key": "name", "agama": "network.connections[].id", "support": "yes" },
           { "key": "description", "support": "no" },
           {
             "key": "bootproto",
             "support": "no",
-            "agama": "method6",
             "notes": "Different set of values."
           },
           {
@@ -205,7 +245,7 @@
           {
             "key": "lladdr",
             "support": "yes",
-            "agama": "macAddress"
+            "agama": "network.connections[].macAddress"
           },
           {
             "key": "ifplugd_priority",
@@ -217,32 +257,32 @@
           {
             "key": "ipaddr",
             "support": "yes",
-            "agama": "network.connections[].address[]"
+            "agama": "network.connections[].addresses[]"
           },
           {
             "key": "prefixlen",
             "support": "yes",
-            "agama": "network.connections[].address[]"
+            "agama": "network.connections[].addresses[]"
           },
           {
             "key": "netmask",
             "support": "yes",
-            "agama": "network.connections[].address[]"
+            "agama": "network.connections[].addresses[]"
           },
           {
             "key": "aliases",
             "support": "yes",
-            "agama": "network.connections[].address[]"
+            "agama": "network.connections[].addresses[]"
           },
           {
             "key": "broadcast",
             "support": "yes",
-            "agama": "network.connections[].address[]"
+            "agama": "network.connections[].addresses[]"
           },
           {
             "key": "network",
             "support": "yes",
-            "agama": "network.connections[].address[]"
+            "agama": "network.connections[].addresses[]"
           },
           {
             "key": "mtu",
@@ -271,59 +311,64 @@
           {
             "key": "bonding_slave0",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave1",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave2",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave3",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave4",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave5",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave6",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave7",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave8",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           {
             "key": "bonding_slave9",
             "support": "yes",
-            "agama": "network.connections[].bond.ports"
+            "agama": "network.connections[].bond.ports[]"
           },
           { "key": "bridge", "support": "planned" },
           { "key": "bridge_forwarddelay", "support": "planned" },
           { "key": "bridge_ports", "support": "planned" },
           { "key": "bridge_stp", "support": "planned" },
           { "key": "vlan_id", "support": "planned" },
-          { "key": "wireless_auth_mode", "support": "yes" },
+          {
+            "key": "wireless_auth_mode",
+            "support": "yes",
+            "agama": "network.connections[].wireless.security",
+            "notes": "Map 'psk' to 'wpa-psk' and 'eap' to 'wpa-eap'; anything else becomes 'none'."
+          },
           { "key": "wireless_ap", "support": "no" },
           { "key": "wireless_bitrate", "support": "no" },
           { "key": "wireless_ca_cert", "support": "no" },
@@ -334,7 +379,12 @@
           { "key": "wireless_default_key", "support": "no" },
           { "key": "wireless_eap_auth", "support": "no" },
           { "key": "wireless_eap_mode", "support": "no" },
-          { "key": "wireless_essid", "support": "yes", "agama": "ssid" },
+          {
+            "key": "wireless_essid",
+            "support": "yes",
+            "agama": "network.connections[].wireless.ssid",
+            "notes": "Map 'ad-hoc' to 'adhoc', 'master' to 'ap' and 'managed' to 'infrastructure'."
+          },
           { "key": "wireless_frequency", "support": "no" },
           { "key": "wireless_key", "support": "no" },
           { "key": "wireless_key_0", "support": "no" },
@@ -352,9 +402,13 @@
           {
             "key": "wireless_wpa_password",
             "support": "yes",
-            "agama": "password"
+            "agama": "network.connections[].wireless.password"
           },
-          { "key": "wireless_wpa_psk", "support": "yes", "agama": "password" }
+          {
+            "key": "wireless_wpa_psk",
+            "support": "yes",
+            "agama": "network.connections[].wireless.password"
+          }
         ]
       }
     ]
@@ -372,7 +426,8 @@
         "children": [
           {
             "key": "service",
-            "support": "yes"
+            "support": "yes",
+            "notes": "The list of services is enabled using a post-installation script."
           }
         ]
       },
@@ -381,7 +436,8 @@
         "children": [
           {
             "key": "service",
-            "support": "yes"
+            "support": "yes",
+            "notes": "The list of services is disabled using a post-installation script."
           }
         ]
       },
@@ -390,7 +446,8 @@
         "children": [
           {
             "key": "service",
-            "support": "yes"
+            "support": "yes",
+            "notes": "The list of services is enabled on-demand using a post-installation script."
           }
         ]
       }
@@ -640,7 +697,7 @@
   {
     "key": "timezone",
     "children": [
-      { "key": "timezone", "support": "yes", "agama": "localization.timezone" },
+      { "key": "timezone", "support": "yes", "agama": "l10n.timezone" },
       { "key": "hwclock", "support": "no" }
     ]
   },
@@ -658,9 +715,9 @@
             "key": "portal",
             "support": "yes",
             "agama": "iscsi.targets[].address",
-            "notes": "Splitted into two values, address and port."
+            "notes": "Splitted into two values, iscsi.targets[].address and iscsi.targets[].port."
           },
-          { "key": "startup", "support": "yes" },
+          { "key": "startup", "support": "yes", "agama": "iscsi.targets[].startup" },
           { "key": "target", "support": "yes", "agama": "iscsi.targets[].name" },
           { "key": "iface", "support": "yes", "agama": "iscsi.targets[].interface" }
         ]
@@ -673,15 +730,40 @@
     "children": [
       { "key": "username", "support": "yes", "agama": "user.userName" },
       { "key": "fullName", "support": "yes", "agama": "user.fullName" },
-      { "key": "password", "support": "yes", "agama": "user.password" },
+      { "key": "password", "support": "yes", "agama": "user.password or root.password" },
       {
         "key": "encrypted",
         "support": "yes",
-        "agama": "user.hashedPassword",
+        "agama": "user.hashedPassword or root.hashedPassword",
         "notes": "If set to true, it uses \"hashedPassword\" instead of \"password\""
       },
-      { "key": "authorized_keys", "support": "yes", "agama": "root.sshPublicKeys" }
+      { "key": "authorized_keys", "support": "yes", "agama": "user.sshPublicKeys" }
     ]
   },
-  { "key": "zfcp", "support": "yes" }
+  {
+    "key": "zfcp",
+    "support": "yes",
+    "children": [
+      {
+        "key": "devices[]",
+        "children": [
+          {
+            "key": "controller_id",
+            "support": "yes",
+            "agama": "zfcp.devices[].channel"
+          },
+          {
+            "key": "wwpn",
+            "support": "yes",
+            "agama": "zfcp.devices[].wwpn"
+          },
+          {
+            "key": "fcp_lun",
+            "support": "yes",
+            "agama": "zfcp.devices[].lun"
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/service/test/agama/autoyast/wireless_reader_test.rb
+++ b/service/test/agama/autoyast/wireless_reader_test.rb
@@ -31,8 +31,8 @@ Yast.import "Profile"
 describe Agama::AutoYaST::WirelessReader do
   let(:profile) do
     {
-      "wireless_auth_mode" => auth_mode,
-      "wireless_mode"      => mode,
+      "wireless_auth_mode" => auth_mode.short_name,
+      "wireless_mode"      => mode.short_name,
       "wireless_essid"     => "DUMMY_NETWORK"
     }
   end

--- a/service/test/agama/autoyast/zfcp_reader_test.rb
+++ b/service/test/agama/autoyast/zfcp_reader_test.rb
@@ -50,7 +50,7 @@ describe Agama::AutoYaST::ZFCPReader do
           {
             "controller_id" => "0.0.fa00",
             "wwpn"          => "0x500507630300c562",
-            "lun"           => "0x4010403300000000"
+            "fcp_lun"       => "0x4010403300000000"
           }
         ]
       end


### PR DESCRIPTION
## Problem

While checking the new version of the SUSE documentation, I found a set of problems in the AutoYaST support:

- There are some omissions in the compatibility specification.
- Some properties are not handled properly.

## Solution

- Fix the import of some network attributes (`lladdr`, `wireless_auth_mode`, `wireless_mode`).
- Use `fcp_lun` instead of `lun` in zFCP.
- Fix and extend the compatibility specification.

## Testing

- Updated unit tests
- Tested manually
