### PR TITLE
Sanitize rust dependencies

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -67,6 +67,54 @@ jobs:
     - name: Run rustfmt
       run: cargo fmt --all -- --check
 
+  # Detects dependencies which are declared in a Cargo.toml but never used, so
+  # they do not pile up unnoticed. It only parses the manifests and the sources,
+  # no compilation and no system libraries are needed, hence the plain runner.
+  machete:
+    # the default timeout is 6 hours, that's too much if the job gets stuck
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./rust
+
+    env:
+      # keep the version pinned so the check cannot start failing on its own
+      CARGO_MACHETE_VERSION: 0.9.2
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v7
+
+    - name: Rust toolchain
+      run: |
+        rustup show
+        cargo --version
+
+    - name: cargo-machete cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cargo/bin/cargo-machete
+        key: ${{ runner.os }}-cargo-machete-${{ env.CARGO_MACHETE_VERSION }}
+
+    - name: Install cargo-machete
+      run: |
+        if ! [ -x ~/.cargo/bin/cargo-machete ]; then
+          cargo install --locked cargo-machete --version "$CARGO_MACHETE_VERSION"
+        fi
+
+    # --with-metadata is required: without it the check reports plenty of false
+    # positives for crates whose library name differs from the package name
+    # (gettext-rs/gettextrs, for instance).
+    #
+    # A dependency which is only used from a doctest is not detected either, as
+    # cargo-machete does not scan doc comments. Add those to the
+    # [package.metadata.cargo-machete] "ignored" list of the affected crate.
+    - name: Run cargo-machete
+      run: cargo machete --with-metadata
+
   clippy:
     # the default timeout is 6 hours, that's too much if the job gets stuck
     timeout-minutes: 20

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -14,10 +14,6 @@ version = "0.1.0"
 dependencies = [
  "agama-utils",
  "async-trait",
- "gettext-rs",
- "openssl",
- "tempfile",
- "test-context",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -27,7 +23,6 @@ dependencies = [
 name = "agama-autoinstall"
 version = "0.1.0"
 dependencies = [
- "agama-l10n",
  "agama-lib",
  "agama-transfer",
  "agama-utils",
@@ -49,10 +44,8 @@ dependencies = [
  "agama-storage-client",
  "agama-utils",
  "async-trait",
- "gettext-rs",
  "serde",
  "serde_json",
- "test-context",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
@@ -71,7 +64,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "console",
  "crossterm",
  "fluent-uri 0.4.1",
  "futures-util",
@@ -93,7 +85,6 @@ dependencies = [
 name = "agama-files"
 version = "0.1.0"
 dependencies = [
- "agama-l10n",
  "agama-utils",
  "async-trait",
  "gettext-rs",
@@ -103,7 +94,6 @@ dependencies = [
  "test-context",
  "thiserror 2.0.18",
  "tokio",
- "tokio-test",
  "tracing",
 ]
 
@@ -155,7 +145,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-test",
  "tracing",
  "zbus",
 ]
@@ -168,7 +157,6 @@ dependencies = [
  "agama-utils",
  "anyhow",
  "chrono",
- "env_logger",
  "fluent-uri 0.4.1",
  "fs_extra",
  "home",
@@ -238,7 +226,6 @@ dependencies = [
  "test-context",
  "thiserror 2.0.18",
  "tokio",
- "tokio-test",
  "tracing",
  "zbus",
 ]
@@ -271,7 +258,6 @@ dependencies = [
 name = "agama-ntp"
 version = "0.1.0"
 dependencies = [
- "agama-l10n",
  "agama-utils",
  "async-trait",
  "merge",
@@ -289,7 +275,6 @@ dependencies = [
  "agama-utils",
  "anyhow",
  "async-trait",
- "gettext-rs",
  "strum",
  "tempfile",
  "thiserror 2.0.18",
@@ -336,15 +321,11 @@ version = "0.1.0"
 dependencies = [
  "agama-l10n",
  "agama-lib",
- "agama-locale-data",
  "agama-manager",
- "agama-network",
- "agama-software",
  "agama-transfer",
  "agama-utils",
  "aide",
  "anyhow",
- "async-trait",
  "axum",
  "axum-extra",
  "bindgen 0.69.5",
@@ -353,7 +334,6 @@ dependencies = [
  "futures-util",
  "gethostname",
  "gettext-rs",
- "http-body-util",
  "hyper",
  "hyper-util",
  "indexmap 2.13.0",
@@ -370,7 +350,6 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tokio-stream",
- "tokio-test",
  "tokio-util",
  "tower",
  "tower-http",
@@ -395,7 +374,6 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_yaml",
- "strum",
  "suseconnect-agama",
  "tempfile",
  "thiserror 2.0.18",
@@ -458,10 +436,8 @@ dependencies = [
  "gettext-rs",
  "schemars 1.2.1",
  "serde",
- "test-context",
  "thiserror 2.0.18",
  "tokio",
- "tokio-test",
  "tracing",
 ]
 
@@ -1385,19 +1361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,12 +1727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,29 +1760,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2788,7 +2722,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4780,7 +4714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6070,13 +6004,11 @@ dependencies = [
  "agama-cli",
  "agama-server",
  "agama-utils",
- "clap",
  "clap-markdown",
  "clap_complete",
  "clap_mangen",
  "serde_json",
  "serde_yaml",
- "tokio",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "agama-autoinstall",
+    "agama-bootloader",
     "agama-cli",
     "agama-files",
     "agama-hostname",
@@ -36,14 +37,26 @@ edition = "2021"
 
 [workspace.dependencies]
 agama-access = { path = "agama-access" }
+agama-bootloader = { path = "agama-bootloader" }
+agama-cli = { path = "agama-cli" }
+agama-files = { path = "agama-files" }
+agama-hostname = { path = "agama-hostname" }
+agama-iscsi = { path = "agama-iscsi" }
 agama-l10n = { path = "agama-l10n" }
 agama-lib = { path = "agama-lib" }
 agama-locale-data = { path = "agama-locale-data" }
+agama-manager = { path = "agama-manager" }
 agama-network = { path = "agama-network" }
+agama-ntp = { path = "agama-ntp" }
+agama-proxy = { path = "agama-proxy" }
+agama-s390 = { path = "agama-s390" }
 agama-security = { path = "agama-security" }
+agama-server = { path = "agama-server" }
 agama-software = { path = "agama-software" }
+agama-storage = { path = "agama-storage" }
 agama-storage-client = { path = "agama-storage-client" }
 agama-transfer = { path = "agama-transfer" }
+agama-users = { path = "agama-users" }
 agama-utils = { path = "agama-utils" }
 anyhow = { version = "1.0.100" }
 async-trait = { version = "0.1.89" }
@@ -69,6 +82,7 @@ serde_json = { version = "1.0.145", features = ["raw_value"] }
 serde_with = { version = "3.16.1" }
 serde_yaml = { version = "0.9.34" }
 strum = { version = "0.27.2", features = ["derive"] }
+suseconnect-agama = { path = "suseconnect-agama" }
 tempfile = { version = "3.27.0" }
 test-context = { version = "0.4.1" }
 thiserror = { version = "2.0.18" }

--- a/rust/agama-access/Cargo.toml
+++ b/rust/agama-access/Cargo.toml
@@ -7,12 +7,7 @@ edition.workspace = true
 [dependencies]
 agama-utils = { workspace = true }
 async-trait = { workspace = true }
-gettext-rs = { workspace = true }
-openssl = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-[dev-dependencies]
-tempfile = { workspace = true }
-test-context = { workspace = true }

--- a/rust/agama-autoinstall/Cargo.toml
+++ b/rust/agama-autoinstall/Cargo.toml
@@ -5,7 +5,6 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-l10n = { workspace = true }
 agama-lib = { workspace = true }
 agama-transfer = { workspace = true }
 agama-utils = { workspace = true }

--- a/rust/agama-autoinstall/Cargo.toml
+++ b/rust/agama-autoinstall/Cargo.toml
@@ -13,7 +13,9 @@ fluent-uri = { workspace = true }
 gettext-rs = { workspace = true }
 i18n-format = { workspace = true }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/rust/agama-bootloader/Cargo.toml
+++ b/rust/agama-bootloader/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 agama-storage-client = { workspace = true }
 agama-utils = { workspace = true }
 async-trait = { workspace = true }
-gettext-rs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -17,5 +16,7 @@ tracing = { workspace = true }
 zbus = { workspace = true }
 
 [dev-dependencies]
-test-context = { workspace = true }
 tokio-test = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["tokio-test"]

--- a/rust/agama-cli/Cargo.toml
+++ b/rust/agama-cli/Cargo.toml
@@ -13,7 +13,6 @@ agama-utils = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-console = "0.15.8"
 crossterm = { version = "0.29", features = ["event-stream"] }
 fluent-uri = { workspace = true }
 futures-util = { workspace = true }

--- a/rust/agama-files/Cargo.toml
+++ b/rust/agama-files/Cargo.toml
@@ -15,7 +15,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-agama-l10n = { workspace = true }
 serde_json = { workspace = true }
 test-context = { workspace = true }
-tokio-test = { workspace = true }

--- a/rust/agama-files/Cargo.toml
+++ b/rust/agama-files/Cargo.toml
@@ -9,11 +9,11 @@ agama-utils = { workspace = true }
 async-trait = { workspace = true }
 gettext-rs = { workspace = true }
 strum = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+tempfile = { workspace = true }
 serde_json = { workspace = true }
 test-context = { workspace = true }

--- a/rust/agama-hostname/Cargo.toml
+++ b/rust/agama-hostname/Cargo.toml
@@ -16,5 +16,4 @@ tracing = { workspace = true }
 zbus = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 test-context = { workspace = true }

--- a/rust/agama-iscsi/Cargo.toml
+++ b/rust/agama-iscsi/Cargo.toml
@@ -19,3 +19,6 @@ zbus = { workspace = true }
 [dev-dependencies]
 test-context = { workspace = true }
 tokio-test = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["tokio-test"]

--- a/rust/agama-l10n/Cargo.toml
+++ b/rust/agama-l10n/Cargo.toml
@@ -19,7 +19,6 @@ zbus = { workspace = true }
 
 [dev-dependencies]
 test-context = { workspace = true }
-tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-lib/Cargo.toml
+++ b/rust/agama-lib/Cargo.toml
@@ -35,5 +35,4 @@ zbus = { workspace = true }
 zypp-agama = { workspace = true }
 
 [dev-dependencies]
-env_logger = "0.11.5"
 httpmock = "0.8.3"

--- a/rust/agama-manager/Cargo.toml
+++ b/rust/agama-manager/Cargo.toml
@@ -6,19 +6,19 @@ edition.workspace = true
 
 [dependencies]
 agama-access = { workspace = true }
-agama-bootloader = { path = "../agama-bootloader" }
-agama-files = { path = "../agama-files" }
-agama-hostname = { path = "../agama-hostname" }
-agama-iscsi = { path = "../agama-iscsi" }
+agama-bootloader = { workspace = true }
+agama-files = { workspace = true }
+agama-hostname = { workspace = true }
+agama-iscsi = { workspace = true }
 agama-l10n = { workspace = true }
 agama-network = { workspace = true }
-agama-ntp = { path = "../agama-ntp" }
-agama-proxy = { version = "0.1.0", path = "../agama-proxy" }
-agama-s390 = { path = "../agama-s390" }
+agama-ntp = { workspace = true }
+agama-proxy = { workspace = true }
+agama-s390 = { workspace = true }
 agama-security = { workspace = true }
 agama-software = { workspace = true }
-agama-storage = { path = "../agama-storage" }
-agama-users = { path = "../agama-users" }
+agama-storage = { workspace = true }
+agama-users = { workspace = true }
 agama-utils = { workspace = true }
 async-trait = { workspace = true }
 gettext-rs = { workspace = true }

--- a/rust/agama-manager/Cargo.toml
+++ b/rust/agama-manager/Cargo.toml
@@ -35,7 +35,6 @@ zbus = { workspace = true }
 
 [dev-dependencies]
 test-context = { workspace = true }
-tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-ntp/Cargo.toml
+++ b/rust/agama-ntp/Cargo.toml
@@ -13,6 +13,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-agama-l10n = { workspace = true }
 tempfile = { workspace = true }
 test-context = { workspace = true }

--- a/rust/agama-proxy/Cargo.toml
+++ b/rust/agama-proxy/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 agama-utils = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-gettext-rs = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/rust/agama-s390/Cargo.toml
+++ b/rust/agama-s390/Cargo.toml
@@ -19,3 +19,6 @@ zbus = { workspace = true }
 [dev-dependencies]
 test-context = { workspace = true }
 tokio-test = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["tokio-test"]

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 agama-l10n = { workspace = true }
 agama-lib = { workspace = true }
-agama-manager = { path = "../agama-manager" }
+agama-manager = { workspace = true }
 agama-transfer = { workspace = true }
 agama-utils = { workspace = true }
 aide = { version = "0.16.0-alpha.4", features = ["axum", "axum-extra", "axum-json", "axum-query", "macros"] }

--- a/rust/agama-server/Cargo.toml
+++ b/rust/agama-server/Cargo.toml
@@ -9,15 +9,11 @@ rust-version.workspace = true
 [dependencies]
 agama-l10n = { workspace = true }
 agama-lib = { workspace = true }
-agama-locale-data = { workspace = true }
 agama-manager = { path = "../agama-manager" }
-agama-network = { workspace = true }
-agama-software = { workspace = true }
 agama-transfer = { workspace = true }
 agama-utils = { workspace = true }
 aide = { version = "0.16.0-alpha.4", features = ["axum", "axum-extra", "axum-json", "axum-query", "macros"] }
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 axum = { version = "0.8.9", features = ["ws", "macros"] }
 axum-extra = { version = "0.12.6", features = ["cookie", "typed-header"] }
 clap = { workspace = true }
@@ -54,15 +50,16 @@ name = "agama-web-server"
 path = "src/agama-web-server.rs"
 
 [dev-dependencies]
-http-body-util = "0.1.2"
 test-context = { workspace = true }
-tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }
 
-# here we force runtime for bindgen otherwise pam-sys fails.
-# Also it intentionally force old version of bindgen, which is
-# the exact one that is used for pam-sys ( it looks like unmaintained for some years )
+# Forces "runtime" feature on bindgen 0.69.5 (the version pam-sys uses) via Cargo feature
+# unification, so pam-sys's build script can load libclang dynamically. No build.rs needed.
 [build-dependencies]
 bindgen = { version = "0.69.5", features = ["runtime"] }
+
+[package.metadata.cargo-machete]
+ignored = ["bindgen"]
+

--- a/rust/agama-software/Cargo.toml
+++ b/rust/agama-software/Cargo.toml
@@ -16,7 +16,7 @@ i18n-format = { workspace = true }
 openssl = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-suseconnect-agama = { path = "../suseconnect-agama" }
+suseconnect-agama = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -24,7 +24,6 @@ url = { workspace = true }
 zypp-agama = { workspace = true }
 
 [dev-dependencies]
-glob = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/agama-software/Cargo.toml
+++ b/rust/agama-software/Cargo.toml
@@ -16,7 +16,6 @@ i18n-format = { workspace = true }
 openssl = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-strum = { workspace = true }
 suseconnect-agama = { path = "../suseconnect-agama" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rust/agama-storage/Cargo.toml
+++ b/rust/agama-storage/Cargo.toml
@@ -19,3 +19,6 @@ zbus = { workspace = true }
 [dev-dependencies]
 test-context = { workspace = true }
 tokio-test = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["tokio-test"]

--- a/rust/agama-users/Cargo.toml
+++ b/rust/agama-users/Cargo.toml
@@ -15,9 +15,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-[dev-dependencies]
-test-context = { workspace = true }
-tokio-test = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)'] }

--- a/rust/agama-utils/Cargo.toml
+++ b/rust/agama-utils/Cargo.toml
@@ -29,7 +29,6 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 strum = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -41,6 +40,7 @@ zbus = { workspace = true }
 zvariant = "5.5.2"
 
 [dev-dependencies]
+tempfile = { workspace = true }
 test-context = { workspace = true }
 tokio-test = { workspace = true }
 

--- a/rust/agama-utils/Cargo.toml
+++ b/rust/agama-utils/Cargo.toml
@@ -43,3 +43,6 @@ zvariant = "5.5.2"
 [dev-dependencies]
 test-context = { workspace = true }
 tokio-test = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["tokio-test"]

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep  2 14:09:43 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Sanitize rust dependencies and add CI task to check unused
+  dependencies (gh#agama-project/agama#3856).
+
+-------------------------------------------------------------------
 Tue Sep  1 15:51:02 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 24

--- a/rust/suseconnect-agama/suseconnect-agama-sys/Cargo.toml
+++ b/rust/suseconnect-agama/suseconnect-agama-sys/Cargo.toml
@@ -5,3 +5,6 @@ edition.workspace = true
 
 [build-dependencies]
 bindgen = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["bindgen"]

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -5,8 +5,8 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-agama-cli = { path = "../agama-cli" }
-agama-server = { path = "../agama-server" }
+agama-cli = { workspace = true }
+agama-server = { workspace = true }
 agama-utils = { workspace = true }
 clap-markdown = "0.1.4"
 clap_complete = "4.5.32"

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -8,10 +8,8 @@ edition.workspace = true
 agama-cli = { path = "../agama-cli" }
 agama-server = { path = "../agama-server" }
 agama-utils = { workspace = true }
-clap = { workspace = true }
 clap-markdown = "0.1.4"
 clap_complete = "4.5.32"
 clap_mangen = "0.2.23"
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-tokio = { workspace = true }

--- a/rust/zypp-agama/zypp-agama-sys/Cargo.toml
+++ b/rust/zypp-agama/zypp-agama-sys/Cargo.toml
@@ -7,3 +7,6 @@ edition.workspace = true
 
 [build-dependencies]
 bindgen = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["bindgen"]


### PR DESCRIPTION
## Problem

Shared dependencies are defined at workspace level. Therefore, all rust packages use the very same versions. But some packages include unused dependencies.

https://trello.com/c/bSRNyNt3/5980-5-reduce-node-javascript-and-rust-dependencies

## Solution

Analyzed rust dependencies using `cargo-machete 0.9.2` with the `--with-metadata` flag (more accurate, avoids
false positives from feature-gated or macro-only usage). Source code was cross-checked for borderline cases.

Run command:
```
cargo machete --with-metadata
```

### Findings

| Crate | Dependency | Section | Verdict |
| --- | --- | --- | --- |
| `agama-access` | `gettext-rs` | dependencies | Unused — no reference in src/ |
| `agama-access` | `openssl` | dependencies | Unused — no reference in src/ |
| `agama-access` | `tempfile` | dependencies | Unused — no reference in src/ |
| `agama-access` | `test-context` | dev-dependencies | Unused — no reference in src/ |
| `agama-autoinstall` | `agama-l10n` | dependencies | Unused — no reference in src/ |
| `agama-bootloader` | `gettext-rs` | dependencies | Unused — no reference in src/ |
| `agama-bootloader` | `test-context` | dev-dependencies | Unused — no reference in src/ |
| `agama-bootloader` | `tokio-test` | dev-dependencies | Kept — used by the doc-test in `test_utils.rs` |
| `agama-cli` | `console` | dependencies | Unused — no reference in src/ |
| `agama-files` | `agama-l10n` | dependencies | Unused — no reference in src/ |
| `agama-files` | `tokio-test` | dev-dependencies | Unused |
| `agama-iscsi` | `tokio-test` | dev-dependencies | Kept — used by the doc-test in `test_utils.rs` |
| `agama-l10n` | `tokio-test` | dev-dependencies | Unused |
| `agama-lib` | `env_logger` | dependencies | Unused — no reference in src/ |
| `agama-manager` | `tokio-test` | dev-dependencies | Unused |
| `agama-ntp` | `agama-l10n` | dependencies | Unused — no reference in src/ |
| `agama-proxy` | `gettext-rs` | dependencies | Unused — no reference in src/ |
| `agama-s390` | `tokio-test` | dev-dependencies | Kept — used by the doc-test in `test_utils.rs` |
| `agama-server` | `agama-locale-data` | dependencies | Unused — no reference in src/ |
| `agama-server` | `agama-network` | dependencies | Unused — no reference in src/ |
| `agama-server` | `agama-software` | dependencies | Unused — no reference in src/ |
| `agama-server` | `async-trait` | dependencies | Unused — no reference in src/ |
| `agama-server` | `bindgen` | build-dependencies | Unused — no `build.rs` exists in this crate |
| `agama-server` | `http-body-util` | dev-dependencies | Unused — no reference in src/ |
| `agama-server` | `tokio-test` | dev-dependencies | Unused |
| `agama-software` | `strum` | dependencies | Unused — no reference in src/ |
| `agama-storage` | `tokio-test` | dev-dependencies | Kept — used by the doc-test in `test_utils.rs` |
| `agama-users` | `test-context` | dev-dependencies | Unused — no reference in src/ |
| `agama-users` | `tokio-test` | dev-dependencies | Unused |
| `agama-utils` | `tokio-test` | dev-dependencies | kept — appears in a doc example |
| `xtask` | `clap` | dependencies | Unused directly — CLI types come from `agama-cli::build_cli()` |
| `xtask` | `tokio` | dependencies | Unused — async runtime is provided by `agama_utils::runtime::run_async` |

### False positives

These entries are flagged by cargo-machete because it does not scan `build.rs` files. They are legitimately needed and suppressed via `ignored = ["bindgen"]` in each crate.

| Crate | Dependency | Reason |
|---|---|---|
| `zypp-agama-sys` | `bindgen` (build-dep) | Used in `build.rs` for FFI binding generation |
| `suseconnect-agama-sys` | `bindgen` (build-dep) | Used in `build.rs` for FFI binding generation |
| `agama-server` | `bindgen` (build-dep) | Forces `runtime` feature on bindgen 0.69.5 via Cargo feature unification so that `pam-sys`'s build script can load libclang dynamically. No `build.rs` needed. |

## Bonus

Added CI task to automatically run `cargo machete`.