### PR TITLE
Fix panic on missing profile in /private/profile endpoints

### DIFF
--- a/rust/agama-server/src/profile/web.rs
+++ b/rust/agama-server/src/profile/web.rs
@@ -70,35 +70,48 @@ pub enum ProfileError {
     InvalidJson(#[from] serde_json::Error),
     #[error("{0}")]
     BadRequest(String),
+    #[error("No profile was given. Provide one of: path, url or profile (request body).")]
+    MissingProfile,
 }
 
-impl IntoResponse for ProfileError {
-    fn into_response(self) -> Response {
-        let problem = match self {
+impl ProfileError {
+    /// Converts this error into RFC 9457 Problem Details
+    ///
+    /// Each variant is mapped to a status code by `ProblemDetails::status_code()`:
+    /// `internal_error()` results in a 500, `bad_request()` results in a 400.
+    pub fn into_problem_details(self) -> ProblemDetails {
+        match self {
             // Server errors (500)
             ProfileError::ValidatorSetup(_) => ProblemDetails::internal_error(self.to_string()),
             ProfileError::Autoyast(AutoyastError::Execute(..)) => {
                 ProblemDetails::internal_error(self.to_string())
             }
+            ProfileError::InvalidJson(_) => ProblemDetails::internal_error(self.to_string()),
             // Client errors (400) - specific titles for better UX
             ProfileError::ValidationError(msg) | ProfileError::EvaluationError(msg) => {
-                ProblemDetails::generic(gettext("Profile validation failed"), msg)
+                ProblemDetails::bad_request(gettext("Profile validation failed"), msg)
             }
             ProfileError::UrlRetrieval { .. } | ProfileError::FileRead { .. } => {
-                ProblemDetails::generic(gettext("Could not retrieve profile"), self.to_string())
+                ProblemDetails::bad_request(gettext("Could not retrieve profile"), self.to_string())
             }
             ProfileError::InvalidUtf8 { .. } => {
-                ProblemDetails::generic(gettext("Invalid profile encoding"), self.to_string())
+                ProblemDetails::bad_request(gettext("Invalid profile encoding"), self.to_string())
             }
-            ProfileError::UrlParse(_) | ProfileError::BadRequest(_) => {
-                ProblemDetails::generic(gettext("Invalid profile request"), self.to_string())
+            ProfileError::UrlParse(_)
+            | ProfileError::BadRequest(_)
+            | ProfileError::MissingProfile => {
+                ProblemDetails::bad_request(gettext("Invalid profile request"), self.to_string())
             }
             ProfileError::Autoyast(_) => {
-                ProblemDetails::generic(gettext("AutoYaST conversion failed"), self.to_string())
+                ProblemDetails::bad_request(gettext("AutoYaST conversion failed"), self.to_string())
             }
-            ProfileError::InvalidJson(_) => ProblemDetails::internal_error(self.to_string()),
-        };
-        problem.into_response()
+        }
+    }
+}
+
+impl IntoResponse for ProfileError {
+    fn into_response(self) -> Response {
+        self.into_problem_details().into_response()
     }
 }
 
@@ -176,7 +189,9 @@ async fn validate(body: String) -> Result<(), Response> {
         .map_err(|e| Error::from(e).bad_request())?;
     let profile_string = match profile_content {
         Some(retrieved) => retrieved,
-        None => profile.json.expect("Missing profile"),
+        None => {
+            return Err(Error::from(ProfileError::MissingProfile).bad_request());
+        }
     };
     let json: serde_json::Value =
         serde_json::from_str(&profile_string).map_err(|e| Error::from(e).bad_request())?;
@@ -188,7 +203,7 @@ async fn evaluate(body: String) -> Result<String, ProfileError> {
     let profile = ProfileBody::from_string(body);
     let profile_string = match profile.retrieve_profile()? {
         Some(retrieved) => retrieved,
-        None => profile.json.expect("Missing profile"),
+        None => return Err(ProfileError::MissingProfile),
     };
     let evaluator = ProfileEvaluator {};
     let output = evaluator
@@ -216,4 +231,43 @@ async fn autoyast(body: String) -> Result<Json<AutoyastConversionResult>, Profil
         profile,
         unsupported: importer.unsupported,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::web::error::ProblemDetailsExt;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn retrieve_profile_returns_none_without_path_url_or_profile() {
+        let body = ProfileBody::from_string("{}".to_string());
+        let result = body.retrieve_profile().expect("should not fail");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn retrieve_profile_returns_none_for_empty_body() {
+        let body = ProfileBody::from_string(String::new());
+        let result = body.retrieve_profile().expect("should not fail");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn retrieve_profile_returns_inline_json() {
+        let body = ProfileBody::from_string(r#"{"profile": "{\"foo\": 1}"}"#.to_string());
+        let result = body.retrieve_profile().expect("should not fail");
+        assert_eq!(result, Some(r#"{"foo": 1}"#.to_string()));
+    }
+
+    /// Regression test for a bug where an absent profile (no "path", "url" or
+    /// "profile" key) made `retrieve_profile()` return `Ok(None)`, which the
+    /// handlers then unwrapped via `.expect("Missing profile")`, panicking on
+    /// a plain HTTP request instead of returning a proper error.
+    #[test]
+    fn missing_profile_maps_to_a_bad_request_response() {
+        let error = ProfileError::MissingProfile;
+        let problem = error.into_problem_details();
+        assert_eq!(problem.status_code(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/rust/agama-server/src/server/web.rs
+++ b/rust/agama-server/src/server/web.rs
@@ -86,7 +86,7 @@ impl Error {
                 gettext("Missing Language Tag"),
                 "The language tag is required",
             ),
-            Error::Profile(e) => ProblemDetails::generic(gettext("Profile error"), e.to_string()),
+            Error::Profile(e) => e.into_problem_details(),
         }
     }
 

--- a/rust/agama-server/src/web/error.rs
+++ b/rust/agama-server/src/web/error.rs
@@ -55,6 +55,7 @@ impl ProblemDetailsExt for ProblemDetails {
             ProblemDetails::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ProblemDetails::Unauthorized { .. } => StatusCode::UNAUTHORIZED,
             ProblemDetails::Generic { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ProblemDetails::BadRequest { .. } => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/rust/agama-server/tests/profile_service.rs
+++ b/rust/agama-server/tests/profile_service.rs
@@ -1,0 +1,119 @@
+// Copyright (c) [2026] SUSE LLC
+//
+// All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, contact SUSE LLC.
+//
+// To contact SUSE LLC about this file by physical or electronic mail, you may
+// find current contact information at www.suse.com.
+
+pub mod common;
+use agama_manager::test_utils::start_service;
+use agama_server::{
+    profile::profile_service,
+    server::web::{server_with_state, ServerState},
+};
+use agama_utils::{question, test};
+use axum::http::{Method, Request, StatusCode};
+use std::{error::Error, path::PathBuf};
+use test_context::{test_context, AsyncTestContext};
+use tokio::{sync::broadcast::channel, test};
+
+use crate::common::Client;
+
+struct Context {
+    client: Client,
+}
+
+impl AsyncTestContext for Context {
+    async fn setup() -> Context {
+        let share_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test/share");
+        std::env::set_var("AGAMA_SHARE_DIR", share_dir.display().to_string());
+        let schema_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../share");
+        std::env::set_var("AGAMA_SCHEMA_DIR", schema_dir.display().to_string());
+
+        let (events_tx, _events_rx) = channel(100);
+        let dbus = test::dbus::connection().await.unwrap();
+
+        let questions = question::start(events_tx.clone()).await.unwrap();
+        let manager = start_service(events_tx, dbus).await;
+        let profile = profile_service().await;
+
+        let service = server_with_state(ServerState::new(manager, questions), profile)
+            .expect("Could not create the testing router");
+        Context {
+            client: Client::new(service),
+        }
+    }
+}
+
+fn post_request(uri: &str, body: &str) -> Request<String> {
+    Request::builder()
+        .uri(uri)
+        .header("Content-Type", "application/json")
+        .method(Method::POST)
+        .body(body.to_string())
+        .unwrap()
+}
+
+/// Regression test: sending an empty body (no "path", "url" or "profile" key)
+/// used to make the "validate" handler panic (`.expect("Missing profile")`)
+/// instead of returning a proper HTTP error response.
+#[test_context(Context)]
+#[test]
+async fn test_validate_without_profile_returns_bad_request(
+    ctx: &mut Context,
+) -> Result<(), Box<dyn Error>> {
+    let request = post_request("/private/profile/validate", "{}");
+    let response = ctx.client.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    Ok(())
+}
+
+/// Same regression, but for an empty (not even valid JSON object) body.
+#[test_context(Context)]
+#[test]
+async fn test_validate_with_empty_body_returns_bad_request(
+    ctx: &mut Context,
+) -> Result<(), Box<dyn Error>> {
+    let request = post_request("/private/profile/validate", "");
+    let response = ctx.client.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    Ok(())
+}
+
+/// Regression test: sending an empty body used to make the "evaluate"
+/// handler panic (`.expect("Missing profile")`) instead of returning a
+/// proper HTTP error response.
+#[test_context(Context)]
+#[test]
+async fn test_evaluate_without_profile_returns_bad_request(
+    ctx: &mut Context,
+) -> Result<(), Box<dyn Error>> {
+    let request = post_request("/private/profile/evaluate", "{}");
+    let response = ctx.client.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    Ok(())
+}
+
+/// A profile given inline (as the "profile" key) should validate correctly.
+#[test_context(Context)]
+#[test]
+async fn test_validate_with_inline_profile(ctx: &mut Context) -> Result<(), Box<dyn Error>> {
+    let body = r#"{"profile": "{}"}"#;
+    let request = post_request("/private/profile/validate", body);
+    let response = ctx.client.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}

--- a/rust/agama-utils/src/api/problem_details.rs
+++ b/rust/agama-utils/src/api/problem_details.rs
@@ -104,6 +104,13 @@ pub enum ProblemDetails {
     /// Generic error without specific type (HTTP 500)
     #[serde(rename = "about:blank", rename_all = "camelCase")]
     Generic { title: String, detail: String },
+
+    /// Generic client error (HTTP 400)
+    #[serde(
+        rename = "tag:agama.opensuse.org,2026:problems/bad-request",
+        rename_all = "camelCase"
+    )]
+    BadRequest { title: String, detail: String },
 }
 
 impl ProblemDetails {
@@ -149,6 +156,14 @@ impl ProblemDetails {
             detail: detail.into(),
         }
     }
+
+    /// Creates a generic client error (bad request) problem
+    pub fn bad_request(title: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self::BadRequest {
+            title: title.into(),
+            detail: detail.into(),
+        }
+    }
 }
 
 impl Display for ProblemDetails {
@@ -169,7 +184,8 @@ impl Display for ProblemDetails {
 
             Self::Unauthorized { title, detail }
             | Self::InternalError { title, detail }
-            | Self::Generic { title, detail } => write_problem(f, title, Some(detail), None)?,
+            | Self::Generic { title, detail }
+            | Self::BadRequest { title, detail } => write_problem(f, title, Some(detail), None)?,
 
             ProblemDetails::InvalidJson { title, detail } => {
                 write_problem(f, title, detail.as_deref(), None)?

--- a/rust/package/agama.changes
+++ b/rust/package/agama.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep  4 10:52:03 UTC 2026 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when validating or evaluating a profile without
+  content (bsc#1278737).
+
+-------------------------------------------------------------------
 Wed Sep  2 14:15:16 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Improve storage schema to force the encryption key size to be


### PR DESCRIPTION
## Problem

* [bsc#1278738](https://bugzilla.suse.com/show_bug.cgi?id=1278737)

`POST /api/private/profile/evaluate` or `.../validate` with an empty/`{}` body panicked the request handler (`.expect("Missing profile")`) instead of returning an error.

## Fix
- Add `ProfileError::MissingProfile` and return it as a proper error instead of panicking.
- Fix the error→HTTP-status mapping: `ProfileError` relied on `ProblemDetails::generic()`, which always maps to 500 despite comments claiming these were 400 client errors. Added a real `ProblemDetails::BadRequest` (400) variant and used it where appropriate.
- Fix `server::web::Error::Profile`, which was discarding `ProfileError`'s per-variant mapping and collapsing every profile error into a generic 500.

## Tests
- Unit tests for `retrieve_profile()`'s "nothing given" cases and the new error mapping.
- New `tests/profile_service.rs` integration tests hitting `/private/profile/validate` and `/private/profile/evaluate` over HTTP, asserting 400 instead of a crash.

Full `agama-server`/`agama-utils` test suite, `cargo fmt`, and `cargo clippy` pass with no new warnings.