### PR TITLE
CI: validate the *.kiwi file

### DIFF
--- a/.github/workflows/ci-live-kiwi.yml
+++ b/.github/workflows/ci-live-kiwi.yml
@@ -39,7 +39,7 @@ jobs:
         run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
 
       - name: Install the required tools
-        run: zypper --non-interactive install --no-recommends python3-kiwi git
+        run: zypper --non-interactive install --no-recommends python3-kiwi git make
 
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ci-live-kiwi.yml
+++ b/.github/workflows/ci-live-kiwi.yml
@@ -1,0 +1,48 @@
+name: CI - Kiwi Configuration
+
+permissions:
+  contents: read
+
+on:
+  push:
+    paths:
+      # NOTE: GitHub Actions do not allow using YAML references, the same path
+      # list is used below for the pull request event. Keep both lists in sync!!
+
+      # this file as well
+      - .github/workflows/ci-live-kiwi.yml
+      # any change in the Kiwi definition
+      - live/src/*.kiwi
+
+  pull_request:
+    paths:
+      # NOTE: GitHub Actions do not allow using YAML references, the same path
+      # list is used above for the push event. Keep both lists in sync!!
+
+      # this file as well
+      - .github/workflows/ci-live-kiwi.yml
+      # any change in the Kiwi definition
+      - live/src/*.kiwi
+
+  # allow running manually
+  workflow_dispatch:
+
+jobs:
+  kiwi-validate:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.opensuse.org/opensuse/tumbleweed:latest
+
+    steps:
+      - name: Configure and refresh repositories
+        # disable unused repositories to have faster refresh
+        run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
+
+      - name: Install the required tools
+        run: zypper --non-interactive install --no-recommends python3-kiwi git
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Validate the Kiwi image definition
+        run: kiwi-ng image info --description live/src

--- a/.github/workflows/ci-live-kiwi.yml
+++ b/.github/workflows/ci-live-kiwi.yml
@@ -45,4 +45,5 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Validate the Kiwi image definition
-        run: kiwi-ng image info --description live/src
+        run: make validate
+        working-directory: live/

--- a/live/Makefile
+++ b/live/Makefile
@@ -80,6 +80,9 @@ build: $(DESTDIR)
 check:
 	for i in ./test/*_test.*; do $${i} || exit 1; done
 
+validate:
+	kiwi-ng image info --description src
+
 # Shellcheck reports lots of warnings, run it in the error-only mode first. If that succeeds run it
 # in full mode with warnings but ignore the failures (some are false positives).
 # TODO: Fix/disable the warnings and run it in more strict mode.


### PR DESCRIPTION
## Problem

- We do not validate the Kiwi XML file in CI, that could help to find the issues sooner.

## Solution

- Validate the Kiwi XML files with `kiwi-ng image info`

## Testing

- Added a new CI test, see [example run](https://github.com/agama-project/agama/actions/runs/33394848242/job/99496810088#step:6:5)
