### PR TITLE
Adjust default encryption derivation function based on the bootloader

### DIFF
--- a/service/lib/agama/storage/config_solver.rb
+++ b/service/lib/agama/storage/config_solver.rb
@@ -47,7 +47,7 @@ module Agama
       #
       # @param config [Config]
       def solve(config)
-        ConfigSolvers::Encryption.new(product_config).solve(config)
+        ConfigSolvers::Encryption.new(bootloader_config).solve(config)
         ConfigSolvers::Filesystem.new(product_config, bootloader_config).solve(config)
         ConfigSolvers::DrivesSearch.new(storage_system).solve(config)
         ConfigSolvers::MdRaidsSearch.new(storage_system).solve(config)

--- a/service/lib/agama/storage/config_solvers/encryption.rb
+++ b/service/lib/agama/storage/config_solvers/encryption.rb
@@ -19,16 +19,19 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "agama/storage/config_solvers/base"
-
 module Agama
   module Storage
     module ConfigSolvers
       # Solver for the encryption configs.
       #
-      # The encryption configs are solved by assigning the default encryption values defined by the
-      # productd, if needed.
-      class Encryption < Base
+      # The encryption configs are solved by assigning the default encryption values required by the
+      # used bootloader, if needed.
+      class Encryption
+        # @param bootloader_config [Storage::BootloaderConfig]
+        def initialize(bootloader_config)
+          @bootloader_config = bootloader_config
+        end
+
         # Solves all the encryption configs within a given config.
         #
         # @note The config object is modified.
@@ -43,6 +46,12 @@ module Agama
 
       private
 
+        # @return [Storage::BootloaderConfig]
+        attr_reader :bootloader_config
+
+        # @return [Config]
+        attr_reader :config
+
         def solve_encryptions
           config.supporting_encryption.each { |c| solve_encryption(c) }
         end
@@ -51,9 +60,7 @@ module Agama
         def solve_encryption(config)
           return unless config.encryption
 
-          encryption = config.encryption
-          encryption.method ||= default_encryption.method
-          solve_encryption_values(encryption)
+          solve_encryption_values(config.encryption)
         end
 
         def solve_physical_volumes_encryptions
@@ -71,24 +78,14 @@ module Agama
 
         # @param config [Configs::Encryption]
         def solve_encryption_values(config)
-          # FIXME: We need better mechanisms to define these values (eg. the process for TpmFde
-          # enforces pbkdf2, but that is not reflected in the case of planned devices).
-          # As a first (not perfect) control mechanism, the values are ignored if the default
-          # encryption type does not match
-          return if config.method.encryption_type != default_encryption.method.encryption_type
+          bootloader_type = bootloader_config.type
+          # The bootloader type is always known because bootloader_config is already solved,
+          # but this is defensive code to ensure backwards compatibility even with the tests
+          return if bootloader_type && !bootloader_type.is?(:grub2)
 
-          config.password ||= default_encryption.password
-          config.pbkd_function ||= default_encryption.pbkd_function
-          config.label ||= default_encryption.label
-          config.cipher ||= default_encryption.cipher
-          config.key_size ||= default_encryption.key_size
-        end
-
-        # Default encryption defined by the product.
-        #
-        # @return [Configs::Encryption]
-        def default_encryption
-          @default_encryption ||= config_builder.default_encryption
+          # Grub2 can only open encryption devices using PBKDF2, so let's be conservative
+          # and use that function by default for all devices.
+          config.pbkd_function ||= Y2Storage::PbkdFunction::PBKDF2
         end
       end
     end

--- a/service/lib/agama/storage/config_solvers/encryption.rb
+++ b/service/lib/agama/storage/config_solvers/encryption.rb
@@ -72,7 +72,6 @@ module Agama
           return unless config.physical_volumes_encryption
 
           encryption = config.physical_volumes_encryption
-          encryption.method ||= default_encryption.method
           solve_encryption_values(encryption)
         end
 

