### PR TITLE
Do not cancel remaining tasks when network configuration fails

### DIFF
--- a/rust/agama-manager/src/actions.rs
+++ b/rust/agama-manager/src/actions.rs
@@ -634,9 +634,7 @@ impl SetConfigAction {
                 .run(|| async move {
                     if let Err(error) = handler.update_config(network_config).await {
                         tracing::error!("Failed to update the network configuration: {error}");
-                    }
-
-                    if let Err(error) = handler.apply().await {
+                    } else if let Err(error) = handler.apply().await {
                         tracing::error!("Failed to apply the network configuration: {error}");
                     }
                     Ok(())

--- a/rust/agama-manager/src/actions.rs
+++ b/rust/agama-manager/src/actions.rs
@@ -632,11 +632,13 @@ impl SetConfigAction {
                 )
                 .depends_on(dependencies)
                 .run(|| async move {
-                    handler
-                        .update_config(network_config)
-                        .await
-                        .map_err(TaskError::from_error)?;
-                    handler.apply().await.map_err(TaskError::from_error)?;
+                    if let Err(error) = handler.update_config(network_config).await {
+                        tracing::error!("Failed to update the network configuration: {error}");
+                    }
+
+                    if let Err(error) = handler.apply().await {
+                        tracing::error!("Failed to apply the network configuration: {error}");
+                    }
                     Ok(())
                 })
                 .await,

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 26 12:06:59 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not cancel remaining tasks if some part of the network
+  configuration cannot be applied (bsc#1276875).
+
+-------------------------------------------------------------------
 Wed Aug 26 09:57:09 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - "agama config generate" prints unsupported AutoYaST elements


### PR DESCRIPTION
## Problem

- [bsc#1276875](https://bugzilla.suse.com/show_bug.cgi?id=1276875)

If network configuration cannot be applied, Agama will not execute the remaining tasks
(including reading repositories and so on). The real problem happens in cases where you
try to, for instance, apply a wireless configuration to a device that does not exist.

## Solution

For 16.1, we will just log the error and not propagate the error, so the remaining tasks are not
canceled. For 16.2, we should go for registering issues instead.

## Testing

- Tested manually