### PR TITLE
Products: No longer rely on deprecated microos_hardware pattern

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 18 06:28:54 UTC 2026 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Microos/Kalpa: No longer reference deprecated microos_hardware
+  pattern (boo#1275469).
+
+-------------------------------------------------------------------
 Fri Jul 24 07:03:30 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added generic storage volumes to the immutables modes, as

--- a/products.d/kalpa.yaml
+++ b/products.d/kalpa.yaml
@@ -100,7 +100,7 @@ software:
     - microos_base
     - microos_base_zypper
     - microos_defaults
-    - microos_hardware
+    - hardware
     - microos_kde_desktop
     - microos_selinux
   optional_patterns: []

--- a/products.d/microos.yaml
+++ b/products.d/microos.yaml
@@ -156,7 +156,7 @@ software:
     - microos_base
     - microos_base_zypper
     - microos_defaults
-    - microos_hardware
+    - hardware
     - microos_selinux
   optional_patterns: []
   user_patterns:


### PR DESCRIPTION
Hardware and microos_hardware have been consolidated and only hardware exists now. Stop relying on the deprecated pattern.


## Problem

Microos and Kalpa reference the `microos_hardware` patterns that is being dropped in favor of `hardware` (from pattersn-base)

[- *Bugzilla link*](https://bugzilla.opensuse.org/show_bug.cgi?id=1275469)
https://build.opensuse.org/request/show/1371005


## Solution

Replace references to microos_hardware with hardware


## Testing

N/A

## Screenshots

N/A

## Documentation

N/A