### PR TITLE
web: fix package submission; clean up RPM .spec

### DIFF
--- a/web/package/_service
+++ b/web/package/_service
@@ -17,6 +17,8 @@
   </service>
   <service name="node_modules" mode="manual">
     <param name="cpio">node_modules.obscpio</param>
+    <!-- obs-service-node_modules version 3 needs this -->
+    <param name="legacy-container">true</param>
     <param name="output">node_modules.spec.inc</param>
     <param name="source-offset">1000</param>
   </service>

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,6 +1,8 @@
 -------------------------------------------------------------------
 Fri Sep 11 08:46:42 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
+- web: update _service to work with obs-service-node_modules 3
+  (gh#openSUSE/obs-service-node_modules#51)
 - web: remove leftovers from spec file
 
 -------------------------------------------------------------------

--- a/web/package/agama-web-ui.changes
+++ b/web/package/agama-web-ui.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 11 08:46:42 UTC 2026 - Martin Vidner <mvidner@suse.com>
+
+- web: remove leftovers from spec file
+
+-------------------------------------------------------------------
 Thu Sep  3 08:13:38 UTC 2026 - David Diaz <dgonzalez@suse.com>
 
 - Offer applying the installer language and keyboard to the product

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -42,7 +42,7 @@ Agama web UI for the experimental Agama installer.
 %prep
 %autosetup -p1 -n agama
 rm -f package-lock.json
-local-npm-registry %{_sourcedir} install --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
+local-npm-registry %{_sourcedir} install --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug*.log' -print0 | xargs -0 cat; false)
 
 %build
 NODE_ENV="production" npm run build

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -43,8 +43,6 @@ Agama web UI for the experimental Agama installer.
 %autosetup -p1 -n agama
 rm -f package-lock.json
 local-npm-registry %{_sourcedir} install --with=dev --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
-# temporary remove tests as its types are broken now
-find src -name *.test.tsx -delete
 
 %build
 NODE_ENV="production" npm run build

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -31,7 +31,6 @@ Source12:       node_modules.sums
 %include %_sourcedir/node_modules.spec.inc
 BuildArch:      noarch
 BuildRequires:  local-npm-registry
-BuildRequires:  appstream-glib
 
 # do not include in the 32bit repos, the Agama is 64bit only
 ExcludeArch:    %ix86 s390 ppc64

--- a/web/package/agama-web-ui.spec
+++ b/web/package/agama-web-ui.spec
@@ -42,7 +42,7 @@ Agama web UI for the experimental Agama installer.
 %prep
 %autosetup -p1 -n agama
 rm -f package-lock.json
-local-npm-registry %{_sourcedir} install --with=dev --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
+local-npm-registry %{_sourcedir} install --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
 
 %build
 NODE_ENV="production" npm run build


### PR DESCRIPTION
## Problem

obs-service-node_modules has changed in an incompatible way

- https://github.com/agama-project/agama/actions/runs/34576340312/job/103189541429
- https://github.com/openSUSE/obs-service-node_modules/issues/51

## Solution

- Adapt to that
- also, mostly unrelated, clean up the spec file

## Testing

- Tested manually: `osc service manualrun node_modules; osc build` still works


## Screenshots

No

## Documentation

The changes file is enough