### PR TITLE
Update actions/checkout action to v7

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Configure and refresh repositories
       # disable unused repositories to have faster refresh

--- a/.github/workflows/ci-devel.yml
+++ b/.github/workflows/ci-devel.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         # checkout only the "devel" subdirectory
         sparse-checkout: |

--- a/.github/workflows/ci-doc-check.yml
+++ b/.github/workflows/ci-doc-check.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Fix the file owner
       # fix the file owner

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     # TODO: Cache the Ruby gems and node packages
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         # fetch complete history with tags, agama.gemspec calls "git describe --tags"
         # that would fail with just last commit checked out
@@ -32,7 +32,7 @@ jobs:
         fetch-tags: true
 
     - name: Checkout integration tests
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         path: integration-tests
         repository: ${{ github.repository_owner }}/integration-tests

--- a/.github/workflows/ci-live.yml
+++ b/.github/workflows/ci-live.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Configure and refresh repositories
       # disable unused repositories to have faster refresh

--- a/.github/workflows/ci-products.yml
+++ b/.github/workflows/ci-products.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Configure git
       run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/ci-profile-schema.yml
+++ b/.github/workflows/ci-profile-schema.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         # checkout only the directory with the schema
         sparse-checkout: |

--- a/.github/workflows/ci-rubocop.yml
+++ b/.github/workflows/ci-rubocop.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # cache the locally installed Ruby gems for the next invocation to speed up the run,
     # installing Rubocop from scratch takes about 1 minute, the cache is restored in about 2 seconds

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Rust toolchain
       run: |
@@ -100,7 +100,7 @@ jobs:
       run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchains
       run: rustup toolchain install stable
@@ -171,7 +171,7 @@ jobs:
       run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchains
       run: rustup toolchain install stable
@@ -278,7 +278,7 @@ jobs:
         rustup
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install Rust toolchains
       run: rustup toolchain install stable

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Configure git
       run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -148,7 +148,7 @@ jobs:
 
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Download coverage result
       uses: actions/download-artifact@v8

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -51,7 +51,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6

--- a/.github/workflows/obs-service-shared.yml
+++ b/.github/workflows/obs-service-shared.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Git Checkout (full history)
         if: ${{ github.ref_type != 'tag' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # fetch all history, we need to find the latest tag and offset for the version number
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
         run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # fetch all history with tags, we need to find the latest version tag
           fetch-depth: 0

--- a/.github/workflows/obs-staging-live.yml
+++ b/.github/workflows/obs-staging-live.yml
@@ -37,7 +37,7 @@ jobs:
              findutils git make osc obs-service-format_spec_file
 
       - name: Git Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Configure git
         run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/obs-staging-shared.yml
+++ b/.github/workflows/obs-staging-shared.yml
@@ -58,7 +58,7 @@ jobs:
              ${{ inputs.install_packages }}
 
       - name: Git Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # fetch all history with tags, we need to find the latest version tag
           fetch-depth: 0

--- a/.github/workflows/weblate-merge-po-sle16.yml
+++ b/.github/workflows/weblate-merge-po-sle16.yml
@@ -48,14 +48,14 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
           # checkout the SLE-16 branch
           ref: SLE-16
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-merge-po.yml
+++ b/.github/workflows/weblate-merge-po.yml
@@ -48,12 +48,12 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-merge-products-po-sle16.yml
+++ b/.github/workflows/weblate-merge-products-po-sle16.yml
@@ -48,14 +48,14 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
           # checkout the SLE-16 branch
           ref: SLE-16
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-merge-products-po.yml
+++ b/.github/workflows/weblate-merge-products-po.yml
@@ -48,12 +48,12 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-merge-rust-po.yml
+++ b/.github/workflows/weblate-merge-rust-po.yml
@@ -48,12 +48,12 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-merge-service-po-sle16.yml
+++ b/.github/workflows/weblate-merge-service-po-sle16.yml
@@ -48,14 +48,14 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
           # checkout the SLE-16 branch
           ref: SLE-16
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-merge-service-po.yml
+++ b/.github/workflows/weblate-merge-service-po.yml
@@ -48,12 +48,12 @@ jobs:
           git config --global user.email "yast-devel@opensuse.org"
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
 
       - name: Checkout Agama-weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate

--- a/.github/workflows/weblate-update-pot.yml
+++ b/.github/workflows/weblate-update-pot.yml
@@ -63,12 +63,12 @@ jobs:
           zypper --non-interactive install --no-recommends diffutils git gettext-tools npm-default "rubygem(ruby:$RUBY_VERSION:yast-rake)" "rubygem(ruby:$RUBY_VERSION:gettext)" yast2-devtools which
 
       - name: Checkout Agama sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama
 
       - name: Checkout Weblate sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: agama-weblate
           repository: ${{ github.repository_owner }}/agama-weblate


### PR DESCRIPTION
## Change

- Update to the latest version of the `actions/checkout` GitHub Action. It should have [safer fork pull request handling](https://github.com/actions/checkout#checkout-v7).
