### PR TITLE
products: Remove beta tag to de SLES and SLES4SAP product names

### DIFF
--- a/products.d/agama-products.changes
+++ b/products.d/agama-products.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 25 12:10:18 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Remove beta tag from the SLES and SLES for SAP product names
+  (gh#agama-project/agama#3836).
+
+-------------------------------------------------------------------
 Tue Aug 18 06:28:54 UTC 2026 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Microos/Kalpa: No longer reference deprecated microos_hardware

--- a/products.d/sles_161.yaml
+++ b/products.d/sles_161.yaml
@@ -1,5 +1,5 @@
 id: SLES
-name: SUSE Linux Enterprise Server 16.1 Beta
+name: SUSE Linux Enterprise Server 16.1
 registration: true
 version: "16.1"
 license: "license.final"

--- a/products.d/sles_sap_161.yaml
+++ b/products.d/sles_sap_161.yaml
@@ -1,5 +1,5 @@
 id: SLES_SAP
-name: SUSE Linux Enterprise Server for SAP applications 16.1 Beta
+name: SUSE Linux Enterprise Server for SAP applications 16.1
 archs: x86_64,ppc
 registration: true
 version: "16.1"


### PR DESCRIPTION
(Aug 25)
We are about to release RC3, so this cannot be considered beta anymore.

(Sep 17)
RC3 is released and now is the time to actually remove the label
- https://bugzilla.suse.com/show_bug.cgi?id=1272606