### PR TITLE
feat(web): dress the whole medium, not just one product at a time

### DIFF
--- a/doc/theming.md
+++ b/doc/theming.md
@@ -1,33 +1,39 @@
-# Creating a product appearance
+# Creating a product or brand appearance
 
-The Agama web UI can be restyled for a product without touching application
-code: colors, logo, and a handful of other roles are set in a single per-product
-file, loaded at runtime after Agama's own styles.
+The Agama web UI can be restyled without touching application code: colors,
+logo, and a handful of other roles are set in a single CSS file, loaded after
+Agama's own styles. The same roles and the same file format restyle a single
+product or a whole medium; see [The two kinds of
+appearance](#the-two-kinds-of-appearance).
 
-Two things meet in that file, and this document keeps them apart. The **product
-appearance** is what a product writes: the palette, the logo and a few related
-roles that make the installer read as that product. The **color scheme** is
-light or dark, and it belongs to whoever is installing, who picks it in the
-appearance menu or inherits it from their system, alongside a separate contrast
-setting. A product writes the stylesheet and never picks the scheme, so that
-stylesheet has to say how its colors behave in both.
+Two things meet in that file, and this document keeps them apart. The
+**appearance** is what a product or a brand writes: the palette, the logo and a
+few related roles that make the installer read as that product or that vendor.
+The **color scheme** is light or dark, and it belongs to whoever is installing,
+who picks it in the appearance menu or inherits it from their system, alongside
+a separate contrast setting. The stylesheet never picks the scheme, so it has to
+say how its colors behave in both.
 
 This document is about designing and writing that file.
-[product_theming_packaging.md](product_theming_packaging.md) covers getting it
-onto a medium, which a product ships from its own package: no change to Agama's
-source or style files is involved.
+[theming_packaging.md](theming_packaging.md) covers getting it onto a medium,
+which both kinds ship from their own package: no change to Agama's source or
+style files is involved.
 
 **The short version.** Copy `example.css`, set only the roles the brand needs,
 add a light and a dark logo. Measure every contrast pair the checklist lists, in
 both color schemes, with the script rather than the eye. Then look at the result
 in a running installer, because half of what goes wrong has no number attached.
 If the brand needs something no role covers, propose the role instead of
-reaching past it: that contract is the whole reason a product stylesheet
-survives an Agama upgrade.
+reaching past it: that contract is the whole reason either kind of stylesheet
+survives an Agama upgrade. A brand appearance skips the logo and is otherwise
+written exactly the same way.
 
+- [The two kinds of appearance](#the-two-kinds-of-appearance), for one product
+  or for a whole medium, and how they combine
 - [What a product can change](#what-a-product-can-change) and [what it
   cannot](#what-a-product-cannot-change)
 - [The roles](#the-roles), and [the steps](#steps) in order
+- [Brand appearances](#brand-appearances), the one that covers a whole medium
 - [Contrast checklist](#contrast-checklist), plus [brand colors that cannot be a
   fill](#when-the-brand-color-cannot-be-a-fill) and [elevation in dark
   mode](#elevation-in-dark-mode-and-why-tooltips-differ)
@@ -38,6 +44,62 @@ survives an Agama upgrade.
 - [Optional: starting from an AI draft](#optional-starting-from-an-ai-draft),
   and why [the second round is the real
   one](#the-second-round-is-the-real-one)
+
+## The two kinds of appearance
+
+Both kinds set the same roles, in the same file format. What differs is how far
+they reach:
+
+- A **product appearance** restyles Agama for one product, and applies once that
+  product is selected. It is named after the product id, and it is the only one
+  that can change the logo.
+- A **brand appearance** restyles Agama for a whole medium: whatever product is
+  selected, and before any product is selected at all. It is a single
+  `brand.css`, and it covers two cases a product appearance cannot. A vendor, an
+  OEM or an institution whose medium offers several products would otherwise
+  copy the same file once per product id and keep the copies in sync forever.
+  And the product selection screen, the first screen anyone sees, comes before
+  any product is picked, so no product appearance is loaded there yet.
+
+They are not alternatives: a medium can carry both, and they combine.
+
+### Precedence
+
+Three layers, resolved **role by role**, not file by file:
+
+```
+product appearance  >  brand appearance  >  Agama default
+```
+
+Every role carries its own default in `_semantic.scss`, so a role nobody sets
+keeps Agama's value. A role the brand sets and the product does not is the
+brand's. A role the product sets is the product's, whatever the brand said.
+
+The consequence worth planning for: a product appearance that sets only its
+accent color inherits the brand's surfaces, borders and radii, not Agama's. That
+is usually what a medium wants. When it is not, the product file has to set
+those roles too. A partial file does not replace the file below it; only the
+roles it sets do.
+
+The same resolution happens independently in each color scheme, so a product may
+override the dark palette and inherit the brand's light one.
+
+### Keep the selectors at zero specificity
+
+Precedence works because both files declare their roles at the same specificity,
+which leaves the load order to decide. The examples get this right by wrapping
+the scheme condition in `:where()`:
+
+```css
+:root:where(.pf-v6-theme-dark) {
+  /* ... */
+}
+```
+
+`:where()` contributes no specificity, so the block competes on equal terms with
+a plain `:root`. Writing `:root.pf-v6-theme-dark` instead raises the specificity
+and lets a brand appearance beat a product one, which breaks the order above.
+Copy the selectors from the examples rather than writing your own.
 
 ## What a product can change
 
@@ -128,7 +190,7 @@ Three files in the Agama sources carry the role set:
 
 Read one of the examples before writing your own.
 
-**A product stylesheet sets these roles and nothing else.** Raw PatternFly
+**Either kind of stylesheet sets these roles and nothing else.** Raw PatternFly
 tokens, component-level variables and selectors of your own are out of bounds:
 unsupported, and at risk of breaking silently the next time the mapping
 underneath them moves. The roles exist so that a product never has to know how
@@ -196,11 +258,42 @@ styles instead of starting an arms race with them.
 7. **Look at it in a running installer**, following the manual checks. The
    quickest loop copies the file straight into the served directory of a
    running installer, no rebuild in between; see
-   [product_theming_packaging.md](product_theming_packaging.md).
+   [theming_packaging.md](theming_packaging.md).
 
 None of this needs a build of Agama, or a change to it. If you would rather
 start from a draft than from a blank file, there is a prompt for an AI at the
 end of this document, but everything above is written to be followed by hand.
+
+The same steps write a brand appearance, except for the file name and the logo;
+see below.
+
+## Brand appearances
+
+A medium carries at most one brand appearance, so the file needs no id:
+
+```
+assets/appearance/brand.css
+```
+
+Agama ships none. The file is a slot that is empty by design, linked statically
+from the page rather than loaded once a product is known, which has two
+effects:
+
+- It is in effect **at first paint**, the product selection screen included.
+- It is loaded **before** the product appearance, so where both set the same
+  role, the product still wins. See [Precedence](#precedence).
+
+Writing one is the [Steps](#steps) list with two changes. The name is fixed, so
+there is no product id to look up. And the logo step does not apply: logos
+belong to products, since Agama renders the `icon:` declared in the product
+definition. There is no brand-level logo.
+
+The verification is the same, plus two checks a product appearance has no reason
+to make: the product selection screen with nothing selected, and a product that
+ships its own appearance, to confirm that the two combine as the brand expects.
+
+Shipping one, and trying one on a running installer, are covered in
+[theming_packaging.md](theming_packaging.md).
 
 ## Contrast checklist
 
@@ -361,7 +454,7 @@ designing, but the official ISO ships only the curated set Agama's own defaults
 need, so a typeface of your own has to travel with the product.
 
 Where the font file itself lives, its license, and its size are packaging
-concerns: see [product_theming_packaging.md](product_theming_packaging.md).
+concerns: see [theming_packaging.md](theming_packaging.md).
 
 ## Manual checks
 
@@ -382,10 +475,14 @@ Where the roles actually surface:
 - the skip link, by pressing Tab on a freshly loaded page: it takes the brand
   fill and its text color, and it is the first thing a keyboard user meets.
 
+A brand appearance adds two more: the product selection screen with no product
+selected, and a product that ships its own file next to it, since the two
+combine role by role.
+
 The quickest way to iterate is to write the file straight into the served
 directory of a running installer, described in
-[product_theming_packaging.md](product_theming_packaging.md): the reload picks
-it up, with no rebuild in between.
+[theming_packaging.md](theming_packaging.md): the reload picks it up, with no
+rebuild in between.
 
 ## Extending the role API
 
@@ -426,17 +523,26 @@ by making sure those exist. Fill in the placeholders and paste:
 > are how you find the current role set, and answering from memory instead
 > produces a stylesheet that looks plausible and sets roles that do not exist.
 >
-> Create a product stylesheet for `<PRODUCT_ID>` using this brand: `<paste
-colors, and/or a link to the brand's site or guidelines>`. Take the id from
-> the `id:` field of the matching file in `products.d/`, not from a logo file
-> name: the two often differ. The file is `<id>.css`, and a name that does not
-> match loads nothing and says nothing about why.
+> Create a stylesheet for Agama using this brand: `<paste colors, and/or a link
+to the brand's site or guidelines>`. Scope: `<one of: "a product appearance
+for <PRODUCT_ID>, written as <id>.css, restyling that product only" | "a brand
+appearance, a single brand.css meant to be installed at
+assets/appearance/brand.css on the medium, restyling every product and the
+product selection screen, and which cannot change the logo">`.
+>
+> For a product, take the id from the `id:` field of the matching file in
+> `products.d/`, not from a logo file name: the two often differ. The file is
+> `<id>.css`, and a name that does not match loads nothing and says nothing
+> about why.
 >
 > First read `web/src/assets/products/example.css`, `example-advanced.css`, and
 > the role-index comment at the top of
 > `web/src/assets/styles/tokens/_semantic.scss`, so you know the current
-> `--agm-t--*` role set rather than assuming it. A product file only ever sets
-> these roles; never a raw PatternFly or component-level variable directly.
+> `--agm-t--*` role set rather than assuming it. The file only ever sets these
+> roles; never a raw PatternFly or component-level variable directly. Copy the
+> `:where()` selectors from the examples rather than writing your own: raising
+> their specificity breaks the precedence between a brand and a product
+> appearance.
 >
 > Set only the roles the brand actually needs. Every role left unset keeps
 > Agama's own value, so a file that sets colors, a logo and a font family is
@@ -453,7 +559,7 @@ colors, and/or a link to the brand's site or guidelines>`. Take the id from
 > it sits on, 3:1 for borders, icons, focus indicators and anything else that is
 > not text. That is the bar whether or not you can open the files named here.
 >
-> Read `doc/product_theming.md` for which pairs to check, and compute each one
+> Read `doc/theming.md` for which pairs to check, and compute each one
 > explicitly with `web/scripts/check-contrast.js <foreground> <background>
 [--target=4.5]` (run from the repo root; `--target=3` for the non-text ones),
 > in both light and dark separately, rather than eyeballing. Measure every row
@@ -506,18 +612,9 @@ colors, and/or a link to the brand's site or guidelines>`. Take the id from
 > An icon is not automatically the color of the text it labels. If you change
 > the icon color role, check it against both headings and status icons.
 >
-> For the logo: a light and a dark SVG with a transparent background, named
-> after the product's `icon:` field rather than its id, the dark one with
-> `-dark` before the extension. Read `ProductLogo` and its callers first to find
-> the actual rendered size each usage needs, keep the aspect ratio roughly
-> square so the logo survives all of them, and center the drawing inside the
-> viewBox, since the UI aligns the image box and not the ink. Validate any
-> hand-edited SVG with `xmllint --noout` and a rendered preview at the real
-> consuming size, in both color schemes, before calling it done.
->
 > **If something can't be done with the current `--agm-t--*` role set, don't get
 > creative.** Do not set a raw PatternFly token or component-variable override
-> from the product CSS file, and do not work around the "products only set
+> from the CSS file, and do not work around the "appearances only set
 > `--agm-t--*` roles" contract. Stop and present a plan for extending the shared
 > token API instead: the new role's name, where it gets documented (a role-index
 > comment in `_semantic.scss`) and resolved (a PF global token in
@@ -532,6 +629,18 @@ colors, and/or a link to the brand's site or guidelines>`. Take the id from
 > Finally, list what you could not verify yourself, so it can be checked in the
 > running installer. Be specific: "a tooltip over a busy screen", "the overview
 > at 1024x768", not "please review".
+
+A product appearance also needs a logo, so paste this paragraph too. Skip it for
+a brand appearance, which cannot change the logo.
+
+> For the logo: a light and a dark SVG with a transparent background, named
+> after the product's `icon:` field rather than its id, the dark one with
+> `-dark` before the extension. Read `ProductLogo` and its callers first to find
+> the actual rendered size each usage needs, keep the aspect ratio roughly
+> square so the logo survives all of them, and center the drawing inside the
+> viewBox, since the UI aligns the image box and not the ink. Validate any
+> hand-edited SVG with `xmllint --noout` and a rendered preview at the real
+> consuming size, in both color schemes, before calling it done.
 
 ### The second round is the real one
 

--- a/doc/theming.md
+++ b/doc/theming.md
@@ -67,8 +67,9 @@ They are not alternatives: a medium can carry both, and they combine.
 
 Three layers, resolved **role by role**, not file by file:
 
-```
-product appearance  >  brand appearance  >  Agama default
+```mermaid
+flowchart LR
+  b1(Product appearance) --> b2(Brand appearance) --> b3(Agama default)
 ```
 
 Every role carries its own default in `_semantic.scss`, so a role nobody sets

--- a/doc/theming_packaging.md
+++ b/doc/theming_packaging.md
@@ -105,7 +105,7 @@ Once the values settle, the files travel onto a medium the way everything else
 does: as an RPM. It needs no scriptlets and no dependencies beyond the web UI,
 since it only adds files to a directory that is already served:
 
-```
+```rpm-spec
 %install
 install -Dm644 MyProduct.css %{buildroot}%{_datadir}/agama/web_ui/assets/appearance/MyProduct.css
 install -Dm644 MyProduct.svg %{buildroot}%{_datadir}/agama/web_ui/assets/logos/MyProduct.svg
@@ -114,7 +114,7 @@ install -Dm644 MyProduct-dark.svg %{buildroot}%{_datadir}/agama/web_ui/assets/lo
 
 A branding package ships the one file instead:
 
-```
+```rpm-spec
 %install
 install -Dm644 brand.css %{buildroot}%{_datadir}/agama/web_ui/assets/appearance/brand.css
 ```
@@ -123,7 +123,7 @@ Since a medium has room for exactly one brand appearance, branding packages
 should declare a virtual provide and conflict on it, so two of them fail at
 install time instead of racing for the same path:
 
-```
+```rpm-spec
 Provides:  agama-branding
 Conflicts: agama-branding
 ```
@@ -162,7 +162,7 @@ that side of the line.
 - **A stale precompressed sibling wins.** The server prefers a `.gz` next to a
   file when the browser accepts gzip, so a leftover `<product-id>.css.gz` (or
   `brand.css.gz`) from an earlier build keeps being served after the plain file
-  is updated. Ship both or neither.
+  is updated. Ship both or none.
 - **A name mismatch is silent.** A file named after the product _name_ instead of
   its `id:`, or a logo not matching `icon:`, simply never loads.
 

--- a/doc/theming_packaging.md
+++ b/doc/theming_packaging.md
@@ -1,20 +1,21 @@
-# Shipping a product appearance on a medium
+# Shipping an appearance on a medium
 
-Companion to [product_theming.md](product_theming.md), which is about designing
-and writing that stylesheet. This one is only about getting it onto a medium.
+Companion to [theming.md](theming.md), which is about designing and writing that
+stylesheet, whether it is a product appearance, named after a product id, or a
+brand appearance, a single `brand.css` reaching every screen of the medium. This
+one is only about getting either of them onto a medium.
 
-A product does not have to contribute its branding to Agama. The web server
-serves a plain static directory, so the package that builds the medium can drop
-the files into it and own them end to end: no pull request, no waiting for an
-Agama
-release, and the branding stays in the product's own repository, versioned with
-the rest of the product.
+Nobody has to contribute their branding to Agama. The web server serves a plain
+static directory, so the package that builds the medium can drop the files into
+it and own them end to end: no pull request, no waiting for an Agama release,
+and the branding stays in its own repository, versioned with the rest of the
+product.
 
-Agama itself ships no product appearance. The `example.css` and
-`example-advanced.css`
-files in its sources are documentation, and the web UI package installs only its
-own assets, so a product package adding files under the served directory is not
-overriding anything: it is filling in a slot that is empty by design.
+Agama itself ships neither kind of appearance. The `example.css` and
+`example-advanced.css` files in its sources are documentation, and the web UI
+package installs only its own assets, so a package adding files under the served
+directory is not overriding anything: it is filling in a slot that is empty by
+design.
 
 ## Where the files go
 
@@ -24,7 +25,8 @@ to it:
 
 | What                                  | Path                                               |
 | ------------------------------------- | -------------------------------------------------- |
-| the stylesheet                        | `assets/appearance/<product-id>.css`               |
+| the product stylesheet                | `assets/appearance/<product-id>.css`               |
+| the brand stylesheet                  | `assets/appearance/brand.css`                      |
 | logo                                  | `assets/logos/<icon>`                              |
 | dark logo                             | same name with `-dark` before the extension        |
 | fonts and anything else it references | wherever it points at, relative to the file itself |
@@ -41,6 +43,11 @@ icon: MyProduct.svg
 is served `assets/appearance/MyProduct.css` and `assets/logos/MyProduct.svg`,
 with `MyProduct-dark.svg` used on the dark scheme when present. The names have to
 match exactly, and a product without a dark logo falls back to the light one.
+
+The brand stylesheet takes no id, since a medium carries at most one, and it
+brings no logo: logos are named after a product's `icon:`. Everything else it
+references, fonts included, resolves relative to the file itself, exactly as for
+a product.
 
 Keeping a product's own files next to its stylesheet, for instance
 `assets/appearance/fonts/MyProductMono.woff2` referenced as
@@ -78,6 +85,16 @@ scp MyLogo.svg  root@installer:/usr/share/agama/web_ui/assets/logos/Tumbleweed.s
 Reload the browser and select that product. Everything lives in RAM, so a reboot
 wipes the experiment, which is the property to want while trying values out.
 
+A brand stylesheet goes in the same way, under its fixed name and with no
+product to pick:
+
+```console
+scp brand.css root@installer:/usr/share/agama/web_ui/assets/appearance/brand.css
+```
+
+Reload the browser and it is already in effect on the product selection screen,
+before anything is selected, which is the fastest look at it.
+
 From the Agama sources, `setup-web.sh` points the served directory at the
 development build, so everything the build emits (the examples included) is
 served straight away.
@@ -93,6 +110,22 @@ since it only adds files to a directory that is already served:
 install -Dm644 MyProduct.css %{buildroot}%{_datadir}/agama/web_ui/assets/appearance/MyProduct.css
 install -Dm644 MyProduct.svg %{buildroot}%{_datadir}/agama/web_ui/assets/logos/MyProduct.svg
 install -Dm644 MyProduct-dark.svg %{buildroot}%{_datadir}/agama/web_ui/assets/logos/MyProduct-dark.svg
+```
+
+A branding package ships the one file instead:
+
+```
+%install
+install -Dm644 brand.css %{buildroot}%{_datadir}/agama/web_ui/assets/appearance/brand.css
+```
+
+Since a medium has room for exactly one brand appearance, branding packages
+should declare a virtual provide and conflict on it, so two of them fail at
+install time instead of racing for the same path:
+
+```
+Provides:  agama-branding
+Conflicts: agama-branding
 ```
 
 Then it has to reach the image build. The Agama live image is built with KIWI,
@@ -127,9 +160,9 @@ that side of the line.
   load and the UI keeps the Agama defaults, which is what makes this safe to
   add late in a medium's build.
 - **A stale precompressed sibling wins.** The server prefers a `.gz` next to a
-  file when the browser accepts gzip, so a leftover `<product-id>.css.gz` from an
-  earlier build keeps being served after the plain file is updated. Ship both or
-  neither.
+  file when the browser accepts gzip, so a leftover `<product-id>.css.gz` (or
+  `brand.css.gz`) from an earlier build keeps being served after the plain file
+  is updated. Ship both or neither.
 - **A name mismatch is silent.** A file named after the product _name_ instead of
   its `id:`, or a logo not matching `icon:`, simply never loads.
 
@@ -173,5 +206,6 @@ the Agama version that lands on the medium rather than against a newer one.
 
 ## Before shipping
 
-Walk the manual checks from [product_theming.md](product_theming.md): light, dark
-and high contrast, on the screens listed there.
+Walk the manual checks from [theming.md](theming.md): light, dark and high
+contrast, on the screens listed there. A brand appearance adds the product
+selection screen, and a product that ships its own file next to it.

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug 25 12:05:19 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Allow restyling the whole medium with an optional brand appearance
+  (gh#agama-project/agama#3834).
+- Add appearance roles to set the corner radius per shape size and
+  for buttons alone (gh#agama-project/agama#3834).
+
+-------------------------------------------------------------------
 Thu Aug 13 10:46:43 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not wait in the selection page after selecting a product

--- a/web/src/assets/products/example-advanced.css
+++ b/web/src/assets/products/example-advanced.css
@@ -89,13 +89,18 @@
      3. --agm-t--control--border-radius layers on top of the small tier for
         just the interactive controls (buttons, text inputs/textareas,
         selects/dropdowns), leaving tables, tooltips and menus behind.
+     4. --agm-t--button--border-radius is narrower again: buttons only, plus
+        the toggles that read as buttons (split-button children, primary and
+        secondary menu toggles). Reach for it when the brand rounds its buttons
+        more than its text fields; a fully rounded button is 999px.
 
      Anything left unset falls through to the layer above it and, in the end,
      to PatternFly's stock radius. Below: 6px everywhere, except roomier modal
-     dialogs and squarer controls. */
+     dialogs, squarer text fields and fully rounded buttons. */
   --agm-t--border-radius: 6px;
   --agm-t--border-radius--large: 12px;
   --agm-t--control--border-radius: 2px;
+  --agm-t--button--border-radius: 999px;
 
   /* Product logo (see components/product/ProductLogo). Two size roles per
      usage context (each unset keeps that usage's own current default), plus

--- a/web/src/assets/products/example-advanced.css
+++ b/web/src/assets/products/example-advanced.css
@@ -76,16 +76,26 @@
   --agm-t--icon--size--700: 2rem;
   --agm-t--icon--size--800: 2.25rem;
 
-  /* Corner radius, two layers. --agm-t--border-radius is the base: it
-     redefines all three PF radius tiers at once (small: buttons, text inputs,
-     selects, tables, tooltips, menus; medium: cards, popovers, expandable
-     sections; large: modal dialogs). --agm-t--control--border-radius layers
-     on top for just the interactive controls (buttons, text inputs/textareas,
-     selects/dropdowns), letting a product give controls a different radius
-     than cards/dialogs; set only the base if everything should match. Both
-     unset keep PatternFly's stock radius. */
+  /* Corner radius, three layers, each narrower than the one before.
+
+     1. --agm-t--border-radius is the master: it retunes all three PF radius
+        tiers at once. Set only this one if everything should match.
+     2. --agm-t--border-radius--{small,medium,large} retune a single tier and
+        win over the master, so you can give containers and controls different
+        shapes. small: buttons, text inputs, selects, tables, tooltips, menus,
+        pills. medium: cards, popovers, expandable sections. large: modal
+        dialogs and the login card (PF also puts the switch and slider thumbs
+        and the calendar dates in this tier, so raising it rounds those too).
+     3. --agm-t--control--border-radius layers on top of the small tier for
+        just the interactive controls (buttons, text inputs/textareas,
+        selects/dropdowns), leaving tables, tooltips and menus behind.
+
+     Anything left unset falls through to the layer above it and, in the end,
+     to PatternFly's stock radius. Below: 6px everywhere, except roomier modal
+     dialogs and squarer controls. */
   --agm-t--border-radius: 6px;
-  --agm-t--control--border-radius: 6px;
+  --agm-t--border-radius--large: 12px;
+  --agm-t--control--border-radius: 2px;
 
   /* Product logo (see components/product/ProductLogo). Two size roles per
      usage context (each unset keeps that usage's own current default), plus

--- a/web/src/assets/styles/components/_patternfly-overrides.scss
+++ b/web/src/assets/styles/components/_patternfly-overrides.scss
@@ -138,10 +138,12 @@
 .pf-v6-c-button {
   // Buttons follow the same controls role as text inputs and selects (see
   // tokens/_semantic.scss), so a product retunes --agm-t--control--border-radius
-  // once for all three instead of each separately.
+  // once for all three instead of each separately. --agm-t--button--border-radius
+  // wins over it for a product that needs buttons to differ from the fields,
+  // and with both unset the small tier applies exactly as before.
   --pf-v6-c-button--BorderRadius: var(
-    --agm-t--control--border-radius,
-    var(--pf-t--global--border--radius--small)
+    --agm-t--button--border-radius,
+    var(--agm-t--control--border-radius, var(--pf-t--global--border--radius--small))
   );
 
   &:disabled {

--- a/web/src/assets/styles/tokens/_semantic.scss
+++ b/web/src/assets/styles/tokens/_semantic.scss
@@ -34,17 +34,23 @@
 //   --agm-t--status--{info,caution,danger,success,custom}--color
 //                                                 alert / status variants
 //                                                 (caution maps to PF "warning")
-//   --agm-t--border-radius                        base corner radius: every PF
+//   --agm-t--border-radius                        master corner radius: every PF
 //                                                 component across all three PF
-//                                                 radius tiers (small: buttons,
+//                                                 radius tiers at once
+//   --agm-t--border-radius--small                 just the small tier (buttons,
 //                                                 controls, tables, tooltips,
-//                                                 menus; medium: cards, popovers,
-//                                                 expandable sections; large:
-//                                                 modal dialogs)
+//                                                 menus, pills)
+//   --agm-t--border-radius--medium                just the medium tier (cards,
+//                                                 popovers, expandable sections)
+//   --agm-t--border-radius--large                 just the large tier (modal
+//                                                 dialogs, login card, switch and
+//                                                 slider thumbs, calendar dates)
+//                                                 Each tier role wins over the
+//                                                 master; unset ones follow it.
 //   --agm-t--control--border-radius               narrower override for just
 //                                                 buttons, text inputs/textareas
 //                                                 and selects/dropdowns, layered
-//                                                 on top of --agm-t--border-radius
+//                                                 on top of the small tier
 //   --agm-t--logo--size--header                   product logo width in the masthead
 //                                                 (see layout/Header)
 //   --agm-t--logo--size--inline                   product logo width next to the
@@ -129,30 +135,36 @@
   --pf-t--global--breakpoint--lg: 64rem;
   --pf-t--global--font--size--body--sm: var(--pf-t--global--font--size--sm);
 
-  // Base corner radius override hook. PatternFly splits radius into three
+  // Corner radius override hooks. PatternFly splits radius into three
   // independent tiers (small: buttons/controls/tables/tooltips/menus; medium:
-  // cards/popovers/expandable sections; large: modal dialogs), so this
-  // redefines all three from the one role. Unset by default, so every
-  // component keeps its stock look; redefine --agm-t--border-radius (e.g. to
-  // 0) from a product override to reskin all of them in one shot.
+  // cards/popovers/expandable sections; large: modal dialogs and the login
+  // card, plus the switch/slider thumbs and calendar dates that share the
+  // tier). --agm-t--border-radius is the master: setting it alone retunes all
+  // three at once. Each tier also has its own role, which wins over the master
+  // when set, so a product can fine-tune one tier and let the others follow
+  // the master (or PatternFly, if the master is unset too). Precedence: tier
+  // role, master role, PatternFly default. Everything unset keeps the stock
+  // look, and a skin that only sets the master behaves exactly as before.
   --pf-t--global--border--radius--small: var(
-    --agm-t--border-radius,
-    var(--pf-t--global--border--radius--200)
+    --agm-t--border-radius--small,
+    var(--agm-t--border-radius, var(--pf-t--global--border--radius--200))
   );
   --pf-t--global--border--radius--medium: var(
-    --agm-t--border-radius,
-    var(--pf-t--global--border--radius--300)
+    --agm-t--border-radius--medium,
+    var(--agm-t--border-radius, var(--pf-t--global--border--radius--300))
   );
   --pf-t--global--border--radius--large: var(
-    --agm-t--border-radius,
-    var(--pf-t--global--border--radius--400)
+    --agm-t--border-radius--large,
+    var(--agm-t--border-radius, var(--pf-t--global--border--radius--400))
   );
   // Pill-shaped controls (primary/secondary buttons, split-button children)
-  // follow the same small radius rather than PF's default fully-rounded pill.
+  // follow the same small radius rather than PF's default fully-rounded pill,
+  // so --agm-t--border-radius--small reaches them too.
   --pf-t--global--border--radius--pill: var(--pf-t--global--border--radius--small);
   // Narrower override for just the interactive controls (buttons, text
-  // inputs/textareas, selects/dropdowns), layered on top of the base above so
-  // a product can give controls a different radius than containers.
+  // inputs/textareas, selects/dropdowns), layered on top of the small tier
+  // above so a product can give controls a different radius than the rest of
+  // that tier (tables, tooltips, menus) and than the containers.
   --pf-t--global--border--radius--control--default: var(
     --agm-t--control--border-radius,
     var(--pf-t--global--border--radius--small)

--- a/web/src/assets/styles/tokens/_semantic.scss
+++ b/web/src/assets/styles/tokens/_semantic.scss
@@ -51,6 +51,13 @@
 //                                                 buttons, text inputs/textareas
 //                                                 and selects/dropdowns, layered
 //                                                 on top of the small tier
+//   --agm-t--button--border-radius                narrower still: only buttons and
+//                                                 the toggles that read as buttons
+//                                                 (split-button children, primary
+//                                                 and secondary menu toggles), so a
+//                                                 brand can round its buttons
+//                                                 without rounding text inputs.
+//                                                 Falls back to the control role
 //   --agm-t--logo--size--header                   product logo width in the masthead
 //                                                 (see layout/Header)
 //   --agm-t--logo--size--inline                   product logo width next to the
@@ -172,6 +179,18 @@
   --pf-t--global--border--radius--control--form-element: var(
     --agm-t--control--border-radius,
     var(--pf-t--global--border--radius--small)
+  );
+  // Buttons sit one step narrower than the controls role, so a brand can round
+  // its buttons without rounding the text fields (Material is the usual case).
+  // PatternFly keeps a separate radius for the things that read as buttons
+  // without being one: split-button children, and primary and secondary menu
+  // toggles. It defaults to the pill token, which the line above pins to the
+  // small tier, and that is the fallback kept here: deliberately not the
+  // control role, so a skin that sets only --agm-t--control--border-radius
+  // keeps rendering these exactly as it does today.
+  --pf-t--global--border--radius--action--default: var(
+    --agm-t--button--border-radius,
+    var(--pf-t--global--border--radius--pill)
   );
 
   // Icon size scale (theme-independent). Unset by default: every consumption

--- a/web/src/hooks/use-product-appearance.test.ts
+++ b/web/src/hooks/use-product-appearance.test.ts
@@ -39,6 +39,18 @@ describe("useProductAppearance", () => {
     expect(window.localStorage.getItem("agm-product-id")).toBeNull();
   });
 
+  it("removes the stylesheet link and the persisted id when the product is deselected", () => {
+    const { rerender } = renderHook(
+      ({ productId }: { productId?: string }) => useProductAppearance(productId),
+      { initialProps: { productId: "Tumbleweed" } },
+    );
+
+    rerender({ productId: undefined });
+
+    expect(getLink()).toBeNull();
+    expect(window.localStorage.getItem("agm-product-id")).toBeNull();
+  });
+
   it("injects the product's stylesheet link and persists the product id", () => {
     renderHook(() => useProductAppearance("Tumbleweed"));
 

--- a/web/src/hooks/use-product-appearance.ts
+++ b/web/src/hooks/use-product-appearance.ts
@@ -43,11 +43,23 @@ const PRODUCT_ID_KEY = "agm-product-id";
  * the next load, avoiding a flash from the stock Agama colors to the
  * product's own palette.
  *
+ * Without a product id there is no product appearance: any previously injected
+ * stylesheet is removed and the persisted id is dropped, so that whatever sits
+ * underneath (a brand skin, or Agama's own defaults) applies again.
+ *
  * @param productId - active product id; the stylesheet is named after it.
  */
 export default function useProductAppearance(productId?: string): void {
   useEffect(() => {
-    if (!productId) return;
+    if (!productId) {
+      document.getElementById(LINK_ID)?.remove();
+      try {
+        window.localStorage.removeItem(PRODUCT_ID_KEY);
+      } catch {
+        // Ignore write errors; the stylesheet is already gone this session.
+      }
+      return;
+    }
 
     try {
       window.localStorage.setItem(PRODUCT_ID_KEY, productId);

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -33,6 +33,16 @@
       })();
     </script>
     <!--
+      Optional brand-level appearance stylesheet, shipped by a branding package
+      and absent from Agama itself. Static so it is already in effect at first
+      paint, including on the product selection screen, where no product is
+      selected yet. Must stay above the product appearance script below: the
+      product link is appended to the head at runtime and therefore always
+      lands after this one, which is what makes a product skin win role by
+      role. A missing/404 stylesheet is harmless (see doc/theming.md).
+    -->
+    <link rel="stylesheet" href="assets/appearance/brand.css" />
+    <!--
       Apply the last known product's appearance stylesheet before first paint,
       to avoid a flash from the stock Agama colors to the product's own
       palette. Runs before React boots, so it reads localStorage directly;

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -48,7 +48,7 @@
       palette. Runs before React boots, so it reads localStorage directly;
       kept in sync with src/hooks/use-product-appearance.ts (same key, same
       link element id). A missing/404 stylesheet is harmless (see
-      doc/product_theming.md).
+      doc/theming.md).
     -->
     <script>
       (function () {


### PR DESCRIPTION
## Problem

[Get Agama dressed for success](https://agama-project.github.io/blog/2026/08/11/dressed-for-success) introduced product skins: drop a CSS file named after your product id, set a handful of `--agm-t--*` roles, and Agama wears your colors, your logo, your typography. 

That works beautifully as long as "the thing being branded" is a product. But a medium is not always one product, and it is never *only* products:

- Multi-product media (the openSUSE ISO, or any vendor ISO offering several flavors) would need the same CSS copied once per product id, and kept in sync forever.
- The **product selection and login screens**  appear *before* any product is picked, so no product skin is loaded yet. The first screen users see was the one screen that stayed stock. Not the best first impression for a branded medium.
- Some branding is not about the product at all. It is the vendor, the OEM, the hospital, the lab: one visual identity across everything on the medium.

So this PR takes the wardrobe up one size.

## Solution

### 1. Brand skins

A second, broader scope: a single `brand.css` installed at `assets/appearance/brand.css` on the medium. Agama does not ship it; a branding package does. If it is not there, nothing changes at all.

It is linked statically from `index.html`, which buys two things:

- It is in effect **at first paint**, including on the product selection screen.
- It is loaded **before** the runtime product link, which is appended to the `<head>` later. So when both exist, the product skin still wins, role by role: a product can override just its accent color and inherit the rest of the brand.

The resulting cascade, in plain terms:

```
product skin  >  brand skin  >  Agama defaults
```

Nobody has to choose. A vendor sets the house style once; a product refines it where it matters.

### 2. No product selected means no product skin

Agama remembers the last product's appearance so returning users do not get a flash of stock colors before the skin loads. That memory now gets cleared when there is no active product, so whatever is underneath (the brand skin, or Agama's own defaults) applies again instead of a stale product's palette lingering.

### 3. Corner radius, now per shape size

Skins already had `--agm-t--border-radius`, one knob for the whole UI. Real brands rarely work that way: they define a *shape scale*, usually a large radius for big containers, a medium one for cards, a small one for buttons and inputs. PatternFly happens to split radius into exactly three tiers under the hood, so the role set now exposes them:

| Role | Reaches |
| --- | --- |
| `--agm-t--border-radius` | **master**: all three tiers at once (unchanged) |
| `--agm-t--border-radius--small` | buttons, inputs, selects, tables, tooltips, menus, pills |
| `--agm-t--border-radius--medium` | cards, popovers, expandable sections |
| `--agm-t--border-radius--large` | modal dialogs, login card (plus switch/slider thumbs and calendar dates, which PatternFly puts in the same tier) |
| `--agm-t--button--border-radius` | buttons only, plus the toggles that read as buttons (split-button children, primary and secondary menu toggles) |

The last one is the narrow end of a chain that already existed: `--agm-t--control--border-radius` covers buttons, text inputs and selects together, which is all most brands need, and the button role splits buttons back out for the ones that round their buttons more than their fields. The login screen below is where that split shows most plainly, since it puts a button and a password field side by side.

**Fully backwards compatible.** Each tier falls back to the master, which falls back to PatternFly's stock value; the button role falls back to the control role, and that to the small tier. A skin that only sets `--agm-t--border-radius` behaves exactly as it does today; a skin that sets nothing looks exactly as it does today. Already-deployed skins keep working untouched, including the split-button and menu-toggle shapes, which keep following the pill token rather than being quietly rerouted through the control role.


### 4. Documentation

`doc/product_theming.md` and `doc/product_theming_packaging.md` become `doc/theming.md` and `doc/theming_packaging.md`, since they now cover both scopes rather than products only. The design document gains the two scopes and how they compose, why the selectors must stay at zero specificity, and a section on writing a brand appearance; the packaging one gains where `brand.css` goes, how to ship it (including the virtual provide that keeps two branding packages off the same path), and how to drop it onto a running installer. The AI prompt at the end picks the scope in one placeholder, with the logo paragraph split out so a brand appearance can skip it.

`example-advanced.css` gains a worked example of the three radius tiers, and the role index at the top of `_semantic.scss` documents them.

## Testing

One brand proves a skin is possible. Two, picked to break in different places, show the role set is not shaped around a single vendor. Both are built from openly licensed design tokens, measured with `web/scripts/check-contrast.js` against the surfaces each color actually lands on, in each theme separately, with any value that falls short replaced by another from the same system's own ramp.

**[Material Design 3](https://m3.material.io/)** is the interesting case for shape. Material assigns a different corner radius per component, so the three radius tiers land exactly on its scale: 4dp for inputs and menus, 12dp for cards, 28dp for dialogs. It also defines only one status color, `error`, so the other four are generated the way Material does it, one tonal palette each read at the same tone. That is why every status in it lands within a tenth of a point of the others: same tone, same contrast, by construction.


<details>
<summary>Click to show/hide screenshots</summary>

---


<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130329 611" src="https://github.com/user-attachments/assets/0dba7ae8-e614-4559-8c73-945eb44bcf46" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130350 078" src="https://github.com/user-attachments/assets/de856435-d12c-45bb-883a-de697ba58065" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130355 776" src="https://github.com/user-attachments/assets/090961ac-e600-4b4a-be9b-6a0d50328e64" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130421 164" src="https://github.com/user-attachments/assets/fc1484e3-824f-4cc1-a075-ec13211ed06c" />

<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130307 763" src="https://github.com/user-attachments/assets/58ce58f4-fb62-43cb-aa61-f281e646f4bb" />

<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130408 319" src="https://github.com/user-attachments/assets/f9bf1d56-347c-4712-ad27-a01fbc1ef26b" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130403 948" src="https://github.com/user-attachments/assets/cc0940a7-daa4-4d7a-a268-a74e9a6f40dc" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T130415 506" src="https://github.com/user-attachments/assets/c8c9eea5-5442-4c50-8db0-ccd19fd2a06b" />

</details>


**[Acorn](https://acorn.firefox.com/latest/home/acorn-aRSAh0Sp)**, Firefox's design system, stresses a different corner. Its palette is written in OKLCH rather than hex, its accent changes hue between schemes (blue in light, cyan in dark), and several of its tokens are `color-mix()` recipes rather than fixed colors. All of it expressible: converted, composited, and set through the same roles as everything else.


<details>
<summary>Click to show/hide screenshots</summary>

---


<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132406 869" src="https://github.com/user-attachments/assets/7d712c8f-eb40-4598-8495-80768f715b08" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132436 546" src="https://github.com/user-attachments/assets/df43f19f-9b5c-401a-a716-66e9b935ce31" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132440 071" src="https://github.com/user-attachments/assets/527b3881-9c41-47f4-96a7-5cfca4a80306" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132446 438" src="https://github.com/user-attachments/assets/e2559536-7ff3-424b-b2ec-e90bae43c256" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132418 687" src="https://github.com/user-attachments/assets/5ad9b94e-880e-4ba0-af69-18b44bcab761" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132424 667" src="https://github.com/user-attachments/assets/f022bdd9-d2cd-4d8f-9818-c5e9283f3170" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132429 836" src="https://github.com/user-attachments/assets/ea0463a3-f78e-4f65-bbc2-0c4f3aac28ff" />
<img width="2048" height="1536" alt="localhost_8080_ - 2026-08-25T132452 396" src="https://github.com/user-attachments/assets/7d8b4af3-d6d7-4907-9606-7ce0691f2e26" />
</details>

Both turned up the same weak spots, which is the useful result. Each specifies a caution yellow, a subtle border, and a disabled text color that fall short of WCAG AA as published, because each leans on an exemption the theming guide deliberately does not take. And in each, the first draft put a status color directly on top of the link color, the exact collision the accessibility notes warn about.

Material also found a real gap, and it is fixed here rather than written down for later. Its buttons are fully rounded while its text fields are not, and until now both were driven by the same role, so a skin could have one or the other. There is a narrower role for that now, and Material's shape scale goes in whole.

Neither skin ships with Agama. They exist here as the exercises that validated the role set, built from public documentation and using no logos or wordmarks.


## Trying it

Drop a `brand.css` into the served assets and reload:

```
scp brand.css root@<installer>:/usr/share/agama/web_ui/assets/appearance/brand.css
```

Then reload the browser. No rebuild, no Agama release. As the blog post put it: your branding stays in your repository and ships on your schedule.

## Checklist for reviewers

- [ ] Brand skin applies on the product selection screen (before any product is chosen).
- [ ] With both files present, the product skin wins where it sets a role and inherits the brand elsewhere.
- [ ] Going back to product selection drops the previous product's colors.
- [ ] An existing skin that sets only `--agm-t--border-radius` renders identically to before.
- [ ] Both light and dark, plus high contrast.

---

Co-Authored-By: Claude Code <noreply@anthropic.com>