### PR TITLE
fix(service): activate unknown zFCP LUNs

### DIFF
--- a/service/lib/agama/storage/zfcp/device.rb
+++ b/service/lib/agama/storage/zfcp/device.rb
@@ -23,18 +23,38 @@ module Agama
   module Storage
     module ZFCP
       # zFCP device.
+      #
+      # [ Mainframe Linux ]
+      #          │
+      #          ▼ (Channel: e.g., 0.0.1700)
+      # ┌─────────────────┐
+      # │ zFCP Host Port  │
+      # └─────────────────┘
+      #          │
+      #          ▼ (WWPN: e.g., 0x5005076303030123)
+      # ┌─────────────────┐
+      # │ Storage Array   │
+      # └─────────────────┘
+      #          │
+      #          ▼ (LUN: e.g., 0x4010400000000000)
+      # ┌─────────────────┐
+      # │  Disk Volume    │ ──► Presented to Linux as /dev/sda
+      # └─────────────────┘
       class Device
-        # zFCP controller channel id
+        # The Channel represents the physical and virtual I/O hardware interface on the mainframe
+        # (e.g., "0.0.1700").
         #
         # @return [String]
         attr_reader :channel
 
-        # zFCP WWPN
+        # The WWPN is a unique 64-bit address (represented as a 16-character hexadecimal string)
+        # assigned to a Fibre Channel port (e.g., "0x5005076303030123").
         #
         # @return [String]
         attr_reader :wwpn
 
-        # zFCP LUN
+        # The LUN is an 18-character hexadecimal identifier that represents an individual logical
+        # disk volume carved out on the storage array (e.g., "0x4010400000000000").
         #
         # @return [String]
         attr_reader :lun

--- a/service/lib/agama/storage/zfcp/manager.rb
+++ b/service/lib/agama/storage/zfcp/manager.rb
@@ -222,6 +222,9 @@ module Agama
 
         # Activates a device if it is not active yet.
         #
+        # @note This method receives channel, wwpn and lun instead of a device because in some cases
+        #   the devices are not discoverable (see bsc#1271376).
+        #
         # @param channel [String]
         # @param wwpn [String]
         # @param lun [String]
@@ -259,8 +262,9 @@ module Agama
 
         # Deactivates a device if it is active.
         #
-        # @note: If the disk is unknown or "allow_lun_scan" is active, then the disk deactivation
-        #   is not performed (noop).
+        # @note This method receives channel, wwpn and lun instead of a device because in some cases
+        #   the devices are not discoverable (see bsc#1271376). If the disk is unknown or
+        #   "allow_lun_scan" is active, then the disk deactivation is not performed (noop).
         #
         # @param channel [String]
         # @param wwpn [String]

--- a/service/lib/agama/storage/zfcp/manager.rb
+++ b/service/lib/agama/storage/zfcp/manager.rb
@@ -89,7 +89,6 @@ module Agama
 
           configure_controllers(config)
           configure_devices(config)
-          add_issues(config)
         end
 
         # Whether the option for allowing automatic LUN scan (allow_lun_scan) is active
@@ -182,8 +181,6 @@ module Agama
           ].flatten.uniq
 
           channels
-            .map { |c| find_controller(c) }
-            .compact
             .map { |c| activate_controller(c) }
             .any?
         end
@@ -192,18 +189,20 @@ module Agama
         #
         # @note: If "allow_lun_scan" is active, then all its LUNs are automatically activated.
         #
-        # @param controller [Controller]
+        # @param channel [String]
         # @return [Boolean] Whether the controller was activated.
-        def activate_controller(controller)
-          return false if controller.active?
+        def activate_controller(channel)
+          controller = find_controller(channel)
+          return false if controller&.active?
 
-          logger.info("Activating zFCP controller: #{controller.inspect}")
-          output = yast_zfcp.activate_controller(controller.channel)
+          logger.info("Activating zFCP controller: #{channel}")
+          output = yast_zfcp.activate_controller(channel)
           success = output["exit"] == 0
           return true if success
 
           @issues << Issue.new(
-            format(_("The zFCP controller %s cannot be activated"), controller.channel),
+            # TRANSLATORS: %s is replaced by a zFCP channel (e.g., "0.0.5223").
+            format(_("The zFCP controller %s cannot be activated"), channel),
             kind: :zfcp_controller_activation
           )
 
@@ -217,26 +216,30 @@ module Agama
         def activate_devices(config)
           config.devices
             .select(&:active?)
-            .map { |d| find_device(d.channel, d.wwpn, d.lun) }
-            .compact
-            .map { |d| activate_device(d) }
+            .map { |d| activate_device(d.channel, d.wwpn, d.lun) }
             .any?
         end
 
         # Activates a device if it is not active yet.
         #
