### PR TITLE
Use camelCase for issue class/kind identifiers

### DIFF
--- a/rust/agama-l10n/src/service.rs
+++ b/rust/agama-l10n/src/service.rs
@@ -185,21 +185,21 @@ impl Service {
         let mut issues = vec![];
         if !self.model.locales_db().exists(&config.locale) {
             issues.push(Issue::new(
-                "unknown_locale",
+                "unknownLocale",
                 &format!("Locale '{}' is unknown", config.locale),
             ));
         }
 
         if !self.model.keymaps_db().exists(&config.keymap) {
             issues.push(Issue::new(
-                "unknown_keymap",
+                "unknownKeymap",
                 &format!("Keymap '{}' is unknown", config.keymap),
             ));
         }
 
         if !self.model.timezones_db().exists(&config.timezone) {
             issues.push(Issue::new(
-                "unknown_timezone",
+                "unknownTimezone",
                 &format!("Timezone '{}' is unknown", config.timezone),
             ));
         }

--- a/rust/agama-manager/src/service.rs
+++ b/rust/agama-manager/src/service.rs
@@ -607,7 +607,7 @@ impl Service {
             self.issues
                 .cast(issue::message::Clear::new(Scope::Manager))?;
         } else {
-            let issue = Issue::new("no_product", "No product has been selected.");
+            let issue = Issue::new("noProduct", "No product has been selected.");
             self.issues
                 .cast(issue::message::Set::new(Scope::Manager, vec![issue]))?;
         }

--- a/rust/agama-software/src/service.rs
+++ b/rust/agama-software/src/service.rs
@@ -292,7 +292,7 @@ impl Service {
                 .await
                 .unwrap_or_else(|e| {
                     let new_issue = Issue::new(
-                        "software_proposal_failed",
+                        "softwareProposalFailed",
                         &gettext("Due to an internal error, it was not possible to create a software proposal."),
                     )
                     .with_details(&e.to_string());

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -428,9 +428,9 @@ impl ZyppServer {
 
             if let Err(error) = result {
                 let message = format!("Could not add the repository {}", repo.alias);
-                issues.software.push(
-                    Issue::new("addRepo", &message).with_details(&error.to_string()),
-                );
+                issues
+                    .software
+                    .push(Issue::new("addRepo", &message).with_details(&error.to_string()));
             }
         }
 
@@ -445,9 +445,9 @@ impl ZyppServer {
                 let message = gettext("Could not remove the repository %s")
                     .as_str()
                     .replace("%s", &repo.alias);
-                issues.software.push(
-                    Issue::new("removeRepo", &message).with_details(&error.to_string()),
-                );
+                issues
+                    .software
+                    .push(Issue::new("removeRepo", &message).with_details(&error.to_string()));
             }
         }
 
@@ -463,9 +463,9 @@ impl ZyppServer {
 
         if let Err(error) = result {
             let message = gettext("Could not read the repositories");
-            issues.software.push(
-                Issue::new("loadSource", &message).with_details(&error.to_string()),
-            );
+            issues
+                .software
+                .push(Issue::new("loadSource", &message).with_details(&error.to_string()));
         }
 
         // repositories refresh finished
@@ -565,9 +565,7 @@ impl ZyppServer {
 
         if let Ok(false) = zypp.run_solver(self.only_required, self.save_solver_testcase) {
             let message = gettext("There are conflicts in the software selection");
-            issues
-                .software
-                .push(Issue::new("conflict", &message));
+            issues.software.push(Issue::new("conflict", &message));
         }
 
         Self::send_issues_and_finish(issues, tx, progress)
@@ -598,8 +596,7 @@ impl ZyppServer {
                     .replacen("%s", &r#type.to_string(), 1)
                     .replace("%s", name);
                 issues.push(
-                    Issue::new("selectResolvable", &message)
-                        .with_details(&error.to_string()),
+                    Issue::new("selectResolvable", &message).with_details(&error.to_string()),
                 );
             }
         }

--- a/rust/agama-software/src/zypp_server.rs
+++ b/rust/agama-software/src/zypp_server.rs
@@ -429,7 +429,7 @@ impl ZyppServer {
             if let Err(error) = result {
                 let message = format!("Could not add the repository {}", repo.alias);
                 issues.software.push(
-                    Issue::new("software.add_repo", &message).with_details(&error.to_string()),
+                    Issue::new("addRepo", &message).with_details(&error.to_string()),
                 );
             }
         }
@@ -446,7 +446,7 @@ impl ZyppServer {
                     .as_str()
                     .replace("%s", &repo.alias);
                 issues.software.push(
-                    Issue::new("software.remove_repo", &message).with_details(&error.to_string()),
+                    Issue::new("removeRepo", &message).with_details(&error.to_string()),
                 );
             }
         }
@@ -464,7 +464,7 @@ impl ZyppServer {
         if let Err(error) = result {
             let message = gettext("Could not read the repositories");
             issues.software.push(
-                Issue::new("software.load_source", &message).with_details(&error.to_string()),
+                Issue::new("loadSource", &message).with_details(&error.to_string()),
             );
         }
 
@@ -499,10 +499,10 @@ impl ZyppServer {
 
             let issue = if state.allow_registration && !self.is_registered() {
                 let message = gettext("Failed to find the product in the repositories. You might need to register the system.");
-                Issue::new("missing_registration", &message).with_details(&error.to_string())
+                Issue::new("missingRegistration", &message).with_details(&error.to_string())
             } else {
                 let message = gettext("Failed to find the product in the repositories.");
-                Issue::new("missing_product", &message).with_details(&error.to_string())
+                Issue::new("missingProduct", &message).with_details(&error.to_string())
             };
 
             issues.software.push(issue);
@@ -567,7 +567,7 @@ impl ZyppServer {
             let message = gettext("There are conflicts in the software selection");
             issues
                 .software
-                .push(Issue::new("software.conflict", &message));
+                .push(Issue::new("conflict", &message));
         }
 
         Self::send_issues_and_finish(issues, tx, progress)
@@ -598,7 +598,7 @@ impl ZyppServer {
                     .replacen("%s", &r#type.to_string(), 1)
                     .replace("%s", name);
                 issues.push(
-                    Issue::new("software.select_resolvable", &message)
+                    Issue::new("selectResolvable", &message)
                         .with_details(&error.to_string()),
                 );
             }
@@ -1005,7 +1005,7 @@ impl ZyppServer {
             Err(error) => {
                 issues.product.push(
                     Issue::new(
-                        "system_registration_failed",
+                        "systemRegistrationFailed",
                         &gettext("Failed to register the system"),
                     )
                     .with_details(&error.to_string()),
@@ -1034,7 +1034,7 @@ impl ZyppServer {
             }
             if let Err(error) = registration.register_addon(zypp, security, addon) {
                 let message = format!("Failed to register the add-on {}", addon.id);
-                let issue_id = format!("addon_registration_failed[{}]", addon.id);
+                let issue_id = format!("addonRegistrationFailed[{}]", addon.id);
                 let issue = Issue::new(&issue_id, &message).with_details(&error.to_string());
                 issues.product.push(issue);
             }

--- a/rust/agama-software/tests/zypp_server.rs
+++ b/rust/agama-software/tests/zypp_server.rs
@@ -148,7 +148,7 @@ async fn test_start_zypp_server() {
         1,
         "There are unexpected issues size {issues:#?}"
     );
-    assert_eq!(issues.software[0].class, "missing_product");
+    assert_eq!(issues.software[0].class, "missingProduct");
 
     let questions = question_handler
         .call(question::message::Get)

--- a/rust/agama-users/src/service.rs
+++ b/rust/agama-users/src/service.rs
@@ -173,7 +173,7 @@ impl Service {
         let mut issues = vec![];
         if self.full_config.is_empty() {
             issues.push(Issue::new(
-                "users.no_auth",
+                "noAuth",
                 &gettext(
                     "Defining a user, setting the root password or a SSH public key is required",
                 ),
@@ -187,7 +187,7 @@ impl Service {
             .is_some_and(|u| !u.is_valid())
         {
             issues.push(Issue::new(
-                "users.invalid_user",
+                "invalidUser",
                 &gettext("First user information is incomplete"),
             ));
         }

--- a/rust/agama-utils/src/issue.rs
+++ b/rust/agama-utils/src/issue.rs
@@ -52,7 +52,7 @@ mod tests {
     fn build_issue() -> Issue {
         Issue {
             description: "Product not selected".to_string(),
-            class: "missing_product".to_string(),
+            class: "missingProduct".to_string(),
             details: Some("A product is required.".to_string()),
         }
     }

--- a/service/lib/agama/storage/issue_classes.rb
+++ b/service/lib/agama/storage/issue_classes.rb
@@ -38,7 +38,7 @@ module Agama
         MISUSED_MD_MEMBER        = :configMisusedMdMember
 
         # A device that is a PV of a reused VG is chosen to be used with other purpose
-        MISUSED_PV               = :configMisusedMdMember
+        MISUSED_PV               = :configMisusedPv
 
         # Reused and new devices are both used as target for generating PVs for the same LV
         INCOMPATIBLE_PV_TARGETS  = :configIncompatiblePvTargets

--- a/service/lib/agama/storage/zfcp/manager.rb
+++ b/service/lib/agama/storage/zfcp/manager.rb
@@ -203,7 +203,7 @@ module Agama
           @issues << Issue.new(
             # TRANSLATORS: %s is replaced by a zFCP channel (e.g., "0.0.5223").
             format(_("The zFCP controller %s cannot be activated"), channel),
-            kind: :zfcp_controller_activation
+            kind: :zfcpControllerActivation
           )
 
           false
@@ -243,7 +243,7 @@ module Agama
             # TRANSLATORS: %s is replaced by a zFCP device (e.g.,
             #   "0.0.5223 0x500507681015a2b2 0x0186000000000000").
             format(_("The zFCP device %s cannot be activated"), "#{channel} #{wwpn} #{lun}"),
-            kind: :zfcp_lun_activation
+            kind: :zfcpLunActivation
           )
 
           false
@@ -287,7 +287,7 @@ module Agama
             # TRANSLATORS: %s is replaced by a zFCP device (e.g.,
             #   "0.0.5223 0x500507681015a2b2 0x0186000000000000").
             format(_("The zFCP device %s cannot be deactivated"), "#{channel} #{wwpn} #{lun}"),
-            kind: :zfcp_lun_deactivation
+            kind: :zfcpLunDeactivation
           )
 
           false

--- a/web/src/components/overview/OverviewPage.tsx
+++ b/web/src/components/overview/OverviewPage.tsx
@@ -113,7 +113,7 @@ const ProductNotFound = () => (
 export default function OverviewPage() {
   const issues = useIssues();
   const product = useProductInfo();
-  const missingProduct = issues.some((i) => i.class === "missing_product");
+  const missingProduct = issues.some((i) => i.class === "missingProduct");
 
   return (
     <Page

--- a/web/src/components/product/ProductRegistrationPage.test.tsx
+++ b/web/src/components/product/ProductRegistrationPage.test.tsx
@@ -320,7 +320,7 @@ describe("ProductRegistrationPage", () => {
           mockIssues = [
             {
               scope: "product",
-              class: "addon_registration_failed[sle-ha]",
+              class: "addonRegistrationFailed[sle-ha]",
               description: "Failed to register the add-on sle-ha",
               details: "No subscription with registration code 'jkljkljkl' found",
             },
@@ -355,7 +355,7 @@ describe("ProductRegistrationPage", () => {
     mockIssues = [
       {
         scope: "product",
-        class: "system_registration_failed",
+        class: "systemRegistrationFailed",
         description: "Failed to register",
       },
       {
@@ -378,7 +378,7 @@ describe("ProductRegistrationPage", () => {
     mockIssues = [
       {
         scope: "product",
-        class: "system_registration_failed",
+        class: "systemRegistrationFailed",
         description: "Failed to register",
       },
     ];

--- a/web/src/components/product/ProductRegistrationPage.tsx
+++ b/web/src/components/product/ProductRegistrationPage.tsx
@@ -184,7 +184,7 @@ const Extensions = () => {
   if (!extensions || extensions.length === 0) return null;
 
   const extensionComponents = extensions.map((ext) => {
-    const issue = issues.find((i) => i.class === `addon_registration_failed[${ext.id}]`);
+    const issue = issues.find((i) => i.class === `addonRegistrationFailed[${ext.id}]`);
     const config = (product?.addons || []).find((c) => c.id === ext.id);
 
     return (
@@ -216,8 +216,8 @@ const Extensions = () => {
 export default function ProductRegistrationPage() {
   const { registration } = useSystem();
   const issues = useIssues("product");
-  const registrationIssue = issues.find((i) => i.class === "system_registration_failed");
-  const nonRegistrationIssues = issues.filter((i) => i.class !== "system_registration_failed");
+  const registrationIssue = issues.find((i) => i.class === "systemRegistrationFailed");
+  const nonRegistrationIssues = issues.filter((i) => i.class !== "systemRegistrationFailed");
   // Avoid repeating the alert after registration attempt
   const showHostnameAlert = !registration && !registrationIssue;
 

--- a/web/src/components/product/registration-form/Form.test.tsx
+++ b/web/src/components/product/registration-form/Form.test.tsx
@@ -220,7 +220,7 @@ describe("ProductRegistrationForm", () => {
       mockIssues = [
         {
           scope: "software",
-          class: "system_registration_failed",
+          class: "systemRegistrationFailed",
           description: "Unauthorized code",
         },
       ];
@@ -269,7 +269,7 @@ describe("ProductRegistrationForm", () => {
       mockIssues = [
         {
           scope: "software",
-          class: "system_registration_failed",
+          class: "systemRegistrationFailed",
           description: "Unauthorized code",
         },
       ];
@@ -320,7 +320,7 @@ describe("ProductRegistrationForm", () => {
       mockIssues = [
         {
           scope: "software",
-          class: "system_registration_failed",
+          class: "systemRegistrationFailed",
           description: "Invalid registration code",
         },
       ];
@@ -343,7 +343,7 @@ describe("ProductRegistrationForm", () => {
     it("re-enables button when backend returns same registration issue object", async () => {
       const sameIssue = {
         scope: "software" as const,
-        class: "system_registration_failed",
+        class: "systemRegistrationFailed",
         description: "Unauthorized code",
       };
 

--- a/web/src/components/product/registration-form/Form.tsx
+++ b/web/src/components/product/registration-form/Form.tsx
@@ -53,7 +53,7 @@ export default function ProductRegistrationForm() {
   const config = useConfig();
   const product = useProduct();
   const issues = useIssues("product");
-  const registrationIssue = issues.find((i) => i.class === "system_registration_failed");
+  const registrationIssue = issues.find((i) => i.class === "systemRegistrationFailed");
 
   // Track system query which refetches after putConfig completes (success or failure).
   // On success: parent sees new registration data and unmounts this component.

--- a/web/src/components/software/PatternSelectionUnavailable.test.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.test.tsx
@@ -45,12 +45,12 @@ describe("PatternSelectionUnavailable", () => {
     screen.getByText("Software selection is not available");
   });
 
-  describe("when there is a missing_registration issue", () => {
+  describe("when there is a missingRegistration issue", () => {
     it("shows the issue description", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_registration",
+          class: "missingRegistration",
           description: "Product registration is required",
         },
       ]);
@@ -64,7 +64,7 @@ describe("PatternSelectionUnavailable", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_registration",
+          class: "missingRegistration",
           description: "Product registration is required",
         },
       ]);
@@ -76,12 +76,12 @@ describe("PatternSelectionUnavailable", () => {
     });
   });
 
-  describe("when there is a missing_product issue", () => {
+  describe("when there is a missingProduct issue", () => {
     it("shows the issue description", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Base product is not available",
         },
       ]);
@@ -95,7 +95,7 @@ describe("PatternSelectionUnavailable", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Base product is not available",
         },
       ]);
@@ -109,7 +109,7 @@ describe("PatternSelectionUnavailable", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Base product is not available",
         },
       ]);

--- a/web/src/components/software/PatternSelectionUnavailable.tsx
+++ b/web/src/components/software/PatternSelectionUnavailable.tsx
@@ -35,7 +35,7 @@ import { _ } from "~/i18n";
  * These issues signal that the product cannot be found, either because
  * registration is required but missing, or because product detection failed.
  */
-export const PRODUCT_AVAILABILITY_ISSUES = ["missing_registration", "missing_product"];
+export const PRODUCT_AVAILABILITY_ISSUES = ["missingRegistration", "missingProduct"];
 
 /**
  * Empty state shown when software selection is unavailable.
@@ -52,8 +52,8 @@ export default function PatternSelectionUnavailable() {
   const issues = useIssues("software");
   const { all: patterns } = useAvailablePatterns();
 
-  const missingRegistration = issues.find((i) => i.class === "missing_registration");
-  const missingProduct = issues.find((i) => i.class === "missing_product");
+  const missingRegistration = issues.find((i) => i.class === "missingRegistration");
+  const missingProduct = issues.find((i) => i.class === "missingProduct");
 
   // TRANSLATORS: empty state title when software cannot be selected
   const title = _("Software selection is not available");

--- a/web/src/components/software/SoftwarePage.test.tsx
+++ b/web/src/components/software/SoftwarePage.test.tsx
@@ -245,12 +245,12 @@ describe("SoftwarePage", () => {
       mockUseIssues.mockReturnValue([
         {
           scope: "software",
-          class: "missing_registration",
+          class: "missingRegistration",
           description: "Product registration is required",
         },
         {
           scope: "software",
-          class: "missing_product",
+          class: "missingProduct",
           description: "Product is not available",
         },
         {
@@ -302,7 +302,7 @@ describe("SoftwarePage", () => {
         mockUseIssues.mockReturnValue([
           {
             scope: "software",
-            class: "software.load_source",
+            class: "loadSource",
             description: "Could not read the repositories",
           },
         ]);

--- a/web/src/components/software/SoftwarePage.tsx
+++ b/web/src/components/software/SoftwarePage.tsx
@@ -68,7 +68,7 @@ import { SelectedBy } from "~/model/proposal/software";
  * Reading them requires a working connection, so it shows up when the
  * installation medium has no access to the network.
  */
-const UNREADABLE_SOURCES_ISSUE = "software.load_source";
+const UNREADABLE_SOURCES_ISSUE = "loadSource";
 
 /**
  * Empty state for a software section where nothing has been selected yet.

--- a/web/src/components/storage/ProposalPage.tsx
+++ b/web/src/components/storage/ProposalPage.tsx
@@ -277,6 +277,7 @@ function ProposalPageContent(): React.ReactNode {
     "configMissingPaths",
     "configOverusedPvTarget",
     "configMisusedMdMember",
+    "configMisusedPv",
     "proposal",
   ];
   const configIssues = issues.filter((i) => i.class !== "proposal");


### PR DESCRIPTION
## Problem

`Issue` ids (`class` field in Rust, `kind` field in Ruby) used
inconsistent naming conventions: some were `camelCase`, others
`snake_case`, and some had a dotted prefix (e.g. `software.load_source`,
`users.no_auth`). Additionally, `Storage::IssueClasses::Config::MISUSED_PV`
and `MISUSED_MD_MEMBER` accidentally shared the same value
(`:configMisusedMdMember`), so PV-misuse issues were indistinguishable
from MD-member-misuse issues.

## Changes

- Renamed all Rust issue `class` ids to `camelCase` and dropped the
  dotted-domain prefix (e.g. `"software.load_source"` -> `"loadSource"`,
  `"users.no_auth"` -> `"noAuth"`, `"missing_product"` -> `"missingProduct"`, etc.)
  across `agama-manager`, `agama-software`, `agama-l10n`, and `agama-users`.
- Renamed the Ruby zFCP issue `kind` symbols to `camelCase`
  (e.g. `:zfcp_controller_activation` -> `:zfcpControllerActivation`).
- Fixed the `MISUSED_PV` / `MISUSED_MD_MEMBER` bug: `MISUSED_PV` now has
  its own distinct value, `:configMisusedPv`.
- Updated every producer/consumer of these ids, including the web
  frontend components that branch on `issue.class` (registration,
  software patterns, storage proposal pages) and their tests.

## Testing

- `cargo build --workspace` and `cargo test` for `agama-software`,
  `agama-l10n`, `agama-users`, `agama-manager`, `agama-utils` — all pass.
- Ruby RSpec: storage config checkers, zFCP tests, and the full
  `service/test/agama/storage` suite — all pass.
- Web: Jest suites for the touched components — all pass.