### PR TITLE
Fix SLE-16 schema links

### DIFF
--- a/rust/agama-lib/share/iscsi.schema.json
+++ b/rust/agama-lib/share/iscsi.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/SLE-16/rust/agama-lib/share/iscsi.schema.json",
+  "$id": "https://raw.githubusercontent.com/openSUSE/agama/refs/heads/SLE-16/rust/agama-lib/share/iscsi.schema.json",
   "title": "Config",
   "description": "iSCSI config.",
   "type": "object",

--- a/rust/agama-lib/share/iscsi.schema.json
+++ b/rust/agama-lib/share/iscsi.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/iscsi.schema.json",
+  "$id": "https://github.com/openSUSE/agama/blob/SLE-16/rust/agama-lib/share/iscsi.schema.json",
   "title": "Config",
   "description": "iSCSI config.",
   "type": "object",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/SLE-16/rust/agama-lib/share/profile.schema.json",
+  "$id": "https://raw.githubusercontent.com/openSUSE/agama/refs/heads/SLE-16/rust/agama-lib/share/profile.schema.json",
   "title": "Profile",
   "description": "Profile definition for automated installation",
   "type": "object",

--- a/rust/agama-lib/share/profile.schema.json
+++ b/rust/agama-lib/share/profile.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/profile.schema.json",
+  "$id": "https://github.com/openSUSE/agama/blob/SLE-16/rust/agama-lib/share/profile.schema.json",
   "title": "Profile",
   "description": "Profile definition for automated installation",
   "type": "object",

--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Based on doc/auto_storage.md",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/SLE-16/rust/agama-lib/share/storage.schema.json",
+  "$id": "https://raw.githubusercontent.com/openSUSE/agama/refs/heads/SLE-16/rust/agama-lib/share/storage.schema.json",
   "title": "Config",
   "description": "Storage config.",
   "type": "object",

--- a/rust/agama-lib/share/storage.schema.json
+++ b/rust/agama-lib/share/storage.schema.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Based on doc/auto_storage.md",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/openSUSE/agama/blob/master/rust/agama-lib/share/storage.schema.json",
+  "$id": "https://github.com/openSUSE/agama/blob/SLE-16/rust/agama-lib/share/storage.schema.json",
   "title": "Config",
   "description": "Storage config.",
   "type": "object",


### PR DESCRIPTION
## Problem

The JSON schemas in the SLE-16 branch still use `$id` URLs pointing to
the master branch and to the old schema location.

This makes the schema URLs incorrect for SLE-16. In particular, the
SLE-16 profile schema is referenced by the documentation for editing
autoinstallation profiles, but the schema itself still points to the
master branch.

The SLE-16 profile schema is documented here:

https://agama-project.github.io/docs/user/guides/editing_profile

## Solution

Update the `$id` URLs of the SLE-16 `iscsi`, `profile`, and `storage`
schemas to point to their corresponding files in the SLE-16 branch
using the raw GitHub URLs.

## Testing

- Verified that the updated schema URLs resolve to the corresponding
  files in the SLE-16 branch.
- Verified that the profile schema URL documented for SLE-16 resolves
  correctly.
- Checked that the modified files remain valid JSON.

## Screenshots

Not applicable.

## Documentation

No user-facing documentation changes are required. The existing
documentation already points SLE-16 users to the SLE-16 profile schema.