-        # @param device [Device]
+        # @param channel [String]
+        # @param wwpn [String]
+        # @param lun [String]
+        #
         # @return [Boolean] Whether the device was activated.
-        def activate_device(device)
-          return false if device.active?
+        def activate_device(channel, wwpn, lun)
+          device = find_device(channel, wwpn, lun)
+          return false if device&.active?
 
-          logger.info("Activating zFCP device: #{device.inspect}")
-          output = yast_zfcp.activate_disk(device.channel, device.wwpn, device.lun)
+          logger.info("Activating zFCP device: #{channel} #{wwpn} #{lun}")
+          output = yast_zfcp.activate_disk(channel, wwpn, lun)
           success = output["exit"] == 0
           return true if success
 
           @issues << Issue.new(
-            format(_("The zFCP device %s cannot be activated"), device.to_s),
+            # TRANSLATORS: %s is replaced by a zFCP device (e.g.,
+            #   "0.0.5223 0x500507681015a2b2 0x0186000000000000").
+            format(_("The zFCP device %s cannot be activated"), "#{channel} #{wwpn} #{lun}"),
             kind: :zfcp_lun_activation
           )
 
@@ -250,80 +253,40 @@ module Agama
         def deactivate_devices(config)
           config.devices
             .reject(&:active?)
-            .map { |d| find_device(d.channel, d.wwpn, d.lun) }
-            .compact
-            .map { |d| deactivate_device(d) }
+            .map { |d| deactivate_device(d.channel, d.wwpn, d.lun) }
             .any?
         end
 
         # Deactivates a device if it is active.
         #
-        # @note: If "allow_lun_scan" is active, then the disk cannot be deactivated.
+        # @note: If the disk is unknown or "allow_lun_scan" is active, then the disk deactivation
+        #   is not performed (noop).
         #
-        # @param device [Device]
+        # @param channel [String]
+        # @param wwpn [String]
+        # @param lun [String]
+        #
         # @return [Boolean] Whether the device was deactivated.
-        def deactivate_device(device)
-          return false unless device.active?
+        def deactivate_device(channel, wwpn, lun)
+          device = find_device(channel, wwpn, lun)
+          return false unless device&.active?
 
-          controller = find_controller(device.channel)
+          controller = find_controller(channel)
           return false if controller&.lun_scan?
 
-          logger.info("Deactivating zFCP device: #{device.inspect}")
-          output = yast_zfcp.deactivate_disk(device.channel, device.wwpn, device.lun)
+          logger.info("Deactivating zFCP device: #{channel} #{wwpn} #{lun}")
+          output = yast_zfcp.deactivate_disk(channel, wwpn, lun)
           success = output["exit"] == 0
           return true if success
 
           @issues << Issue.new(
-            format(_("The zFCP device %s cannot be deactivated"), device.to_s),
+            # TRANSLATORS: %s is replaced by a zFCP device (e.g.,
+            #   "0.0.5223 0x500507681015a2b2 0x0186000000000000").
+            format(_("The zFCP device %s cannot be deactivated"), "#{channel} #{wwpn} #{lun}"),
             kind: :zfcp_lun_deactivation
           )
 
           false
