### PR TITLE
Faster redirection after selecting the product

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,9 +2,9 @@
 Thu Aug 13 10:46:43 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not wait in the selection page after selecting a product
-  (gh#agama-project/agama#3820).
+  (related to bsc#1275030, gh#agama-project/agama#3820).
 - Fix an sporadic issue with "software" and "storage" skeletons
-  not disappearing (gh#agama-project/agama#3819).
+  not disappearing (bsc#1275027, gh#agama-project/agama#3819).
 
 -------------------------------------------------------------------
 Fri Aug  7 15:07:47 UTC 2026 - David Diaz <dgonzalez@suse.com>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Aug 13 10:46:43 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not wait in the selection page after selecting a product
+  (gh#agama-project/agama#3820).
+- Fix an sporadic issue with "software" and "storage" skeletons
+  not disappearing (gh#agama-project/agama#3819).
+
+-------------------------------------------------------------------
 Fri Aug  7 15:07:47 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Fix typography and layout details that a product skin makes

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,7 +21,7 @@
  */
 
 import React, { useEffect } from "react";
-import { Outlet, useLocation } from "react-router";
+import { Navigate, Outlet, useLocation } from "react-router";
 import { useStatusChanges, useStatus } from "~/hooks/model/status";
 import { useSystemChanges } from "~/hooks/model/system";
 import { useProposal, useProposalChanges } from "~/hooks/model/proposal";
@@ -33,6 +33,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { InstallationFinished, InstallationProgress } from "./components/core";
 import InstallationFailed from "./components/core/InstallationFailed";
 import TerminalDock from "~/components/core/TerminalDock";
+import { PRODUCT } from "./routes/paths";
 
 /**
  * Content guard and flow control component.
@@ -64,6 +65,10 @@ const Content = () => {
     product,
     location: location.pathname,
   });
+
+  if (!product && location.pathname !== PRODUCT.root) {
+    return <Navigate to={PRODUCT.root} />;
+  }
 
   if (status?.stage === "failed") {
     return <InstallationFailed />;

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -21,7 +21,6 @@
  */
 
 import React from "react";
-import { Navigate } from "react-router";
 import { Content, Divider, Flex, Grid, GridItem, Stack } from "@patternfly/react-core";
 import Interpolate from "~/components/core/Interpolate";
 import Page from "~/components/core/Page";
@@ -33,7 +32,6 @@ import InstallationSettings from "~/components/overview/InstallationSettings";
 import SystemInformationSection from "~/components/overview/SystemInformationSection";
 import { useProductInfo } from "~/hooks/model/config/product";
 import { useIssues } from "~/hooks/model/issue";
-import { PRODUCT } from "~/routes/paths";
 import { _ } from "~/i18n";
 
 import type { Product } from "~/model/system";
@@ -112,8 +110,9 @@ const ProductNotFound = () => (
   </>
 );
 
-const OverviewPageContent = ({ product }: { product: Product }) => {
+export default function OverviewPage() {
   const issues = useIssues();
+  const product = useProductInfo();
   const missingProduct = issues.some((i) => i.class === "missing_product");
 
   return (
@@ -139,14 +138,4 @@ const OverviewPageContent = ({ product }: { product: Product }) => {
       </Page.Content>
     </Page>
   );
-};
-
-export default function OverviewPage() {
-  const product = useProductInfo();
-
-  if (!product) {
-    return <Navigate to={PRODUCT.root} />;
-  }
-
-  return <OverviewPageContent product={product} />;
 }

--- a/web/src/components/overview/SoftwareSummary.tsx
+++ b/web/src/components/overview/SoftwareSummary.tsx
@@ -28,7 +28,7 @@ import { sprintf } from "sprintf-js";
 import Summary from "~/components/core/Summary";
 import Link from "~/components/core/Link";
 import Text from "~/components/core/Text";
-import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
+import { PROPOSAL_QUERY_KEY } from "~/hooks/model/proposal";
 import { useProposal } from "~/hooks/model/proposal/software";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { useIsDesktopMissing, useSelectedPatterns } from "~/hooks/model/system/software";
@@ -148,10 +148,7 @@ const Description = () => {
  * A software installation summary.
  */
 export default function SoftwareSummary() {
-  const { loading } = useProgressTracking("software", [
-    PROPOSAL_QUERY_KEY,
-    EXTENDED_CONFIG_QUERY_KEY,
-  ]);
+  const { loading } = useProgressTracking("software", [PROPOSAL_QUERY_KEY]);
   const issues = useIssues("software");
   const hasIssues = !isEmpty(issues);
 

--- a/web/src/components/overview/StorageSummary.tsx
+++ b/web/src/components/overview/StorageSummary.tsx
@@ -29,7 +29,7 @@ import Link from "~/components/core/Link";
 import Text from "~/components/core/Text";
 import { useProgressTracking } from "~/hooks/use-progress-tracking";
 import { useConfigModel, STORAGE_MODEL_QUERY_KEY } from "~/hooks/model/storage/config-model";
-import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
+import { PROPOSAL_QUERY_KEY } from "~/hooks/model/proposal";
 import {
   useFlattenDevices as useSystemFlattenDevices,
   useAvailableDevices,
@@ -176,11 +176,7 @@ const Description = () => {
  *  - Hidden when configuration issues exist
  */
 export default function StorageSummary() {
-  const { loading } = useProgressTracking("storage", [
-    PROPOSAL_QUERY_KEY,
-    EXTENDED_CONFIG_QUERY_KEY,
-    STORAGE_MODEL_QUERY_KEY,
-  ]);
+  const { loading } = useProgressTracking("storage", [PROPOSAL_QUERY_KEY, STORAGE_MODEL_QUERY_KEY]);
   const issues = useIssues("storage");
   const zfcpIssues = useIssues("zfcp");
 

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -56,7 +56,7 @@ import { SOFTWARE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 
 import type { TranslatedString } from "~/i18n";
-import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
+import { PROPOSAL_QUERY_KEY } from "~/hooks/model/proposal";
 
 import type { Pattern } from "~/model/system/software";
 import type { PatternsSelection } from "~/model/proposal/software";
@@ -395,7 +395,7 @@ function SoftwarePage() {
       breadcrumbs={[{ label: _("Software") }]}
       progress={{
         scope: "software",
-        awaitQueriesRefetch: [PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY],
+        awaitQueriesRefetch: [PROPOSAL_QUERY_KEY],
       }}
     >
       <Page.Content>

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -56,7 +56,7 @@ import { useIssues } from "~/hooks/model/issue";
 import { useReset } from "~/hooks/model/config/storage";
 import { useProposal } from "~/hooks/model/proposal/storage";
 import { STORAGE_MODEL_QUERY_KEY, useConfigModel } from "~/hooks/model/storage/config-model";
-import { PROPOSAL_QUERY_KEY, EXTENDED_CONFIG_QUERY_KEY } from "~/hooks/model/proposal";
+import { PROPOSAL_QUERY_KEY } from "~/hooks/model/proposal";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { _, n_ } from "~/i18n";
 import { useLocation } from "react-router";
@@ -325,11 +325,7 @@ export default function ProposalPage(): React.ReactNode {
       additionalContent={<ConnectedDevicesMenu />}
       progress={{
         scope: "storage",
-        awaitQueriesRefetch: [
-          PROPOSAL_QUERY_KEY,
-          EXTENDED_CONFIG_QUERY_KEY,
-          STORAGE_MODEL_QUERY_KEY,
-        ],
+        awaitQueriesRefetch: [PROPOSAL_QUERY_KEY, STORAGE_MODEL_QUERY_KEY],
       }}
     >
       <Page.Content>

--- a/web/src/hooks/model/config/product.ts
+++ b/web/src/hooks/model/config/product.ts
@@ -21,7 +21,7 @@
  */
 import { useCallback } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { extendedConfigQuery } from "~/hooks/model/config";
+import { configQuery } from "~/hooks/model/config";
 import { useSystem } from "~/hooks/model/system";
 import type { Config, Product } from "~/model/config";
 import type * as System from "~/model/system";
@@ -30,7 +30,7 @@ const selectProduct = (data: Config | null): Product.Config | null => data?.prod
 
 function useProduct(): Product.Config | null {
   const { data } = useSuspenseQuery({
-    ...extendedConfigQuery,
+    ...configQuery,
     select: selectProduct,
   });
   return data;
@@ -41,7 +41,7 @@ function useProduct(): Product.Config | null {
 function useProductInfo(): System.Product | null {
   const products = useSystem()?.products;
   const { data } = useSuspenseQuery({
-    ...extendedConfigQuery,
+    ...configQuery,
     select: useCallback(
       (data: Config | null): System.Product | null => {
         return products?.find((p) => p.id === data?.product?.id) || null;

--- a/web/src/hooks/model/system/software.test.ts
+++ b/web/src/hooks/model/system/software.test.ts
@@ -100,7 +100,7 @@ function mockScenario(product: Product, patterns: Software.Pattern[], selection:
     products: [product],
     software: { patterns, addons: [], repositories: [] },
   });
-  mockQuery(["extendedConfig"], { product: { id: product.id } });
+  mockQuery(["config"], { product: { id: product.id } });
   mockQuery(["proposal"], { software: { patterns: selection, usedSpace: 0 } });
 }
 


### PR DESCRIPTION
## Problem

After the fix when applying the software configuration (#3817), the web UI does not navigate to the overview until the repositories are loaded.

## Solution

- Redirect right after selecting the product.
- The faster redirection revealed a sporadic problem with the skeleton of the "software" and "storage" sections (#3819). It is fixed in this PR too.

## Testing

- Tested manually
- You can try the [testing image](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/faster-product-redirection/images/iso/).