### PR TITLE
Drop agama integration tests

### DIFF
--- a/live/src/agama-installer.changes
+++ b/live/src/agama-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 31 12:55:59 UTC 2026 - Martin Vidner <mvidner@suse.com>
+
+- Remove agama-integration-tests, keep just nodejs(engine)
+  (gh#agama-project/agama#3852)
+
+-------------------------------------------------------------------
 Fri Aug 28 15:31:19 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Added Kiwi profile definition for the SLES for NVIDIA product,

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -154,7 +154,6 @@
     <!-- packages for local installation (desktop, browser, etc.) -->
     <packages type="image" profiles="Leap_16.1,openSUSE,SUSE_SLE_16.1,SUSE_SLE_NV_16.1">
         <package name="bluez-firmware"/>
-        <package name="agama-integration-tests"/>
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="xauth"/>

--- a/live/src/agama-installer.kiwi
+++ b/live/src/agama-installer.kiwi
@@ -154,6 +154,8 @@
     <!-- packages for local installation (desktop, browser, etc.) -->
     <packages type="image" profiles="Leap_16.1,openSUSE,SUSE_SLE_16.1,SUSE_SLE_NV_16.1">
         <package name="bluez-firmware"/>
+        <!-- for openQA to run their puppeteer tests, just injecting a *.js file -->
+        <package name="nodejs(engine)"/>
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="xauth"/>


### PR DESCRIPTION
## Problem

We get many security bug reports in the many (currently 446) NPM packages that agama-integration-tests.rpm depends on. Example: https://github.com/agama-project/integration-tests/pull/15

The tests themselves are very basic smoke tests of the React UI. Real testing is done in openQA with other code.

Including the RPM on the DVD makes it slightly easier to make screenshots of the UI, but that is less important as we are done with major UI changes.

- https://trello.com/c/bSRNyNt3/5980-5-reduce-node-javascript-and-rust-dependencies

## Solution

First, do not ship the RPM

## Testing

Built the ISO manually (`osc build -M openSUSE images`)

## Screenshots

No

## Documentation

- [x] .changes
