### PR TITLE
Use camelCase for ieee8021x in Agama Network HTTP API

### DIFF
--- a/rust/agama-utils/src/api/network/settings.rs
+++ b/rust/agama-utils/src/api/network/settings.rs
@@ -351,7 +351,11 @@ pub struct NetworkConnection {
     #[serde(skip_serializing_if = "is_zero", default)]
     pub mtu: u32,
     /// IEEE 802.1X settings
-    #[serde(rename = "ieee-8021x", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ieee8021x",
+        alias = "ieee-8021x",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub ieee_8021x: Option<IEEE8021XSettings>,
     /// Specifies if the connection should automatically connect
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -420,6 +424,36 @@ mod tests {
         }"#;
         let conn: NetworkConnection = serde_json::from_str(json).unwrap();
         assert_eq!(conn.dns_searchlist, vec!["example.org"]);
+    }
+
+    #[test]
+    fn test_network_connection_ieee8021x_serialization() {
+        let json = r#"{
+            "id": "eth0",
+            "ieee8021x": { "eap": ["tls"], "identity": "jane" }
+        }"#;
+        let conn: NetworkConnection = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            conn.ieee_8021x.as_ref().unwrap().identity.as_deref(),
+            Some("jane")
+        );
+
+        let serialized = serde_json::to_string(&conn).unwrap();
+        assert!(serialized.contains("\"ieee8021x\":"));
+        assert!(!serialized.contains("\"ieee-8021x\""));
+    }
+
+    #[test]
+    fn test_network_connection_ieee8021x_alias() {
+        let json = r#"{
+            "id": "eth0",
+            "ieee-8021x": { "eap": ["tls"], "identity": "jane" }
+        }"#;
+        let conn: NetworkConnection = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            conn.ieee_8021x.as_ref().unwrap().identity.as_deref(),
+            Some("jane")
+        );
     }
 
     #[test]

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep  2 11:31:32 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+
+- Use camelCase consistently for the JSON API keys renaming the
+  network connection "ieee-8021x" key to "ieee8021x", still
+  accepting the old name for backward compatibility.
+
+-------------------------------------------------------------------
 Fri Aug 28 15:32:30 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
 - update runtime dependencies to:

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Wed Sep  2 11:31:32 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
+Wed Sep  2 09:31:32 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Use camelCase consistently for the JSON API keys renaming the
   network connection "ieee-8021x" key to "ieee8021x", still

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -3,7 +3,8 @@ Wed Sep  2 09:31:32 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Use camelCase consistently for the JSON API keys renaming the
   network connection "ieee-8021x" key to "ieee8021x", still
-  accepting the old name for backward compatibility.
+  accepting the old name for backward compatibility
+  (gh#agama-project/agama#3858).
 
 -------------------------------------------------------------------
 Fri Aug 28 15:32:30 UTC 2026 - Martin Vidner <mvidner@suse.com>

--- a/rust/share/profile.schema.json
+++ b/rust/share/profile.schema.json
@@ -603,86 +603,12 @@
                   }
                 }
               },
