### PR TITLE
Improve documentation of the AutoYaST `services-manager` section handling

### DIFF
--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -626,7 +626,7 @@
       { "key": "packages[]", "support": "yes", "agama": "software.packages[]" },
       { "key": "post-packages[]", "support": "no" },
       { "key": "patterns[]", "support": "yes", "agama": "software.patterns[]" },
-      { "key": "products[]", "support": "yes", "agama": "software.id" },
+      { "key": "products[]", "support": "yes", "agama": "product.id" },
       { "key": "remove-packages[]", "support": "no" },
       { "key": "remove-patterns[]", "support": "no" },
       { "key": "remove-products[]", "support": "no" }

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -415,7 +415,7 @@
   },
   {
     "key": "services-manager",
-    "notes": "Agama does not implement support to enable/disable services on demand, so this section is converted to a post-installation script which enable/disable the services.",
+    "notes": "Agama does not implement support to enable/disable services on demand, so this section is converted to a post-installation script which enables/disables the services.",
     "children": [
       {
         "key": "default_target",

--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -415,41 +415,27 @@
   },
   {
     "key": "services-manager",
-    "notes": "Automatically converted into post-installation script",
+    "notes": "Agama does not implement support to enable/disable services on demand, so this section is converted to a post-installation script which enable/disable the services.",
     "children": [
       {
         "key": "default_target",
-        "support": "yes"
+        "support": "yes",
+        "notes": "Add a call to \"systemctl set-target\" in the post-installation script."
       },
       {
-        "key": "enable",
-        "children": [
-          {
-            "key": "service",
-            "support": "yes",
-            "notes": "The list of services is enabled using a post-installation script."
-          }
-        ]
+        "key": "enable[]",
+        "support": "yes",
+        "notes": "Services are enabled in the post-installation script."
       },
       {
-        "key": "disable",
-        "children": [
-          {
-            "key": "service",
-            "support": "yes",
-            "notes": "The list of services is disabled using a post-installation script."
-          }
-        ]
+        "key": "disable[]",
+        "support": "yes",
+        "notes": "Services are disabled in the post-installation script."
       },
       {
-        "key": "on_demand",
-        "children": [
-          {
-            "key": "service",
-            "support": "yes",
-            "notes": "The list of services is enabled on-demand using a post-installation script."
-          }
-        ]
+        "key": "on_demand[]",
+        "support": "yes",
+        "notes": "Services are enabled on-demand in the post-installation script."
       }
     ]
   },


### PR DESCRIPTION
## Problem

The description of how Agama handles the `services-manager` section from an AutoYaST profile
is pretty confusing.


## Solution

Use a single table with some notes to improve the description.

## Screenshots

<details>
<summary>Before</summary>

<img width="699" height="960" alt="imagen" src="https://github.com/user-attachments/assets/aada4bab-1a43-46f8-b33e-f3dfb8a833bc" />
</details>

<details>
<summary>Now</summary>
<img width="940" height="427" alt="imagen" src="https://github.com/user-attachments/assets/abc5f532-7980-4240-986d-56a4fa5cbd3f" />

</details>