### PR TITLE
Explicitly omit the "multipath" dracut module

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -5,7 +5,7 @@ Tue Aug 25 10:12:59 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
   freeze during the boot process. In 16.0 it was omitted
   automatically by Kiwi, but that hardcoded omit list has been
   removed and now we need to omit the dracut module explicitly
-  here. (bsc#1274053)
+  here. (bsc#1274053, bsc#1271407)
 
 -------------------------------------------------------------------
 Tue Aug 18 12:58:28 UTC 2026 - Steffen Winterfeldt <snwint@suse.com>

--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Aug 25 10:12:59 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Omit the "multipath" dracut module from the initrd, it might
+  freeze during the boot process. In 16.0 it was omitted
+  automatically by Kiwi, but that hardcoded omit list has been
+  removed and now we need to omit the dracut module explicitly
+  here. (bsc#1274053)
+
+-------------------------------------------------------------------
 Tue Aug 18 12:58:28 UTC 2026 - Steffen Winterfeldt <snwint@suse.com>
 
 - remove ppc64 hacks from boot config scripts (gh#agama-project/agama#3826)

--- a/live/src/config.sh
+++ b/live/src/config.sh
@@ -349,6 +349,9 @@ if [ "$(arch)" == "aarch64" ]; then
   echo 'install_items+=" /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcadsp8280.mbn.xz /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qccdsp8280.mbn.xz "' >>/etc/dracut.conf.d/x13s_modules.conf
 fi
 
+# do not activate multipath in dracut, leave that for Agama
+echo 'omit_dracutmodules+=" multipath "' >> /etc/dracut.conf.d/omit-multipath.conf
+
 # Decompress kernel modules, better for squashfs (boo#1192457)
 find /lib/modules/*/kernel -name '*.ko.xz' -exec xz -d {} +
 find /lib/modules/*/kernel -name '*.ko.zst' -exec zstd --rm -d {} +


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1274053
- https://bugzilla.suse.com/show_bug.cgi?id=1271407
- The system might freeze during boot

## Details

- Related to https://github.com/OSInside/kiwi/commit/1a34162f6878a0751e692b0695f3e8f66f220d66
- Kiwi does not omit the "multipath" module anymore, now it needs to be handled by the image authors in the kiwi file.

In 16.0 the "multipath" module was omitted automatically (note the `--omit ' multipath '` parameter):

```console
> isoinfo -R -i SLES-16.0-Online-x86_64-GM.install.iso -x /boot/x86_64/loader/initrd > initrd
> lsinitrd initrd | grep multipath
Arguments:  --verbose --reproducible --no-hostonly --no-hostonly-cmdline --install '/.profile' --add ' dmsquash-live livenet pollcdrom ' --omit ' multipath '
-rw-r--r--   1 root     root       127896 Aug 12  2025 usr/lib/modules/6.12.0-160000.5-default/kernel/drivers/md/dm-multipath.ko
-rw-r--r--   1 root     root           34 Mar  5  2025 usr/lib/tmpfiles.d/multipath.conf
```

In 16.1 that does not happen anymore:

```console
> isoinfo -R -i SLES-16.1-Full-x86_64-Build63.1.install.iso -x /boot/x86_64/loader/initrd > initrd
> lsinitrd initrd | grep Arguments
Arguments:  --verbose --reproducible --no-hostonly --no-hostonly-cmdline --install '/.profile' --add ' dmsquash-live livenet pollcdrom '
> lsinitrd initrd | grep multipath
multipath
-rw-r--r--   1 root     root           37 Jul  9 11:27 etc/multipath.conf
lrwxrwxrwx   1 root     root           42 Aug 11 11:29 etc/systemd/system/sysinit.target.wants/multipathd.service -> /usr/lib/systemd/system/multipathd.service
-rw-r--r--   1 root     root       127816 Aug  6 11:32 usr/lib/modules/6.12.0-160099.49-default/kernel/drivers/md/dm-multipath.ko
-rw-r--r--   1 root     root          806 Aug 11 09:47 usr/lib/systemd/system/multipathd.service
-rw-r--r--   1 root     root           34 Jul 17 21:58 usr/lib/tmpfiles.d/multipath.conf
-rw-r--r--   1 root     root         4378 Jul 17 21:58 usr/lib/udev/rules.d/56-multipath.rules
-rwxr-xr-x   1 root     root       424768 Jul 17 21:58 usr/lib64/libmultipath.so.0
drwxr-xr-x   2 root     root            0 Aug 11 11:29 usr/lib64/multipath
-rwxr-xr-x   1 root     root        30848 Jul 17 21:58 usr/lib64/multipath/libforeign-nvme.so
-rwxr-xr-x   1 root     root        14304 Jul 17 21:58 usr/lib64/multipath/libcheckcciss_tur.so
-rwxr-xr-x   1 root     root        14376 Jul 17 21:58 usr/lib64/multipath/libcheckdirectio.so
-rwxr-xr-x   1 root     root        14408 Jul 17 21:58 usr/lib64/multipath/libcheckemc_clariion.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libcheckhp_sw.so
-rwxr-xr-x   1 root     root        14400 Jul 17 21:58 usr/lib64/multipath/libcheckrdac.so
-rwxr-xr-x   1 root     root        14232 Jul 17 21:58 usr/lib64/multipath/libcheckreadsector0.so
-rwxr-xr-x   1 root     root        14448 Jul 17 21:58 usr/lib64/multipath/libchecktur.so
-rwxr-xr-x   1 root     root        14376 Jul 17 21:58 usr/lib64/multipath/libprioalua.so
-rwxr-xr-x   1 root     root        14456 Jul 17 21:58 usr/lib64/multipath/libprioana.so
-rwxr-xr-x   1 root     root        14000 Jul 17 21:58 usr/lib64/multipath/libprioconst.so
-rwxr-xr-x   1 root     root        14304 Jul 17 21:58 usr/lib64/multipath/libpriodatacore.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libprioemc.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libpriohds.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libpriohp_sw.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libprioiet.so
-rwxr-xr-x   1 root     root        14384 Jul 17 21:58 usr/lib64/multipath/libprioontap.so
-rwxr-xr-x   1 root     root        14304 Jul 17 21:58 usr/lib64/multipath/libpriopath_latency.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libpriorandom.so
-rwxr-xr-x   1 root     root        14296 Jul 17 21:58 usr/lib64/multipath/libpriordac.so
-rwxr-xr-x   1 root     root        14376 Jul 17 21:58 usr/lib64/multipath/libpriosysfs.so
-rwxr-xr-x   1 root     root        14392 Jul 17 21:58 usr/lib64/multipath/libprioweightedpath.so
-rwxr-xr-x   1 root     root        35016 Jul 17 21:58 usr/sbin/multipath
-rwxr-xr-x   1 root     root       153968 Jul 17 21:58 usr/sbin/multipathd
-rwxr-xr-x   1 root     root          221 Aug 11 09:47 var/lib/dracut/hooks/cleanup/80-multipathd-needshutdown.sh
-rwxr-xr-x   1 root     root          173 Aug 11 09:47 var/lib/dracut/hooks/shutdown/20-multipath-shutdown.sh
```

## Solution

- Omit the "multipath" dracut module explicitly by creating a dracut *.conf file in the `config.sh` script.

## Testing

- Tested manually, I built the openSUSE ISO image locally with and without the patch.

Before applying the patch:

```console
> lsinitrd initrd-with-multipath | grep multipath
Image: initrd-with-multipath: 126M
multipath
-rw-r--r--   1 root     root           37 Aug 17 13:18 etc/multipath.conf
lrwxrwxrwx   1 root     root           42 Aug 18 14:58 etc/systemd/system/sysinit.target.wants/multipathd.service -> /usr/lib/systemd/system/multipathd.service
-rw-r--r--   1 root     root       119675 Aug 10 07:04 usr/lib/modules/7.1.8-1-default/kernel/drivers/md/dm-multipath.ko
-rw-r--r--   1 root     root          865 Jul 23 10:34 usr/lib/systemd/system/multipathd.service
drwxr-xr-x   2 root     root            0 Aug 18 14:58 usr/lib/systemd/system/multipathd.service.d
-rw-r--r--   1 root     root           50 Aug 18 14:58 usr/lib/systemd/system/multipathd.service.d/multipathd-dracut.conf
-rw-r--r--   1 root     root           34 Jul 23 10:34 usr/lib/tmpfiles.d/multipath.conf
-rw-r--r--   1 root     root         4378 Jul 23 10:34 usr/lib/udev/rules.d/56-multipath.rules
-rwxr-xr-x   1 root     root       440104 Jul 23 10:34 usr/lib64/libmultipath.so.0
drwxr-xr-x   2 root     root            0 Aug 18 14:58 usr/lib64/multipath
-rwxr-xr-x   1 root     root        30928 Jul 23 10:34 usr/lib64/multipath/libforeign-nvme.so
-rwxr-xr-x   1 root     root        14376 Jul 23 10:34 usr/lib64/multipath/libcheckcciss_tur.so
-rwxr-xr-x   1 root     root        18544 Jul 23 10:34 usr/lib64/multipath/libcheckdirectio.so
-rwxr-xr-x   1 root     root        14480 Jul 23 10:34 usr/lib64/multipath/libcheckemc_clariion.so
-rwxr-xr-x   1 root     root        14296 Jul 23 10:34 usr/lib64/multipath/libcheckhp_sw.so
-rwxr-xr-x   1 root     root        14472 Jul 23 10:34 usr/lib64/multipath/libcheckrdac.so
-rwxr-xr-x   1 root     root        14304 Jul 23 10:34 usr/lib64/multipath/libcheckreadsector0.so
-rwxr-xr-x   1 root     root        14392 Jul 23 10:34 usr/lib64/multipath/libchecktur.so
-rwxr-xr-x   1 root     root        14448 Jul 23 10:34 usr/lib64/multipath/libprioalua.so
-rwxr-xr-x   1 root     root        14536 Jul 23 10:34 usr/lib64/multipath/libprioana.so
-rwxr-xr-x   1 root     root        14000 Jul 23 10:34 usr/lib64/multipath/libprioconst.so
-rwxr-xr-x   1 root     root        14376 Jul 23 10:34 usr/lib64/multipath/libpriodatacore.so
-rwxr-xr-x   1 root     root        14368 Jul 23 10:34 usr/lib64/multipath/libprioemc.so
-rwxr-xr-x   1 root     root        14368 Jul 23 10:34 usr/lib64/multipath/libpriohds.so
-rwxr-xr-x   1 root     root        14368 Jul 23 10:34 usr/lib64/multipath/libpriohp_sw.so
-rwxr-xr-x   1 root     root        14368 Jul 23 10:34 usr/lib64/multipath/libprioiet.so
-rwxr-xr-x   1 root     root        14456 Jul 23 10:34 usr/lib64/multipath/libprioontap.so
-rwxr-xr-x   1 root     root        14376 Jul 23 10:34 usr/lib64/multipath/libpriopath_latency.so
-rwxr-xr-x   1 root     root        14368 Jul 23 10:34 usr/lib64/multipath/libpriorandom.so
-rwxr-xr-x   1 root     root        14368 Jul 23 10:34 usr/lib64/multipath/libpriordac.so
-rwxr-xr-x   1 root     root        14448 Jul 23 10:34 usr/lib64/multipath/libpriosysfs.so
-rwxr-xr-x   1 root     root        14464 Jul 23 10:34 usr/lib64/multipath/libprioweightedpath.so
-rwxr-xr-x   1 root     root        39184 Jul 23 10:34 usr/sbin/multipath
-rwxr-xr-x   1 root     root       162232 Jul 23 10:34 usr/sbin/multipathd
-rwxr-xr-x   1 root     root          222 Aug 18 14:58 var/lib/dracut/hooks/cleanup/80-multipathd-needshutdown.sh
-rwxr-xr-x   1 root     root          173 Aug 18 14:58 var/lib/dracut/hooks/shutdown/20-multipath-shutdown.sh
```

After applying the patch:
```console
> lsinitrd initrd-without-multipath | grep multipath
Image: initrd-without-multipath: 126M
-rw-r--r--   1 root     root       119675 Aug 10 07:04 usr/lib/modules/7.1.8-1-default/kernel/drivers/md/dm-multipath.ko
-rw-r--r--   1 root     root           34 Jul 23 10:34 usr/lib/tmpfiles.d/multipath.conf
```
With the patch the file list is exactly same as in 16.0. :+1: 