+              "ieee8021x": {
+                "$ref": "#/$defs/ieee8021xSettings"
+              },
               "ieee-8021x": {
-                "type": "object",
-                "title": "IEEE 802.1x (EAP) settings",
-                "properties": {
-                  "eap": {
-                    "type": "array",
-                    "items": {
-                      "title": "List of EAP methods used",
-                      "type": "string",
-                      "enum": [
-                        "leap",
-                        "md5",
-                        "tls",
-                        "peap",
-                        "ttls",
-                        "pwd",
-                        "fast"
-                      ]
-                    }
-                  },
-                  "phase2Auth": {
-                    "title": "Phase 2 inner auth method",
-                    "type": "string",
-                    "enum": [
-                      "pap",
-                      "chap",
-                      "mschap",
-                      "mschapv2",
-                      "gtc",
-                      "otp",
-                      "md5",
-                      "tls"
-                    ]
-                  },
-                  "identity": {
-                    "title": "Identity string, often for example the user's login name",
-                    "type": "string"
-                  },
-                  "password": {
-                    "title": "Password string used for EAP authentication",
-                    "type": "string"
-                  },
-                  "caCert": {
-                    "title": "Path to CA certificate",
-                    "type": "string"
-                  },
-                  "caCertPassword": {
-                    "title": "Password string for CA certificate if it is encrypted",
-                    "type": "string"
-                  },
-                  "clientCert": {
-                    "title": "Path to client certificate",
-                    "type": "string"
-                  },
-                  "clientCertPassword": {
-                    "title": "Password string for client certificate if it is encrypted",
-                    "type": "string"
-                  },
-                  "privateKey": {
-                    "title": "Path to private key",
-                    "type": "string"
-                  },
-                  "privateKeyPassword": {
-                    "title": "Password string for private key if it is encrypted",
-                    "type": "string"
-                  },
-                  "anonymousIdentity": {
-                    "title": "Anonymous identity string for EAP authentication methods",
-                    "type": "string"
-                  },
-                  "peapVersion": {
-                    "title": "Which PEAP version is used when PEAP is set as the EAP method in the 'eap' property",
-                    "type": "string",
-                    "enum": ["0", "1"]
-                  },
-                  "peapLabel": {
-                    "title": "Force the use of the new PEAP label during key derivation",
-                    "type": "boolean"
-                  }
-                }
+                "$ref": "#/$defs/ieee8021xSettings",
+                "deprecated": true
               },
               "vlan": {
                 "type": "object",
@@ -896,6 +822,87 @@
     }
   },
   "$defs": {
+    "ieee8021xSettings": {
+      "type": "object",
+      "title": "IEEE 802.1x (EAP) settings",
+      "properties": {
+        "eap": {
+          "type": "array",
+          "items": {
+            "title": "List of EAP methods used",
+            "type": "string",
+            "enum": [
+              "leap",
+              "md5",
+              "tls",
+              "peap",
+              "ttls",
+              "pwd",
+              "fast"
+            ]
+          }
+        },
+        "phase2Auth": {
+          "title": "Phase 2 inner auth method",
+          "type": "string",
+          "enum": [
+            "pap",
+            "chap",
+            "mschap",
+            "mschapv2",
+            "gtc",
+            "otp",
+            "md5",
+            "tls"
+          ]
+        },
+        "identity": {
+          "title": "Identity string, often for example the user's login name",
+          "type": "string"
+        },
+        "password": {
+          "title": "Password string used for EAP authentication",
+          "type": "string"
+        },
+        "caCert": {
+          "title": "Path to CA certificate",
+          "type": "string"
+        },
+        "caCertPassword": {
+          "title": "Password string for CA certificate if it is encrypted",
+          "type": "string"
+        },
+        "clientCert": {
+          "title": "Path to client certificate",
+          "type": "string"
+        },
+        "clientCertPassword": {
+          "title": "Password string for client certificate if it is encrypted",
+          "type": "string"
+        },
+        "privateKey": {
+          "title": "Path to private key",
+          "type": "string"
+        },
+        "privateKeyPassword": {
+          "title": "Password string for private key if it is encrypted",
+          "type": "string"
+        },
+        "anonymousIdentity": {
+          "title": "Anonymous identity string for EAP authentication methods",
+          "type": "string"
+        },
+        "peapVersion": {
+          "title": "Which PEAP version is used when PEAP is set as the EAP method in the 'eap' property",
+          "type": "string",
+          "enum": ["0", "1"]
+        },
+        "peapLabel": {
+          "title": "Force the use of the new PEAP label during key derivation",
+          "type": "boolean"
+        }
+      }
+    },
     "ntpSource": {
       "title": "NTP source",
       "type": "object",


### PR DESCRIPTION
## Problem

The network connection setting key `"ieee-8021x"` was defined in kebab-case, which deviated from our agreed design convention of using `camelCase` for all JavaScript and JSON objects in the Agama HTTP API.

## Solution

Consistent with our agreed API style guide, the serialized key was updated to camelCase (`"ieee8021x"`):
- Renamed the serialization/deserialization target to `"ieee8021x"`.
- Retained the old `"ieee-8021x"` key as an alias (`alias = "ieee-8021x"`) to ensure seamless backward compatibility with any older client configurations.

## Testing

- Added two new unit tests in `rust/agama-utils/src/api/network/settings.rs`:
  - `test_network_connection_ieee8021x_serialization` to verify serialization/deserialization of the camelCase key.
  - `test_network_connection_ieee8021x_alias` to verify backward-compatible deserialization of the kebab-case key.
