### PR TITLE
Rename question classes and improve backward-compatible answer matching

### DIFF
--- a/doc/answers_example.json
+++ b/doc/answers_example.json
@@ -2,7 +2,7 @@
     "answers": [
         {
             "answer": "decrypt",
-            "class": "luks_activation",
+            "class": "luksActivation",
             "password": "my_password"
         }
     ]

--- a/doc/answers_example.json
+++ b/doc/answers_example.json
@@ -2,7 +2,7 @@
     "answers": [
         {
             "answer": "decrypt",
-            "class": "storage.luks_activation",
+            "class": "luks_activation",
             "password": "my_password"
         }
     ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "fluent-uri 0.4.1",
  "fs-err",
  "gettext-rs",
+ "heck",
  "libsystemd",
  "macaddr",
  "merge",

--- a/rust/agama-autoinstall/src/questions.rs
+++ b/rust/agama-autoinstall/src/questions.rs
@@ -46,7 +46,7 @@ impl UserQuestions {
     ) -> anyhow::Result<Option<String>> {
         let localized_retry = gettextrs::gettext("Reload configuration");
         let localized_manual = gettextrs::gettext("Skip and configure manually");
-        let question = QuestionSpec::new(text, "load.retry")
+        let question = QuestionSpec::new(text, "load_config_error")
             .with_actions(&[
                 ("Retry", localized_retry.as_str()),
                 ("Manual", localized_manual.as_str()),
@@ -91,7 +91,7 @@ impl UserQuestions {
 
         let localized_continue = gettextrs::gettext("Continue");
         let localized_abort = gettextrs::gettext("Abort");
-        let question = QuestionSpec::new(&text, "autoyast.unsupported")
+        let question = QuestionSpec::new(&text, "autoyast_unsupported")
             .with_actions(&[
                 ("Continue", localized_continue.as_str()),
                 ("Abort", localized_abort.as_str()),

--- a/rust/agama-autoinstall/src/questions.rs
+++ b/rust/agama-autoinstall/src/questions.rs
@@ -46,7 +46,7 @@ impl UserQuestions {
     ) -> anyhow::Result<Option<String>> {
         let localized_retry = gettextrs::gettext("Reload configuration");
         let localized_manual = gettextrs::gettext("Skip and configure manually");
-        let question = QuestionSpec::new(text, "load_config_error")
+        let question = QuestionSpec::new(text, "loadConfigError")
             .with_actions(&[
                 ("Retry", localized_retry.as_str()),
                 ("Manual", localized_manual.as_str()),
@@ -91,7 +91,7 @@ impl UserQuestions {
 
         let localized_continue = gettextrs::gettext("Continue");
         let localized_abort = gettextrs::gettext("Abort");
-        let question = QuestionSpec::new(&text, "autoyast_unsupported")
+        let question = QuestionSpec::new(&text, "autoyastUnsupported")
             .with_actions(&[
                 ("Continue", localized_continue.as_str()),
                 ("Abort", localized_abort.as_str()),

--- a/rust/agama-autoinstall/src/questions.rs
+++ b/rust/agama-autoinstall/src/questions.rs
@@ -47,7 +47,6 @@ impl UserQuestions {
         let localized_retry = gettextrs::gettext("Reload configuration");
         let localized_manual = gettextrs::gettext("Skip and configure manually");
         let question = QuestionSpec::new(text, "load_config_error")
-            .with_deprecated_class("load.retry")
             .with_actions(&[
                 ("Retry", localized_retry.as_str()),
                 ("Manual", localized_manual.as_str()),
@@ -93,7 +92,6 @@ impl UserQuestions {
         let localized_continue = gettextrs::gettext("Continue");
         let localized_abort = gettextrs::gettext("Abort");
         let question = QuestionSpec::new(&text, "autoyast_unsupported")
-            .with_deprecated_class("autoyast.unsupported")
             .with_actions(&[
                 ("Continue", localized_continue.as_str()),
                 ("Abort", localized_abort.as_str()),

--- a/rust/agama-autoinstall/src/questions.rs
+++ b/rust/agama-autoinstall/src/questions.rs
@@ -47,6 +47,7 @@ impl UserQuestions {
         let localized_retry = gettextrs::gettext("Reload configuration");
         let localized_manual = gettextrs::gettext("Skip and configure manually");
         let question = QuestionSpec::new(text, "load_config_error")
+            .with_deprecated_class("load.retry")
             .with_actions(&[
                 ("Retry", localized_retry.as_str()),
                 ("Manual", localized_manual.as_str()),
@@ -92,6 +93,7 @@ impl UserQuestions {
         let localized_continue = gettextrs::gettext("Continue");
         let localized_abort = gettextrs::gettext("Abort");
         let question = QuestionSpec::new(&text, "autoyast_unsupported")
+            .with_deprecated_class("autoyast.unsupported")
             .with_actions(&[
                 ("Continue", localized_continue.as_str()),
                 ("Abort", localized_abort.as_str()),

--- a/rust/agama-cli/src/monitor/ui/question.rs
+++ b/rust/agama-cli/src/monitor/ui/question.rs
@@ -352,7 +352,7 @@ impl<'a> QuestionWidget<'a> {
 
     fn render_field_input(&self, lines: &mut Vec<Line<'a>>) {
         let is_field_active = self.state.app_mode == AppMode::FieldInput;
-        let is_load_retry = self.question.spec.class == "load.retry";
+        let is_load_retry = self.question.spec.class == "load_config_error";
 
         let cursor = if is_field_active {
             Span::styled("_", Style::default().add_modifier(Modifier::SLOW_BLINK))

--- a/rust/agama-cli/src/monitor/ui/question.rs
+++ b/rust/agama-cli/src/monitor/ui/question.rs
@@ -352,7 +352,7 @@ impl<'a> QuestionWidget<'a> {
 
     fn render_field_input(&self, lines: &mut Vec<Line<'a>>) {
         let is_field_active = self.state.app_mode == AppMode::FieldInput;
-        let is_load_retry = self.question.spec.class == "load_config_error";
+        let is_load_retry = self.question.spec.class == "loadConfigError";
 
         let cursor = if is_field_active {
             Span::styled("_", Style::default().add_modifier(Modifier::SLOW_BLINK))

--- a/rust/agama-files/src/runner.rs
+++ b/rust/agama-files/src/runner.rs
@@ -142,7 +142,7 @@ impl ScriptsRunner {
             "Running the script '{}' failed. Do you want to try again?",
             script.name()
         );
-        let mut question = QuestionSpec::new(&text, "retry_script").with_yes_no_actions();
+        let mut question = QuestionSpec::new(&text, "retryScript").with_yes_no_actions();
 
         if let Error::Script { status, stderr } = error {
             let exit_status = status

--- a/rust/agama-files/src/runner.rs
+++ b/rust/agama-files/src/runner.rs
@@ -142,9 +142,7 @@ impl ScriptsRunner {
             "Running the script '{}' failed. Do you want to try again?",
             script.name()
         );
-        let mut question = QuestionSpec::new(&text, "retry_script")
-            .with_deprecated_class("scripts.retry")
-            .with_yes_no_actions();
+        let mut question = QuestionSpec::new(&text, "retry_script").with_yes_no_actions();
 
         if let Error::Script { status, stderr } = error {
             let exit_status = status

--- a/rust/agama-files/src/runner.rs
+++ b/rust/agama-files/src/runner.rs
@@ -142,7 +142,7 @@ impl ScriptsRunner {
             "Running the script '{}' failed. Do you want to try again?",
             script.name()
         );
-        let mut question = QuestionSpec::new(&text, "scripts.retry").with_yes_no_actions();
+        let mut question = QuestionSpec::new(&text, "retry_script").with_yes_no_actions();
 
         if let Error::Script { status, stderr } = error {
             let exit_status = status

--- a/rust/agama-files/src/runner.rs
+++ b/rust/agama-files/src/runner.rs
@@ -142,7 +142,9 @@ impl ScriptsRunner {
             "Running the script '{}' failed. Do you want to try again?",
             script.name()
         );
-        let mut question = QuestionSpec::new(&text, "retry_script").with_yes_no_actions();
+        let mut question = QuestionSpec::new(&text, "retry_script")
+            .with_deprecated_class("scripts.retry")
+            .with_yes_no_actions();
 
         if let Error::Script { status, stderr } = error {
             let exit_status = status

--- a/rust/agama-files/src/service.rs
+++ b/rust/agama-files/src/service.rs
@@ -184,7 +184,6 @@ impl Service {
             let text = &gettext("Failed to retrieve the script %s. Do you want to try again?")
                 .replace("%s", script.name());
             let question = QuestionSpec::new(text, "write_script_error")
-                .with_deprecated_class("write_script_failed")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),
@@ -209,7 +208,6 @@ impl Service {
             let text = &gettext("Failed to write the file %s. Do you want to try again?")
                 .replace("%s", &file.destination);
             let question = QuestionSpec::new(text, "write_file_error")
-                .with_deprecated_class("write_file_failed")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),

--- a/rust/agama-files/src/service.rs
+++ b/rust/agama-files/src/service.rs
@@ -183,7 +183,7 @@ impl Service {
             // TRANSLATORS: %s is replaced by the script name.
             let text = &gettext("Failed to retrieve the script %s. Do you want to try again?")
                 .replace("%s", script.name());
-            let question = QuestionSpec::new(text, "write_script_failed")
+            let question = QuestionSpec::new(text, "write_script_error")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),
@@ -207,7 +207,7 @@ impl Service {
             // TRANSLATORS: %s is replaced by the script name.
             let text = &gettext("Failed to write the file %s. Do you want to try again?")
                 .replace("%s", &file.destination);
-            let question = QuestionSpec::new(text, "write_file_failed")
+            let question = QuestionSpec::new(text, "write_file_error")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),

--- a/rust/agama-files/src/service.rs
+++ b/rust/agama-files/src/service.rs
@@ -184,6 +184,7 @@ impl Service {
             let text = &gettext("Failed to retrieve the script %s. Do you want to try again?")
                 .replace("%s", script.name());
             let question = QuestionSpec::new(text, "write_script_error")
+                .with_deprecated_class("write_script_failed")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),
@@ -208,6 +209,7 @@ impl Service {
             let text = &gettext("Failed to write the file %s. Do you want to try again?")
                 .replace("%s", &file.destination);
             let question = QuestionSpec::new(text, "write_file_error")
+                .with_deprecated_class("write_file_failed")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),

--- a/rust/agama-files/src/service.rs
+++ b/rust/agama-files/src/service.rs
@@ -183,7 +183,7 @@ impl Service {
             // TRANSLATORS: %s is replaced by the script name.
             let text = &gettext("Failed to retrieve the script %s. Do you want to try again?")
                 .replace("%s", script.name());
-            let question = QuestionSpec::new(text, "write_script_error")
+            let question = QuestionSpec::new(text, "writeScriptError")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),
@@ -207,7 +207,7 @@ impl Service {
             // TRANSLATORS: %s is replaced by the script name.
             let text = &gettext("Failed to write the file %s. Do you want to try again?")
                 .replace("%s", &file.destination);
-            let question = QuestionSpec::new(text, "write_file_error")
+            let question = QuestionSpec::new(text, "writeFileError")
                 .with_yes_no_actions()
                 .with_data(&[
                     ("attempt", &attempt.to_string()),

--- a/rust/agama-l10n/src/service.rs
+++ b/rust/agama-l10n/src/service.rs
@@ -185,21 +185,21 @@ impl Service {
         let mut issues = vec![];
         if !self.model.locales_db().exists(&config.locale) {
             issues.push(Issue::new(
-                "unknown_locale",
+                "unknownLocale",
                 &format!("Locale '{}' is unknown", config.locale),
             ));
         }
 
         if !self.model.keymaps_db().exists(&config.keymap) {
             issues.push(Issue::new(
-                "unknown_keymap",
+                "unknownKeymap",
                 &format!("Keymap '{}' is unknown", config.keymap),
             ));
         }
 
         if !self.model.timezones_db().exists(&config.timezone) {
             issues.push(Issue::new(
-                "unknown_timezone",
+                "unknownTimezone",
                 &format!("Timezone '{}' is unknown", config.timezone),
             ));
         }

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -607,7 +607,7 @@ impl Service {
             self.issues
                 .cast(issue::message::Clear::new(Scope::Manager))?;
         } else {
-            let issue = Issue::new("no_product", "No product has been selected.");
+            let issue = Issue::new("noProduct", "No product has been selected.");
             self.issues
                 .cast(issue::message::Set::new(Scope::Manager, vec![issue]))?;
         }

--- a/rust/agama-security/src/lib.rs
+++ b/rust/agama-security/src/lib.rs
@@ -162,10 +162,7 @@ mod tests {
             loop {
                 // Poll for the question
                 let pending = questions.call(question::message::Get).await.unwrap();
-                if let Some(q) = pending
-                    .iter()
-                    .find(|q| q.spec.class == "self_signed_regcert")
-                {
+                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegcert") {
                     questions
                         .call(question::message::Answer {
                             id: q.id,
@@ -208,10 +205,7 @@ mod tests {
             loop {
                 // Poll for the question
                 let pending = questions.call(question::message::Get).await.unwrap();
-                if let Some(q) = pending
-                    .iter()
-                    .find(|q| q.spec.class == "self_signed_regcert")
-                {
+                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegcert") {
                     questions
                         .call(question::message::Answer {
                             id: q.id,
@@ -254,10 +248,7 @@ mod tests {
             loop {
                 // Poll for the question
                 let pending = questions.call(question::message::Get).await.unwrap();
-                if let Some(q) = pending
-                    .iter()
-                    .find(|q| q.spec.class == "self_signed_regcert")
-                {
+                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegcert") {
                     questions
                         .call(question::message::Answer {
                             id: q.id,

--- a/rust/agama-security/src/lib.rs
+++ b/rust/agama-security/src/lib.rs
@@ -162,7 +162,7 @@ mod tests {
             loop {
                 // Poll for the question
                 let pending = questions.call(question::message::Get).await.unwrap();
-                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegcert") {
+                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegCert") {
                     questions
                         .call(question::message::Answer {
                             id: q.id,
@@ -205,7 +205,7 @@ mod tests {
             loop {
                 // Poll for the question
                 let pending = questions.call(question::message::Get).await.unwrap();
-                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegcert") {
+                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegCert") {
                     questions
                         .call(question::message::Answer {
                             id: q.id,
@@ -248,7 +248,7 @@ mod tests {
             loop {
                 // Poll for the question
                 let pending = questions.call(question::message::Get).await.unwrap();
-                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegcert") {
+                if let Some(q) = pending.iter().find(|q| q.spec.class == "selfSignedRegCert") {
                     questions
                         .call(question::message::Answer {
                             id: q.id,

--- a/rust/agama-security/src/lib.rs
+++ b/rust/agama-security/src/lib.rs
@@ -164,7 +164,7 @@ mod tests {
                 let pending = questions.call(question::message::Get).await.unwrap();
                 if let Some(q) = pending
                     .iter()
-                    .find(|q| q.spec.class == "registration.certificate")
+                    .find(|q| q.spec.class == "self_signed_regcert")
                 {
                     questions
                         .call(question::message::Answer {
@@ -210,7 +210,7 @@ mod tests {
                 let pending = questions.call(question::message::Get).await.unwrap();
                 if let Some(q) = pending
                     .iter()
-                    .find(|q| q.spec.class == "registration.certificate")
+                    .find(|q| q.spec.class == "self_signed_regcert")
                 {
                     questions
                         .call(question::message::Answer {
@@ -256,7 +256,7 @@ mod tests {
                 let pending = questions.call(question::message::Get).await.unwrap();
                 if let Some(q) = pending
                     .iter()
-                    .find(|q| q.spec.class == "registration.certificate")
+                    .find(|q| q.spec.class == "self_signed_regcert")
                 {
                     questions
                         .call(question::message::Answer {

--- a/rust/agama-security/src/service.rs
+++ b/rust/agama-security/src/service.rs
@@ -226,7 +226,7 @@ impl Service {
         let labels = [gettext("Trust"), gettext("Reject")];
         let msg = gettext("Trying to import a self-signed certificate. Do you want to trust it and register the product?");
 
-        let question = QuestionSpec::new(&msg, "registration.certificate")
+        let question = QuestionSpec::new(&msg, "self_signed_regcert")
             .with_owned_data(certificate.to_data())
             .with_actions(&[
                 ("Trust", labels[0].as_str()),

--- a/rust/agama-security/src/service.rs
+++ b/rust/agama-security/src/service.rs
@@ -227,7 +227,6 @@ impl Service {
         let msg = gettext("Trying to import a self-signed certificate. Do you want to trust it and register the product?");
 
         let question = QuestionSpec::new(&msg, "self_signed_regcert")
-            .with_deprecated_class("registration.certificate")
             .with_owned_data(certificate.to_data())
             .with_actions(&[
                 ("Trust", labels[0].as_str()),

--- a/rust/agama-security/src/service.rs
+++ b/rust/agama-security/src/service.rs
@@ -227,6 +227,7 @@ impl Service {
         let msg = gettext("Trying to import a self-signed certificate. Do you want to trust it and register the product?");
 
         let question = QuestionSpec::new(&msg, "self_signed_regcert")
+            .with_deprecated_class("registration.certificate")
             .with_owned_data(certificate.to_data())
             .with_actions(&[
                 ("Trust", labels[0].as_str()),

--- a/rust/agama-security/src/service.rs
+++ b/rust/agama-security/src/service.rs
@@ -226,7 +226,7 @@ impl Service {
         let labels = [gettext("Trust"), gettext("Reject")];
         let msg = gettext("Trying to import a self-signed certificate. Do you want to trust it and register the product?");
 
-        let question = QuestionSpec::new(&msg, "selfSignedRegcert")
+        let question = QuestionSpec::new(&msg, "selfSignedRegCert")
             .with_owned_data(certificate.to_data())
             .with_actions(&[
                 ("Trust", labels[0].as_str()),

--- a/rust/agama-security/src/service.rs
+++ b/rust/agama-security/src/service.rs
@@ -226,7 +226,7 @@ impl Service {
         let labels = [gettext("Trust"), gettext("Reject")];
         let msg = gettext("Trying to import a self-signed certificate. Do you want to trust it and register the product?");
 
-        let question = QuestionSpec::new(&msg, "self_signed_regcert")
+        let question = QuestionSpec::new(&msg, "selfSignedRegcert")
             .with_owned_data(certificate.to_data())
             .with_actions(&[
                 ("Trust", labels[0].as_str()),

--- a/rust/agama-software/examples/write_bench.rs
+++ b/rust/agama-software/examples/write_bench.rs
@@ -91,7 +91,7 @@ async fn main() {
         value: None,
     };
     let rule = AnswerRule {
-        class: Some("import_gpg".to_string()),
+        class: Some("importGpg".to_string()),
         text: None,
         data: None,
         answer,

--- a/rust/agama-software/examples/write_bench.rs
+++ b/rust/agama-software/examples/write_bench.rs
@@ -91,7 +91,7 @@ async fn main() {
         value: None,
     };
     let rule = AnswerRule {
-        class: Some("software.import_gpg".to_string()),
+        class: Some("import_gpg".to_string()),
         text: None,
         data: None,
         answer,

--- a/rust/agama-software/src/callbacks/commit_download.rs
+++ b/rust/agama-software/src/callbacks/commit_download.rs
@@ -41,7 +41,7 @@ impl Callback for CommitDownload {
         description: String,
     ) -> zypp_agama::callbacks::ProblemResponse {
         let error_str = error.to_string();
-        let question = QuestionSpec::new(description.as_str(), "package_provide_error")
+        let question = QuestionSpec::new(description.as_str(), "packageProvideError")
             // TODO: make it generic for any problemResponse questions
             // TODO: we need support for abort and make it default action
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])

--- a/rust/agama-software/src/callbacks/commit_download.rs
+++ b/rust/agama-software/src/callbacks/commit_download.rs
@@ -43,6 +43,7 @@ impl Callback for CommitDownload {
         let error_str = error.to_string();
         let question =
             QuestionSpec::new(description.as_str(), "package_provide_error")
+                .with_deprecated_class("software.package_error.provide_error")
                 // TODO: make it generic for any problemResponse questions
                 // TODO: we need support for abort and make it default action
                 .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])

--- a/rust/agama-software/src/callbacks/commit_download.rs
+++ b/rust/agama-software/src/callbacks/commit_download.rs
@@ -42,7 +42,7 @@ impl Callback for CommitDownload {
     ) -> zypp_agama::callbacks::ProblemResponse {
         let error_str = error.to_string();
         let question =
-            QuestionSpec::new(description.as_str(), "software.package_error.provide_error")
+            QuestionSpec::new(description.as_str(), "package_provide_error")
                 // TODO: make it generic for any problemResponse questions
                 // TODO: we need support for abort and make it default action
                 .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])

--- a/rust/agama-software/src/callbacks/commit_download.rs
+++ b/rust/agama-software/src/callbacks/commit_download.rs
@@ -41,16 +41,14 @@ impl Callback for CommitDownload {
         description: String,
     ) -> zypp_agama::callbacks::ProblemResponse {
         let error_str = error.to_string();
-        let question =
-            QuestionSpec::new(description.as_str(), "package_provide_error")
-                .with_deprecated_class("software.package_error.provide_error")
-                // TODO: make it generic for any problemResponse questions
-                // TODO: we need support for abort and make it default action
-                .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])
-                .with_data(&[
-                    ("package", name.as_str()),
-                    ("error_code", error_str.as_str()),
-                ]);
+        let question = QuestionSpec::new(description.as_str(), "package_provide_error")
+            // TODO: make it generic for any problemResponse questions
+            // TODO: we need support for abort and make it default action
+            .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])
+            .with_data(&[
+                ("package", name.as_str()),
+                ("error_code", error_str.as_str()),
+            ]);
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);

--- a/rust/agama-software/src/callbacks/install.rs
+++ b/rust/agama-software/src/callbacks/install.rs
@@ -51,7 +51,7 @@ impl install::Callback for Install {
             description
         );
 
-        let question = QuestionSpec::new(&description, "software.package_error.install_error")
+        let question = QuestionSpec::new(&description, "package_install_error")
             // TODO: add abort when it is properly handled in UI/backend
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])
             .with_data(&[("package", package_name.as_str())]);
@@ -77,7 +77,7 @@ impl install::Callback for Install {
 
         let message = gettext("There was a problem running a package script.");
         let full_message = message + "\n\n" + &description;
-        let question = QuestionSpec::new(&full_message, "software.script_problem")
+        let question = QuestionSpec::new(&full_message, "package_script_problem")
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Continue")])
             .with_data(&[("details", &description)]);
 

--- a/rust/agama-software/src/callbacks/install.rs
+++ b/rust/agama-software/src/callbacks/install.rs
@@ -52,6 +52,7 @@ impl install::Callback for Install {
         );
 
         let question = QuestionSpec::new(&description, "package_install_error")
+            .with_deprecated_class("software.package_error.install_error")
             // TODO: add abort when it is properly handled in UI/backend
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])
             .with_data(&[("package", package_name.as_str())]);
@@ -78,6 +79,7 @@ impl install::Callback for Install {
         let message = gettext("There was a problem running a package script.");
         let full_message = message + "\n\n" + &description;
         let question = QuestionSpec::new(&full_message, "package_script_problem")
+            .with_deprecated_class("software.script_problem")
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Continue")])
             .with_data(&[("details", &description)]);
 

--- a/rust/agama-software/src/callbacks/install.rs
+++ b/rust/agama-software/src/callbacks/install.rs
@@ -52,7 +52,6 @@ impl install::Callback for Install {
         );
 
         let question = QuestionSpec::new(&description, "package_install_error")
-            .with_deprecated_class("software.package_error.install_error")
             // TODO: add abort when it is properly handled in UI/backend
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])
             .with_data(&[("package", package_name.as_str())]);
@@ -79,7 +78,6 @@ impl install::Callback for Install {
         let message = gettext("There was a problem running a package script.");
         let full_message = message + "\n\n" + &description;
         let question = QuestionSpec::new(&full_message, "package_script_problem")
-            .with_deprecated_class("software.script_problem")
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Continue")])
             .with_data(&[("details", &description)]);
 

--- a/rust/agama-software/src/callbacks/install.rs
+++ b/rust/agama-software/src/callbacks/install.rs
@@ -51,7 +51,7 @@ impl install::Callback for Install {
             description
         );
 
-        let question = QuestionSpec::new(&description, "package_install_error")
+        let question = QuestionSpec::new(&description, "packageInstallError")
             // TODO: add abort when it is properly handled in UI/backend
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Ignore")])
             .with_data(&[("package", package_name.as_str())]);
@@ -77,7 +77,7 @@ impl install::Callback for Install {
 
         let message = gettext("There was a problem running a package script.");
         let full_message = message + "\n\n" + &description;
-        let question = QuestionSpec::new(&full_message, "package_script_problem")
+        let question = QuestionSpec::new(&full_message, "packageScriptProblem")
             .with_action_ids(&[gettext_noop("Retry"), gettext_noop("Continue")])
             .with_data(&[("details", &description)]);
 

--- a/rust/agama-software/src/callbacks/security.rs
+++ b/rust/agama-software/src/callbacks/security.rs
@@ -56,7 +56,7 @@ impl security::Callback for Security {
                 and integrity of the file cannot be verified. Use it anyway?"
             )
         };
-        let question = QuestionSpec::new(&text, "software.unsigned_file")
+        let question = QuestionSpec::new(&text, "unsigned_file")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -107,7 +107,7 @@ impl security::Callback for Security {
             &key_name,
             &human_fingerprint
         );
-        let question = QuestionSpec::new(&text, "software.import_gpg")
+        let question = QuestionSpec::new(&text, "import_gpg")
             .with_action_ids(&[gettext_noop("Trust"), gettext_noop("Skip")])
             .with_data(&[
                 ("id", key_id.as_str()),
@@ -148,7 +148,7 @@ impl security::Callback for Security {
                 the following unknown GnuPG key: {key_id}. Use it anyway?"
             )
         };
-        let question = QuestionSpec::new(&text, "software.unknown_gpg")
+        let question = QuestionSpec::new(&text, "unknown_gpg")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str()), ("id", key_id.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -190,7 +190,7 @@ impl security::Callback for Security {
                 Use it anyway?"
             )
         };
-        let question = QuestionSpec::new(&text, "software.verification_failed")
+        let question = QuestionSpec::new(&text, "gpg_verification_error")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -210,7 +210,7 @@ impl security::Callback for Security {
               although the file is part of the signed repository, the list of checksums \
               does not mention this file. Use it anyway?"
         );
-        let question = QuestionSpec::new(&text, "software.digest.no_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "no_digest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -232,7 +232,7 @@ impl security::Callback for Security {
               Use it anyway?"
         );
         let question =
-            QuestionSpec::new(&text, "software.digest.unknown_digest").with_yes_no_actions();
+            QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -256,7 +256,7 @@ impl security::Callback for Security {
         );
 
         let question =
-            QuestionSpec::new(&text, "software.digest.unknown_digest").with_yes_no_actions();
+            QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);

--- a/rust/agama-software/src/callbacks/security.rs
+++ b/rust/agama-software/src/callbacks/security.rs
@@ -56,7 +56,7 @@ impl security::Callback for Security {
                 and integrity of the file cannot be verified. Use it anyway?"
             )
         };
-        let question = QuestionSpec::new(&text, "unsigned_file")
+        let question = QuestionSpec::new(&text, "unsignedFile")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -107,7 +107,7 @@ impl security::Callback for Security {
             &key_name,
             &human_fingerprint
         );
-        let question = QuestionSpec::new(&text, "import_gpg")
+        let question = QuestionSpec::new(&text, "importGpg")
             .with_action_ids(&[gettext_noop("Trust"), gettext_noop("Skip")])
             .with_data(&[
                 ("id", key_id.as_str()),
@@ -148,7 +148,7 @@ impl security::Callback for Security {
                 the following unknown GnuPG key: {key_id}. Use it anyway?"
             )
         };
-        let question = QuestionSpec::new(&text, "unknown_gpg")
+        let question = QuestionSpec::new(&text, "unknownGpg")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str()), ("id", key_id.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -190,7 +190,7 @@ impl security::Callback for Security {
                 Use it anyway?"
             )
         };
-        let question = QuestionSpec::new(&text, "gpg_verification_error")
+        let question = QuestionSpec::new(&text, "gpgVerificationError")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -210,7 +210,7 @@ impl security::Callback for Security {
               although the file is part of the signed repository, the list of checksums \
               does not mention this file. Use it anyway?"
         );
-        let question = QuestionSpec::new(&text, "no_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "noDigest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -231,7 +231,7 @@ impl security::Callback for Security {
               unknown. This means that the origin and integrity of the file cannot be verified. \
               Use it anyway?"
         );
-        let question = QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "unknownDigest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -254,7 +254,7 @@ impl security::Callback for Security {
               creater signed it. Use it anyway?"
         );
 
-        let question = QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "unknownDigest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);

--- a/rust/agama-software/src/callbacks/security.rs
+++ b/rust/agama-software/src/callbacks/security.rs
@@ -57,6 +57,7 @@ impl security::Callback for Security {
             )
         };
         let question = QuestionSpec::new(&text, "unsigned_file")
+            .with_deprecated_class("software.unsigned_file")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -108,6 +109,7 @@ impl security::Callback for Security {
             &human_fingerprint
         );
         let question = QuestionSpec::new(&text, "import_gpg")
+            .with_deprecated_class("software.import_gpg")
             .with_action_ids(&[gettext_noop("Trust"), gettext_noop("Skip")])
             .with_data(&[
                 ("id", key_id.as_str()),
@@ -149,6 +151,7 @@ impl security::Callback for Security {
             )
         };
         let question = QuestionSpec::new(&text, "unknown_gpg")
+            .with_deprecated_class("software.unknown_gpg")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str()), ("id", key_id.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -191,6 +194,7 @@ impl security::Callback for Security {
             )
         };
         let question = QuestionSpec::new(&text, "gpg_verification_error")
+            .with_deprecated_class("software.verification_failed")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -210,7 +214,9 @@ impl security::Callback for Security {
               although the file is part of the signed repository, the list of checksums \
               does not mention this file. Use it anyway?"
         );
-        let question = QuestionSpec::new(&text, "no_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "no_digest")
+            .with_deprecated_class("software.digest.no_digest")
+            .with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -231,8 +237,9 @@ impl security::Callback for Security {
               unknown. This means that the origin and integrity of the file cannot be verified. \
               Use it anyway?"
         );
-        let question =
-            QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "unknown_digest")
+            .with_deprecated_class("software.digest.unknown_digest")
+            .with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -255,8 +262,9 @@ impl security::Callback for Security {
               creater signed it. Use it anyway?"
         );
 
-        let question =
-            QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "unknown_digest")
+            .with_deprecated_class("software.digest.unknown_digest")
+            .with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);

--- a/rust/agama-software/src/callbacks/security.rs
+++ b/rust/agama-software/src/callbacks/security.rs
@@ -57,7 +57,6 @@ impl security::Callback for Security {
             )
         };
         let question = QuestionSpec::new(&text, "unsigned_file")
-            .with_deprecated_class("software.unsigned_file")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -109,7 +108,6 @@ impl security::Callback for Security {
             &human_fingerprint
         );
         let question = QuestionSpec::new(&text, "import_gpg")
-            .with_deprecated_class("software.import_gpg")
             .with_action_ids(&[gettext_noop("Trust"), gettext_noop("Skip")])
             .with_data(&[
                 ("id", key_id.as_str()),
@@ -151,7 +149,6 @@ impl security::Callback for Security {
             )
         };
         let question = QuestionSpec::new(&text, "unknown_gpg")
-            .with_deprecated_class("software.unknown_gpg")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str()), ("id", key_id.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -194,7 +191,6 @@ impl security::Callback for Security {
             )
         };
         let question = QuestionSpec::new(&text, "gpg_verification_error")
-            .with_deprecated_class("software.verification_failed")
             .with_yes_no_actions()
             .with_data(&[("filename", file.as_str())]);
         let result = ask_software_question(&self.questions, question);
@@ -214,9 +210,7 @@ impl security::Callback for Security {
               although the file is part of the signed repository, the list of checksums \
               does not mention this file. Use it anyway?"
         );
-        let question = QuestionSpec::new(&text, "no_digest")
-            .with_deprecated_class("software.digest.no_digest")
-            .with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "no_digest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -237,9 +231,7 @@ impl security::Callback for Security {
               unknown. This means that the origin and integrity of the file cannot be verified. \
               Use it anyway?"
         );
-        let question = QuestionSpec::new(&text, "unknown_digest")
-            .with_deprecated_class("software.digest.unknown_digest")
-            .with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);
@@ -262,9 +254,7 @@ impl security::Callback for Security {
               creater signed it. Use it anyway?"
         );
 
-        let question = QuestionSpec::new(&text, "unknown_digest")
-            .with_deprecated_class("software.digest.unknown_digest")
-            .with_yes_no_actions();
+        let question = QuestionSpec::new(&text, "unknown_digest").with_yes_no_actions();
         let result = ask_software_question(&self.questions, question);
         let Ok(answer) = result else {
             tracing::warn!("Failed to ask question {:?}", result);

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -292,7 +292,7 @@ impl Service {
                 .await
                 .unwrap_or_else(|e| {
                     let new_issue = Issue::new(
-                        "software_proposal_failed",
+                        "softwareProposalFailed",
                         &gettext("Due to an internal error, it was not possible to create a software proposal."),
                     )
                     .with_details(&e.to_string());

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -312,7 +312,9 @@ impl ZyppServer {
             let text =
                 gettext("Packages download and installation failed. Would you like to retry?");
             let question_spec =
-                QuestionSpec::new(&text, "retry_installation").with_yes_no_actions();
+                QuestionSpec::new(&text, "retry_installation")
+                    .with_deprecated_class("software.installation_retry")
+                    .with_yes_no_actions();
             // TODO: it would be nice if we can in backend split between auto selected option and focused option
             // TODO: if needed we would need to extend C API to get more details about failure
             let answer = ask_software_question(&question, question_spec);

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -311,8 +311,7 @@ impl ZyppServer {
 
             let text =
                 gettext("Packages download and installation failed. Would you like to retry?");
-            let question_spec =
-                QuestionSpec::new(&text, "retry_installation").with_yes_no_actions();
+            let question_spec = QuestionSpec::new(&text, "retryInstallation").with_yes_no_actions();
             // TODO: it would be nice if we can in backend split between auto selected option and focused option
             // TODO: if needed we would need to extend C API to get more details about failure
             let answer = ask_software_question(&question, question_spec);

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -428,9 +428,9 @@ impl ZyppServer {
 
             if let Err(error) = result {
                 let message = format!("Could not add the repository {}", repo.alias);
-                issues.software.push(
-                    Issue::new("addRepo", &message).with_details(&error.to_string()),
-                );
+                issues
+                    .software
+                    .push(Issue::new("addRepo", &message).with_details(&error.to_string()));
             }
         }
 
@@ -445,9 +445,9 @@ impl ZyppServer {
                 let message = gettext("Could not remove the repository %s")
                     .as_str()
                     .replace("%s", &repo.alias);
-                issues.software.push(
-                    Issue::new("removeRepo", &message).with_details(&error.to_string()),
-                );
+                issues
+                    .software
+                    .push(Issue::new("removeRepo", &message).with_details(&error.to_string()));
             }
         }
 
@@ -463,9 +463,9 @@ impl ZyppServer {
 
         if let Err(error) = result {
             let message = gettext("Could not read the repositories");
-            issues.software.push(
-                Issue::new("loadSource", &message).with_details(&error.to_string()),
-            );
+            issues
+                .software
+                .push(Issue::new("loadSource", &message).with_details(&error.to_string()));
         }
 
         // repositories refresh finished
@@ -565,9 +565,7 @@ impl ZyppServer {
 
         if let Ok(false) = zypp.run_solver(self.only_required, self.save_solver_testcase) {
             let message = gettext("There are conflicts in the software selection");
-            issues
-                .software
-                .push(Issue::new("conflict", &message));
+            issues.software.push(Issue::new("conflict", &message));
         }
 
         Self::send_issues_and_finish(issues, tx, progress)
@@ -598,8 +596,7 @@ impl ZyppServer {
                     .replacen("%s", &r#type.to_string(), 1)
                     .replace("%s", name);
                 issues.push(
-                    Issue::new("selectResolvable", &message)
-                        .with_details(&error.to_string()),
+                    Issue::new("selectResolvable", &message).with_details(&error.to_string()),
                 );
             }
         }

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -312,7 +312,7 @@ impl ZyppServer {
             let text =
                 gettext("Packages download and installation failed. Would you like to retry?");
             let question_spec =
-                QuestionSpec::new(&text, "software.installation_retry").with_yes_no_actions();
+                QuestionSpec::new(&text, "retry_installation").with_yes_no_actions();
             // TODO: it would be nice if we can in backend split between auto selected option and focused option
             // TODO: if needed we would need to extend C API to get more details about failure
             let answer = ask_software_question(&question, question_spec);

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -429,7 +429,7 @@ impl ZyppServer {
             if let Err(error) = result {
                 let message = format!("Could not add the repository {}", repo.alias);
                 issues.software.push(
-                    Issue::new("software.add_repo", &message).with_details(&error.to_string()),
+                    Issue::new("addRepo", &message).with_details(&error.to_string()),
                 );
             }
         }
@@ -446,7 +446,7 @@ impl ZyppServer {
                     .as_str()
                     .replace("%s", &repo.alias);
                 issues.software.push(
-                    Issue::new("software.remove_repo", &message).with_details(&error.to_string()),
+                    Issue::new("removeRepo", &message).with_details(&error.to_string()),
                 );
             }
         }
@@ -464,7 +464,7 @@ impl ZyppServer {
         if let Err(error) = result {
             let message = gettext("Could not read the repositories");
             issues.software.push(
-                Issue::new("software.load_source", &message).with_details(&error.to_string()),
+                Issue::new("loadSource", &message).with_details(&error.to_string()),
             );
         }
 
@@ -499,10 +499,10 @@ impl ZyppServer {
 
             let issue = if state.allow_registration && !self.is_registered() {
                 let message = gettext("Failed to find the product in the repositories. You might need to register the system.");
-                Issue::new("missing_registration", &message).with_details(&error.to_string())
+                Issue::new("missingRegistration", &message).with_details(&error.to_string())
             } else {
                 let message = gettext("Failed to find the product in the repositories.");
-                Issue::new("missing_product", &message).with_details(&error.to_string())
+                Issue::new("missingProduct", &message).with_details(&error.to_string())
             };
 
             issues.software.push(issue);
@@ -567,7 +567,7 @@ impl ZyppServer {
             let message = gettext("There are conflicts in the software selection");
             issues
                 .software
-                .push(Issue::new("software.conflict", &message));
+                .push(Issue::new("conflict", &message));
         }
 
         Self::send_issues_and_finish(issues, tx, progress)
@@ -598,7 +598,7 @@ impl ZyppServer {
                     .replacen("%s", &r#type.to_string(), 1)
                     .replace("%s", name);
                 issues.push(
-                    Issue::new("software.select_resolvable", &message)
+                    Issue::new("selectResolvable", &message)
                         .with_details(&error.to_string()),
                 );
             }
@@ -1005,7 +1005,7 @@ impl ZyppServer {
             Err(error) => {
                 issues.product.push(
                     Issue::new(
-                        "system_registration_failed",
+                        "systemRegistrationFailed",
                         &gettext("Failed to register the system"),
                     )
                     .with_details(&error.to_string()),
@@ -1034,7 +1034,7 @@ impl ZyppServer {
             }
             if let Err(error) = registration.register_addon(zypp, security, addon) {
                 let message = format!("Failed to register the add-on {}", addon.id);
-                let issue_id = format!("addon_registration_failed[{}]", addon.id);
+                let issue_id = format!("addonRegistrationFailed[{}]", addon.id);
                 let issue = Issue::new(&issue_id, &message).with_details(&error.to_string());
                 issues.product.push(issue);
             }

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -312,9 +312,7 @@ impl ZyppServer {
             let text =
                 gettext("Packages download and installation failed. Would you like to retry?");
             let question_spec =
-                QuestionSpec::new(&text, "retry_installation")
-                    .with_deprecated_class("software.installation_retry")
-                    .with_yes_no_actions();
+                QuestionSpec::new(&text, "retry_installation").with_yes_no_actions();
             // TODO: it would be nice if we can in backend split between auto selected option and focused option
             // TODO: if needed we would need to extend C API to get more details about failure
             let answer = ask_software_question(&question, question_spec);

--- a/rust/agama-software/tests/zypp_server.rs
+++ b/rust/agama-software/tests/zypp_server.rs
@@ -148,7 +148,7 @@ async fn test_start_zypp_server() {
         1,
         "There are unexpected issues size {issues:#?}"
     );
-    assert_eq!(issues.software[0].class, "missing_product");
+    assert_eq!(issues.software[0].class, "missingProduct");
 
     let questions = question_handler
         .call(question::message::Get)

--- a/rust/agama-software/tests/zypp_server.rs
+++ b/rust/agama-software/tests/zypp_server.rs
@@ -97,7 +97,7 @@ async fn test_start_zypp_server() {
         value: None,
     };
     let rule = AnswerRule {
-        class: Some("import_gpg".to_string()),
+        class: Some("importGpg".to_string()),
         text: None,
         data: None,
         answer,

--- a/rust/agama-software/tests/zypp_server.rs
+++ b/rust/agama-software/tests/zypp_server.rs
@@ -97,7 +97,7 @@ async fn test_start_zypp_server() {
         value: None,
     };
     let rule = AnswerRule {
-        class: Some("software.import_gpg".to_string()),
+        class: Some("import_gpg".to_string()),
         text: None,
         data: None,
         answer,

--- a/rust/agama-users/src/service.rs
+++ b/rust/agama-users/src/service.rs
@@ -173,7 +173,7 @@ impl Service {
         let mut issues = vec![];
         if self.full_config.is_empty() {
             issues.push(Issue::new(
-                "users.no_auth",
+                "noAuth",
                 &gettext(
                     "Defining a user, setting the root password or a SSH public key is required",
                 ),
@@ -187,7 +187,7 @@ impl Service {
             .is_some_and(|u| !u.is_valid())
         {
             issues.push(Issue::new(
-                "users.invalid_user",
+                "invalidUser",
                 &gettext("First user information is incomplete"),
             ));
         }

--- a/rust/agama-utils/Cargo.toml
+++ b/rust/agama-utils/Cargo.toml
@@ -18,6 +18,7 @@ cidr = { workspace = true }
 fluent-uri = { workspace = true }
 fs-err = "3.2.0"
 gettext-rs = { workspace = true }
+heck = "0.5.0"
 libsystemd = "0.7.2"
 macaddr = { workspace = true }
 merge = { workspace = true }

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -90,7 +90,7 @@ fn resolve_class(class: &str) -> &str {
         "autoyast.popup" => "autoyastPopup",
         "autoyast.unsupported" => "autoyastUnsupported",
         "load.retry" => "loadConfigError",
-        "registration.certificate" => "selfSignedRegcert",
+        "registration.certificate" => "selfSignedRegCert",
         "scripts.retry" => "retryScript",
         "software.digest.no_digest" => "noDigest",
         "software.digest.unknown_digest" => "unknownDigest",

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -76,12 +76,11 @@ pub struct AnswerRule {
     pub answer: Answer,
 }
 
-/// Resolves a (possibly deprecated) question class into its current name.
+/// Resolves a question class into its current name.
 ///
 /// Some question classes were renamed to use a more consistent naming
 /// scheme. This maps the old names to the new ones so that existing answer
-/// rules (e.g., in an AutoYaST-like profile or an answers file) keep
-/// matching the corresponding question after the renaming.
+/// rules keep matching the corresponding question after the renaming.
 ///
 /// If a class is renamed again in the future, update the entry below to
 /// point directly to the latest name (do not chain deprecated classes).

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -171,7 +171,7 @@ impl Question {
 pub struct QuestionSpec {
     /// Question text.
     pub text: String,
-    /// Question class (e.g., "autoyast.unsupported"). It works as a hint for
+    /// Question class (e.g., "autoyast_unsupported"). It works as a hint for
     /// the UI or to match pre-defined answers. The values that are understood
     /// by Agama's UI are documented [in the Questions
     /// page](https://agama-project.github.io/docs/user/reference/profile/answers).

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -75,15 +75,49 @@ pub struct AnswerRule {
     pub answer: Answer,
 }
 
+/// Resolves a (possibly deprecated) question class into its current name.
+///
+/// Some question classes were renamed to use a more consistent naming
+/// scheme. This maps the old names to the new ones so that existing answer
+/// rules (e.g., in an AutoYaST-like profile or an answers file) keep
+/// matching the corresponding question after the renaming.
+///
+/// If a class is renamed again in the future, update the entry below to
+/// point directly to the latest name (do not chain deprecated classes).
+fn resolve_class(class: &str) -> &str {
+    match class {
+        "autoyast.password" => "autoyast_password",
+        "autoyast.popup" => "autoyast_popup",
+        "autoyast.unsupported" => "autoyast_unsupported",
+        "load.retry" => "load_config_error",
+        "registration.certificate" => "self_signed_regcert",
+        "scripts.retry" => "retry_script",
+        "software.digest.no_digest" => "no_digest",
+        "software.digest.unknown_digest" => "unknown_digest",
+        "software.import_gpg" => "import_gpg",
+        "software.installation_retry" => "retry_installation",
+        "software.package_error.install_error" => "package_install_error",
+        "software.package_error.provide_error" => "package_provide_error",
+        "software.script_problem" => "package_script_problem",
+        "software.unknown_gpg" => "unknown_gpg",
+        "software.unsigned_file" => "unsigned_file",
+        "software.verification_failed" => "gpg_verification_error",
+        "storage.activate_multipath" => "activate_multipath",
+        "storage.commit_error" => "storage_commit_error",
+        "storage.luks_activation" => "luks_activation",
+        "write_file_failed" => "write_file_error",
+        "write_script_failed" => "write_script_error",
+        other => other,
+    }
+}
+
 impl AnswerRule {
     /// Determines whether the answer responds to the given question.
     ///
     /// * `spec`: question spec to compare with.
     pub fn answers_to(&self, spec: &QuestionSpec) -> bool {
         if let Some(class) = &self.class {
-            let matches_class =
-                spec.class == *class || spec.deprecated_class.as_deref() == Some(class.as_str());
-            if !matches_class {
+            if spec.class != resolve_class(class) {
                 return false;
             }
         }
@@ -178,14 +212,6 @@ pub struct QuestionSpec {
     /// by Agama's UI are documented [in the Questions
     /// page](https://agama-project.github.io/docs/user/reference/profile/answers).
     pub class: String,
-    /// Previous class name, kept for backward compatibility.
-    ///
-    /// When a question class is renamed, the old name can be set here so
-    /// that [AnswerRule]s written against the previous name (e.g., in an
-    /// existing AutoYaST-like profile) still match the question (see
-    /// [AnswerRule::answers_to]).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deprecated_class: Option<String>,
     /// Optionally, a question might define an additional field (e.g., a
     /// password, a selector, etc.).
     #[serde(default)]
@@ -210,20 +236,11 @@ impl QuestionSpec {
         Self {
             text: text.to_string(),
             class: class.to_string(),
-            deprecated_class: None,
             field: QuestionField::None,
             actions: vec![],
             default_action: None,
             data: HashMap::new(),
         }
-    }
-
-    /// Sets the deprecated class name.
-    ///
-    /// * `class`: previous class name.
-    pub fn with_deprecated_class(mut self, class: &str) -> Self {
-        self.deprecated_class = Some(class.to_string());
-        self
     }
 
     /// Sets the question field to be a string.
@@ -530,9 +547,10 @@ mod tests {
             value: None,
         };
 
-        let q = QuestionSpec::new("Activate the LUKS device?", "luks_activation")
-            .with_deprecated_class("storage.luks_activation")
-            .with_yes_no_actions();
+        // The question is created with its current class name only, the
+        // mapping to the deprecated one is resolved internally.
+        let q =
+            QuestionSpec::new("Activate the LUKS device?", "luks_activation").with_yes_no_actions();
 
         // A rule using the old (deprecated) class still matches.
         let rule_by_deprecated_class = AnswerRule {
@@ -560,6 +578,14 @@ mod tests {
             answer: answer.clone(),
         };
         assert!(!rule_by_unrelated_class.answers_to(&q));
+    }
+
+    #[test]
+    fn test_resolve_class() {
+        assert_eq!(resolve_class("storage.luks_activation"), "luks_activation");
+        // A class that was never renamed is returned as-is.
+        assert_eq!(resolve_class("luks_activation"), "luks_activation");
+        assert_eq!(resolve_class("some_unknown_class"), "some_unknown_class");
     }
 
     #[test]

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -102,7 +102,7 @@ fn resolve_class(class: &str) -> &str {
         "software.unknown_gpg" => "unknownGpg",
         "software.unsigned_file" => "unsignedFile",
         "software.verification_failed" => "gpgVerificationError",
-        "storage.activate_multipath" => "activateMultipath",
+        "storage.activate_multipath" => "multipathActivation",
         "storage.commit_error" => "storageCommitError",
         "storage.luks_activation" => "luksActivation",
         "write_file_failed" => "writeFileError",

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -20,6 +20,7 @@
 
 use crate::gettext_noop;
 use gettextrs::gettext;
+use heck::{ToLowerCamelCase, ToSnakeCase};
 use merge::Merge;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -111,6 +112,23 @@ fn resolve_class(class: &str) -> &str {
     }
 }
 
+/// Checks whether the given key/value pair is present in the question's
+/// data, regardless of whether the key uses snake_case or camelCase.
+///
+/// Answer rules and the actual question data are not consistent about the
+/// naming convention used for the data keys (e.g., "error_code" vs.
+/// "errorCode"). To avoid relying on users guessing the right one, both
+/// forms of the given key are checked against the question's data.
+fn data_matches(data: &HashMap<String, String>, key: &str, value: &str) -> bool {
+    let camel = key.to_lower_camel_case();
+    let snake = key.to_snake_case();
+
+    [key, camel.as_str(), snake.as_str()]
+        .iter()
+        .filter_map(|k| data.get(*k))
+        .any(|v| v == value)
+}
+
 impl AnswerRule {
     /// Determines whether the answer responds to the given question.
     ///
@@ -129,13 +147,9 @@ impl AnswerRule {
         }
 
         if let Some(data) = &self.data {
-            return data.iter().all(|(key, value)| {
-                let Some(e_val) = spec.data.get(key) else {
-                    return false;
-                };
-
-                e_val == value
-            });
+            return data
+                .iter()
+                .all(|(key, value)| data_matches(&spec.data, key, value));
         }
 
         true
@@ -586,6 +600,87 @@ mod tests {
         // A class that was never renamed is returned as-is.
         assert_eq!(resolve_class("luks_activation"), "luks_activation");
         assert_eq!(resolve_class("some_unknown_class"), "some_unknown_class");
+    }
+
+    #[test]
+    fn test_answers_to_data_snake_case_rule_matches_camel_case_data() {
+        let answer = Answer {
+            action: "Retry".to_string(),
+            value: None,
+        };
+
+        // The question data uses camelCase, as some producers do.
+        let q = QuestionSpec::new("Failed to install the package", "package_provide_error")
+            .with_data(&[("errorCode", "INVALID")]);
+
+        let rule = AnswerRule {
+            text: Default::default(),
+            class: Default::default(),
+            data: Some(HashMap::from([(
+                "error_code".to_string(),
+                "INVALID".to_string(),
+            )])),
+            answer: answer.clone(),
+        };
+        assert!(rule.answers_to(&q));
+    }
+
+    #[test]
+    fn test_answers_to_data_camel_case_rule_matches_snake_case_data() {
+        let answer = Answer {
+            action: "Manual".to_string(),
+            value: None,
+        };
+
+        // The question data uses snake_case, as some producers do.
+        let q = QuestionSpec::new("Failed to load the configuration", "load_config_error")
+            .with_data(&[("original_value", "http://example.com/profile.json")]);
+
+        let rule = AnswerRule {
+            text: Default::default(),
+            class: Default::default(),
+            data: Some(HashMap::from([(
+                "originalValue".to_string(),
+                "http://example.com/profile.json".to_string(),
+            )])),
+            answer: answer.clone(),
+        };
+        assert!(rule.answers_to(&q));
+    }
+
+    #[test]
+    fn test_answers_to_data_not_matching() {
+        let answer = Answer {
+            action: "Retry".to_string(),
+            value: None,
+        };
+
+        let q = QuestionSpec::new("Failed to install the package", "package_provide_error")
+            .with_data(&[("errorCode", "INVALID")]);
+
+        // Same key (in both forms), but a different value.
+        let rule_with_wrong_value = AnswerRule {
+            text: Default::default(),
+            class: Default::default(),
+            data: Some(HashMap::from([(
+                "error_code".to_string(),
+                "OTHER".to_string(),
+            )])),
+            answer: answer.clone(),
+        };
+        assert!(!rule_with_wrong_value.answers_to(&q));
+
+        // A key that is not present under any naming variant.
+        let rule_with_unknown_key = AnswerRule {
+            text: Default::default(),
+            class: Default::default(),
+            data: Some(HashMap::from([(
+                "unknown_key".to_string(),
+                "INVALID".to_string(),
+            )])),
+            answer: answer.clone(),
+        };
+        assert!(!rule_with_unknown_key.answers_to(&q));
     }
 
     #[test]

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -81,7 +81,9 @@ impl AnswerRule {
     /// * `spec`: question spec to compare with.
     pub fn answers_to(&self, spec: &QuestionSpec) -> bool {
         if let Some(class) = &self.class {
-            if spec.class != *class {
+            let matches_class =
+                spec.class == *class || spec.deprecated_class.as_deref() == Some(class.as_str());
+            if !matches_class {
                 return false;
             }
         }
@@ -176,6 +178,14 @@ pub struct QuestionSpec {
     /// by Agama's UI are documented [in the Questions
     /// page](https://agama-project.github.io/docs/user/reference/profile/answers).
     pub class: String,
+    /// Previous class name, kept for backward compatibility.
+    ///
+    /// When a question class is renamed, the old name can be set here so
+    /// that [AnswerRule]s written against the previous name (e.g., in an
+    /// existing AutoYaST-like profile) still match the question (see
+    /// [AnswerRule::answers_to]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated_class: Option<String>,
     /// Optionally, a question might define an additional field (e.g., a
     /// password, a selector, etc.).
     #[serde(default)]
@@ -200,11 +210,20 @@ impl QuestionSpec {
         Self {
             text: text.to_string(),
             class: class.to_string(),
+            deprecated_class: None,
             field: QuestionField::None,
             actions: vec![],
             default_action: None,
             data: HashMap::new(),
         }
+    }
+
+    /// Sets the deprecated class name.
+    ///
+    /// * `class`: previous class name.
+    pub fn with_deprecated_class(mut self, class: &str) -> Self {
+        self.deprecated_class = Some(class.to_string());
+        self
     }
 
     /// Sets the question field to be a string.
@@ -502,6 +521,45 @@ mod tests {
             answer: answer.clone(),
         };
         assert!(!not_matching_rule.answers_to(&q));
+    }
+
+    #[test]
+    fn test_answers_to_deprecated_class() {
+        let answer = Answer {
+            action: "Yes".to_string(),
+            value: None,
+        };
+
+        let q = QuestionSpec::new("Activate the LUKS device?", "luks_activation")
+            .with_deprecated_class("storage.luks_activation")
+            .with_yes_no_actions();
+
+        // A rule using the old (deprecated) class still matches.
+        let rule_by_deprecated_class = AnswerRule {
+            text: Default::default(),
+            class: Some("storage.luks_activation".to_string()),
+            data: Default::default(),
+            answer: answer.clone(),
+        };
+        assert!(rule_by_deprecated_class.answers_to(&q));
+
+        // A rule using the current class still matches.
+        let rule_by_current_class = AnswerRule {
+            text: Default::default(),
+            class: Some("luks_activation".to_string()),
+            data: Default::default(),
+            answer: answer.clone(),
+        };
+        assert!(rule_by_current_class.answers_to(&q));
+
+        // A rule using an unrelated class does not match.
+        let rule_by_unrelated_class = AnswerRule {
+            text: Default::default(),
+            class: Some("storage.commit_error".to_string()),
+            data: Default::default(),
+            answer: answer.clone(),
+        };
+        assert!(!rule_by_unrelated_class.answers_to(&q));
     }
 
     #[test]

--- a/rust/agama-utils/src/api/question.rs
+++ b/rust/agama-utils/src/api/question.rs
@@ -86,27 +86,27 @@ pub struct AnswerRule {
 /// point directly to the latest name (do not chain deprecated classes).
 fn resolve_class(class: &str) -> &str {
     match class {
-        "autoyast.password" => "autoyast_password",
-        "autoyast.popup" => "autoyast_popup",
-        "autoyast.unsupported" => "autoyast_unsupported",
-        "load.retry" => "load_config_error",
-        "registration.certificate" => "self_signed_regcert",
-        "scripts.retry" => "retry_script",
-        "software.digest.no_digest" => "no_digest",
-        "software.digest.unknown_digest" => "unknown_digest",
-        "software.import_gpg" => "import_gpg",
-        "software.installation_retry" => "retry_installation",
-        "software.package_error.install_error" => "package_install_error",
-        "software.package_error.provide_error" => "package_provide_error",
-        "software.script_problem" => "package_script_problem",
-        "software.unknown_gpg" => "unknown_gpg",
-        "software.unsigned_file" => "unsigned_file",
-        "software.verification_failed" => "gpg_verification_error",
-        "storage.activate_multipath" => "activate_multipath",
-        "storage.commit_error" => "storage_commit_error",
-        "storage.luks_activation" => "luks_activation",
-        "write_file_failed" => "write_file_error",
-        "write_script_failed" => "write_script_error",
+        "autoyast.password" => "autoyastPassword",
+        "autoyast.popup" => "autoyastPopup",
+        "autoyast.unsupported" => "autoyastUnsupported",
+        "load.retry" => "loadConfigError",
+        "registration.certificate" => "selfSignedRegcert",
+        "scripts.retry" => "retryScript",
+        "software.digest.no_digest" => "noDigest",
+        "software.digest.unknown_digest" => "unknownDigest",
+        "software.import_gpg" => "importGpg",
+        "software.installation_retry" => "retryInstallation",
+        "software.package_error.install_error" => "packageInstallError",
+        "software.package_error.provide_error" => "packageProvideError",
+        "software.script_problem" => "packageScriptProblem",
+        "software.unknown_gpg" => "unknownGpg",
+        "software.unsigned_file" => "unsignedFile",
+        "software.verification_failed" => "gpgVerificationError",
+        "storage.activate_multipath" => "activateMultipath",
+        "storage.commit_error" => "storageCommitError",
+        "storage.luks_activation" => "luksActivation",
+        "write_file_failed" => "writeFileError",
+        "write_script_failed" => "writeScriptError",
         other => other,
     }
 }
@@ -220,7 +220,7 @@ impl Question {
 pub struct QuestionSpec {
     /// Question text.
     pub text: String,
-    /// Question class (e.g., "autoyast_unsupported"). It works as a hint for
+    /// Question class (e.g., "autoyastUnsupported"). It works as a hint for
     /// the UI or to match pre-defined answers. The values that are understood
     /// by Agama's UI are documented [in the Questions
     /// page](https://agama-project.github.io/docs/user/reference/profile/answers).
@@ -563,7 +563,7 @@ mod tests {
         // The question is created with its current class name only, the
         // mapping to the deprecated one is resolved internally.
         let q =
-            QuestionSpec::new("Activate the LUKS device?", "luks_activation").with_yes_no_actions();
+            QuestionSpec::new("Activate the LUKS device?", "luksActivation").with_yes_no_actions();
 
         // A rule using the old (deprecated) class still matches.
         let rule_by_deprecated_class = AnswerRule {
@@ -577,7 +577,7 @@ mod tests {
         // A rule using the current class still matches.
         let rule_by_current_class = AnswerRule {
             text: Default::default(),
-            class: Some("luks_activation".to_string()),
+            class: Some("luksActivation".to_string()),
             data: Default::default(),
             answer: answer.clone(),
         };
@@ -595,9 +595,9 @@ mod tests {
 
     #[test]
     fn test_resolve_class() {
-        assert_eq!(resolve_class("storage.luks_activation"), "luks_activation");
+        assert_eq!(resolve_class("storage.luks_activation"), "luksActivation");
         // A class that was never renamed is returned as-is.
-        assert_eq!(resolve_class("luks_activation"), "luks_activation");
+        assert_eq!(resolve_class("luksActivation"), "luksActivation");
         assert_eq!(resolve_class("some_unknown_class"), "some_unknown_class");
     }
 
@@ -609,7 +609,7 @@ mod tests {
         };
 
         // The question data uses camelCase, as some producers do.
-        let q = QuestionSpec::new("Failed to install the package", "package_provide_error")
+        let q = QuestionSpec::new("Failed to install the package", "packageProvideError")
             .with_data(&[("errorCode", "INVALID")]);
 
         let rule = AnswerRule {
@@ -632,7 +632,7 @@ mod tests {
         };
 
         // The question data uses snake_case, as some producers do.
-        let q = QuestionSpec::new("Failed to load the configuration", "load_config_error")
+        let q = QuestionSpec::new("Failed to load the configuration", "loadConfigError")
             .with_data(&[("original_value", "http://example.com/profile.json")]);
 
         let rule = AnswerRule {
@@ -654,7 +654,7 @@ mod tests {
             value: None,
         };
 
-        let q = QuestionSpec::new("Failed to install the package", "package_provide_error")
+        let q = QuestionSpec::new("Failed to install the package", "packageProvideError")
             .with_data(&[("errorCode", "INVALID")]);
 
         // Same key (in both forms), but a different value.

--- a/rust/agama-utils/src/issue.rs
+++ b/rust/agama-utils/src/issue.rs
@@ -52,7 +52,7 @@ mod tests {
     fn build_issue() -> Issue {
         Issue {
             description: "Product not selected".to_string(),
-            class: "missing_product".to_string(),
+            class: "missingProduct".to_string(),
             details: Some("A product is required.".to_string()),
         }
     }

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -4,7 +4,7 @@ Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 - Rename the question classes to use a consistent naming scheme
   and make the answer matching backward compatible with the
   previous class names and tolerant to the data keys naming
-  convention (gh#agama-project/agama#3841).
+  convention (bsc#1277393).
 
 -------------------------------------------------------------------
 Wed Aug 26 12:06:59 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,10 +1,10 @@
 -------------------------------------------------------------------
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Rename the question classes to use a consistent naming scheme
-  and make the answer matching backward compatible with the
-  previous class names and tolerant to the data keys naming
-  convention (bsc#1277393).
+- Rename question and issues classes to use a consistent naming
+  scheme. Make the answer matching backward compatible with the
+  previous class names and support using camelCase and snake_case
+  in the questions "data" object (bsc#1277393).
 
 -------------------------------------------------------------------
 Wed Aug 26 12:06:59 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rename the question classes to use a consistent naming scheme
+  and make the answer matching backward compatible with the
+  previous class names and tolerant to the data keys naming
+  convention (gh#agama-project/agama#3841).
+
+-------------------------------------------------------------------
 Wed Aug 26 12:06:59 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not cancel remaining tasks if some part of the network

--- a/rust/share/profile.schema.json
+++ b/rust/share/profile.schema.json
@@ -1105,7 +1105,7 @@
           "title": "Question class",
           "description": "Each question has a \"class\" which works as an identifier.",
           "type": "string",
-          "examples": ["storage.activate_multipath"]
+          "examples": ["activate_multipath"]
         },
         "text": {
           "title": "Question text",

--- a/rust/share/profile.schema.json
+++ b/rust/share/profile.schema.json
@@ -1105,7 +1105,7 @@
           "title": "Question class",
           "description": "Each question has a \"class\" which works as an identifier.",
           "type": "string",
-          "examples": ["activateMultipath"]
+          "examples": ["multipathActivation"]
         },
         "text": {
           "title": "Question text",

--- a/rust/share/profile.schema.json
+++ b/rust/share/profile.schema.json
@@ -1105,7 +1105,7 @@
           "title": "Question class",
           "description": "Each question has a \"class\" which works as an identifier.",
           "type": "string",
-          "examples": ["activate_multipath"]
+          "examples": ["activateMultipath"]
         },
         "text": {
           "title": "Question text",

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -52,7 +52,7 @@ module Yast2
         questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))
 
         question = Agama::Question.new(
-          qclass:         "autoyast.popup",
+          qclass:         "autoyast_popup",
           text:           text,
           options:        generate_options(buttons),
           default_option: focus || options.first,
@@ -96,7 +96,7 @@ module UI
 
     def run
       question = Agama::QuestionWithPassword.new(
-        qclass:         "autoyast.password",
+        qclass:         "autoyast_password",
         text:           @label,
         options:        [:ok, :cancel],
         default_option: :cancel,

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -52,7 +52,7 @@ module Yast2
         questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))
 
         question = Agama::Question.new(
-          qclass:         "autoyast_popup",
+          qclass:         "autoyastPopup",
           text:           text,
           options:        generate_options(buttons),
           default_option: focus || options.first,
@@ -96,7 +96,7 @@ module UI
 
     def run
       question = Agama::QuestionWithPassword.new(
-        qclass:         "autoyast_password",
+        qclass:         "autoyastPassword",
         text:           @label,
         options:        [:ok, :cancel],
         default_option: :cancel,

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -52,11 +52,12 @@ module Yast2
         questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))
 
         question = Agama::Question.new(
-          qclass:         "autoyast_popup",
-          text:           text,
-          options:        generate_options(buttons),
-          default_option: focus || options.first,
-          data:           {}
+          qclass:           "autoyast_popup",
+          deprecated_class: "autoyast.popup",
+          text:             text,
+          options:          generate_options(buttons),
+          default_option:   focus || options.first,
+          data:             {}
         )
 
         questions_client.ask(question) do |answer|
@@ -96,11 +97,12 @@ module UI
 
     def run
       question = Agama::QuestionWithPassword.new(
-        qclass:         "autoyast_password",
-        text:           @label,
-        options:        [:ok, :cancel],
-        default_option: :cancel,
-        data:           {}
+        qclass:           "autoyast_password",
+        deprecated_class: "autoyast.password",
+        text:             @label,
+        options:          [:ok, :cancel],
+        default_option:   :cancel,
+        data:             {}
       )
 
       questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))

--- a/service/lib/agama/autoyast/report_patching.rb
+++ b/service/lib/agama/autoyast/report_patching.rb
@@ -52,12 +52,11 @@ module Yast2
         questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))
 
         question = Agama::Question.new(
-          qclass:           "autoyast_popup",
-          deprecated_class: "autoyast.popup",
-          text:             text,
-          options:          generate_options(buttons),
-          default_option:   focus || options.first,
-          data:             {}
+          qclass:         "autoyast_popup",
+          text:           text,
+          options:        generate_options(buttons),
+          default_option: focus || options.first,
+          data:           {}
         )
 
         questions_client.ask(question) do |answer|
@@ -97,12 +96,11 @@ module UI
 
     def run
       question = Agama::QuestionWithPassword.new(
-        qclass:           "autoyast_password",
-        deprecated_class: "autoyast.password",
-        text:             @label,
-        options:          [:ok, :cancel],
-        default_option:   :cancel,
-        data:             {}
+        qclass:         "autoyast_password",
+        text:           @label,
+        options:        [:ok, :cancel],
+        default_option: :cancel,
+        data:           {}
       )
 
       questions_client = Agama::HTTP::Clients::Questions.new(Logger.new($stdout))

--- a/service/lib/agama/question.rb
+++ b/service/lib/agama/question.rb
@@ -40,15 +40,6 @@ module Agama
     # @return [String]
     attr_reader :qclass
 
-    # Previous class of the question, kept for backward compatibility
-    #
-    # When a question class is renamed, the old name can be set here so that
-    # answer rules written against the previous name (e.g., in an existing
-    # AutoYaST-like profile) still match the question.
-    #
-    # @return [String, nil]
-    attr_reader :deprecated_class
-
     # Text of the question
     #
     # @return [String]
@@ -84,14 +75,13 @@ module Agama
       def from_api(hash)
         answer = Answer.from_api(hash["answer"]) if hash["answer"]
         question = new(
-          qclass:           hash["class"],
-          deprecated_class: hash["deprecatedClass"],
-          text:             hash["text"],
-          options:          hash["actions"].map { |a| a["id"].to_sym },
-          default_option:   hash["defaultAction"]&.to_sym,
-          data:             hash["data"] || {},
-          answer:           answer,
-          field:            hash["field"]
+          qclass:         hash["class"],
+          text:           hash["text"],
+          options:        hash["actions"].map { |a| a["id"].to_sym },
+          default_option: hash["defaultAction"]&.to_sym,
+          data:           hash["data"] || {},
+          answer:         answer,
+          field:          hash["field"]
         )
         question.send(:id=, hash["id"])
         question
@@ -99,11 +89,9 @@ module Agama
     end
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(qclass:, text:, options:, default_option: nil, data: {}, answer: nil, field: nil,
-      deprecated_class: nil)
+    def initialize(qclass:, text:, options:, default_option: nil, data: {}, answer: nil, field: nil)
       @id = nil
       @qclass = qclass
-      @deprecated_class = deprecated_class
       @text = text
       @options = options
       @default_option = default_option
@@ -131,7 +119,6 @@ module Agama
         "data"          => @data
       }
 
-      question["deprecatedClass"] = @deprecated_class if @deprecated_class
       question["field"] = { "type" => @field } if @field
       question
     end

--- a/service/lib/agama/question.rb
+++ b/service/lib/agama/question.rb
@@ -40,6 +40,15 @@ module Agama
     # @return [String]
     attr_reader :qclass
 
+    # Previous class of the question, kept for backward compatibility
+    #
+    # When a question class is renamed, the old name can be set here so that
+    # answer rules written against the previous name (e.g., in an existing
+    # AutoYaST-like profile) still match the question.
+    #
+    # @return [String, nil]
+    attr_reader :deprecated_class
+
     # Text of the question
     #
     # @return [String]
@@ -75,13 +84,14 @@ module Agama
       def from_api(hash)
         answer = Answer.from_api(hash["answer"]) if hash["answer"]
         question = new(
-          qclass:         hash["class"],
-          text:           hash["text"],
-          options:        hash["actions"].map { |a| a["id"].to_sym },
-          default_option: hash["defaultAction"]&.to_sym,
-          data:           hash["data"] || {},
-          answer:         answer,
-          field:          hash["field"]
+          qclass:           hash["class"],
+          deprecated_class: hash["deprecatedClass"],
+          text:             hash["text"],
+          options:          hash["actions"].map { |a| a["id"].to_sym },
+          default_option:   hash["defaultAction"]&.to_sym,
+          data:             hash["data"] || {},
+          answer:           answer,
+          field:            hash["field"]
         )
         question.send(:id=, hash["id"])
         question
@@ -89,9 +99,11 @@ module Agama
     end
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(qclass:, text:, options:, default_option: nil, data: {}, answer: nil, field: nil)
+    def initialize(qclass:, text:, options:, default_option: nil, data: {}, answer: nil, field: nil,
+      deprecated_class: nil)
       @id = nil
       @qclass = qclass
+      @deprecated_class = deprecated_class
       @text = text
       @options = options
       @default_option = default_option
@@ -119,6 +131,7 @@ module Agama
         "data"          => @data
       }
 
+      question["deprecatedClass"] = @deprecated_class if @deprecated_class
       question["field"] = { "type" => @field } if @field
       question
     end

--- a/service/lib/agama/storage/callbacks/activate_luks.rb
+++ b/service/lib/agama/storage/callbacks/activate_luks.rb
@@ -76,11 +76,12 @@ module Agama
             "attempt" => attempt.to_s
           }
           QuestionWithPassword.new(
-            qclass:         "luks_activation",
-            text:           generate_text(data),
-            options:        [:skip, :decrypt],
-            default_option: :decrypt,
-            data:           data
+            qclass:           "luks_activation",
+            deprecated_class: "storage.luks_activation",
+            text:             generate_text(data),
+            options:          [:skip, :decrypt],
+            default_option:   :decrypt,
+            data:             data
           )
         end
 

--- a/service/lib/agama/storage/callbacks/activate_luks.rb
+++ b/service/lib/agama/storage/callbacks/activate_luks.rb
@@ -76,7 +76,7 @@ module Agama
             "attempt" => attempt.to_s
           }
           QuestionWithPassword.new(
-            qclass:         "luks_activation",
+            qclass:         "luksActivation",
             text:           generate_text(data),
             options:        [:skip, :decrypt],
             default_option: :decrypt,

--- a/service/lib/agama/storage/callbacks/activate_luks.rb
+++ b/service/lib/agama/storage/callbacks/activate_luks.rb
@@ -76,12 +76,11 @@ module Agama
             "attempt" => attempt.to_s
           }
           QuestionWithPassword.new(
-            qclass:           "luks_activation",
-            deprecated_class: "storage.luks_activation",
-            text:             generate_text(data),
-            options:          [:skip, :decrypt],
-            default_option:   :decrypt,
-            data:             data
+            qclass:         "luks_activation",
+            text:           generate_text(data),
+            options:        [:skip, :decrypt],
+            default_option: :decrypt,
+            data:           data
           )
         end
 

--- a/service/lib/agama/storage/callbacks/activate_luks.rb
+++ b/service/lib/agama/storage/callbacks/activate_luks.rb
@@ -76,7 +76,7 @@ module Agama
             "attempt" => attempt.to_s
           }
           QuestionWithPassword.new(
-            qclass:         "storage.luks_activation",
+            qclass:         "luks_activation",
             text:           generate_text(data),
             options:        [:skip, :decrypt],
             default_option: :decrypt,

--- a/service/lib/agama/storage/callbacks/activate_multipath.rb
+++ b/service/lib/agama/storage/callbacks/activate_multipath.rb
@@ -67,7 +67,7 @@ module Agama
                  "Do you want to activate multipath?"
 
           Question.new(
-            qclass:         "storage.activate_multipath",
+            qclass:         "activate_multipath",
             text:           text,
             options:        [:yes, :no],
             default_option: :yes

--- a/service/lib/agama/storage/callbacks/activate_multipath.rb
+++ b/service/lib/agama/storage/callbacks/activate_multipath.rb
@@ -67,7 +67,7 @@ module Agama
                  "Do you want to activate multipath?"
 
           Question.new(
-            qclass:         "activateMultipath",
+            qclass:         "multipathActivation",
             text:           text,
             options:        [:yes, :no],
             default_option: :yes

--- a/service/lib/agama/storage/callbacks/activate_multipath.rb
+++ b/service/lib/agama/storage/callbacks/activate_multipath.rb
@@ -67,7 +67,7 @@ module Agama
                  "Do you want to activate multipath?"
 
           Question.new(
-            qclass:         "activate_multipath",
+            qclass:         "activateMultipath",
             text:           text,
             options:        [:yes, :no],
             default_option: :yes

--- a/service/lib/agama/storage/callbacks/activate_multipath.rb
+++ b/service/lib/agama/storage/callbacks/activate_multipath.rb
@@ -67,11 +67,10 @@ module Agama
                  "Do you want to activate multipath?"
 
           Question.new(
-            qclass:           "activate_multipath",
-            deprecated_class: "storage.activate_multipath",
-            text:             text,
-            options:          [:yes, :no],
-            default_option:   :yes
+            qclass:         "activate_multipath",
+            text:           text,
+            options:        [:yes, :no],
+            default_option: :yes
           )
         end
       end

--- a/service/lib/agama/storage/callbacks/activate_multipath.rb
+++ b/service/lib/agama/storage/callbacks/activate_multipath.rb
@@ -67,10 +67,11 @@ module Agama
                  "Do you want to activate multipath?"
 
           Question.new(
-            qclass:         "activate_multipath",
-            text:           text,
-            options:        [:yes, :no],
-            default_option: :yes
+            qclass:           "activate_multipath",
+            deprecated_class: "storage.activate_multipath",
+            text:             text,
+            options:          [:yes, :no],
+            default_option:   :yes
           )
         end
       end

--- a/service/lib/agama/storage/callbacks/commit_error.rb
+++ b/service/lib/agama/storage/callbacks/commit_error.rb
@@ -74,12 +74,11 @@ module Agama
                  "Do you want to continue with the rest of storage actions?"
 
           Question.new(
-            qclass:           "storage_commit_error",
-            deprecated_class: "storage.commit_error",
-            text:             text,
-            options:          [:yes, :no],
-            default_option:   :no,
-            data:             { "details" => details }
+            qclass:         "storage_commit_error",
+            text:           text,
+            options:        [:yes, :no],
+            default_option: :no,
+            data:           { "details" => details }
           )
         end
       end

--- a/service/lib/agama/storage/callbacks/commit_error.rb
+++ b/service/lib/agama/storage/callbacks/commit_error.rb
@@ -74,7 +74,7 @@ module Agama
                  "Do you want to continue with the rest of storage actions?"
 
           Question.new(
-            qclass:         "storage_commit_error",
+            qclass:         "storageCommitError",
             text:           text,
             options:        [:yes, :no],
             default_option: :no,

--- a/service/lib/agama/storage/callbacks/commit_error.rb
+++ b/service/lib/agama/storage/callbacks/commit_error.rb
@@ -74,7 +74,7 @@ module Agama
                  "Do you want to continue with the rest of storage actions?"
 
           Question.new(
-            qclass:         "storage.commit_error",
+            qclass:         "storage_commit_error",
             text:           text,
             options:        [:yes, :no],
             default_option: :no,

--- a/service/lib/agama/storage/callbacks/commit_error.rb
+++ b/service/lib/agama/storage/callbacks/commit_error.rb
@@ -74,11 +74,12 @@ module Agama
                  "Do you want to continue with the rest of storage actions?"
 
           Question.new(
-            qclass:         "storage_commit_error",
-            text:           text,
-            options:        [:yes, :no],
-            default_option: :no,
-            data:           { "details" => details }
+            qclass:           "storage_commit_error",
+            deprecated_class: "storage.commit_error",
+            text:             text,
+            options:          [:yes, :no],
+            default_option:   :no,
+            data:             { "details" => details }
           )
         end
       end

--- a/service/lib/agama/storage/issue_classes.rb
+++ b/service/lib/agama/storage/issue_classes.rb
@@ -38,7 +38,7 @@ module Agama
         MISUSED_MD_MEMBER        = :configMisusedMdMember
 
         # A device that is a PV of a reused VG is chosen to be used with other purpose
-        MISUSED_PV               = :configMisusedMdMember
+        MISUSED_PV               = :configMisusedPv
 
         # Reused and new devices are both used as target for generating PVs for the same LV
         INCOMPATIBLE_PV_TARGETS  = :configIncompatiblePvTargets

--- a/service/lib/agama/storage/zfcp/manager.rb
+++ b/service/lib/agama/storage/zfcp/manager.rb
@@ -203,7 +203,7 @@ module Agama
           @issues << Issue.new(
             # TRANSLATORS: %s is replaced by a zFCP channel (e.g., "0.0.5223").
             format(_("The zFCP controller %s cannot be activated"), channel),
-            kind: :zfcp_controller_activation
+            kind: :zfcpControllerActivation
           )
 
           false
@@ -243,7 +243,7 @@ module Agama
             # TRANSLATORS: %s is replaced by a zFCP device (e.g.,
             #   "0.0.5223 0x500507681015a2b2 0x0186000000000000").
             format(_("The zFCP device %s cannot be activated"), "#{channel} #{wwpn} #{lun}"),
-            kind: :zfcp_lun_activation
+            kind: :zfcpLunActivation
           )
 
           false
@@ -287,7 +287,7 @@ module Agama
             # TRANSLATORS: %s is replaced by a zFCP device (e.g.,
             #   "0.0.5223 0x500507681015a2b2 0x0186000000000000").
             format(_("The zFCP device %s cannot be deactivated"), "#{channel} #{wwpn} #{lun}"),
-            kind: :zfcp_lun_deactivation
+            kind: :zfcpLunDeactivation
           )
 
           false

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Rename the question classes to use a consistent naming scheme
-  (bsc#1277393).
+- Rename questions and issues classes to use a consistent naming
+  scheme (bsc#1277393).
 
 -------------------------------------------------------------------
 Mon Aug 17 09:07:56 UTC 2026 - Knut Anderssen <kanderssen@suse.com>

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rename the question classes to use a consistent naming scheme
+  (gh#agama-project/agama#3841).
+
+-------------------------------------------------------------------
 Mon Aug 17 09:07:56 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Improve the AutoYaST network conversion

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -2,7 +2,7 @@
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename the question classes to use a consistent naming scheme
-  (gh#agama-project/agama#3841).
+  (bsc#1277393).
 
 -------------------------------------------------------------------
 Mon Aug 17 09:07:56 UTC 2026 - Knut Anderssen <kanderssen@suse.com>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -2,7 +2,7 @@
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename the question classes to use a consistent naming scheme
-  (gh#agama-project/agama#3841).
+  (bsc#1277393).
 
 -------------------------------------------------------------------
 Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rename the question classes to use a consistent naming scheme
+  (gh#agama-project/agama#3841).
+
+-------------------------------------------------------------------
 Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
 - update development dependencies to:

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Rename the question classes to use a consistent naming scheme
-  (bsc#1277393).
+- Rename questions and issues classes to use a consistent naming
+  scheme (bsc#1277393).
 
 -------------------------------------------------------------------
 Wed Aug 26 11:30:21 UTC 2026 - Martin Vidner <mvidner@suse.com>

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -113,7 +113,7 @@ const ProductNotFound = () => (
 export default function OverviewPage() {
   const issues = useIssues();
   const product = useProductInfo();
-  const missingProduct = issues.some((i) => i.class === "missing_product");
+  const missingProduct = issues.some((i) => i.class === "missingProduct");
 
   return (
     <Page

--- a/web/src/components/product/ProductRegistrationPage.test.tsx
+++ b/web/src/components/product/ProductRegistrationPage.test.tsx
@@ -320,7 +320,7 @@ describe("ProductRegistrationPage", () => {
           mockIssues = [
             {
               scope: "product",
-              class: "addon_registration_failed[sle-ha]",
+              class: "addonRegistrationFailed[sle-ha]",
               description: "Failed to register the add-on sle-ha",
               details: "No subscription with registration code 'jkljkljkl' found",
             },
@@ -355,7 +355,7 @@ describe("ProductRegistrationPage", () => {
     mockIssues = [
       {
         scope: "product",
-        class: "system_registration_failed",
+        class: "systemRegistrationFailed",
         description: "Failed to register",
       },
       {
@@ -378,7 +378,7 @@ describe("ProductRegistrationPage", () => {
     mockIssues = [
       {
         scope: "product",
-        class: "system_registration_failed",
+        class: "systemRegistrationFailed",
         description: "Failed to register",
       },
     ];

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -184,7 +184,7 @@ const Extensions = () => {
   if (!extensions || extensions.length === 0) return null;
 
   const extensionComponents = extensions.map((ext) => {
-    const issue = issues.find((i) => i.class === `addon_registration_failed[${ext.id}]`);
+    const issue = issues.find((i) => i.class === `addonRegistrationFailed[${ext.id}]`);
     const config = (product?.addons || []).find((c) => c.id === ext.id);
 
     return (
@@ -216,8 +216,8 @@ const Extensions = () => {
 export default function ProductRegistrationPage() {
   const { registration } = useSystem();
   const issues = useIssues("product");
-  const registrationIssue = issues.find((i) => i.class === "system_registration_failed");
-  const nonRegistrationIssues = issues.filter((i) => i.class !== "system_registration_failed");
+  const registrationIssue = issues.find((i) => i.class === "systemRegistrationFailed");
+  const nonRegistrationIssues = issues.filter((i) => i.class !== "systemRegistrationFailed");
   // Avoid repeating the alert after registration attempt
   const showHostnameAlert = !registration && !registrationIssue;
 

--- a/web/src/components/product/registration-form/Form.test.tsx
+++ b/web/src/components/product/registration-form/Form.test.tsx
@@ -220,7 +220,7 @@ describe("ProductRegistrationForm", () => {
       mockIssues = [
         {
           scope: "software",
-          class: "system_registration_failed",
+          class: "systemRegistrationFailed",
           description: "Unauthorized code",
         },
       ];
@@ -269,7 +269,7 @@ describe("ProductRegistrationForm", () => {
       mockIssues = [
         {
           scope: "software",
-          class: "system_registration_failed",
+          class: "systemRegistrationFailed",
           description: "Unauthorized code",
         },
       ];
@@ -320,7 +320,7 @@ describe("ProductRegistrationForm", () => {
       mockIssues = [
         {
           scope: "software",
-          class: "system_registration_failed",
+          class: "systemRegistrationFailed",
           description: "Invalid registration code",
         },
       ];
@@ -343,7 +343,7 @@ describe("ProductRegistrationForm", () => {
     it("re-enables button when backend returns same registration issue object", async () => {
       const sameIssue = {
         scope: "software" as const,
-        class: "system_registration_failed",
+        class: "systemRegistrationFailed",
         description: "Unauthorized code",
       };
 

--- a/web/src/components/product/registration-form/Form.tsx
+++ b/web/src/components/product/registration-form/Form.tsx
@@ -53,7 +53,7 @@ export default function ProductRegistrationForm() {
   const config = useConfig();
   const product = useProduct();
   const issues = useIssues("product");
-  const registrationIssue = issues.find((i) => i.class === "system_registration_failed");
+  const registrationIssue = issues.find((i) => i.class === "systemRegistrationFailed");
 
   // Track system query which refetches after putConfig completes (success or failure).
   // On success: parent sees new registration data and unmounts this component.

--- a/web/src/components/questions/LuksActivationQuestion.test.tsx
+++ b/web/src/components/questions/LuksActivationQuestion.test.tsx
@@ -34,7 +34,7 @@ import { Product } from "~/model/system";
 let question: Question;
 const questionMock: Question = {
   id: 1,
-  class: "luks_activation",
+  class: "luksActivation",
   text: "A Luks device found. Do you want to open it?",
   field: { type: FieldType.String },
   actions: [

--- a/web/src/components/questions/LuksActivationQuestion.test.tsx
+++ b/web/src/components/questions/LuksActivationQuestion.test.tsx
@@ -34,7 +34,7 @@ import { Product } from "~/model/system";
 let question: Question;
 const questionMock: Question = {
   id: 1,
-  class: "storage.luks_activation",
+  class: "luks_activation",
   text: "A Luks device found. Do you want to open it?",
   field: { type: FieldType.String },
   actions: [

--- a/web/src/components/questions/PackageErrorQuestion.test.tsx
+++ b/web/src/components/questions/PackageErrorQuestion.test.tsx
@@ -29,7 +29,7 @@ import PackageErrorQuestion from "~/components/questions/PackageErrorQuestion";
 const answerFn = jest.fn();
 const question: Question = {
   id: 1,
-  class: "software.package_error.provide_error",
+  class: "package_provide_error",
   text: "Package download failed",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/PackageErrorQuestion.test.tsx
+++ b/web/src/components/questions/PackageErrorQuestion.test.tsx
@@ -29,7 +29,7 @@ import PackageErrorQuestion from "~/components/questions/PackageErrorQuestion";
 const answerFn = jest.fn();
 const question: Question = {
   id: 1,
-  class: "package_provide_error",
+  class: "packageProvideError",
   text: "Package download failed",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/PackageErrorQuestion.tsx
+++ b/web/src/components/questions/PackageErrorQuestion.tsx
@@ -47,8 +47,7 @@ export default function PackageErrorQuestion({
   };
 
   const warning =
-    question.class === "package_provide_error" &&
-    question.data.error_code === "INVALID"
+    question.class === "package_provide_error" && question.data.error_code === "INVALID"
       ? // TRANSLATORS: a special warning message for installing broken package
         _("Installing a broken package affects system stability and is a big security risk!")
       : // TRANSLATORS: a generic warning message, consequences of skipping a package installation

--- a/web/src/components/questions/PackageErrorQuestion.tsx
+++ b/web/src/components/questions/PackageErrorQuestion.tsx
@@ -47,7 +47,7 @@ export default function PackageErrorQuestion({
   };
 
   const warning =
-    question.class === "software.package_error.provide_error" &&
+    question.class === "package_provide_error" &&
     question.data.error_code === "INVALID"
       ? // TRANSLATORS: a special warning message for installing broken package
         _("Installing a broken package affects system stability and is a big security risk!")

--- a/web/src/components/questions/PackageErrorQuestion.tsx
+++ b/web/src/components/questions/PackageErrorQuestion.tsx
@@ -47,7 +47,7 @@ export default function PackageErrorQuestion({
   };
 
   const warning =
-    question.class === "package_provide_error" && question.data.error_code === "INVALID"
+    question.class === "packageProvideError" && question.data.error_code === "INVALID"
       ? // TRANSLATORS: a special warning message for installing broken package
         _("Installing a broken package affects system stability and is a big security risk!")
       : // TRANSLATORS: a generic warning message, consequences of skipping a package installation

--- a/web/src/components/questions/Questions.test.tsx
+++ b/web/src/components/questions/Questions.test.tsx
@@ -73,7 +73,7 @@ const passwordQuestion: Question = {
 
 const luksActivationQuestion: Question = {
   id: 3,
-  class: "luks_activation",
+  class: "luksActivation",
   text: "Password to decrypt the device",
   field: { type: FieldType.Password },
   actions: [
@@ -85,7 +85,7 @@ const luksActivationQuestion: Question = {
 
 const loadConfigurationQuestion: Question = {
   id: 4,
-  class: "load_config_error",
+  class: "loadConfigError",
   text: "Do you want to retry loading the configuration?",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/Questions.test.tsx
+++ b/web/src/components/questions/Questions.test.tsx
@@ -73,7 +73,7 @@ const passwordQuestion: Question = {
 
 const luksActivationQuestion: Question = {
   id: 3,
-  class: "storage.luks_activation",
+  class: "luks_activation",
   text: "Password to decrypt the device",
   field: { type: FieldType.Password },
   actions: [
@@ -85,7 +85,7 @@ const luksActivationQuestion: Question = {
 
 const loadConfigurationQuestion: Question = {
   id: 4,
-  class: "load.retry",
+  class: "load_config_error",
   text: "Do you want to retry loading the configuration?",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/Questions.tsx
+++ b/web/src/components/questions/Questions.tsx
@@ -71,7 +71,7 @@ export default function Questions(): React.ReactNode {
   }
 
   // special popup for self signed registration certificate
-  if (questionClass === "selfSignedRegcert") {
+  if (questionClass === "selfSignedRegCert") {
     QuestionComponent = RegistrationCertificateQuestion;
   }
 

--- a/web/src/components/questions/Questions.tsx
+++ b/web/src/components/questions/Questions.tsx
@@ -57,26 +57,26 @@ export default function Questions(): React.ReactNode {
 
   // show specialized popup for luks activation question
   // more can follow as it will be needed
-  if (questionClass === "storage.luks_activation") {
+  if (questionClass === "luks_activation") {
     QuestionComponent = LuksActivationQuestion;
   }
 
-  if (questionClass === "autoyast.unsupported") {
+  if (questionClass === "autoyast_unsupported") {
     QuestionComponent = UnsupportedAutoYaST;
   }
 
   // special popup for package errors (libzypp callbacks)
-  if (questionClass.startsWith("software.package_error.")) {
+  if (questionClass === "package_install_error" || questionClass === "package_provide_error") {
     QuestionComponent = PackageErrorQuestion;
   }
 
   // special popup for self signed registration certificate
-  if (questionClass === "registration.certificate") {
+  if (questionClass === "self_signed_regcert") {
     QuestionComponent = RegistrationCertificateQuestion;
   }
 
   // special popup for self signed registration certificate
-  if (questionClass === "load.retry") {
+  if (questionClass === "load_config_error") {
     QuestionComponent = LoadConfigRetryQuestion;
   }
 

--- a/web/src/components/questions/Questions.tsx
+++ b/web/src/components/questions/Questions.tsx
@@ -57,26 +57,26 @@ export default function Questions(): React.ReactNode {
 
   // show specialized popup for luks activation question
   // more can follow as it will be needed
-  if (questionClass === "luks_activation") {
+  if (questionClass === "luksActivation") {
     QuestionComponent = LuksActivationQuestion;
   }
 
-  if (questionClass === "autoyast_unsupported") {
+  if (questionClass === "autoyastUnsupported") {
     QuestionComponent = UnsupportedAutoYaST;
   }
 
   // special popup for package errors (libzypp callbacks)
-  if (questionClass === "package_install_error" || questionClass === "package_provide_error") {
+  if (questionClass === "packageInstallError" || questionClass === "packageProvideError") {
     QuestionComponent = PackageErrorQuestion;
   }
 
   // special popup for self signed registration certificate
-  if (questionClass === "self_signed_regcert") {
+  if (questionClass === "selfSignedRegcert") {
     QuestionComponent = RegistrationCertificateQuestion;
   }
 
   // special popup for self signed registration certificate
-  if (questionClass === "load_config_error") {
+  if (questionClass === "loadConfigError") {
     QuestionComponent = LoadConfigRetryQuestion;
   }
 

--- a/web/src/components/questions/RegistrationCertificateQuestion.test.tsx
+++ b/web/src/components/questions/RegistrationCertificateQuestion.test.tsx
@@ -28,7 +28,7 @@ import RegistrationCertificateQuestion from "~/components/questions/Registration
 
 const question: Question = {
   id: 1,
-  class: "registration.certificate",
+  class: "self_signed_regcert",
   text: "Trust certificate?",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/RegistrationCertificateQuestion.test.tsx
+++ b/web/src/components/questions/RegistrationCertificateQuestion.test.tsx
@@ -28,7 +28,7 @@ import RegistrationCertificateQuestion from "~/components/questions/Registration
 
 const question: Question = {
   id: 1,
-  class: "selfSignedRegcert",
+  class: "selfSignedRegCert",
   text: "Trust certificate?",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/RegistrationCertificateQuestion.test.tsx
+++ b/web/src/components/questions/RegistrationCertificateQuestion.test.tsx
@@ -28,7 +28,7 @@ import RegistrationCertificateQuestion from "~/components/questions/Registration
 
 const question: Question = {
   id: 1,
-  class: "self_signed_regcert",
+  class: "selfSignedRegcert",
   text: "Trust certificate?",
   field: { type: FieldType.None },
   actions: [

--- a/web/src/components/questions/UnsupportedAutoYaST.test.tsx
+++ b/web/src/components/questions/UnsupportedAutoYaST.test.tsx
@@ -28,7 +28,7 @@ import { plainRender } from "~/test-utils";
 
 const question: Question = {
   id: 1,
-  class: "autoyast.unsupported",
+  class: "autoyast_unsupported",
   text: "Some elements from the AutoYaST profile are not supported.",
   field: { type: FieldType.String },
   actions: [

--- a/web/src/components/questions/UnsupportedAutoYaST.test.tsx
+++ b/web/src/components/questions/UnsupportedAutoYaST.test.tsx
@@ -28,7 +28,7 @@ import { plainRender } from "~/test-utils";
 
 const question: Question = {
   id: 1,
-  class: "autoyast_unsupported",
+  class: "autoyastUnsupported",
   text: "Some elements from the AutoYaST profile are not supported.",
   field: { type: FieldType.String },
   actions: [

--- a/web/src/components/software/PatternSelectionUnavailable.test.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.test.tsx
@@ -45,12 +45,12 @@ describe("PatternSelectionUnavailable", () => {
     screen.getByText("Software selection is not available");
   });
 
-  describe("when there is a missing_registration issue", () => {
+  describe("when there is a missingRegistration issue", () => {
     it("shows the issue description", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_registration",
+          class: "missingRegistration",
           description: "Product registration is required",
         },
       ]);
@@ -64,7 +64,7 @@ describe("PatternSelectionUnavailable", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_registration",
+          class: "missingRegistration",
           description: "Product registration is required",
         },
       ]);
@@ -76,12 +76,12 @@ describe("PatternSelectionUnavailable", () => {
     });
   });
 
-  describe("when there is a missing_product issue", () => {
+  describe("when there is a missingProduct issue", () => {
     it("shows the issue description", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Base product is not available",
         },
       ]);
@@ -95,7 +95,7 @@ describe("PatternSelectionUnavailable", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Base product is not available",
         },
       ]);
@@ -109,7 +109,7 @@ describe("PatternSelectionUnavailable", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Base product is not available",
         },
       ]);

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -35,7 +35,7 @@ import { _ } from "~/i18n";
  * These issues signal that the product cannot be found, either because
  * registration is required but missing, or because product detection failed.
  */
-export const PRODUCT_AVAILABILITY_ISSUES = ["missing_registration", "missing_product"];
+export const PRODUCT_AVAILABILITY_ISSUES = ["missingRegistration", "missingProduct"];
 
 /**
  * Empty state shown when software selection is unavailable.
@@ -52,8 +52,8 @@ export default function PatternSelectionUnavailable() {
   const issues = useIssues("software");
   const { all: patterns } = useAvailablePatterns();
 
-  const missingRegistration = issues.find((i) => i.class === "missing_registration");
-  const missingProduct = issues.find((i) => i.class === "missing_product");
+  const missingRegistration = issues.find((i) => i.class === "missingRegistration");
+  const missingProduct = issues.find((i) => i.class === "missingProduct");
 
   // TRANSLATORS: empty state title when software cannot be selected
   const title = _("Software selection is not available");

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -245,12 +245,12 @@ describe("SoftwarePage", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_registration",
+          class: "missingRegistration",
           description: "Product registration is required",
         },
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Product is not available",
         },
         {
@@ -302,7 +302,7 @@ describe("SoftwarePage", () => {
         mockUseIssues.mockReturnValue([
           {
             scope: "software",
-            class: "software.load_source",
+            class: "loadSource",
             description: "Could not read the repositories",
           },
         ]);

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -68,7 +68,7 @@ import { SelectedBy } from "~/model/proposal/software";
  * Reading them requires a working connection, so it shows up when the
  * installation medium has no access to the network.
  */
-const UNREADABLE_SOURCES_ISSUE = "software.load_source";
+const UNREADABLE_SOURCES_ISSUE = "loadSource";
 
 /**
  * Empty state for a software section where nothing has been selected yet.

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -277,6 +277,7 @@ function ProposalPageContent(): React.ReactNode {
     "configMissingPaths",
     "configOverusedPvTarget",
     "configMisusedMdMember",
+    "configMisusedPv",
     "proposal",
   ];
   const configIssues = issues.filter((i) => i.class !== "proposal");


### PR DESCRIPTION
## Problem

Question "class" identifiers were inconsistent (mixed dotted/underscore
naming, e.g. `software.package_error.provide_error`), not compatible with
previously used names, and their `data` map keys mixed snake_case/camelCase
with no tolerance in `AnswerRule` matching.

## Solution

- Rename all question classes to consistent snake_case identifiers (Rust,
  Ruby, web UI, and docs updated accordingly).
- Add a centralized `resolve_class()` map next to `AnswerRule` so answer
  rules/profiles written against the old class names keep matching.
- Make `AnswerRule::answers_to` tolerant of both snake_case and camelCase
  `data` key naming.

## Testing

- `cargo build --workspace` / `cargo test --workspace`
- `bundle exec rspec` for the affected Ruby specs
- `npm test` (jest) for the affected web components