### PR TITLE
Do not run software SetConfig in background

### DIFF
--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -285,18 +285,10 @@ impl Service {
             return Ok(());
         };
 
-        let model = self.model.clone();
-        let progress = self.progress.clone();
-        let issues = self.issues.clone();
-        let l10n = self.l10n.clone();
-        let state = self.state.clone();
-        let events = self.events.clone();
         tracing::info!("Synchronizing the wanted software state");
-
-        tokio::task::spawn(async move {
-            let mut my_model = model.lock().await;
-            let found_issues = my_model
-                .write(wanted_state, l10n, progress)
+        let mut my_model = self.model.lock().await;
+        let found_issues = my_model
+            .write(wanted_state, self.l10n.clone(), self.progress.clone())
                 .await
                 .unwrap_or_else(|e| {
                     let new_issue = Issue::new(
@@ -310,18 +302,17 @@ impl Service {
                     }
                 });
 
-            _ = issues.cast(issue::message::Set::new(
-                Scope::Software,
-                found_issues.software,
-            ));
+        _ = self.issues.cast(issue::message::Set::new(
+            Scope::Software,
+            found_issues.software,
+        ));
 
-            _ = issues.cast(issue::message::Set::new(
-                Scope::Product,
-                found_issues.product,
-            ));
+        _ = self.issues.cast(issue::message::Set::new(
+            Scope::Product,
+            found_issues.product,
+        ));
 
-            Self::update_state(state, my_model, events).await;
-        });
+        Self::update_state(self.state.clone(), my_model, self.events.clone()).await;
 
         Ok(())
     }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -3,7 +3,7 @@ Wed Aug 12 13:55:31 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Wait for the software service when setting the configuration.
   It prevents the monitor to exit before the Agama is ready
-  (gh#agama-project/agama#3817).
+  (bsc#1275030, gh#agama-project/agama#3817).
 
 -------------------------------------------------------------------
 Tue Aug 11 11:42:44 UTC 2026 - Josef Reidinger <jreidinger@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 12 13:55:31 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Wait for the software service when setting the configuration.
+  It prevents the monitor to exit before the Agama is ready
+  (gh#agama-project/agama#3817).
+
+-------------------------------------------------------------------
 Tue Aug 11 11:42:44 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
 
 - Remove the following elements from the /api/system endpoint:


### PR DESCRIPTION
## Problem

When running the `agama config load` command, it may happen that the monitor exits before the software service starts to refresh the repositories.

## Solution

After the introduction of the `TaskManager`, the call to the software `SetConfig` already happens in the background. Spawning a task in the the in the software service causes that the software task (in the manager) exits while the repositories are still not read.

## Testing

- Tested manually
- A testing ISO is [available here](https://build.opensuse.org/projects/systemsmanagement:Agama:branches:wait-for-software-set-config/packages/agama-installer:openSUSE/repositories/images/binaries).

## Follow-up

- Work on the web UI to reduce the amount of time the user is waiting after selecting a product.