### PR TITLE
Own kernel

### DIFF
--- a/doc/yaml_config.md
+++ b/doc/yaml_config.md
@@ -40,6 +40,10 @@ hardware architectures.
 If the matching disk label is not found then the online installation repository
 from the `installation_repositories` section is used.
 
+#### kernel
+
+Specifies the kernel flavor that should be installed. If not specified, it defaults to `kernel-default`.
+
 #### mandatory\_patterns
 
 Array of patterns that have to be selected.

--- a/rust/agama-software/src/model/state.rs
+++ b/rust/agama-software/src/model/state.rs
@@ -398,7 +398,7 @@ impl<'a> SoftwareStateBuilder<'a> {
         // containers, but for agama usage, it does not make sense to skip kernel
         // If needs arise, we can always add more smarter kernel selection later.
         resolvables.add_or_replace(
-            "kernel-default",
+            software.kernel(),
             ResolvableType::Package,
             ResolvableSelection::AutoSelected {
                 skip_if_missing: false,
@@ -1167,7 +1167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_system_adds_kernel() {
+    fn test_system_adds_default_kernel() {
         let product = build_product_spec("tumbleweed", None);
 
         let state = SoftwareStateBuilder::for_product(&product).build();
@@ -1184,6 +1184,31 @@ mod tests {
             kernel,
             Some((
                 "kernel-default".to_string(),
+                ResolvableType::Package,
+                ResolvableSelection::AutoSelected {
+                    skip_if_missing: false
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_system_adds_custom_kernel() {
+        let mut product = build_product_spec("tumbleweed", None);
+        product.software.kernel = Some("kernel-rt".to_string());
+
+        let state = SoftwareStateBuilder::for_product(&product).build();
+
+        let kernel = state
+            .resolvables
+            .to_vec()
+            .into_iter()
+            .find(|(name, r#type, _)| name == "kernel-rt" && *r#type == ResolvableType::Package);
+
+        assert_eq!(
+            kernel,
+            Some((
+                "kernel-rt".to_string(),
                 ResolvableType::Package,
                 ResolvableSelection::AutoSelected {
                     skip_if_missing: false

--- a/rust/agama-utils/src/products.rs
+++ b/rust/agama-utils/src/products.rs
@@ -424,9 +424,16 @@ pub struct SoftwareSpec {
     pub optional_packages: Vec<String>,
     #[merge(strategy = merge::option::overwrite_none)]
     pub base_product: Option<String>,
+    #[serde(default)]
+    #[merge(strategy = merge::option::overwrite_none)]
+    pub kernel: Option<String>,
 }
 
 impl SoftwareSpec {
+    pub fn kernel(&self) -> &str {
+        self.kernel.as_deref().unwrap_or("kernel-default")
+    }
+
     // NOTE: perhaps implementing our own iterator would be more efficient.
     pub fn repositories(&self) -> Vec<&RepositorySpec> {
         let Ok(arch) = Arch::current() else {

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 20 07:32:07 UTC 2026 - Josef Reidinger <jreidinger@suse.com>
+
+- Add ability for products to define own kernel flavor
+  (jsc#PED-16833) 
+
+-------------------------------------------------------------------
 Mon Aug 17 09:07:56 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not accept the reserved VLAN identifier 4095, which is


### PR DESCRIPTION
## Problem

Agama lacks ability for products to define its own kernel flavor if needed.
- https://jira.suse.com/browse/PED-16833
- https://trello.com/c/cnvDHtLu/5968-feature-agama-products-should-be-allowed-to-choose-the-kernel-flavour


## Solution

Implemented it with new key "kernel" in software section. Note: as it is in `products.d` we can change it in future as we do not keep backward compatibility for products.yaml


## Testing

- *Added a new unit test*