### PR TITLE
feat(web): show link state and speed in the device picker

### DIFF
--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Sep 10 12:39:17 UTC 2026 - Alejandro Bonilla <abonilla@suse.com>
+
+- Show the link state and, if up, the speed of each device offered
+  when picking the ports of a bond or a bridge, so a card can be
+  told apart from another without checking its details elsewhere
+  (bsc#1279417).
+
+-------------------------------------------------------------------
 Mon Sep  7 15:00:00 UTC 2026 - Knut Anderssen <kanderssen@suse.com>
 
 - Pick the ports of a bond or a bridge from the devices found in

--- a/web/src/components/network/connection-form/DeviceSelectorModal.test.tsx
+++ b/web/src/components/network/connection-form/DeviceSelectorModal.test.tsx
@@ -35,6 +35,8 @@ const ethernet = {
   type: CONNECTION_TYPE.ETHERNET,
   state: DeviceState.CONNECTED,
   addresses: [{ address: "192.168.1.10", prefix: 24 }],
+  carrier: true,
+  speed: 1000,
 } as Device;
 
 const wireless = {
@@ -77,8 +79,20 @@ describe("DeviceSelectorModal", () => {
     within(rowFor("enp1s0")).getByText("00:11:22:33:44:55");
     within(rowFor("enp1s0")).getByText("192.168.1.10/24");
     within(rowFor("enp1s0")).getByText("Connected");
+    within(rowFor("enp1s0")).getByText("Up (1000 Mb/s)");
     within(rowFor("wlan0")).getByText("Wi-Fi");
     within(rowFor("wlan0")).getByText("Disconnected");
+    within(rowFor("wlan0")).getByText("Unknown");
+  });
+
+  it("tells a device with no cable plugged in apart from one with an unknown link", () => {
+    renderModal({ devices: [ethernet, { ...wireless, carrier: false }] });
+    within(rowFor("wlan0")).getByText("Down");
+  });
+
+  it("tells a device is up even when its speed is not reported", () => {
+    renderModal({ devices: [ethernet, { ...wireless, carrier: true }] });
+    within(rowFor("wlan0")).getByText("Up");
   });
 
   describe("when no device is bound yet", () => {

--- a/web/src/components/network/connection-form/DeviceSelectorModal.tsx
+++ b/web/src/components/network/connection-form/DeviceSelectorModal.tsx
@@ -27,7 +27,7 @@ import { sprintf } from "sprintf-js";
 import Popup from "~/components/core/Popup";
 import SelectableDataTable from "~/components/core/SelectableDataTable";
 import Text from "~/components/core/Text";
-import { connectionTypeLabel, deviceStateLabel, formatIp } from "~/utils/network";
+import { connectionTypeLabel, deviceLinkLabel, deviceStateLabel, formatIp } from "~/utils/network";
 import { sortCollection } from "~/utils";
 import { _, n_ } from "~/i18n";
 
@@ -68,7 +68,7 @@ const deviceAddresses = (device: Device): string =>
 
 /**
  * Dialog for picking network devices from a table showing more details than a
- * dropdown can hold: name, MAC address, type, addresses and state.
+ * dropdown can hold: name, MAC address, type, addresses, state and link.
  *
  * The table can be sorted, and the pick is only reported to the caller when the
  * user confirms.
@@ -129,6 +129,12 @@ export default function DeviceSelectorModal({
       name: _("State"),
       value: (device: Device) => deviceStateLabel(device.state),
       sortingKey: "state",
+    },
+    {
+      // TRANSLATORS: table column with the physical link of a network device:
+      // whether a cable is plugged in and, if so, at which speed.
+      name: _("Link"),
+      value: (device: Device) => deviceLinkLabel(device),
     },
     ...(portOf
       ? [

--- a/web/src/types/network.ts
+++ b/web/src/types/network.ts
@@ -228,6 +228,10 @@ class Device {
   macAddress: string;
   state: DeviceState;
   connection?: string;
+  /** Whether the device currently has a link (carrier). Best-effort: unset when unknown. */
+  carrier?: boolean;
+  /** Link speed in Mb/s, only reported by wired devices while the link is up. */
+  speed?: number;
 
   static fromApi(device: APIDevice) {
     const { ipConfig, stateReason, ...newDevice } = device;
@@ -268,6 +272,8 @@ type APIDevice = {
   connection?: string;
   ipConfig?: IPConfig;
   stateReason: string;
+  carrier?: boolean;
+  speed?: number;
 };
 
 type APIRoute = {

--- a/web/src/utils/network.ts
+++ b/web/src/utils/network.ts
@@ -22,6 +22,7 @@
 
 import ipaddr from "ipaddr.js";
 import { isUndefined, sift, title } from "radashi";
+import { sprintf } from "sprintf-js";
 import {
   APIRoute,
   ApFlags,
@@ -98,6 +99,38 @@ const DEVICE_STATE_LABELS: Record<DeviceState, MarkedString> = {
  * Returns the translated label for a device state.
  */
 const deviceStateLabel = (state: DeviceState): TranslatedString => _(DEVICE_STATE_LABELS[state]);
+
+/**
+ * Returns the translated label for a device's physical link.
+ *
+ * Both `carrier` and `speed` are best-effort and only reported by wired
+ * devices, and only while a cable is plugged in for the speed. `undefined`
+ * means the device does not say, as opposed to `false`/`0` meaning it does.
+ */
+const deviceLinkLabel = (device: Pick<Device, "carrier" | "speed">): TranslatedString => {
+  const { carrier, speed } = device;
+
+  if (carrier === undefined) {
+    // TRANSLATORS: link state of a network device the system does not report
+    // a carrier for.
+    return _("Unknown");
+  }
+
+  if (!carrier) {
+    // TRANSLATORS: link state of a network device with no cable plugged in.
+    return _("Down");
+  }
+
+  if (speed) {
+    // TRANSLATORS: link state of a network device that is up, running at the
+    // given speed. %d is replaced by the speed in Mb/s, e.g. "Up (1000 Mb/s)".
+    return sprintf(_("Up (%d Mb/s)"), speed);
+  }
+
+  // TRANSLATORS: link state of a network device with a cable plugged in but
+  // unknown speed.
+  return _("Up");
+};
 
 /**
  * Returns true if the given connection type is virtual.
@@ -485,6 +518,7 @@ export {
   connectionTypeLabel,
   controllerOf,
   deviceStateLabel,
+  deviceLinkLabel,
   ensureIPPrefix,
   formatIp,
   generateConnectionName,


### PR DESCRIPTION
## Problem

DeviceSelectorModal (added here) shows a device's MAC address, type, IP addresses and NetworkManager connection state, but not whether it actually has a cable plugged in or how fast the link is. That is exactly the information that is hardest to get by copy/pasting from the Details of other connections, and the original motivation for this feature.

gh#agama-project/agama#3884 adds `carrier` and `speed` to the `Device` API type (best-effort, from NetworkManager's `Device.Wired` interface and `InterfaceFlags`), but leaves them unconsumed: "the UI side is a separate pull request."

## Solution

- Add `carrier`/`speed` to the frontend `Device`/`APIDevice` types.
- Add a `deviceLinkLabel()` helper in `utils/network.ts`: "Down" when there is no carrier, "Up (%d Mb/s)" when the speed is known, "Up" otherwise, "Unknown" when the device does not report a carrier at all.
- Add a "Link" column to `DeviceSelectorModal` using it, next to the existing "State" column.

Opened against `enhance_ports_selection` rather than `master` since it only makes sense on top of this branch's `DeviceSelectorModal`, and depends on #3884 for the backend fields to actually be populated at runtime.

## Testing

- Extended `DeviceSelectorModal.test.tsx` with the "Down"/"Up"/"Up (Mb/s)"/"Unknown" cases.
- Manually verified in a browser against fixture devices covering all four link states.