### PR TITLE
Fix and extend the AutoYaST compatibility reference for scripts

### DIFF
--- a/service/share/autoyast-compat.json
+++ b/service/share/autoyast-compat.json
@@ -507,17 +507,17 @@
           {
             "key": "filename",
             "support": "yes",
-            "agama": "scripts.chroot[].name"
+            "agama": "scripts.post[].name"
           },
           {
             "key": "location",
             "support": "yes",
-            "agama": "scripts.chroot[].url"
+            "agama": "scripts.post[].url"
           },
           {
             "key": "source",
             "support": "yes",
-            "agama": "scripts.chroot[].content"
+            "agama": "scripts.post[].content"
           },
           {
             "key": "interpreter",
@@ -529,7 +529,12 @@
           { "key": "debug", "support": "no" },
           { "key": "notification", "support": "no" },
           { "key": "param-list", "support": "no" },
-          { "key": "rerun", "support": "no" }
+          { "key": "rerun", "support": "no" },
+          {
+            "key": "chrooted",
+            "support": "yes",
+            "agama": "scripts.post[].chroot"
+          }
         ]
       },
       {


### PR DESCRIPTION
## Problem

The AutoYaST compatibility reference omits the `chrooted` element apart from other small problems
in the scripts mapping.

## Solution

Extend the reference and fix the wrong mapping.