### PR TITLE
NPM CVEs of 2026-07 (master)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2434,24 +2434,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2539,24 +2521,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2581,9 +2545,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7055,16 +7019,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7670,13 +7634,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -7829,9 +7786,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9281,24 +9238,6 @@
         "eslint": ">=5.16.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint-plugin-node/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9423,24 +9362,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
@@ -9698,24 +9619,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
@@ -10094,9 +9997,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -10408,24 +10311,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
@@ -10806,23 +10691,6 @@
       },
       "peerDependencies": {
         "tslib": "2"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -13221,9 +13089,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17979,9 +17847,9 @@
       }
     },
     "node_modules/stylelint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -18430,24 +18298,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {

--- a/web/package.json
+++ b/web/package.json
@@ -112,5 +112,8 @@
     "sprintf-js": "^1.1.3",
     "stacktracey": "^2.1.8",
     "xbytes": "^1.9.1"
+  },
+  "overrides": {
+    "brace-expansion": "^5.0.9"
   }
 }

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -6,6 +6,7 @@ Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
 - updated previously, listing its references for tracking:
+  - form-data 4.0.6, CVE-2025-7783 CVE-2026-12143 (bsc#1246822 bsc#1272310)
   - fast-uri 3.1.3, CVE-2026-13676 (bsc#1269595)
 
 -------------------------------------------------------------------

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -6,6 +6,7 @@ Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
 - updated previously, listing its references for tracking:
+  - @babel/core 7.29.7, CVE-2026-49356 (bsc#1272317)
   - websocket-driver 0.7.5, CVE-2026-54466 CVE-2026-54490 (bsc#1272312 bsc#1272313)
   - form-data 4.0.6, CVE-2025-7783 CVE-2026-12143 (bsc#1246822 bsc#1272310)
   - fast-uri 3.1.3, CVE-2026-13676 (bsc#1269595)

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
+
+- update runtime dependencies to:
+- update development dependencies to:
+  - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
+  - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
+- updated previously, listing its references for tracking:
+
+-------------------------------------------------------------------
 Tue Aug 25 12:05:19 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Allow restyling the whole medium with an optional brand appearance

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -6,6 +6,7 @@ Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
 - updated previously, listing its references for tracking:
+  - websocket-driver 0.7.5, CVE-2026-54466 CVE-2026-54490 (bsc#1272312 bsc#1272313)
   - form-data 4.0.6, CVE-2025-7783 CVE-2026-12143 (bsc#1246822 bsc#1272310)
   - fast-uri 3.1.3, CVE-2026-13676 (bsc#1269595)
 

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -6,6 +6,7 @@ Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
 - updated previously, listing its references for tracking:
+  - launch-editor 2.14.1, CVE-2026-53632 (bsc#1272319)
   - http-proxy-middleware 2.0.10, CVE-2026-55602 (bsc#1272318)
   - @babel/core 7.29.7, CVE-2026-49356 (bsc#1272317)
   - websocket-driver 0.7.5, CVE-2026-54466 CVE-2026-54490 (bsc#1272312 bsc#1272313)

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,7 +1,6 @@
 -------------------------------------------------------------------
 Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
-- update runtime dependencies to:
 - update development dependencies to:
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -6,6 +6,7 @@ Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
 - updated previously, listing its references for tracking:
+  - http-proxy-middleware 2.0.10, CVE-2026-55602 (bsc#1272318)
   - @babel/core 7.29.7, CVE-2026-49356 (bsc#1272317)
   - websocket-driver 0.7.5, CVE-2026-54466 CVE-2026-54490 (bsc#1272312 bsc#1272313)
   - form-data 4.0.6, CVE-2025-7783 CVE-2026-12143 (bsc#1246822 bsc#1272310)

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -6,6 +6,7 @@ Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
   - js-yaml 3.15.1 and 4.3.1, CVE-2026-53550 (bsc#1268851)
   - brace-expansion 5.0.9, CVE-2026-13149 (bsc#1269927)
 - updated previously, listing its references for tracking:
+  - fast-uri 3.1.3, CVE-2026-13676 (bsc#1269595)
 
 -------------------------------------------------------------------
 Tue Aug 25 12:05:19 UTC 2026 - David Diaz <dgonzalez@suse.com>


### PR DESCRIPTION
## Problem

Security scans found vulnerabilities in some NPM libraries that agama-web-ui uses.
This PR is intentionally limited to the same set of libraries that #3730 addressed.

Note that all of these are not *runtime* deps, but *development* ones (which for us combine build-time such as webpack and development-time such as eslint)

- https://trello.com/c/dI8FBjDz
- Bugs:
  - [bsc#1246822](https://bugzilla.suse.com/show_bug.cgi?id=1246822)
  - [bsc#1268851](https://bugzilla.suse.com/show_bug.cgi?id=1268851)
  - [bsc#1269595](https://bugzilla.suse.com/show_bug.cgi?id=1269595)
  - [bsc#1269927](https://bugzilla.suse.com/show_bug.cgi?id=1269927)
  - [bsc#1272310](https://bugzilla.suse.com/show_bug.cgi?id=1272310)
  - [bsc#1272312](https://bugzilla.suse.com/show_bug.cgi?id=1272312)
  - [bsc#1272313](https://bugzilla.suse.com/show_bug.cgi?id=1272313)
  - [bsc#1272317](https://bugzilla.suse.com/show_bug.cgi?id=1272317)
  - [bsc#1272318](https://bugzilla.suse.com/show_bug.cgi?id=1272318)
  - [bsc#1272319](https://bugzilla.suse.com/show_bug.cgi?id=1272319)

## Solution

- update *brace-expansion* with an `overrides` directive
- `npm update js-yaml`
- for the remaining libraries that got updated for some other reason in the past, just log that fact with the associated version+bsc+CVE

### Tooling

Used Gemini with a new [agama-npm-cves-update](https://github.com/agama-project/agama-release-checker/blob/skill-npm-cves/.gemini/skills/agama-npm-cves-update/SKILL.md) skill, prompting it:

> Parse this URL and use the extracted bug ids as input for the agama-npm-cves-update skill:
   https://bugzilla.suse.com/buglist.cgi?bug_id=1246822%2C1259169%2C1268851%2C1269359%2C1269595%2C1269927%2C1272310%2C1272311%2C1272312%2C1272313%2C1272317%2C1272318%2C1272319&list_id=14274136

(then guiding it manually a lot because the skill description was not quite yet what I actually wanted in its first version)

## Testing

- [x] Manual: Ran `npm run eslint` and `npm run test` to make sure that the aggressive brace-expansion update did not break things

## Screenshots

No

## Documentation

- [x] .changes