### PR TITLE
fix(web): stop binding new connections to the loopback device

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 14 07:16:16 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Do not bind new connections to the loopback device
+  (gh#agama-project/agama#3821).
+
+-------------------------------------------------------------------
 Tue Aug 11 10:57:37 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Add an application-wide live region for announcing status changes

--- a/web/src/components/network/connection-form/Form.test.tsx
+++ b/web/src/components/network/connection-form/Form.test.tsx
@@ -36,6 +36,15 @@ import ConnectionForm from "./Form";
 // Mock scrollTo which is not available in jsdom
 Element.prototype.scrollTo = jest.fn();
 
+// The loopback device comes first from the backend, as it does on a real
+// system, so anything that seeds a value from the device list meets it first.
+const mockLoopback = {
+  name: "lo",
+  macAddress: "00:00:00:00:00:00",
+  type: CONNECTION_TYPE.LOOPBACK,
+  state: DeviceState.CONNECTED,
+};
+
 const mockDevice1 = {
   name: "enp1s0",
   macAddress: "00:11:22:33:44:55",
@@ -60,7 +69,7 @@ jest.mock("~/hooks/model/config/network", () => ({
 }));
 
 jest.mock("~/hooks/model/system/network", () => ({
-  useDevices: () => [mockDevice1, mockDevice2],
+  useDevices: () => [mockLoopback, mockDevice1, mockDevice2],
   useSystem: () => mockUseSystem(),
 }));
 
@@ -81,6 +90,13 @@ describe("ConnectionForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams({});
+  });
+
+  it("does not bind the connection to the loopback device", async () => {
+    const { user } = installerRender(<ConnectionForm />);
+    await user.click(screen.getByLabelText("Device binding"));
+    await user.click(screen.getByRole("option", { name: /Chosen by name/ }));
+    expect(screen.getByLabelText("Device name")).toHaveTextContent("enp1s0");
   });
 
   it("renders common connection fields and options", () => {

--- a/web/src/components/network/connection-form/Form.tsx
+++ b/web/src/components/network/connection-form/Form.tsx
@@ -81,6 +81,13 @@ type FormValues = typeof defaultOptions.defaultValues;
  * Stays in useAppForm's validators.onSubmitAsync where TanStack Form expects
  * it. useFormSubmit's onSubmit is only called after field validation passes.
  */
+/**
+ * Devices a connection is never bound to. The loopback device is local to the
+ * machine, so binding a connection to it would produce a profile that cannot
+ * reach anything.
+ */
+const UNBINDABLE_DEVICES = ["lo"];
+
 function ConnectionFormContent({
   initialConnection,
   devices,
@@ -89,6 +96,7 @@ function ConnectionFormContent({
   const navigate = useNavigate();
   const { mutateAsync: updateConnection } = useConnectionMutation();
   const isEditing = initialConnection !== null;
+  const bindableDevices = devices.filter((d) => !UNBINDABLE_DEVICES.includes(d.name));
 
   // Generates and writes the auto-computed name when the binding changes, as
   // long as the user has not manually edited it. `isDirty` is used instead of
@@ -126,8 +134,8 @@ function ConnectionFormContent({
 
   const form = useAppForm({
     ...mergeFormDefaults(defaultOptions, {
-      iface: devices[0]?.name ?? "",
-      ifaceMac: devices[0]?.macAddress ?? "",
+      iface: bindableDevices[0]?.name ?? "",
+      ifaceMac: bindableDevices[0]?.macAddress ?? "",
       ...toFormValues(initialConnection),
     }),
     validators: {
@@ -219,7 +227,7 @@ function ConnectionFormContent({
                           by="iface"
                           label={_("Device name")}
                           sync={{ field: "ifaceMac", with: (d) => d.macAddress }}
-                          exclude={{ devices: ["lo"] }}
+                          exclude={{ devices: UNBINDABLE_DEVICES }}
                         />
                       )}
                       {bindingMode === "mac" && (
@@ -228,7 +236,7 @@ function ConnectionFormContent({
                           by="mac"
                           label={_("Device MAC address")}
                           sync={{ field: "iface", with: (d) => d.name }}
-                          exclude={{ devices: ["lo"] }}
+                          exclude={{ devices: UNBINDABLE_DEVICES }}
                         />
                       )}
                     </>


### PR DESCRIPTION
## Problem

While working in a network form upcoming improvement, it was discovered that creating a connection and setting its device binding to "Chosen by name" (or "Chosen by MAC address") starts the form off bound to `lo`. The selector shows `lo` even though it never offers it as an option, and accepting the form submits a connection bound to the loopback device, which cannot reach anything.


| Initial value | Offered values |
|-|-|
| <img width="2048" height="1536" alt="localhost_8080_ - 2026-08-14T080708 096" src="https://github.com/user-attachments/assets/a98390b2-465d-4684-b600-08b4d99ed4b4" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-08-14T080711 370" src="https://github.com/user-attachments/assets/cc3f7fd8-bb1a-496e-b01a-90c8edde19ee" /> |

The form seeds its device fields from the first device the system reports, and that is the loopback one. The selectors do exclude it from their options, but by then the value is already set, and a value that is not among the options is simply printed as-is.

## Solution

The list of devices a connection is never bound to now has one home in the form, and it is used both for the values the form starts from and for the options the selectors offer, so the two cannot drift apart.

| Initial value | Offered values |
|-|-|
| <img width="2048" height="1536" alt="localhost_8080_ - 2026-08-14T080726 703" src="https://github.com/user-attachments/assets/c9997050-9042-42c3-a31a-ebd380583218" /> |<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-14T080729 315" src="https://github.com/user-attachments/assets/55311a67-8bc8-40dd-b26c-2f5dae1e6d01" /> |


## Details

The test fixtures were part of why this went unnoticed: they mocked a device list with no loopback device. It is now first in that list, as the backend reports it, and adding it turned an existing test red, showing the payload carried `iface: "lo"`. A new test covers the case directly.

## Backport

This targets `next`, but `master` carries the same code, identical lines and all, so people installing from it hit the same bug. Happy to backport it, or for anyone who gets there first: the commit cherry-picks onto `master` with no conflicts.

## Testing

- `npm run test -- src/components/network`, `npm run check-types` and `npm run eslint` pass.
- Manually: create a connection, set the device binding to "Chosen by name", and check the selector shows a real device. Same with "Chosen by MAC address".
