### PR TITLE
fix(web): offer installer l10n settings before product selection

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep  3 08:13:38 UTC 2026 - David Diaz <dgonzalez@suse.com>
+
+- Offer applying the installer language and keyboard to the product
+  to install also while the product is being selected (bsc#1277718).
+
+-------------------------------------------------------------------
 Wed Sep  2 14:47:52 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Close dialogs with Escape or a close button, answer questions by

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -289,11 +289,26 @@ describe("InstallerL10nOptions", () => {
         mockProduct(undefined);
       });
 
-      it("does not allow reusing setting", async () => {
-        await renderAndOpen();
-        const dialog = screen.getByRole("dialog");
-        expect(within(dialog).queryByRole("checkbox")).toBeNull();
-        screen.getByText(/This will affect only the installer interface/);
+      it("still allows reusing settings", async () => {
+        const { user } = await renderAndOpen();
+        const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
+        const reuseSettings = within(dialog).getByRole("checkbox", {
+          name: /Use these same settings/,
+        });
+        const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
+
+        expect(reuseSettings).toBeChecked();
+
+        await chooseOption(user, dialog, "Language", "Español");
+        await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
+
+        await user.click(acceptButton);
+        expect(mockPatchConfigFn).toHaveBeenCalledWith({
+          l10n: {
+            locale: "es_ES.UTF-8",
+            keymap: "gb",
+          },
+        });
       });
 
       it("does not include a link to localization page", async () => {
@@ -418,11 +433,20 @@ describe("InstallerL10nOptions", () => {
         mockProduct(undefined);
       });
 
-      it("does not allow reusing setting", async () => {
-        await renderAndOpen();
-        const dialog = screen.getByRole("dialog");
-        expect(within(dialog).queryByRole("checkbox")).toBeNull();
-        screen.getByText(/This will affect only the installer interface/);
+      it("still allows reusing settings", async () => {
+        const { user } = await renderAndOpen({ variant: "language" });
+        const dialog = screen.getByRole("dialog", { name: "Change Language" });
+        const reuseSettings = within(dialog).getByRole("checkbox", {
+          name: /Use for the selected product too/,
+        });
+        const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
+
+        expect(reuseSettings).toBeChecked();
+
+        await chooseOption(user, dialog, "Language", "Español");
+
+        await user.click(acceptButton);
+        expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { locale: "es_ES.UTF-8" } });
       });
 
       it("does not include a link to localization page", async () => {
@@ -518,11 +542,20 @@ describe("InstallerL10nOptions", () => {
         mockProduct(undefined);
       });
 
-      it("does not allow reusing setting", async () => {
-        await renderAndOpen();
-        const dialog = screen.getByRole("dialog");
-        expect(within(dialog).queryByRole("checkbox")).toBeNull();
-        screen.getByText(/This will affect only the installer interface/);
+      it("still allows reusing settings", async () => {
+        const { user } = await renderAndOpen({ variant: "keyboard" });
+        const dialog = screen.getByRole("dialog", { name: "Change keyboard" });
+        const reuseSettings = within(dialog).getByRole("checkbox", {
+          name: /Use for the selected product too/,
+        });
+        const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
+
+        expect(reuseSettings).toBeChecked();
+
+        await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
+
+        await user.click(acceptButton);
+        expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { keymap: "gb" } });
       });
 
       it("does not include a link to localization page", async () => {

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -289,28 +289,6 @@ describe("InstallerL10nOptions", () => {
         mockProduct(undefined);
       });
 
-      it("still allows reusing settings", async () => {
-        const { user } = await renderAndOpen();
-        const dialog = screen.getByRole("dialog", { name: "Language and keyboard" });
-        const reuseSettings = within(dialog).getByRole("checkbox", {
-          name: /Use these same settings/,
-        });
-        const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
-
-        expect(reuseSettings).toBeChecked();
-
-        await chooseOption(user, dialog, "Language", "Español");
-        await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
-
-        await user.click(acceptButton);
-        expect(mockPatchConfigFn).toHaveBeenCalledWith({
-          l10n: {
-            locale: "es_ES.UTF-8",
-            keymap: "gb",
-          },
-        });
-      });
-
       it("still tells about the product options, although without a link", async () => {
         await renderAndOpen();
         screen.getByText(/Once a product is selected, its language and region settings/);
@@ -434,22 +412,6 @@ describe("InstallerL10nOptions", () => {
         mockProduct(undefined);
       });
 
-      it("still allows reusing settings", async () => {
-        const { user } = await renderAndOpen({ variant: "language" });
-        const dialog = screen.getByRole("dialog", { name: "Change Language" });
-        const reuseSettings = within(dialog).getByRole("checkbox", {
-          name: /Use for the selected product too/,
-        });
-        const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
-
-        expect(reuseSettings).toBeChecked();
-
-        await chooseOption(user, dialog, "Language", "Español");
-
-        await user.click(acceptButton);
-        expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { locale: "es_ES.UTF-8" } });
-      });
-
       it("still tells about the product options, although without a link", async () => {
         await renderAndOpen({ variant: "language" });
         screen.getByText(/Once a product is selected, its language and region settings/);
@@ -542,22 +504,6 @@ describe("InstallerL10nOptions", () => {
     describe("but a product is not selected yet", () => {
       beforeEach(() => {
         mockProduct(undefined);
-      });
-
-      it("still allows reusing settings", async () => {
-        const { user } = await renderAndOpen({ variant: "keyboard" });
-        const dialog = screen.getByRole("dialog", { name: "Change keyboard" });
-        const reuseSettings = within(dialog).getByRole("checkbox", {
-          name: /Use for the selected product too/,
-        });
-        const acceptButton = within(dialog).getByRole("button", { name: "Accept" });
-
-        expect(reuseSettings).toBeChecked();
-
-        await chooseOption(user, dialog, "Keyboard layout", "English (UK)");
-
-        await user.click(acceptButton);
-        expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { keymap: "gb" } });
       });
 
       it("still tells about the product options, although without a link", async () => {

--- a/web/src/components/core/InstallerL10nOptions.test.tsx
+++ b/web/src/components/core/InstallerL10nOptions.test.tsx
@@ -311,8 +311,9 @@ describe("InstallerL10nOptions", () => {
         });
       });
 
-      it("does not include a link to localization page", async () => {
+      it("still tells about the product options, although without a link", async () => {
         await renderAndOpen();
+        screen.getByText(/Once a product is selected, its language and region settings/);
         expect(screen.queryByRole("link", { name: "language and region" })).toBeNull();
       });
     });
@@ -449,8 +450,9 @@ describe("InstallerL10nOptions", () => {
         expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { locale: "es_ES.UTF-8" } });
       });
 
-      it("does not include a link to localization page", async () => {
+      it("still tells about the product options, although without a link", async () => {
         await renderAndOpen({ variant: "language" });
+        screen.getByText(/Once a product is selected, its language and region settings/);
         expect(screen.queryByRole("link", { name: "language and region" })).toBeNull();
       });
     });
@@ -558,8 +560,9 @@ describe("InstallerL10nOptions", () => {
         expect(mockPatchConfigFn).toHaveBeenCalledWith({ l10n: { keymap: "gb" } });
       });
 
-      it("does not include a link to localization page", async () => {
+      it("still tells about the product options, although without a link", async () => {
         await renderAndOpen({ variant: "keyboard" });
+        screen.getByText(/Once a product is selected, its language and region settings/);
         expect(screen.queryByRole("link", { name: "language and region" })).toBeNull();
       });
     });

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -22,8 +22,8 @@
 
 /**
  * This module defines the InstallerL10nOptions component, which allows users to
- * configure installer localization settings, with the option to copy them, when
- * applicable, to the product's localization settings.
+ * configure installer localization settings, with the option to copy them to
+ * the product's localization settings.
  *
  * It supports multiple UI variants (language-only, keyboard-only, or both), and
  * manages both form and dialog state. To avoid scattering complex conditional
@@ -210,8 +210,6 @@ const dialogReducer = (state: DialogState, action: DialogAction): DialogState =>
  */
 type DialogProps = {
   isOpen: boolean;
-  /** Whether the settings can also be applied to the product to install. */
-  allowReusingSettings: boolean;
   /** Called when the user dismisses the dialog. */
   onCancel: () => void;
 };
@@ -236,30 +234,6 @@ type ToggleProps = Pick<ButtonProps, "onClick"> & {
    * from the button's aria-label.
    */
   showValues?: boolean;
-};
-
-/**
- * A component that conditionally displays content based on whether settings can
- * be reused.
- *
- * If reuse is allowed, the content (children) is rendered.
- * If reuse is not allowed, a fallback message is displayed instead.
- *
- * This component helps avoid repeating the same condition in each form variant,
- * as the fallback message should remain the same for all of them.
- */
-const ReusableSettings = ({ isReuseAllowed, children }) => {
-  if (isReuseAllowed) {
-    return children;
-  } else {
-    // TRANSLATORS: This message informs users that they are only changing the
-    // interface language and/or keyboard settings here. The term "localization"
-    // is the name of a separate page where they can configure the localization
-    // settings for the product to install.
-    return _(
-      "This will affect only the installer interface, not the product to be installed. You can adjust the product’s localization later in the Localization settings page.",
-    );
-  }
 };
 
 type TextWithLinkToL10nProps = {
@@ -305,7 +279,11 @@ const TextWithLinkToL10n = ({ text, onClick }: TextWithLinkToL10nProps) => {
 
 /**
  * Renders the checkbox for applying the chosen settings to the product to
- * install too, with a link to the page where they can be fine tuned.
+ * install too.
+ *
+ * The checkbox comes with a link to the page where the product settings can be
+ * fine tuned, but only once a product is chosen. Until then that page cannot be
+ * reached, so pointing to it would lead nowhere.
  */
 const ReuseSettingsField = withForm({
   ...defaultOptions,
@@ -316,6 +294,7 @@ const ReuseSettingsField = withForm({
     onLinkClick?: ButtonProps["onClick"];
   },
   render: function Render({ form, label, onLinkClick }) {
+    const product = useProductInfo();
     const description = _(
       // TRANSLATORS: Explains where users can find more language and keyboard
       // options for the product to install. The text in square brackets [] is a
@@ -328,7 +307,7 @@ const ReuseSettingsField = withForm({
         {(field) => (
           <field.CheckboxField
             label={label}
-            description={<TextWithLinkToL10n text={description} onClick={onLinkClick} />}
+            description={product && <TextWithLinkToL10n text={description} onClick={onLinkClick} />}
           />
         )}
       </form.AppField>
@@ -374,7 +353,7 @@ const DialogButtons = withForm({
 const AllSettingsDialog = withForm({
   ...defaultOptions,
   props: {} as DialogProps,
-  render: function Render({ form, isOpen, allowReusingSettings, onCancel }) {
+  render: function Render({ form, isOpen, onCancel }) {
     return (
       <Popup
         isOpen={isOpen}
@@ -386,13 +365,11 @@ const AllSettingsDialog = withForm({
         <Form id="installer-l10n" onSubmit={submitHandler(form)}>
           <LanguageField form={form} />
           <KeyboardField form={form} />
-          <ReusableSettings isReuseAllowed={allowReusingSettings}>
-            <ReuseSettingsField
-              form={form}
-              label={_("Use these same settings for the selected product")}
-              onLinkClick={onCancel}
-            />
-          </ReusableSettings>
+          <ReuseSettingsField
+            form={form}
+            label={_("Use these same settings for the selected product")}
+            onLinkClick={onCancel}
+          />
         </Form>
       </Popup>
     );
@@ -402,7 +379,7 @@ const AllSettingsDialog = withForm({
 const LanguageOnlyDialog = withForm({
   ...defaultOptions,
   props: {} as DialogProps,
-  render: function Render({ form, isOpen, allowReusingSettings, onCancel }) {
+  render: function Render({ form, isOpen, onCancel }) {
     return (
       <Popup
         isOpen={isOpen}
@@ -413,13 +390,11 @@ const LanguageOnlyDialog = withForm({
       >
         <Form id="installer-l10n" onSubmit={submitHandler(form)}>
           <LanguageField form={form} />
-          <ReusableSettings isReuseAllowed={allowReusingSettings}>
-            <ReuseSettingsField
-              form={form}
-              label={_("Use for the selected product too")}
-              onLinkClick={onCancel}
-            />
-          </ReusableSettings>
+          <ReuseSettingsField
+            form={form}
+            label={_("Use for the selected product too")}
+            onLinkClick={onCancel}
+          />
         </Form>
       </Popup>
     );
@@ -429,7 +404,7 @@ const LanguageOnlyDialog = withForm({
 const KeyboardOnlyDialog = withForm({
   ...defaultOptions,
   props: {} as DialogProps,
-  render: function Render({ form, isOpen, allowReusingSettings, onCancel }) {
+  render: function Render({ form, isOpen, onCancel }) {
     if (!localConnection()) {
       return (
         <Popup
@@ -454,13 +429,11 @@ const KeyboardOnlyDialog = withForm({
       >
         <Form id="installer-l10n" onSubmit={submitHandler(form)}>
           <KeyboardField form={form} />
-          <ReusableSettings isReuseAllowed={allowReusingSettings}>
-            <ReuseSettingsField
-              form={form}
-              label={_("Use for the selected product too")}
-              onLinkClick={onCancel}
-            />
-          </ReusableSettings>
+          <ReuseSettingsField
+            form={form}
+            label={_("Use for the selected product too")}
+            onLinkClick={onCancel}
+          />
         </Form>
       </Popup>
     );
@@ -593,8 +566,6 @@ export default function InstallerL10nOptions({
   const locales = useSystem()?.l10n?.locales ?? [];
   const { language, keymap, changeL10n } = useInstallerL10n();
   const { stage } = useStatus();
-  const selectedProduct = useProductInfo();
-  const allowReusingSettings = !!selectedProduct;
   const [dialogState, dispatchDialogAction] = useReducer(dialogReducer, { isOpen: false });
 
   /**
@@ -636,7 +607,7 @@ export default function InstallerL10nOptions({
 
       await changeL10n(l10nOptions);
 
-      allowReusingSettings && values.reuseSettings && reuseSettings(values);
+      values.reuseSettings && reuseSettings(values);
     } catch (e) {
       console.error(e);
     } finally {
@@ -673,12 +644,7 @@ export default function InstallerL10nOptions({
           dispatchDialogAction({ type: "OPEN" });
         }}
       />
-      <Dialog
-        form={form}
-        isOpen={dialogState.isOpen}
-        allowReusingSettings={allowReusingSettings}
-        onCancel={close}
-      />
+      <Dialog form={form} isOpen={dialogState.isOpen} onCancel={close} />
     </>
   );
 }

--- a/web/src/components/core/InstallerL10nOptions.tsx
+++ b/web/src/components/core/InstallerL10nOptions.tsx
@@ -281,9 +281,10 @@ const TextWithLinkToL10n = ({ text, onClick }: TextWithLinkToL10nProps) => {
  * Renders the checkbox for applying the chosen settings to the product to
  * install too.
  *
- * The checkbox comes with a link to the page where the product settings can be
- * fine tuned, but only once a product is chosen. Until then that page cannot be
- * reached, so pointing to it would lead nowhere.
+ * The checkbox is described by a note about the product offering its own, wider
+ * set of language and region options. Once a product is chosen the note links to
+ * the page holding them. Before that the page cannot be reached, so the note
+ * says when those options come within reach instead of pointing at them.
  */
 const ReuseSettingsField = withForm({
   ...defaultOptions,
@@ -298,8 +299,18 @@ const ReuseSettingsField = withForm({
     const description = _(
       // TRANSLATORS: Explains where users can find more language and keyboard
       // options for the product to install. The text in square brackets [] is a
-      // link to the localization page; keep the brackets.
+      // link to the localization page; keep the brackets. Translate "language
+      // and region" as in the "Language and region" section title, so users
+      // recognize the place being pointed at.
       "The [language and region] settings for the product may offer more options to choose from.",
+    );
+    const pendingDescription = _(
+      // TRANSLATORS: Shown while no product has been chosen yet, to tell users
+      // that more language and keyboard options become available, in the
+      // localization settings, after choosing a product. Translate "language and
+      // region" as in the "Language and region" section title, so users
+      // recognize the place being described.
+      "Once a product is selected, its language and region settings may offer more options to choose from.",
     );
 
     return (
@@ -307,7 +318,13 @@ const ReuseSettingsField = withForm({
         {(field) => (
           <field.CheckboxField
             label={label}
-            description={product && <TextWithLinkToL10n text={description} onClick={onLinkClick} />}
+            description={
+              product ? (
+                <TextWithLinkToL10n text={description} onClick={onLinkClick} />
+              ) : (
+                pendingDescription
+              )
+            }
           />
         )}
       </form.AppField>


### PR DESCRIPTION
## TL;DR

Offer the option to apply the installer language and keyboard to the product to install right from the start, including while the product is still being chosen.

## Problem

The dialog behind the language and keyboard button in the top bar lets users apply the chosen settings to the product to install too. Until a product was selected, that checkbox was hidden and a note took its place, saying the change would affect only the installer interface.

<img width="2048" height="1536" alt="localhost_8080_ - 2026-09-03T090402 920" src="https://github.com/user-attachments/assets/a450fae2-04f7-4b07-a9fa-6b66da0e2b99" />

There was a good reason for hiding it. The installer had nowhere to keep a localization choice made before the product selection, so it dropped it.

That is no longer true. A configuration update is merged into what is already stored, and picking a product is just another update, so an earlier choice survives it. This comes from the config-based API (9cc8b2dba) and the merging logic in #2951, both landed back in [Agama 19](https://agama-project.github.io/blog/2026/03/20/agama-19).

## Solution

The checkbox is now part of the dialog in every case, checked by default as before. The note about affecting only the installer interface, along with the component that decided between the two, is gone.

Fixes [bsc#1277718](https://bugzilla.suse.com/show_bug.cgi?id=1277718) (protected link).

| The dialog sent | Resulting settings |
|-|-|
| <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-03T085734 058" src="https://github.com/user-attachments/assets/9b53686f-1545-4e78-8ca1-fc478ebfdc63" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-03T085748 839" src="https://github.com/user-attachments/assets/ba331c31-5e3b-419a-a5eb-411eec8a4397" /> |
|<img width="2048" height="1536" alt="localhost_8080_ - 2026-09-03T090902 007" src="https://github.com/user-attachments/assets/4c70059d-7413-4589-8881-468edd83176f" /> | <img width="2048" height="1536" alt="localhost_8080_ - 2026-09-03T090655 426" src="https://github.com/user-attachments/assets/cbd4af66-a1fc-493c-8bd0-c0129db4e983" /> |



## Details

The checkbox is described by a note saying the product's own language and region settings may offer more options. That note matters most precisely while the product is being chosen, since the installer list is short and users would otherwise assume it is everything on offer, so it is always shown. What changes is where it sends them: with a product selected it links to the language and region page, and before that, when the page cannot be reached yet, it says the options turn up once a product is chosen. **Pointing at a page nobody can open yet would only raise the question of where that page is.**


> [!NOTE]
> 
> The wording still says "the selected product", which might, or might not, reads a bit ahead of itself during product selection. Left untouched, but happy to reword it if you prefer.

Nothing on the backend side pins down that localization set before product selection survives the selection, so the manual check below is what confirms it.

## Tests

Every dialog variant (language and keyboard, language only, keyboard only) now covers the no-product-selected case: the checkbox is offered, checked by default, and the chosen settings reach the product configuration on accept. The link to the language and region page is still expected to be absent at that point.

- [x] `npm run test`, `npm run eslint` and `npm run check-types` pass
- [x] Boot the installer, open the language and keyboard dialog from the product selection screen, pick a language with the checkbox left checked, then select a product and confirm the language and region page reflects the choice
- [x] Repeat with the checkbox unchecked and confirm the product settings stay untouched
- [ ] Repeat once a product is selected and confirm nothing changed there