-        end
-
-        # Add issues for missing controllers and devices.
-        #
-        # @param config [Config]
-        def add_issues(config)
-          @issues += missing_controllers_issues(config)
-          @issues += missing_devices_issues(config)
-        end
-
-        # Add issues for missing controllers.
-        #
-        # @param config [Config]
-        def missing_controllers_issues(config)
-          config.controllers.map { |c| missing_controller_issue(c) }.compact
-        end
-
-        # Issue if the controller is missing.
-        #
-        # @param channel [String]
-        # @return [Issue, nil]
-        def missing_controller_issue(channel)
-          return if find_controller(channel)
-
-          Issue.new(
-            format(_("Unknown zFCP controller %s"), channel),
-            kind: :missing_zfcp_controller
-          )
-        end
-
-        # Add issues for missing devices.
-        #
-        # @param config [Config]
-        def missing_devices_issues(config)
-          config.devices.map { |c| missing_device_issue(c) }.compact
-        end
-
-        # Issue if the device is missing.
-        #
-        # @param device_config [Configs::Device]
-        # @return [Issue, nil]
-        def missing_device_issue(device_config)
-          return if find_device(device_config.channel, device_config.wwpn, device_config.lun)
-
-          Issue.new(format(_("Unknown zFCP LUN %s"), device_config.to_s), kind: :missing_zfcp_lun)
         end
 
         # Creates a zFCP controller from a YaST record.

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Aug 10 15:14:00 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Allow activating unknown zFCP LUNs (bsc#1271376).
+
+-------------------------------------------------------------------
 Wed Aug  5 15:05:24 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Adapt the exported information of the storage system and proposal

--- a/service/test/agama/storage/zfcp/manager_test.rb
+++ b/service/test/agama/storage/zfcp/manager_test.rb
@@ -279,18 +279,15 @@ describe Agama::Storage::ZFCP::Manager do
       context "if the controller is unknown" do
         let(:config_json) { { controllers: ["0.0.0000"] } }
 
-        it "does not activate the controller" do
-          expect(yast_zfcp).to_not receive(:activate_controller).with("0.0.0000")
+        it "activates the controller" do
+          expect(yast_zfcp)
+            .to receive(:activate_controller).with("0.0.0000").and_return({ "exit" => 0 })
           subject.configure(config_json)
         end
 
-        it "generates an issue" do
+        it "does not generate an issue" do
           subject.configure(config_json)
-          expect(subject.issues).to include(
-            an_object_having_attributes(
-              description: /Unknown zFCP controller 0.0.0000/
-            )
-          )
+          expect(subject.issues).to eq([])
         end
       end
     end
@@ -400,20 +397,17 @@ describe Agama::Storage::ZFCP::Manager do
           }
         end
 
-        it "does not activate the device" do
-          expect(yast_zfcp).to_not receive(:activate_disk)
+        it "activates the device" do
+          expect(yast_zfcp).to receive(:activate_disk)
             .with("0.0.fa00", "0x500507630708d3b3", "0x0000000000000000")
+            .and_return({ "exit" => 0 })
 
           subject.configure(config_json)
         end
 
-        it "generates an issue" do
+        it "does not generate an issue" do
           subject.configure(config_json)
-          expect(subject.issues).to include(
-            an_object_having_attributes(
-              description: /Unknown zFCP LUN 0.0.fa00 0x500507630708d3b3 0x0000000000000000/
-            )
-          )
+          expect(subject.issues).to eq([])
         end
       end
     end
@@ -504,7 +498,8 @@ describe Agama::Storage::ZFCP::Manager do
               {
                 channel: "0.0.fa00",
                 wwpn:    "0x500507630708d3b3",
-                lun:     "0x0000000000000000"
+                lun:     "0x0000000000000000",
+                active:  false
               }
             ]
           }
@@ -517,13 +512,9 @@ describe Agama::Storage::ZFCP::Manager do
           subject.configure(config_json)
         end
 
-        it "generates an issue" do
+        it "does not generate an issue" do
           subject.configure(config_json)
-          expect(subject.issues).to include(
-            an_object_having_attributes(
-              description: /Unknown zFCP LUN 0.0.fa00 0x500507630708d3b3 0x0000000000000000/
-            )
-          )
+          expect(subject.issues).to eq([])
         end
       end
     end


### PR DESCRIPTION
## Problem

On systems using non-NPIV-enabled zFCP controllers, zFCP LUNs provided by storage systems other than the IBM DS8000 family (for example, IBM FlashSystem) may not be listed for enablement after the corresponding zFCP controller has been activated. And unknown LUNs cannot be currently activated with Agama neither loading a JSON config file nor using the UI. Trying to load a config with unknown LUNs makes Agama to report an issue.

There are some workarounds. For example, to manually activate the LUNs on booting time by adding `rd.zdev` kernel boot options:

~~~
rd.zdev=zfcp-lun,0.0.5223:0x500507681015a2a6:0x0186000000000000
rd.zdev=zfcp-lun,0.0.5323:0x500507681015a2b2:0x0186000000000000
~~~ 

Or after loading the installer,  using the command line to manually activate the devices (`chzdev`) and then rescanning the devices with the "Rescan" buntton in the Agama UI.

~~~
$ chzdev -ea 0.0.5223:0x500507681015a2a6:0x0186000000000000
$ chzdev -ea 0.0.5323:0x500507681015a2b2:0x0186000000000000
~~~

https://bugzilla.suse.com/show_bug.cgi?id=1271376

## Solution

Allow indicating unkown LUNs in the Agama JSON config. Now, Agama tries to activate the LUNs instead of reporting an "unknown LUN" issue.

Example:

~~~
$ agama config edit

{
  "zfcp": {
    "devices": [
      {
        "channel": "0.0.fc00",
        "wwpn": "0x500507630b101216",
        "lun": "0x0001000000000000",
        "active": false
      }
    ]
  }
}
~~~

The LUN activation in the UI is still limited to known LUNs only.