### PR TITLE
Fix UI changelog entry

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -7,7 +7,6 @@ Tue Sep  1 14:20:00 UTC 2026 - David Diaz <dgonzalez@suse.com>
   wrong one has to be fixed (bsc#1277313).
 
 -------------------------------------------------------------------
-
 Tue Sep  1 13:10:58 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Allow browsing the network devices with more details when binding


### PR DESCRIPTION
## Problem

There was an extra blank line in the changelog file (`web/package/agama-web-ui.changes`), which violates the expected RPM/packaging format.

## Solution

Remove the redundant empty line between the two changelog entries in `web/package/agama-web-ui.changes`.
