### PR TITLE
Improve service CI in 16.1

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -47,61 +47,49 @@ jobs:
     env:
       COVERAGE: 1
 
-    defaults:
-      run:
-        working-directory: ./service
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distro: [ "tumbleweed" ]
-
     container:
-      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+      # TODO: the 16.1 image is not available yet, use 16.0 for now
+      image: registry.opensuse.org/opensuse/leap:16.0
 
     steps:
+
+    - name: Configure and refresh repositories
+      # disable unused repositories to have faster refresh
+      run: zypper modifyrepo -d openSUSE:repo-openh264 && zypper ref
+
+    - name: Install Ruby development files
+      run: zypper --non-interactive install
+        gawk
+        gcc
+        gcc-c++
+        gettext-tools
+        git
+        libffi-devel
+        libxml2-devel
+        libxslt-devel
+        libyaml-devel
+        make
+        ruby-devel
+        which
+
+    - name: Install required packages
+      # install the YaST packages from the 16.1, we needed a newer version of yast2-storage-ng
+      run: zypper ar -f https://download.opensuse.org/distribution/leap/16.1/repo/oss Leap-16.1 &&
+        zypper --non-interactive install
+        autoyast2-installation
+        yast2
+        yast2-bootloader
+        yast2-devtools
+        yast2-iscsi-client
+        yast2-network
+        yast2-storage-ng
+        yast2-users
 
     - name: Git Checkout
       uses: actions/checkout@v7
 
     - name: Configure git
       run:  git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-    - name: Configure and refresh repositories
-      # disable unused repositories to have faster refresh
-      run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
-
-    - name: Install Ruby development files
-      run: zypper --non-interactive install
-        gcc
-        gcc-c++
-        make
-        openssl-devel
-        ruby-devel
-        augeas-devel
-
-    - name: Install required packages
-      run: |
-        RUBY_VERSION=$(ruby -e "puts RbConfig::CONFIG['ruby_version']")
-        zypper --non-interactive install \
-        suseconnect-ruby-bindings \
-        autoyast2-installation \
-        yast2 \
-        yast2-bootloader \
-        yast2-country \
-        yast2-devtools \
-        yast2-hardware-detection \
-        yast2-installation \
-        yast2-iscsi-client \
-        yast2-network \
-        yast2-proxy \
-        yast2-storage-ng \
-        yast2-users \
-        python3-jsonschema \
-        gettext-tools \
-        "rubygem(ruby:$RUBY_VERSION:yast-rake)" \
-        "rubygem(ruby:$RUBY_VERSION:gettext)" \
-        which
 
     - name: Bundler cache
       id: bundler-cache
@@ -115,16 +103,28 @@ jobs:
           /usr/bin/rxgettext
         key: ${{ runner.os }}-ruby-bundler-master-${{ hashFiles('./service/Gemfile.lock') }}
 
+    # openSUSE Leap 16 does not contain all need Ruby gems, install them with bundler
+    - name: Install additional Ruby gems
+      run: bundle add yast-rake gettext
+      working-directory: ./service
+      env:
+        NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
+
     - name: Install RubyGems dependencies
       run: bundle config set --local with 'development' && bundle install
+      working-directory: ./service
+      env:
+        NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
     - name: Check collecting translatable strings
       run: |
         rake pot
         msgfmt --statistics ../agama.pot
+      working-directory: ./service
 
     - name: Run the tests and generate coverage report
       run: bundle exec rspec
+      working-directory: ./service
 
     - name: Upload coverage result
       uses: actions/upload-artifact@v6

--- a/service/test/agama/storage/autoyast_proposal_test.rb
+++ b/service/test/agama/storage/autoyast_proposal_test.rb
@@ -27,6 +27,11 @@ require "agama/issue"
 require "y2storage"
 require "yaml"
 
+# Restore the ProductFeatures defaults, this resets the values accidentally read
+# from the /etc/YaST2/control.xml file from the system. This file does not exist
+# in SLE-16.x or Leap 16.x, avoid using it in Tumbleweed or Leap 15.x.
+Yast::ProductFeatures.InitFeatures(true)
+
 describe Agama::Storage::Proposal do
   include Agama::RSpec::StorageHelpers
   using Y2Storage::Refinements::SizeCasts
@@ -470,7 +475,7 @@ describe Agama::Storage::Proposal do
         expect(partitions[0].id.is?(:esp)).to eq(true)
         expect(partitions[1].filesystem.root?).to eq(true)
         expect(partitions[2].filesystem.mount_path).to eq("swap")
-        expect(partitions[2].size).to eq 1.GiB
+        expect(partitions[2].size).to eq 0.5.GiB
       end
     end
 


### PR DESCRIPTION
## Problem

- The CI in the SLE-16.1 fails

## Solution

- Fix the unit test so it properly works in the 16.x environment.
- Use the 16.0 container (16.1 is not published yet, will be updated later.)
- Cleanup, do not install not needed packages like `suseconnect-ruby-bindings`

## Testing

- The CI is green now
