### PR TITLE
fix(web): default registration form to the effective registration URL

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -3,7 +3,8 @@ Mon Aug 31 15:53:32 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Default the registration form to the effective registration URL
   (e.g., the one set via the inst.register_url boot argument),
-  instead of only showing it when the user typed a custom one.
+  instead of only showing it when the user typed a custom one
+  (bsc#1277099).
 
 -------------------------------------------------------------------
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 31 15:53:32 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Default the registration form to the effective registration URL
+  (e.g., the one set via the inst.register_url boot argument),
+  instead of only showing it when the user typed a custom one.
+
+-------------------------------------------------------------------
 Fri Aug 28 13:08:30 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Rename questions and issues classes to use a consistent naming

--- a/web/src/components/product/registration-form/Form.test.tsx
+++ b/web/src/components/product/registration-form/Form.test.tsx
@@ -221,7 +221,7 @@ describe("ProductRegistrationForm", () => {
     });
   });
 
-  describe("when a configurations using a \"custom\" URL was already provided", () => {
+  describe("when a custom URL was already provided", () => {
     it("defaults to the URL from the extended configuration", async () => {
       mockExtendedProductConfig({
         id: "sle",

--- a/web/src/components/product/registration-form/Form.test.tsx
+++ b/web/src/components/product/registration-form/Form.test.tsx
@@ -22,7 +22,13 @@
 
 import React from "react";
 import { act, screen, waitFor } from "@testing-library/react";
-import { installerRender, mockProduct, mockProductConfig, mockL10n } from "~/test-utils";
+import {
+  installerRender,
+  mockProduct,
+  mockProductConfig,
+  mockExtendedProductConfig,
+  mockL10n,
+} from "~/test-utils";
 import { Product } from "~/model/system";
 import { RegistrationInfo } from "~/model/system/software";
 import { Config } from "~/model/config";
@@ -151,6 +157,34 @@ describe("ProductRegistrationForm", () => {
           mode: "standard",
           registrationUrl: "https://custom-server.test",
           registrationCode: undefined,
+          registrationEmail: undefined,
+        },
+      });
+    });
+  });
+
+  it("defaults to the URL from the extended configuration (e.g., set via inst.register_url)", async () => {
+    mockExtendedProductConfig({
+      id: "sle",
+      mode: "standard",
+      registrationUrl: "https://preconfigured-server.test",
+    });
+
+    const { user } = installerRender(<ProductRegistrationForm />);
+    const registrationCodeInput = screen.getByLabelText(/Registration code/);
+    await user.type(registrationCodeInput, "INTERNAL-USE-ONLY-1234-5678");
+    const submitButton = screen.getByRole("button", { name: "Register" });
+
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(putConfig).toHaveBeenCalledWith({
+        ...mockConfig,
+        product: {
+          id: "sle",
+          mode: "standard",
+          registrationUrl: "https://preconfigured-server.test",
+          registrationCode: "INTERNAL-USE-ONLY-1234-5678",
           registrationEmail: undefined,
         },
       });

--- a/web/src/components/product/registration-form/Form.test.tsx
+++ b/web/src/components/product/registration-form/Form.test.tsx
@@ -163,34 +163,6 @@ describe("ProductRegistrationForm", () => {
     });
   });
 
-  it("defaults to the URL from the extended configuration (e.g., set via inst.register_url)", async () => {
-    mockExtendedProductConfig({
-      id: "sle",
-      mode: "standard",
-      registrationUrl: "https://preconfigured-server.test",
-    });
-
-    const { user } = installerRender(<ProductRegistrationForm />);
-    const registrationCodeInput = screen.getByLabelText(/Registration code/);
-    await user.type(registrationCodeInput, "INTERNAL-USE-ONLY-1234-5678");
-    const submitButton = screen.getByRole("button", { name: "Register" });
-
-    await user.click(submitButton);
-
-    await waitFor(() => {
-      expect(putConfig).toHaveBeenCalledWith({
-        ...mockConfig,
-        product: {
-          id: "sle",
-          mode: "standard",
-          registrationUrl: "https://preconfigured-server.test",
-          registrationCode: "INTERNAL-USE-ONLY-1234-5678",
-          registrationEmail: undefined,
-        },
-      });
-    });
-  });
-
   describe("if registering with the default server", () => {
     it("shows an error when no registration code is provided", async () => {
       const { user } = installerRender(<ProductRegistrationForm />);
@@ -241,6 +213,36 @@ describe("ProductRegistrationForm", () => {
             id: "sle",
             mode: "standard",
             registrationUrl: "https://custom-server.test",
+            registrationCode: "INTERNAL-USE-ONLY-1234-5678",
+            registrationEmail: undefined,
+          },
+        });
+      });
+    });
+  });
+
+  describe("when a configurations using a \"custom\" URL was already provided", () => {
+    it("defaults to the URL from the extended configuration", async () => {
+      mockExtendedProductConfig({
+        id: "sle",
+        mode: "standard",
+        registrationUrl: "https://preconfigured-server.test",
+      });
+
+      const { user } = installerRender(<ProductRegistrationForm />);
+      const registrationCodeInput = screen.getByLabelText(/Registration code/);
+      await user.type(registrationCodeInput, "INTERNAL-USE-ONLY-1234-5678");
+      const submitButton = screen.getByRole("button", { name: "Register" });
+
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(putConfig).toHaveBeenCalledWith({
+          ...mockConfig,
+          product: {
+            id: "sle",
+            mode: "standard",
+            registrationUrl: "https://preconfigured-server.test",
             registrationCode: "INTERNAL-USE-ONLY-1234-5678",
             registrationEmail: undefined,
           },

--- a/web/src/components/product/registration-form/Form.tsx
+++ b/web/src/components/product/registration-form/Form.tsx
@@ -34,7 +34,7 @@ import {
 import LabelText from "~/components/form/LabelText";
 import { isEmpty } from "radashi";
 import { sprintf } from "sprintf-js";
-import { useProduct } from "~/hooks/model/config/product";
+import { useExtendedProduct } from "~/hooks/model/config/product";
 import { useIssues } from "~/hooks/model/issue";
 import { putConfig } from "~/api";
 import { useConfig } from "~/hooks/model/config";
@@ -51,7 +51,10 @@ export default function ProductRegistrationForm() {
   const loadingHintId = useId();
   const [loading, setLoading] = useState(false);
   const config = useConfig();
-  const product = useProduct();
+  // Use the extended product configuration so the form defaults to the
+  // effective registration URL, even when it comes from the
+  // `inst.register_url` boot argument instead of the user-set configuration.
+  const product = useExtendedProduct();
   const issues = useIssues("product");
   const registrationIssue = issues.find((i) => i.class === "systemRegistrationFailed");
 

--- a/web/src/hooks/model/config/product.ts
+++ b/web/src/hooks/model/config/product.ts
@@ -21,7 +21,7 @@
  */
 import { useCallback } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { configQuery } from "~/hooks/model/config";
+import { configQuery, extendedConfigQuery } from "~/hooks/model/config";
 import { useSystem } from "~/hooks/model/system";
 import type { Config, Product } from "~/model/config";
 import type * as System from "~/model/system";
@@ -31,6 +31,17 @@ const selectProduct = (data: Config | null): Product.Config | null => data?.prod
 function useProduct(): Product.Config | null {
   const { data } = useSuspenseQuery({
     ...configQuery,
+    select: selectProduct,
+  });
+  return data;
+}
+
+// Returns the product configuration, completed with the default values computed
+// by the backend (e.g., the registration URL coming from the `inst.register_url`
+// boot argument when the user did not set one explicitly).
+function useExtendedProduct(): Product.Config | null {
+  const { data } = useSuspenseQuery({
+    ...extendedConfigQuery,
     select: selectProduct,
   });
   return data;
@@ -52,4 +63,4 @@ function useProductInfo(): System.Product | null {
   return data;
 }
 
-export { useProduct, useProductInfo };
+export { useProduct, useExtendedProduct, useProductInfo };

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -199,6 +199,7 @@ const mockUseProductInfo: jest.Mock<Product> = jest.fn().mockReturnValue({
 });
 
 const mockUseProduct = jest.fn().mockReturnValue(null);
+const mockUseExtendedProduct = jest.fn().mockReturnValue(null);
 
 /**
  * Allows mocking useProductInfo for testing purpose
@@ -215,14 +216,28 @@ const mockUseProduct = jest.fn().mockReturnValue(null);
 const mockProduct = (product: Product) => mockUseProductInfo.mockReturnValue(product);
 
 /**
- * Allows mocking useProduct for testing purpose
+ * Allows mocking useProduct and useExtendedProduct for testing purpose.
+ *
+ * By default, both hooks are mocked to return the same value. Use
+ * `mockExtendedProductConfig` if a test needs the extended (computed)
+ * configuration to differ from the plain, user-set one (e.g., to simulate a
+ * value coming from a boot argument such as `inst.register_url`).
  */
-const mockProductConfig = (product: ProductConfig | null) =>
+const mockProductConfig = (product: ProductConfig | null) => {
   mockUseProduct.mockReturnValue(product);
+  mockUseExtendedProduct.mockReturnValue(product);
+};
+
+/**
+ * Allows mocking useExtendedProduct independently of useProduct.
+ */
+const mockExtendedProductConfig = (product: ProductConfig | null) =>
+  mockUseExtendedProduct.mockReturnValue(product);
 
 jest.mock("~/hooks/model/config/product", () => ({
   useProductInfo: () => mockUseProductInfo(),
   useProduct: () => mockUseProduct(),
+  useExtendedProduct: () => mockUseExtendedProduct(),
 }));
 
 /**
@@ -521,6 +536,7 @@ export {
   mockTasks,
   mockProduct,
   mockProductConfig,
+  mockExtendedProductConfig,
   mockSystem,
   mockL10n,
   loadTranslations,


### PR DESCRIPTION
## Problem

* [bsc#1277099](https://bugzilla.suse.com/show_bug.cgi?id=1277099)

The registration form only pre-filled the "Server URL" field (and selected
"Custom" as the registration server) when the user had explicitly typed a
custom URL before. When the URL came only from the `inst.register_url` boot
argument, the effective registration URL used by Agama was invisible to the
user, both before submitting the form and after a failed registration
attempt.

## Fix

The backend already exposes the effective, merged registration URL via
`GET /api/extended_config` (`product.registrationUrl`), regardless of
whether it came from the user-set configuration or from
`inst.register_url`. This change makes the registration form use that
endpoint (via a new `useExtendedProduct()` hook) to compute its defaults,
instead of the plain `/api/config`-backed `useProduct()`.

No backend changes were needed.

## Testing

- Added a test asserting the form defaults to the URL exposed via the
  extended configuration.
- Full frontend test suite and `tsc --noEmit` pass.