### PR TITLE
fix(web): deal with unknown localization settings

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Sep  1 14:20:00 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Cope with unknown localization settings: report them as an
+  installation issue instead of crashing the overview, and keep the
+  recognized language, keyboard and time zone selected so only the
+  wrong one has to be fixed (bsc#1277313).
+
+-------------------------------------------------------------------
 Mon Aug 31 15:53:32 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Default the registration form to the effective registration URL

--- a/web/src/components/l10n/L10nPage.test.tsx
+++ b/web/src/components/l10n/L10nPage.test.tsx
@@ -24,12 +24,12 @@ import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
 import { useSystem } from "~/hooks/model/system/l10n";
-import { useProposal } from "~/hooks/model/proposal/l10n";
+import { useExtendedL10n } from "~/hooks/model/config/l10n";
 import { Keymap, Locale, Timezone } from "~/model/system/l10n";
 import L10nPage from "./L10nPage";
 
 let mockSystemData: ReturnType<typeof useSystem>;
-let mockProposedData: ReturnType<typeof useProposal>;
+let mockConfigData: ReturnType<typeof useExtendedL10n>;
 
 const locales: Locale[] = [
   { id: "en_US.UTF-8", language: "English", territory: "United States" },
@@ -55,9 +55,9 @@ jest.mock("~/hooks/model/system/l10n", () => ({
   useSystem: () => mockSystemData,
 }));
 
-jest.mock("~/hooks/model/proposal/l10n", () => ({
-  ...jest.requireActual("~/hooks/model/proposal/l10n"),
-  useProposal: () => mockProposedData,
+jest.mock("~/hooks/model/config/l10n", () => ({
+  ...jest.requireActual("~/hooks/model/config/l10n"),
+  useExtendedL10n: () => mockConfigData,
 }));
 
 beforeEach(() => {
@@ -67,7 +67,7 @@ beforeEach(() => {
     timezones,
   };
 
-  mockProposedData = {
+  mockConfigData = {
     locale: "en_US.UTF-8",
     keymap: "us",
     timezone: "Europe/Berlin",
@@ -90,4 +90,30 @@ it("renders the language, keyboard and time zone selectors", () => {
   screen.getByRole("combobox", { name: "Language" });
   screen.getByRole("combobox", { name: "Keyboard" });
   screen.getByRole("combobox", { name: "Time zone" });
+});
+
+describe("when a configured id is not recognized", () => {
+  beforeEach(() => {
+    mockConfigData = { locale: "es_ES.UTF-8", keymap: "us", timezone: "Europe/ndorra" };
+  });
+
+  it("keeps the recognized settings selected", () => {
+    installerRender(<L10nPage />);
+    screen.getByRole("combobox", { name: "Language" });
+    expect(screen.getByRole("combobox", { name: "Language" })).toHaveValue("Spanish (Spain)");
+    expect(screen.getByRole("combobox", { name: "Keyboard" })).toHaveValue("English");
+  });
+});
+
+describe("when the system reports no localization data yet", () => {
+  beforeEach(() => {
+    mockSystemData = null;
+  });
+
+  it("renders the selectors with no options to choose from", () => {
+    installerRender(<L10nPage />);
+    expect(screen.getByRole("combobox", { name: "Language" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Keyboard" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Time zone" })).toHaveValue("");
+  });
 });

--- a/web/src/components/l10n/L10nPage.test.tsx
+++ b/web/src/components/l10n/L10nPage.test.tsx
@@ -26,10 +26,12 @@ import { installerRender } from "~/test-utils";
 import { useSystem } from "~/hooks/model/system/l10n";
 import { useExtendedL10n } from "~/hooks/model/config/l10n";
 import { Keymap, Locale, Timezone } from "~/model/system/l10n";
+import type { Issue } from "~/model/issue";
 import L10nPage from "./L10nPage";
 
 let mockSystemData: ReturnType<typeof useSystem>;
 let mockConfigData: ReturnType<typeof useExtendedL10n>;
+let mockIssues: Issue[];
 
 const locales: Locale[] = [
   { id: "en_US.UTF-8", language: "English", territory: "United States" },
@@ -60,6 +62,11 @@ jest.mock("~/hooks/model/config/l10n", () => ({
   useExtendedL10n: () => mockConfigData,
 }));
 
+jest.mock("~/hooks/model/issue", () => ({
+  ...jest.requireActual("~/hooks/model/issue"),
+  useIssues: () => mockIssues,
+}));
+
 beforeEach(() => {
   mockSystemData = {
     locales,
@@ -72,6 +79,8 @@ beforeEach(() => {
     keymap: "us",
     timezone: "Europe/Berlin",
   };
+
+  mockIssues = [];
 });
 
 it("renders a clarification about settings", () => {
@@ -90,6 +99,23 @@ it("renders the language, keyboard and time zone selectors", () => {
   screen.getByRole("combobox", { name: "Language" });
   screen.getByRole("combobox", { name: "Keyboard" });
   screen.getByRole("combobox", { name: "Time zone" });
+});
+
+describe("when the backend reports localization issues", () => {
+  beforeEach(() => {
+    mockIssues = [
+      {
+        scope: "l10n",
+        class: "unknown_timezone",
+        description: "Timezone 'Europe/ndorra' is unknown",
+      },
+    ];
+  });
+
+  it("tells the user what is not recognized", () => {
+    installerRender(<L10nPage />);
+    screen.getByText("Timezone 'Europe/ndorra' is unknown");
+  });
 });
 
 describe("when a configured id is not recognized", () => {

--- a/web/src/components/l10n/L10nPage.tsx
+++ b/web/src/components/l10n/L10nPage.tsx
@@ -24,9 +24,11 @@ import React from "react";
 import { Button } from "@patternfly/react-core";
 import InstallerL10nOptions from "~/components/core/InstallerL10nOptions";
 import Interpolate from "~/components/core/Interpolate";
+import IssuesAlert from "~/components/core/IssuesAlert";
 import Page from "~/components/core/Page";
 import Text from "~/components/core/Text";
 import L10nForm from "~/components/l10n/l10n-form/Form";
+import { useIssues } from "~/hooks/model/issue";
 import { localConnection } from "~/utils";
 import { _ } from "~/i18n";
 
@@ -64,12 +66,19 @@ const InstallerL10nSettingsInfo = () => {
 
 /**
  * Page for configuring localization.
+ *
+ * Reports the localization issues found by the backend, which is where users
+ * learn which of the three settings is not recognized after the overview flags
+ * them as invalid.
  */
 export default function L10nPage() {
+  const issues = useIssues("l10n");
+
   return (
     <Page breadcrumbs={[{ label: "Language and region" }]}>
       <Page.Content>
         <InstallerL10nSettingsInfo />
+        <IssuesAlert issues={issues} />
         <L10nForm />
       </Page.Content>
     </Page>

--- a/web/src/components/l10n/l10n-form/Form.test.tsx
+++ b/web/src/components/l10n/l10n-form/Form.test.tsx
@@ -26,7 +26,7 @@ import { installerRender } from "~/test-utils";
 
 const mockPatchConfig = jest.fn();
 const mockSystem = jest.fn();
-const mockProposal = jest.fn();
+const mockConfig = jest.fn();
 
 jest.mock("~/api", () => ({
   ...jest.requireActual("~/api"),
@@ -37,8 +37,8 @@ jest.mock("~/hooks/model/system/l10n", () => ({
   useSystem: () => mockSystem(),
 }));
 
-jest.mock("~/hooks/model/proposal/l10n", () => ({
-  useProposal: () => mockProposal(),
+jest.mock("~/hooks/model/config/l10n", () => ({
+  useExtendedL10n: () => mockConfig(),
 }));
 
 const SYSTEM = {
@@ -61,7 +61,7 @@ const SYSTEM = {
   ],
 };
 
-const PROPOSAL = {
+const CONFIG = {
   locale: "en_US.UTF-8",
   keymap: "us",
   timezone: "America/New_York",
@@ -72,7 +72,7 @@ const accept = () => screen.getByRole("button", { name: "Accept" });
 
 beforeEach(() => {
   mockSystem.mockReturnValue(SYSTEM);
-  mockProposal.mockReturnValue(PROPOSAL);
+  mockConfig.mockReturnValue(CONFIG);
   mockPatchConfig.mockResolvedValue(true);
 });
 

--- a/web/src/components/l10n/l10n-form/queries.ts
+++ b/web/src/components/l10n/l10n-form/queries.ts
@@ -20,16 +20,21 @@
  * find current contact information at www.suse.com.
  */
 
-import { useProposal } from "~/hooks/model/proposal/l10n";
+import { useExtendedL10n } from "~/hooks/model/config/l10n";
 import { useSystem } from "~/hooks/model/system/l10n";
 
 import type { Keymap, Locale, Timezone } from "~/model/system/l10n";
 
 /**
  * Everything the localization form needs in one shape: the option lists to
- * choose from (from the system) and the currently selected ids (from the
- * proposal). Aggregated here so the form can be wrapped in `withFrozenQuery`
- * and the lists/values do not shift mid-edit.
+ * choose from (from the system) and the ids currently in use (from the extended
+ * configuration). Aggregated here so the form can be wrapped in
+ * `withFrozenQuery` and the lists/values do not shift mid-edit.
+ *
+ * The ids come from the configuration rather than from the proposal because the
+ * backend drops the whole proposal as soon as one of the three values is
+ * unknown. Reading the configuration keeps the two valid fields preselected so
+ * the user only has to correct the one that is actually wrong.
  */
 type L10nData = {
   locales: Locale[];
@@ -42,15 +47,15 @@ type L10nData = {
 
 function useL10nData(): L10nData {
   const system = useSystem();
-  const proposal = useProposal();
+  const config = useExtendedL10n();
 
   return {
     locales: system?.locales ?? [],
     keymaps: system?.keymaps ?? [],
     timezones: system?.timezones ?? [],
-    locale: proposal?.locale,
-    keymap: proposal?.keymap,
-    timezone: proposal?.timezone,
+    locale: config?.locale,
+    keymap: config?.keymap,
+    timezone: config?.timezone,
   };
 }
 

--- a/web/src/components/overview/L10nSummary.test.tsx
+++ b/web/src/components/overview/L10nSummary.test.tsx
@@ -23,41 +23,28 @@
 import React from "react";
 import { screen, within } from "@testing-library/react";
 import { installerRender } from "~/test-utils";
-import L10nSummary from "./L10nSummary";
 import { L10N } from "~/routes/paths";
 import { useSystem } from "~/hooks/model/system/l10n";
+import { useExtendedL10n } from "~/hooks/model/config/l10n";
+import { useIssues } from "~/hooks/model/issue";
+import type { Issue } from "~/model/issue";
+import L10nSummary from "./L10nSummary";
+
+let mockConfig: ReturnType<typeof useExtendedL10n>;
+let mockIssues: Issue[];
 
 jest.mock("~/hooks/model/system/l10n", () => ({
   useSystem: (): ReturnType<typeof useSystem> => ({
     locales: [
-      {
-        id: "es_ES",
-        language: "Spanish",
-        territory: "Spain",
-      },
-      {
-        id: "en_US",
-        language: "English",
-        territory: "United States",
-      },
+      { id: "es_ES", language: "Spanish", territory: "Spain" },
+      { id: "en_US", language: "English", territory: "United States" },
     ],
     keymaps: [
-      {
-        id: "es",
-        description: "Spanish",
-      },
-      {
-        id: "us",
-        description: "English (US)",
-      },
+      { id: "es", description: "Spanish" },
+      { id: "us", description: "English (US)" },
     ],
     timezones: [
-      {
-        id: "Atlantic/Canary",
-        parts: ["Atlantic", "Canary"],
-        country: "Spain",
-        utcOffset: 0,
-      },
+      { id: "Atlantic/Canary", parts: ["Atlantic", "Canary"], country: "Spain", utcOffset: 0 },
       {
         id: "America/New_York",
         parts: ["America", "New_York"],
@@ -68,13 +55,18 @@ jest.mock("~/hooks/model/system/l10n", () => ({
   }),
 }));
 
-jest.mock("~/hooks/model/proposal/l10n", () => ({
-  useProposal: () => ({
-    locale: "es_ES",
-    keymap: "es",
-    timezone: "Atlantic/Canary",
-  }),
+jest.mock("~/hooks/model/config/l10n", () => ({
+  useExtendedL10n: (): ReturnType<typeof useExtendedL10n> => mockConfig,
 }));
+
+jest.mock("~/hooks/model/issue", () => ({
+  useIssues: (): ReturnType<typeof useIssues> => mockIssues,
+}));
+
+beforeEach(() => {
+  mockConfig = { locale: "es_ES", keymap: "es", timezone: "Atlantic/Canary" };
+  mockIssues = [];
+});
 
 describe("L10nSummary", () => {
   it("renders the clickable 'Language and region' header", () => {
@@ -92,5 +84,35 @@ describe("L10nSummary", () => {
   it("renders the keyboard layout and timezone description", () => {
     installerRender(<L10nSummary />);
     screen.getByText("Spanish keyboard - Atlantic/Canary timezone");
+  });
+
+  describe("when the system reports no entry matching the configured ids", () => {
+    beforeEach(() => {
+      mockConfig = { locale: "xx_XX", keymap: "xx", timezone: "Europe/ndorra" };
+    });
+
+    it("falls back to rendering the configured ids", () => {
+      installerRender(<L10nSummary />);
+      screen.getByText("xx_XX");
+      screen.getByText("xx keyboard - Europe/ndorra timezone");
+    });
+  });
+
+  describe("when the localization settings have issues", () => {
+    beforeEach(() => {
+      mockIssues = [
+        {
+          scope: "l10n",
+          class: "unknown_timezone",
+          description: "Timezone 'Europe/ndorra' is unknown",
+        },
+      ];
+    });
+
+    it("reports the settings as invalid instead of describing them", () => {
+      installerRender(<L10nSummary />);
+      screen.getByText("Invalid settings");
+      expect(screen.queryByText(/keyboard/)).toBeNull();
+    });
   });
 });

--- a/web/src/components/overview/L10nSummary.tsx
+++ b/web/src/components/overview/L10nSummary.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2025] SUSE LLC
+ * Copyright (c) [2025-2026] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -21,51 +21,85 @@
  */
 
 import React from "react";
+import { isEmpty } from "radashi";
+import { sprintf } from "sprintf-js";
 import Summary from "~/components/core/Summary";
 import Link from "~/components/core/Link";
-import { useProposal } from "~/hooks/model/proposal/l10n";
+import { useExtendedL10n } from "~/hooks/model/config/l10n";
 import { useSystem } from "~/hooks/model/system/l10n";
+import { useIssues } from "~/hooks/model/issue";
 import { L10N } from "~/routes/paths";
-import { sprintf } from "sprintf-js";
 import { _ } from "~/i18n";
 
 /**
- * Displays a summary of the selected localization settings.
+ * Renders the selected language, as its name and territory.
  *
- * Shows the currently configured language, keyboard layout, and timezone in a
- * consistent summary format. The title is a link that navigates to the
- * localization configuration page.
+ * Falls back to the configured locale id when the system reports no locale
+ * matching it, which is what happens when the id is unknown or misspelled.
  */
-export default function L10nSummary() {
-  const l10nProposal = useProposal();
-  const l10nSystem = useSystem();
-  const locale =
-    l10nProposal.locale && l10nSystem.locales.find((l) => l.id === l10nProposal.locale);
-  const keymap =
-    l10nProposal.keymap && l10nSystem.keymaps.find((k) => k.id === l10nProposal.keymap);
-  const timezone =
-    l10nProposal.timezone && l10nSystem.timezones.find((t) => t.id === l10nProposal.timezone);
+const Value = () => {
+  const config = useExtendedL10n();
+  const system = useSystem();
+  const locale = system?.locales?.find((l) => l.id === config?.locale);
+
+  if (!locale) return config?.locale;
 
   // TRANSLATORS: Summary of the selected language and territory.
   // %1$s is the language name (e.g. "Spanish").
   // %2$s is the territory/region name (e.g. "Spain").
-  const title = sprintf(_("%1$s (%2$s)"), locale.language, locale.territory);
+  return sprintf(_("%1$s (%2$s)"), locale.language, locale.territory);
+};
+
+/**
+ * Renders the selected keyboard layout and time zone.
+ *
+ * The keyboard falls back to its configured id when the system reports no
+ * layout matching it, which is what happens when the id is unknown or
+ * misspelled. Time zones are always shown by id, since that is how users know
+ * them.
+ */
+const Description = () => {
+  const config = useExtendedL10n();
+  const system = useSystem();
+  const keymap = system?.keymaps?.find((k) => k.id === config?.keymap);
+
+  // TRANSLATORS: Additional details shown under the language selection.
+  // %1$s is the keyboard layout name (e.g. "Spanish").
+  // %2$s is the time zone identifier (e.g. "Atlantic/Canary").
+  return sprintf(
+    _("%1$s keyboard - %2$s timezone"),
+    keymap?.description ?? config?.keymap,
+    config?.timezone,
+  );
+};
+
+/**
+ * Displays a summary of the selected localization settings.
+ *
+ * Shows the currently configured language, keyboard layout, and time zone in a
+ * consistent summary format. The title is a link that navigates to the
+ * localization configuration page.
+ *
+ * When the localization settings are reported as invalid, the summary says so
+ * instead of describing them, matching how the other summaries of the overview
+ * behave. The details are left out on purpose: the localization page is where
+ * users find out what is wrong and fix it.
+ */
+export default function L10nSummary() {
+  const issues = useIssues("l10n");
+  const hasIssues = !isEmpty(issues);
 
   return (
     <Summary
+      hasIssues={hasIssues}
       icon="translate"
       title={
         <Link to={L10N.root} variant="link" isInline>
           {_("Language and region")}
         </Link>
       }
-      value={title}
-      description={
-        // TRANSLATORS: Additional details shown under the language selection.
-        // %1$s is the keyboard layout name (e.g. "Spanish").
-        // %2$s is the time zone identifier (e.g. "Atlantic/Canary").
-        sprintf(_("%1$s keyboard - %2$s timezone"), keymap.description, timezone.id)
-      }
+      value={hasIssues ? _("Invalid settings") : <Value />}
+      description={hasIssues ? null : <Description />}
     />
   );
 }

--- a/web/src/hooks/model/config/l10n.ts
+++ b/web/src/hooks/model/config/l10n.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) [2026] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { configQuery, extendedConfigQuery } from "~/hooks/model/config";
+import type { Config } from "~/model/config";
+import type * as L10n from "~/model/config/l10n";
+
+const selectL10n = (data: Config | null): L10n.Config | null => data?.l10n;
+
+/**
+ * Returns the localization settings the user set, through the UI or an
+ * installation profile.
+ *
+ * Locale, keymap and timezone can each be missing, and on a fresh boot all
+ * three usually are. That does not mean Agama has no value for them: it always
+ * resolves one. Use this hook to know what the user chose. To know what will be
+ * installed, or to show a value on screen, use {@link useExtendedL10n}.
+ */
+function useL10n(): L10n.Config | null {
+  const { data } = useSuspenseQuery({
+    ...configQuery,
+    select: selectL10n,
+  });
+  return data;
+}
+
+/**
+ * Returns the localization settings Agama will install: what the user set, on
+ * top of what the system provides. Locale, keymap and timezone are always
+ * present.
+ *
+ * Prefer this over the localization proposal. Both hold the same three values
+ * while the settings are valid, but the backend sends no proposal at all once
+ * one of them is unknown. These settings are still there, bad value included,
+ * so a view can show what is wrong.
+ *
+ * The ids are whatever was configured, so they may not match any entry in the
+ * lists the system reports. Callers looking one up must handle finding nothing.
+ */
+function useExtendedL10n(): L10n.Config | null {
+  const { data } = useSuspenseQuery({
+    ...extendedConfigQuery,
+    select: selectL10n,
+  });
+  return data;
+}
+
+export { useL10n, useExtendedL10n };

--- a/web/src/model/issue.ts
+++ b/web/src/model/issue.ts
@@ -20,7 +20,7 @@
  * find current contact information at www.suse.com.
  */
 
-type Scope = "localization" | "product" | "software" | "storage" | "users" | "iscsi" | "zfcp";
+type Scope = "l10n" | "product" | "software" | "storage" | "users" | "iscsi" | "zfcp";
 
 type Issue = {
   scope: Scope;


### PR DESCRIPTION
## Problem

* [bsc#1277313](https://bugzilla.suse.com/show_bug.cgi?id=1277313)

Agama now accepts a profile with an unknown timezone or locale and registers an installation issue for it, which is the right approach. The web UI does not cope with that case: the overview crashes with "Cannot read properties of undefined" and takes the whole page down.

The backend drops the localization proposal as a whole as soon as one of locale, keymap or timezone is unknown, and the summary read it anyway. On top of that, the issue scope was typed as `localization` while the backend sends `l10n`, so no localization issue was ever noticed by the UI.


| Overview | Page |
|-|-|
| <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-01T154623 979" src="https://github.com/user-attachments/assets/da46d31d-7806-4faa-a200-4499f2d8d9da" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-01T154618 810" src="https://github.com/user-attachments/assets/613cf839-28e2-4dd9-bb3d-1860f9608cbf" /> |


## Solution

The overview and the localization form now read the extended configuration, which always carries the three values, instead of the proposal. The summary reports "Invalid settings" like its neighbours do, and the localization page shows which setting is not recognized.

A nice side effect: the form keeps the recognized language and keyboard selected, so the user only has to fix the one field that is actually wrong instead of picking the three again.

| Overview | Page |
|-|-|
| <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-01T154413 338" src="https://github.com/user-attachments/assets/7cdcae7e-1e20-4ee0-ba5e-d8379b1d50cd" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-01T154416 620" src="https://github.com/user-attachments/assets/275a0b22-72f0-450f-b4f1-18378f8c5369" /> |


## Details

* `model/issue.ts` used a scope name the backend does not send.
* New `hooks/model/config/l10n.ts`, following the `useProduct` / `useExtendedProduct` pair added in #3853.
* The summary falls back to the configured id when the system reports no matching entry, so an unknown value shows as itself rather than as an error page.

## Testing

* New cases for the invalid settings path in the summary and the page, and for the fallback to raw ids.
* `npm run test`, `npm run eslint` and `npm run check-types` pass.
* Checked against a running installer with `timezone: "Europe/ndorra"` in the profile.

