### PR TITLE
Storage improvements

### DIFF
--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep  2 14:15:16 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Improve storage schema to force the encryption key size to be
+  multiple of 8 (gh#agama-project/agama#3854).
+
+-------------------------------------------------------------------
 Wed Sep  2 14:09:43 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Sanitize rust dependencies and add CI task to check unused

--- a/rust/share/storage.schema.json
+++ b/rust/share/storage.schema.json
@@ -1426,7 +1426,8 @@
     },
     "encryptionKeySize": {
       "description": "The value (in bits) has to be a multiple of 8. The possible key sizes are limited by the used cipher.",
-      "type": "integer"
+      "type": "integer",
+      "multipleOf": 8
     },
     "encryptionPbkdFunction": {
       "enum": ["pbkdf2", "argon2i", "argon2id"]

--- a/service/lib/agama/storage/config_builder.rb
+++ b/service/lib/agama/storage/config_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2024-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -35,17 +35,6 @@ module Agama
       # @param product_config [Agama::Config]
       def initialize(product_config)
         @product_config = product_config
-      end
-
-      # Default encryption config from the product definition.
-      #
-      # @return [Configs::Encryption]
-      def default_encryption
-        Configs::Encryption.new.tap do |config|
-          config.password = settings.encryption.password
-          config.method = settings.encryption.method
-          config.pbkd_function = settings.encryption.pbkd_function
-        end
       end
 
       # Default format config from the product definition.


### PR DESCRIPTION
This PR implements 2 small improvements:

* Improve the storage schema: the LUKS key size has to be multiple of 8, but the schema was not forcing it. 
* Remove unused method `ConfigBuilder#default_encryption`. It is not needed anymore after the changes introduced by https://github.com/agama-project/agama/pull/3844.
