### PR TITLE
remove ppc64 hacks from boot config scripts

### DIFF
--- a/live/config-cdroot/fix_bootconfig.ppc64le
+++ b/live/config-cdroot/fix_bootconfig.ppc64le
@@ -1,42 +1,6 @@
 #! /bin/bash
 
-# This script takes an unpacked ppc64le Live iso image in the form KIWI-NG currently creates.
-#
-# It modifies the tree to match ppx64le expectations.
-#
-# Usage:
-#
-# fix_bootconfig.ppc64le DST_DIR
-#
-# iso layout before:
-# .
-# ├── LiveOS
-# │   └── squashfs.img
-# └── boot
-#     └── ppc64le
-#         └── loader
-#             ├── initrd
-#             ├── isolinux.cfg
-#             ├── isolinux.msg
-#             └── linux
-#
-# iso layout adjusted:
-# .
-# ├── LiveOS
-# │   └── squashfs.img
-# ├── boot
-# │   ├── grub2
-# │   │   ├── core.elf
-# │   │   ├── grub.cfg
-# │   │   └── powerpc-ieee1275
-# │   │       └── *.mod
-# │   └── ppc64le
-# │       └── loader
-# │           ├── initrd
-# │           └── linux
-# └── ppc
-#     └── bootinfo.txt
-#
+# Custom boot menu.
 
 set -e
 
@@ -51,25 +15,6 @@ fi
 # from a parent process in our case xorriso
 # but that's not the case.
 test -f $dst/.profile && . $dst/.profile
-
-# ----------------
-
-# Note:
-#
-# KIWI-NG creates an iso with isolinux boot files in boot/ppc64le/loader.
-#
-# These files are not needed except for kernel and initrd (and kernel params from isolinux.cfg).
-#
-# This script removes the isolinux config and adds ppc64le related config
-# files. It also moves kernel and initrd to the usual location (in boot/s390x).
-#
-
-boot_dir=$dst/boot/ppc64le/loader
-grub_dir=$dst/boot/grub2
-
-mkdir -p $boot_dir $grub_dir $dst/ppc
-
-chmod 644 $boot_dir/{initrd,linux}
 
 arch=`uname -m`
 profile=$(echo "$kiwi_profiles" | tr "-" " ")
@@ -110,14 +55,4 @@ menuentry "Rescue System" --class os --unrestricted {
   echo 'Loading initrd...'
   initrd /boot/ppc64le/loader/initrd
 }
-XXX
-
-# Create bootinfo.txt
-#
-cat >$dst/ppc/bootinfo.txt <<XXX
-<chrp-boot>
-<description>Install $label</description>
-<os-name>$label</os-name>
-<boot-script>boot &device;:1,\boot\grub2\grub.elf</boot-script>
-</chrp-boot>
 XXX

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Aug 18 12:58:28 UTC 2026 - Steffen Winterfeldt <snwint@suse.com>
+
+- remove ppc64 hacks from boot config scripts (gh#agama-project/agama#3826)
+
+-------------------------------------------------------------------
 Mon Aug 17 09:30:00 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - HCN: do not collect data from functions that log. dracut's

--- a/live/src/fix_bootconfig
+++ b/live/src/fix_bootconfig
@@ -31,12 +31,6 @@ if [ -f $bootfix ] ; then
   echo "bootconfig script found: \"$bootfix\""
 fi
 
-if [ $arch = ppc64le ] ; then
-  mkdir -p $dst/boot/grub2
-  cp -r usr/share/grub2/powerpc-ieee1275 $dst/boot/grub2
-  mv $dst/boot/grub2/powerpc-ieee1275/grub.elf $dst/boot/grub2
-fi
-
 cat <<XXX >/usr/local/bin/xorriso
 #! /bin/bash
 


### PR DESCRIPTION
## Problem

There are some ppc64 related hacks in kiwi boot config scripts dating back to the time where ppc64 was not supported natively in kiwi.

## Solution

- ppc64 is supported natively in kiwi; remove ppc64 workarounds from boot config scripts

## Testing

- manually tested

## Todo

- s390x not yet ready
