### PR TITLE
Silence clippy::result_large_err for axum Response error handlers

### DIFF
--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -164,6 +164,11 @@ impl ProfileBody {
     }
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn validate(body: String) -> Result<(), Response> {
     let profile = ProfileBody::from_string(body);
     let profile_content = profile

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -180,6 +180,11 @@ pub fn server_with_state(
         .with_state(state))
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_status(State(state): State<ServerState>) -> Result<Json<Status>, Response> {
     let status = state
         .manager
@@ -205,6 +210,11 @@ fn get_status_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns the information about the system.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_system(State(state): State<ServerState>) -> Result<Json<SystemInfo>, Response> {
     let system = state
         .manager
@@ -232,6 +242,11 @@ fn get_system_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns the extended configuration.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_extended_config(State(state): State<ServerState>) -> Result<Json<Config>, Response> {
     let config = state
         .manager
@@ -259,6 +274,11 @@ fn get_extended_config_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns the configuration.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_config(State(state): State<ServerState>) -> Result<Json<Config>, Response> {
     let config = state
         .manager
@@ -284,6 +304,11 @@ fn get_config_docs(op: TransformOperation) -> TransformOperation {
 /// Updates the configuration.
 ///
 /// Replaces the whole configuration. If some value is missing, it will be removed.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn put_config(
     State(state): State<ServerState>,
     Json(json): Json<Value>,
@@ -322,6 +347,11 @@ fn put_config_docs(op: TransformOperation) -> TransformOperation {
 /// Patches the configuration.
 ///
 /// It only changes the specified values, keeping the rest as they are.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn patch_config(
     State(state): State<ServerState>,
     Json(patch): Json<Patch>,
@@ -359,6 +389,11 @@ fn patch_config_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns how the target system is configured (proposal).
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_proposal(State(state): State<ServerState>) -> Result<Response, Response> {
     let proposal = state
         .manager
@@ -387,6 +422,11 @@ fn get_proposal_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns the list of issues.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_issues(
     State(state): State<ServerState>,
 ) -> Result<Json<Vec<IssueWithScope>>, Response> {
@@ -427,6 +467,11 @@ fn get_issues_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns the issues for each scope.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_questions(State(state): State<ServerState>) -> Result<Json<Vec<Question>>, Response> {
     let questions = state
         .questions
@@ -454,6 +499,11 @@ fn get_questions_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Registers a new question.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn ask_question(
     State(state): State<ServerState>,
     Json(question): Json<QuestionSpec>,
@@ -484,6 +534,11 @@ fn ask_question_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Updates the question collection by answering or removing a question.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn update_question(
     State(state): State<ServerState>,
     Json(operation): Json<UpdateQuestion>,
@@ -540,6 +595,11 @@ struct LicenseParams {
 ///
 /// Optionally it can receive a language tag (RFC 5646). Otherwise, it returns
 /// the license in English.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_license(
     State(state): State<ServerState>,
     Path(license): Path<LicenseParams>,
@@ -584,6 +644,11 @@ fn get_license_docs(op: TransformOperation) -> TransformOperation {
         })
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn run_action(
     State(state): State<ServerState>,
     Json(action): Json<Action>,
@@ -621,6 +686,11 @@ fn run_action_docs(op: TransformOperation) -> TransformOperation {
 }
 
 /// Returns how the target system is configured (proposal).
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn get_storage_model(
     State(state): State<ServerState>,
 ) -> Result<Json<Option<Value>>, Response> {
@@ -632,6 +702,11 @@ async fn get_storage_model(
     Ok(Json(model))
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn set_storage_model(
     State(state): State<ServerState>,
     Json(model): Json<Value>,
@@ -645,6 +720,11 @@ async fn set_storage_model(
 }
 
 /// Solves a storage config model.
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn solve_storage_model(
     State(state): State<ServerState>,
     Query(params): Query<query::SolveStorageModel>,
@@ -715,6 +795,11 @@ pub struct PasswordParams {
     password: String,
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "Response is used to short-circuit with a pre-built HTTP response; the extra \
+              bytes are negligible per-request cost (see tokio-rs/axum#3824)"
+)]
 async fn check_password(
     State(state): State<ServerState>,
     Json(password): Json<PasswordParams>,


### PR DESCRIPTION
## Problem

`cargo clippy` flags several `agama-server` handlers with `clippy::result_large_err`:

`axum::response::Response` (`http::Response<axum::body::Body>`) is 128 bytes, exactly at clippy's default `large-error-threshold`. A number of handlers return `Result<T, Response>` (or `Result<Response, Response>`) to short-circuit with a pre-built HTTP response, which trips the lint.

## Solution

Add `#[allow(clippy::result_large_err, reason = "...")]` to the affected functions instead of boxing the response. This matches how axum itself handles the identical situation in its own examples (see [tokio-rs/axum#3824](https://github.com/tokio-rs/axum/pull/3824)): `Response` is the natural short-circuit error type for handlers/middleware, and the extra bytes are negligible compared to the cost of the HTTP request itself. Boxing would just move the cost around for no real benefit.

### Functions annotated

- `agama-server/src/profile/web.rs`: `validate`
- `agama-server/src/server/web.rs`: `get_status`, `get_system`, `get_extended_config`, `get_config`, `put_config`, `patch_config`, `get_proposal`, `get_issues`, `get_questions`, `ask_question`, `update_question`, `get_license`, `run_action`, `get_storage_model`, `set_storage_model`, `solve_storage_model`, `check_password`

## Testing

- `cargo clippy --workspace --all-targets -- -D clippy::result_large_err` passes with no remaining `result_large_err` warnings.
- `cargo build -p agama-server` succeeds.