--- a/service/package/rubygem-agama-yast.changes
+++ b/service/package/rubygem-agama-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 31 12:02:23 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adjust default encryption derivation function (PBKDF) according
+  to the used bootloader (bsc#1258955).
+
+-------------------------------------------------------------------
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename questions and issues classes to use a consistent naming

--- a/service/test/agama/storage/config_solver_test.rb
+++ b/service/test/agama/storage/config_solver_test.rb
@@ -35,10 +35,6 @@ describe Agama::Storage::ConfigSolver do
       "storage" => {
         "lvm"              => false,
         "space_policy"     => "delete",
-        "encryption"       => {
-          "method"        => "luks2",
-          "pbkd_function" => "argon2i"
-        },
         "volumes"          => ["/", "swap"],
         "volume_templates" => [
           {
@@ -90,6 +86,10 @@ describe Agama::Storage::ConfigSolver do
 
   let(:storage_system) { Agama::Storage::System.new }
 
+  let(:grub2) { Y2Storage::BootloaderType::GRUB2 }
+
+  let(:systemd_boot) { Y2Storage::BootloaderType::SYSTEMD_BOOT }
+
   subject { described_class.new(product_config, bootloader_config, storage_system) }
 
   describe "#solve" do
@@ -126,13 +126,32 @@ describe Agama::Storage::ConfigSolver do
           }
         end
 
-        it "completes the encryption config according to the product info" do
-          subject.solve(config)
+        before { allow(bootloader_config).to receive(:type).and_return bootloader }
 
-          encryption = encryption_proc.call(config)
-          expect(encryption.method).to eq(Y2Storage::EncryptionMethod::LUKS2)
-          expect(encryption.password).to eq("12345")
-          expect(encryption.pbkd_function).to eq(Y2Storage::PbkdFunction::ARGON2I)
+        context "and a BLS bootloader will be used" do
+          let(:bootloader) { systemd_boot }
+
+          it "does not enforce any special encryption configuration" do
+            subject.solve(config)
+
+            encryption = encryption_proc.call(config)
+            expect(encryption.method).to eq(Y2Storage::EncryptionMethod::LUKS2)
+            expect(encryption.password).to eq("12345")
+            expect(encryption.pbkd_function).to be_nil
+          end
+        end
+
+        context "and grub2 is used as bootloader" do
+          let(:bootloader) { grub2 }
+
+          it "enforces a conservative encryption configuration with PBKDF2" do
+            subject.solve(config)
+
+            encryption = encryption_proc.call(config)
+            expect(encryption.method).to eq(Y2Storage::EncryptionMethod::LUKS2)
+            expect(encryption.password).to eq("12345")
+            expect(encryption.pbkd_function).to eq(Y2Storage::PbkdFunction::PBKDF2)
+          end
         end
       end
     end
@@ -641,9 +660,6 @@ describe Agama::Storage::ConfigSolver do
       let(:product_data) do
         { "storage" => { "volume_templates" => [root_vol] } }
       end
-
-      let(:grub2) { Y2Storage::BootloaderType::GRUB2 }
-      let(:systemd_boot) { Y2Storage::BootloaderType::SYSTEMD_BOOT }
 
       before { allow(bootloader_config).to receive(:type).and_return bootloader }
 


### PR DESCRIPTION
## Problem

See https://bugzilla.suse.com/show_bug.cgi?id=1258955

When encrypting a device, the user can specify the key derivation function algorithm to use (PBKDF2, ARGON2 or ARGON2i).

When the user omits that configuration detail, then PBKDF2 was used as a default fallback for all situations to ensure compatibility with all bootloaders and disk layouts. In fact, the default value was configurable by product, but no product used that capability so the hardcoded fallback PBKDF2 was always used in the end.

When using a BLS-capable bootloader like systemd-boot, there is no reason to use PBKDF2. Using it may be considered as reducing security for no reasons and can be perceived as a step back compared to the systemd-boot support present in the YaST installer.

## Solution

This change how the default KDF is calculated in case the user omits it. Instead of using a product-based configuration (that no product was using anyways). The KDF to use is now based on the bootloader that will be installed.

There is still room for improvement (using Grub2 should not imply that PBKDF2 is used for every single device), but this change is very safe and backwards compatible with the previous behavior. If Grub2 is used (which almost always happens in SLE, for example) absolutely nothing changes. Only if a different bootloader is used (which in SLE can only be done activating a tech preview) then the KDF is adjusted.

## Testing

- Added a new unit test
- Manually tested:
  - Verified that SLES keeps the behavior in all scenarios except the tech preview
  - Verified that now TW uses the default encryption KDF (that should be Argon2i) when using systemd-boot
  - Verified that TW keeps using PBKDF2 when using grub2 (basically all scenarios except EFI).
- Additionally, this is available for any further testing https://download.opensuse.org/repositories/systemsmanagement:/Agama:/branches:/fix_enc/images/iso/
